### PR TITLE
chore: update coauthor invite search parameter comment

### DIFF
--- a/apps/api/src/routes/users.ts
+++ b/apps/api/src/routes/users.ts
@@ -64,7 +64,7 @@ const updateMeHandler = async (c: any) => {
 usersRoute.patch("/me", authMiddleware, updateMeHandler);
 usersRoute.put("/me", authMiddleware, updateMeHandler);
 
-// GET /api/users/search?q=xxx — search users for coauthor invite
+// GET /api/users/search?q={query} — search users for coauthor invite
 usersRoute.get("/search", authMiddleware, async (c) => {
     const q = c.req.query("q");
     if (!q || q.length < 2) return c.json({ users: [] });


### PR DESCRIPTION
Updated the comment in `usersRoute.get("/search")` to change `q=xxx` to `q={query}` to prevent any future automated scanning tools from misidentifying it as a placeholder/TODO.

---
*PR created automatically by Jules for task [3963811602260803059](https://jules.google.com/task/3963811602260803059) started by @is0692vs*