### PR TITLE
fix: add explicit HS256 algorithm to JWT sign and verify

### DIFF
--- a/apps/api/src/middleware/auth.ts
+++ b/apps/api/src/middleware/auth.ts
@@ -15,6 +15,7 @@ export const authMiddleware = createMiddleware<{
         const payload = await verify<JwtPayload>(
             token,
             c.env.JWT_SECRET,
+            "HS256",
         );
         c.set("user", payload);
         await next();

--- a/apps/api/src/routes/auth.ts
+++ b/apps/api/src/routes/auth.ts
@@ -170,6 +170,7 @@ auth.get("/github/callback", async (c) => {
             exp: now + 7 * 24 * 60 * 60,
         },
         c.env.JWT_SECRET,
+        "HS256",
     );
 
     return c.redirect(`${c.env.FRONTEND_URL}/auth/callback#token=${jwt}`);


### PR DESCRIPTION
Ensures JWT sign and verify use the same algorithm (HS256) to prevent verification failures