### PR TITLE
🧹 [code health improvement] Remove explicit 'as any' cast for HTTP status codes

### DIFF
--- a/apps/api/src/routes/papers.ts
+++ b/apps/api/src/routes/papers.ts
@@ -1,4 +1,5 @@
 import { Hono, type Context } from "hono";
+import type { ContentfulStatusCode } from "hono/utils/http-status";
 import { drizzle } from "drizzle-orm/d1";
 import { eq, and, inArray } from "drizzle-orm";
 import {
@@ -53,11 +54,15 @@ function isValidUrlScheme(urlStr: string): boolean {
     }
 }
 
+type AuthResult =
+    | { ok: true; user?: { sub: string } }
+    | { ok: false; status: ContentfulStatusCode; error: string };
+
 async function authorizePaperAccess(
     c: Context<{ Bindings: Env; Variables: Variables }>,
     db: ReturnType<typeof drizzle>,
     paper: { visibility: string; id: string },
-) {
+): Promise<AuthResult> {
     if (paper.visibility === "public") return { ok: true };
 
     const authHeader = c.req.header("Authorization");
@@ -379,8 +384,8 @@ papersRoute.get("/:id", async (c) => {
     if (!paper) return c.json({ error: "Not found" }, 404);
 
     const access = await authorizePaperAccess(c, db, paper);
-    if (!access.ok) {
-        return c.json({ error: access.error }, access.status as any);
+    if (access.ok !== true) {
+        return c.json({ error: access.error }, access.status);
     }
 
     const [rawFiles, authors] = (await db.batch([
@@ -443,8 +448,8 @@ papersRoute.get("/:id/files/:fileId/download", async (c) => {
     if (!paper) return c.json({ error: "Not found" }, 404);
 
     const access = await authorizePaperAccess(c, db, paper);
-    if (!access.ok) {
-        return c.json({ error: access.error }, access.status as any);
+    if (access.ok !== true) {
+        return c.json({ error: access.error }, access.status);
     }
 
     const file = await db
@@ -489,8 +494,8 @@ papersRoute.get("/:id/files/:fileId/preview", async (c) => {
     if (!paper) return c.json({ error: "Not found" }, 404);
 
     const access = await authorizePaperAccess(c, db, paper);
-    if (!access.ok) {
-        return c.json({ error: access.error }, access.status as any);
+    if (access.ok !== true) {
+        return c.json({ error: access.error }, access.status);
     }
 
     const file = await db
@@ -524,8 +529,8 @@ papersRoute.get("/:id/files/:fileId/stream", async (c) => {
     if (!paper) return c.json({ error: "Not found" }, 404);
 
     const access = await authorizePaperAccess(c, db, paper);
-    if (!access.ok) {
-        return c.json({ error: access.error }, access.status as any);
+    if (access.ok !== true) {
+        return c.json({ error: access.error }, access.status);
     }
 
     const file = await db


### PR DESCRIPTION
🎯 **What:** The code health issue addressed is the explicit `as any` type casting of HTTP status codes across `apps/api/src/routes/papers.ts`. Refactored `authorizePaperAccess` to explicitly return an `AuthResult` discriminated union.
💡 **Why:** Improves code maintainability and readability by replacing unsafe type assertions (`as any`) with correctly typed values, allowing TypeScript to accurately infer the `status` as a `ContentfulStatusCode` instead of throwing a union typing error.
✅ **Verification:** Verified by confirming the codebase passes type checks and unit testing locally after replacing the explicit cast. There are no side effects to external usage.
✨ **Result:** Enhanced the explicit typing and clarity in `apps/api/src/routes/papers.ts` without modifying behavior.

---
*PR created automatically by Jules for task [17202368584835166461](https://jules.google.com/task/17202368584835166461) started by @is0692vs*