### PR TITLE
🧹 chore(api): Remove won't fix TODO for PPT/PPTX deep inspection

### DIFF
--- a/apps/api/src/utils/file.ts
+++ b/apps/api/src/utils/file.ts
@@ -2,7 +2,6 @@ const MIME_COMPATIBILITY: Record<string, readonly string[]> = {
     "application/pdf": ["application/pdf"],
     "image/png": ["image/png"],
     "image/jpeg": ["image/jpeg"],
-    // TODO: For deeper inspection of PPT/PPTX, parse OLE2 streams or check for specific ZIP entries like "ppt/presentation.xml"
     "application/vnd.ms-powerpoint": ["application/x-ole-storage"],
     "application/vnd.openxmlformats-officedocument.presentationml.presentation": ["application/zip"],
 };


### PR DESCRIPTION
🎯 **What:** Removed the unresolved `TODO` comment regarding deeper inspection of PPT/PPTX files via OLE2 or ZIP stream parsing in `apps/api/src/utils/file.ts`.
💡 **Why:** Implementing deeper inspection logic requires significant new code and potentially external dependencies (like an XML/ZIP/OLE2 parser) which adds considerable complexity to the codebase. The current best-effort heuristic, which checks the magic number of the container format (`application/x-ole-storage` and `application/zip`), is generally accepted and sufficient for general format verification without bloating the API implementation. Thus, the `TODO` was treated as a "won't fix" to maintain code health.
✅ **Verification:** Verified that existing unit tests pass using `npm run test`, covering the original upload validation. No functional or behavioral changes were made.
✨ **Result:** A cleaner codebase without stale, unactionable TODO comments, with validation continuing to work as expected.

---
*PR created automatically by Jules for task [4146310091722042863](https://jules.google.com/task/4146310091722042863) started by @is0692vs*