### PR TITLE
🔒 Fix insecure CORS policy

### DIFF
--- a/apps/api/src/index.ts
+++ b/apps/api/src/index.ts
@@ -22,11 +22,12 @@ app.use(
                     .filter(Boolean)
                 : undefined;
 
-            if (allowedOrigins && allowedOrigins.length > 0) {
-                return origin && allowedOrigins.includes(origin) ? origin : "";
-            }
+            if (!origin) return c.env.FRONTEND_URL;
 
-            return c.env.FRONTEND_URL;
+            if (origin === c.env.FRONTEND_URL) return origin;
+            if (allowedOrigins && allowedOrigins.includes(origin)) return origin;
+
+            return null;
         },
         credentials: true,
         allowMethods: ["GET", "POST", "PUT", "PATCH", "DELETE", "OPTIONS"],


### PR DESCRIPTION
🎯 **What:** 
The application's CORS configuration unconditionally returned `c.env.FRONTEND_URL` in the `Access-Control-Allow-Origin` header when the requested origin was not present in the `ALLOWED_ORIGINS` list.

⚠️ **Risk:** 
Although modern browsers will inherently block the request when `Access-Control-Allow-Origin` doesn't match the `Origin` header of an evil domain, returning the `FRONTEND_URL` continuously leaks the configured frontend target. Additionally, it fundamentally violates the implicit rejection standard of CORS, where untrusted origins should receive no origin header at all. Furthermore, the previous logic contained a subtle bug that blocked `FRONTEND_URL` traffic if `ALLOWED_ORIGINS` were defined, unless `FRONTEND_URL` was explicitly redundantly added to the allowed origins.

🛡️ **Solution:** 
Updated the `hono/cors` configuration's `origin` callback to evaluate the origin explicitly:
1. It returns `FRONTEND_URL` if there is no `Origin` header (expected for local/direct server calls).
2. It explicitly checks for an exact match against `FRONTEND_URL` and authorizes it.
3. It checks for an exact match within `ALLOWED_ORIGINS` and authorizes it.
4. For any other origin, it returns `null`. By returning `null`, Hono appropriately omits the `Access-Control-Allow-Origin` header entirely, safely and securely neutralizing untrusted CORS requests.

---
*PR created automatically by Jules for task [15637195177417946433](https://jules.google.com/task/15637195177417946433) started by @is0692vs*