### PR TITLE
fix: switch from cookie to Bearer token auth

### DIFF
--- a/apps/api/src/middleware/auth.ts
+++ b/apps/api/src/middleware/auth.ts
@@ -1,13 +1,13 @@
 import { createMiddleware } from "hono/factory";
 import { verify } from "hono/jwt";
-import { getCookie } from "hono/cookie";
 import type { Env, JwtPayload, Variables } from "../types";
 
 export const authMiddleware = createMiddleware<{
     Bindings: Env;
     Variables: Variables;
 }>(async (c, next) => {
-    const token = getCookie(c, "token");
+    const authHeader = c.req.header("Authorization");
+    const token = authHeader?.startsWith("Bearer ") ? authHeader.slice(7) : null;
     if (!token) {
         return c.json({ error: "Unauthorized" }, 401);
     }

--- a/apps/api/src/routes/auth.ts
+++ b/apps/api/src/routes/auth.ts
@@ -172,16 +172,7 @@ auth.get("/github/callback", async (c) => {
         c.env.JWT_SECRET,
     );
 
-    const isSecure = new URL(c.req.url).protocol === "https:";
-    setCookie(c, "token", jwt, {
-        httpOnly: true,
-        secure: isSecure,
-        sameSite: isSecure ? "None" : "Lax",
-        path: "/",
-        maxAge: 7 * 24 * 60 * 60,
-    });
-
-    return c.redirect(c.env.FRONTEND_URL);
+    return c.redirect(`${c.env.FRONTEND_URL}/auth/callback#token=${jwt}`);
 });
 
 // GET /api/auth/me — current user info
@@ -197,9 +188,8 @@ auth.get("/me", authMiddleware, async (c) => {
     return c.json({ user });
 });
 
-// POST /api/auth/logout — clear cookie
+// POST /api/auth/logout
 auth.post("/logout", async (c) => {
-    deleteCookie(c, "token", { path: "/" });
     return c.json({ ok: true });
 });
 

--- a/apps/web/src/app/auth/callback/page.tsx
+++ b/apps/web/src/app/auth/callback/page.tsx
@@ -1,0 +1,18 @@
+"use client";
+
+import { useEffect } from "react";
+import { useRouter } from "next/navigation";
+
+export default function AuthCallback() {
+  const router = useRouter();
+  useEffect(() => {
+    const hash = window.location.hash.substring(1);
+    const params = new URLSearchParams(hash);
+    const token = params.get("token");
+    if (token) {
+      localStorage.setItem("auth_token", token);
+    }
+    router.replace("/");
+  }, [router]);
+  return <p>ログイン中...</p>;
+}

--- a/apps/web/src/app/invites/page.tsx
+++ b/apps/web/src/app/invites/page.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { useAuth } from "@/components/auth-provider";
+import { apiFetch } from "@/lib/api";
 import { useEffect, useState } from "react";
 import { useRouter } from "next/navigation";
 import Link from "next/link";
@@ -31,9 +32,7 @@ export default function InvitesPage() {
     setFetching(true);
     (async () => {
       try {
-        const r = await fetch("/api/invites/received", {
-          credentials: "include",
-        });
+        const r = await apiFetch("/api/invites/received");
         if (!r.ok) {
           if (!cancelled) setInvites([]);
           return;
@@ -53,9 +52,8 @@ export default function InvitesPage() {
 
   const respond = async (inviteId: string, action: "accept" | "decline") => {
     try {
-      const res = await fetch(`/api/invites/${inviteId}`, {
+      const res = await apiFetch(`/api/invites/${inviteId}`, {
         method: "PATCH",
-        credentials: "include",
         headers: { "Content-Type": "application/json" },
         body: JSON.stringify({ action }),
       });

--- a/apps/web/src/app/papers/[id]/page.tsx
+++ b/apps/web/src/app/papers/[id]/page.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { useAuth } from "@/components/auth-provider";
+import { apiFetch } from "@/lib/api";
 import { useEffect, useState, useCallback } from "react";
 import { useParams } from "next/navigation";
 import Image from "next/image";
@@ -73,9 +74,7 @@ export default function PaperDetailPage() {
 
   const fetchPaper = useCallback(async () => {
     try {
-      const res = await fetch(`/api/papers/${paperId}`, {
-        credentials: "include",
-      });
+      const res = await apiFetch(`/api/papers/${paperId}`);
       if (!res.ok) {
         setError("論文が見つかりません");
         return;
@@ -94,9 +93,7 @@ export default function PaperDetailPage() {
   const fetchInvites = useCallback(async () => {
     if (!isUploader) return;
     try {
-      const res = await fetch(`/api/papers/${paperId}/invites`, {
-        credentials: "include",
-      });
+      const res = await apiFetch(`/api/papers/${paperId}/invites`);
       if (res.ok) {
         const data = await res.json();
         setInvites(data.invites);
@@ -121,9 +118,7 @@ export default function PaperDetailPage() {
       return;
     }
     try {
-      const res = await fetch(`/api/users/search?q=${encodeURIComponent(q)}`, {
-        credentials: "include",
-      });
+      const res = await apiFetch(`/api/users/search?q=${encodeURIComponent(q)}`);
       if (res.ok) {
         const data = await res.json();
         setSearchResults(data.users);
@@ -138,9 +133,8 @@ export default function PaperDetailPage() {
   const handleInvite = async (inviteeId: string) => {
     setInviting(true);
     try {
-      const res = await fetch(`/api/papers/${paperId}/invites`, {
+      const res = await apiFetch(`/api/papers/${paperId}/invites`, {
         method: "POST",
-        credentials: "include",
         headers: { "Content-Type": "application/json" },
         body: JSON.stringify({ inviteeId }),
       });

--- a/apps/web/src/app/settings/page.tsx
+++ b/apps/web/src/app/settings/page.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { useAuth } from "@/components/auth-provider";
+import { apiFetch } from "@/lib/api";
 import { useEffect, useState } from "react";
 import { useRouter } from "next/navigation";
 
@@ -30,9 +31,8 @@ export default function SettingsPage() {
     setMessageType(null);
     try {
       const trimmed = displayName.trim();
-      const res = await fetch("/api/users/me", {
+      const res = await apiFetch("/api/users/me", {
         method: "PATCH",
-        credentials: "include",
         headers: { "Content-Type": "application/json" },
         body: JSON.stringify({
           displayName: trimmed.length > 0 ? trimmed : null,

--- a/apps/web/src/app/upload/page.tsx
+++ b/apps/web/src/app/upload/page.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { useAuth } from "@/components/auth-provider";
+import { apiFetch } from "@/lib/api";
 import { useRouter } from "next/navigation";
 import { useEffect, useRef, useState } from "react";
 
@@ -110,9 +111,8 @@ export default function UploadPage() {
         formData.append(`file_types_${i}`, entry.fileType);
       });
 
-      const res = await fetch("/api/papers", {
+      const res = await apiFetch("/api/papers", {
         method: "POST",
-        credentials: "include",
         body: formData,
       });
 

--- a/apps/web/src/components/auth-provider.tsx
+++ b/apps/web/src/components/auth-provider.tsx
@@ -7,6 +7,7 @@ import {
   useEffect,
   useState,
 } from "react";
+import { apiFetch } from "@/lib/api";
 
 export type User = {
   id: string;
@@ -28,13 +29,18 @@ type AuthContextValue = {
 const AuthContext = createContext<AuthContextValue | null>(null);
 
 export function AuthProvider({ children }: { children: React.ReactNode }) {
-  const API_BASE = process.env.NEXT_PUBLIC_API_URL ?? "";
   const [user, setUser] = useState<User | null>(null);
   const [loading, setLoading] = useState(true);
 
   const fetchUser = useCallback(async () => {
     try {
-      const res = await fetch(`${API_BASE}/api/auth/me`, { credentials: "include" });
+      const token = localStorage.getItem("auth_token");
+      if (!token) {
+        setUser(null);
+        setLoading(false);
+        return;
+      }
+      const res = await apiFetch("/api/auth/me");
       if (res.ok) {
         const data = await res.json();
         setUser(data.user);
@@ -53,14 +59,12 @@ export function AuthProvider({ children }: { children: React.ReactNode }) {
   }, [fetchUser]);
 
   const login = useCallback(() => {
-    window.location.href = `${API_BASE}/api/auth/github`;
+    const apiBase = process.env.NEXT_PUBLIC_API_URL ?? "";
+    window.location.href = `${apiBase}/api/auth/github`;
   }, []);
 
   const logout = useCallback(async () => {
-    await fetch(`${API_BASE}/api/auth/logout`, {
-      method: "POST",
-      credentials: "include",
-    });
+    localStorage.removeItem("auth_token");
     setUser(null);
   }, []);
 

--- a/apps/web/src/lib/api.ts
+++ b/apps/web/src/lib/api.ts
@@ -1,0 +1,19 @@
+const API_BASE = process.env.NEXT_PUBLIC_API_URL ?? "";
+
+export function authHeaders(): HeadersInit {
+    const token =
+        typeof window !== "undefined"
+            ? localStorage.getItem("auth_token")
+            : null;
+    return token ? { Authorization: `Bearer ${token}` } : {};
+}
+
+export async function apiFetch(
+    path: string,
+    init?: RequestInit,
+): Promise<Response> {
+    return fetch(`${API_BASE}${path}`, {
+        ...init,
+        headers: { ...authHeaders(), ...init?.headers },
+    });
+}


### PR DESCRIPTION
## 概要

Chrome が第三者 Cookie をブロックするため、Vercel フロントエンド (`open-shelf-delta.vercel.app`) → Cloudflare Workers API (`openshelf-api.open-shelf.workers.dev`) 間の Cookie ベース認証が動作しません。PR #4 の `SameSite=None` 対応では不十分だったため、**Bearer トークン認証に全面移行**します。

## 変更内容

### API (`apps/api`)
- **`src/routes/auth.ts`**: OAuth コールバック後、JWT を Cookie ではなく URL フラグメント (`/auth/callback#token=...`) でフロントエンドに返却。`/logout` ルートから不要な `deleteCookie` を削除。
- **`src/middleware/auth.ts`**: Cookie からの JWT 取得を廃止し、`Authorization: Bearer <token>` ヘッダーからパース。

### Web (`apps/web`)
- **`src/lib/api.ts`** (新規): 共通 API フェッチヘルパー。`localStorage` からトークンを読み取り `Authorization` ヘッダーに付与。
- **`src/app/auth/callback/page.tsx`** (新規): OAuth コールバックページ。URL ハッシュから JWT を抽出し `localStorage` に保存後、`/` にリダイレクト。
- **`src/components/auth-provider.tsx`**: `apiFetch` を使用。ログアウトは `localStorage.removeItem` のみ（サーバー通信不要）。
- **`src/app/upload/page.tsx`**, **`papers/[id]/page.tsx`**, **`invites/page.tsx`**, **`settings/page.tsx`**: 全 fetch を `apiFetch` に置換、`credentials: "include"` を削除。

### 維持されるもの
- `oauth_state` Cookie（Workers ドメイン上のファーストパーティ Cookie なので問題なし）

## テスト手順
1. GitHub OAuth ログインフローが正常に動作すること
2. トークンが `localStorage` に保存されること
3. 各ページの API コールが `Authorization: Bearer` ヘッダー付きで送信されること
4. ログアウト後 `localStorage` からトークンが削除されること