### PR TITLE
fix: use FRONTEND_URL for GitHub OAuth redirect_uri

### DIFF
--- a/apps/api/src/routes/auth.ts
+++ b/apps/api/src/routes/auth.ts
@@ -22,7 +22,7 @@ auth.get("/github", async (c) => {
     });
     const params = new URLSearchParams({
         client_id: c.env.GITHUB_CLIENT_ID,
-        redirect_uri: `${new URL(c.req.url).origin}/api/auth/github/callback`,
+        redirect_uri: `${c.env.FRONTEND_URL}/api/auth/github/callback`,
         scope: "read:user user:email",
         state,
     });


### PR DESCRIPTION
GitHub OAuth redirect_uri を FRONTEND_URL ベースに変更して、redirect_uri が正しく Vercel ドメインで送信されるようにしました。