### PR TITLE
fix: cross-domain auth cookie (SameSite=None + direct Workers URL)

### DIFF
--- a/apps/api/src/routes/auth.ts
+++ b/apps/api/src/routes/auth.ts
@@ -16,13 +16,13 @@ auth.get("/github", async (c) => {
     setCookie(c, "oauth_state", state, {
         httpOnly: true,
         secure: isSecure,
-        sameSite: "Lax",
+        sameSite: isSecure ? "None" : "Lax",
         path: "/",
         maxAge: 600,
     });
     const params = new URLSearchParams({
         client_id: c.env.GITHUB_CLIENT_ID,
-        redirect_uri: `${c.env.FRONTEND_URL}/api/auth/github/callback`,
+        redirect_uri: `${new URL(c.req.url).origin}/api/auth/github/callback`,
         scope: "read:user user:email",
         state,
     });
@@ -176,7 +176,7 @@ auth.get("/github/callback", async (c) => {
     setCookie(c, "token", jwt, {
         httpOnly: true,
         secure: isSecure,
-        sameSite: "Lax",
+        sameSite: isSecure ? "None" : "Lax",
         path: "/",
         maxAge: 7 * 24 * 60 * 60,
     });

--- a/apps/web/src/components/auth-provider.tsx
+++ b/apps/web/src/components/auth-provider.tsx
@@ -28,12 +28,13 @@ type AuthContextValue = {
 const AuthContext = createContext<AuthContextValue | null>(null);
 
 export function AuthProvider({ children }: { children: React.ReactNode }) {
+  const API_BASE = process.env.NEXT_PUBLIC_API_URL ?? "";
   const [user, setUser] = useState<User | null>(null);
   const [loading, setLoading] = useState(true);
 
   const fetchUser = useCallback(async () => {
     try {
-      const res = await fetch("/api/auth/me", { credentials: "include" });
+      const res = await fetch(`${API_BASE}/api/auth/me`, { credentials: "include" });
       if (res.ok) {
         const data = await res.json();
         setUser(data.user);
@@ -52,11 +53,11 @@ export function AuthProvider({ children }: { children: React.ReactNode }) {
   }, [fetchUser]);
 
   const login = useCallback(() => {
-    window.location.href = "/api/auth/github";
+    window.location.href = `${API_BASE}/api/auth/github`;
   }, []);
 
   const logout = useCallback(async () => {
-    await fetch("/api/auth/logout", {
+    await fetch(`${API_BASE}/api/auth/logout`, {
       method: "POST",
       credentials: "include",
     });


### PR DESCRIPTION
## 問題

Vercel の rewrite プロキシ経由で GitHub OAuth コールバックを処理すると、`Set-Cookie` ヘッダーがクロスドメインにより削除され、認証クッキーがブラウザに届かない。

```
Browser → Vercel (open-shelf-delta.vercel.app)
  → rewrites /api/auth/* → Cloudflare Workers
    → GitHub OAuth → callback → Workers が Set-Cookie
      → Vercel がレスポンスを中継 → Cookie 消える ❌
```

## 解決策

### 1. `apps/api/src/routes/auth.ts`

- **`redirect_uri` を Workers origin に変更**
  - 旧: `${c.env.FRONTEND_URL}/api/auth/github/callback` (Vercel 経由)
  - 新: `${new URL(c.req.url).origin}/api/auth/github/callback` (Workers 直接)

- **Cookie の `SameSite` を本番では `None` に変更**
  - `oauth_state` / `token` 両クッキー
  - `isSecure ? "None" : "Lax"` (HTTP ローカル開発では `Lax` を維持)

### 2. `apps/web/src/components/auth-provider.tsx`

- `NEXT_PUBLIC_API_URL` を `API_BASE` として参照し、全認証リクエスト URL に付与
  - `/api/auth/me` → `${API_BASE}/api/auth/me`
  - `/api/auth/github` → `${API_BASE}/api/auth/github`
  - `/api/auth/logout` → `${API_BASE}/api/auth/logout`
- ローカル開発時は `NEXT_PUBLIC_API_URL` 未設定 → 空文字列 → 同一オリジン動作を維持

## デプロイ時の設定

Vercel プロジェクト設定に以下の環境変数を追加してください:

```
NEXT_PUBLIC_API_URL=https://openshelf-api.open-shelf.workers.dev
```

> `NEXT_PUBLIC_` プレフィックスが必要なため、フロントエンド（クライアントサイド）から参照可能になります。