### PR TITLE
fix(api): fix mask of DB errors as 401 on private paper GET /:id

### DIFF
--- a/apps/api/src/routes/__tests__/papers.test.ts
+++ b/apps/api/src/routes/__tests__/papers.test.ts
@@ -118,6 +118,24 @@ describe("papers routes", () => {
         expect(res.status).toBe(403);
     });
 
+    it("GET /api/papers/:id returns 500 (not 401) on database error during author check", async () => {
+        const token = await createTestJWT({ sub: "user-1", githubId: "123", name: "Uploader" });
+        mockDb.select = vi
+            .fn()
+            .mockImplementationOnce(() => makeQuery({ getResult: { id: "paper-1", title: "P1", visibility: "private" } }))
+            .mockImplementationOnce(() => { throw new Error("DB Error") });
+
+        const app = await createTestApp();
+        const env = createTestEnv();
+        const res = await app.request(
+            "http://localhost/api/papers/paper-1",
+            { headers: { Authorization: `Bearer ${token}` } },
+            env as any
+        );
+
+        expect(res.status).toBe(500);
+    });
+
     it("DELETE /api/papers/:id deletes a paper", async () => {
         const token = await createTestJWT({ sub: "user-1", githubId: "123", name: "Uploader" });
         mockDb.select = vi

--- a/apps/api/src/routes/papers.ts
+++ b/apps/api/src/routes/papers.ts
@@ -1,5 +1,4 @@
 import { Hono } from "hono";
-import { verify } from "hono/jwt";
 import { drizzle } from "drizzle-orm/d1";
 import { eq, and, inArray } from "drizzle-orm";
 import {
@@ -224,26 +223,22 @@ papersRoute.get("/:id", async (c) => {
 
     // Non-public papers require authentication and authorship
     if (paper.visibility !== "public") {
-        const authHeader = c.req.header("Authorization");
-        const token = authHeader?.startsWith("Bearer ") ? authHeader.slice(7) : null;
-        if (!token) return c.json({ error: "Unauthorized" }, 401);
-        try {
-            const payload = await verify(token, c.env.JWT_SECRET, "HS256");
-            const isAuthor = await db
-                .select()
-                .from(paperAuthors)
-                .where(
-                    and(
-                        eq(paperAuthors.paperId, paperId),
-                        eq(paperAuthors.userId, payload.sub as string),
-                    ),
-                )
-                .get();
-            if (!isAuthor)
-                return c.json({ error: "Forbidden" }, 403);
-        } catch {
-            return c.json({ error: "Unauthorized" }, 401);
-        }
+        const authRes = await authMiddleware(c, async () => {});
+        if (authRes) return authRes;
+
+        const user = c.get("user");
+        const isAuthor = await db
+            .select()
+            .from(paperAuthors)
+            .where(
+                and(
+                    eq(paperAuthors.paperId, paperId),
+                    eq(paperAuthors.userId, user.sub as string),
+                ),
+            )
+            .get();
+        if (!isAuthor)
+            return c.json({ error: "Forbidden" }, 403);
     }
 
     const files = await db


### PR DESCRIPTION
## バグの修正内容
PR #20にて手動でBearer tokenを取り出してverifyするように修正されていましたが、以下の問題がありました。
1. Drizzle DBへのクエリ失敗がすべて `catch` 節に握りつぶされ `401 Unauthorized` になる設計だった。本番環境のレイテンシやコネクションプールなどに起因するエラーが401として返っていたことが原因。
2. 共通の `authMiddleware` とロジックが二重管理になっていた。

## 対応
- `apps/api/src/routes/papers.ts` の `GET /:id` エンドポイントでの認証処理を `authMiddleware` を直接呼び出す形にリファクタリングし、クエリエラーが `401 Unauthorized` に丸め込まれないようにしました。
- 再発防止のため、リグレッションテスト `GET /api/papers/:id returns 500 (not 401) on database error during author check` を追加しました。