### PR TITLE
🧹 [code health improvement] Remove explicit 'as any' in collections route

### DIFF
--- a/apps/api/src/routes/collections.ts
+++ b/apps/api/src/routes/collections.ts
@@ -443,7 +443,7 @@ collectionsRoute.delete("/collections/:id/papers/:paperId", authMiddleware, asyn
         .delete(collectionPapers)
         .where(and(eq(collectionPapers.collectionId, collection.id), eq(collectionPapers.paperId, c.req.param("paperId"))));
 
-    if ((result as any).meta?.changes === 0) {
+    if (result.meta?.changes === 0) {
         return c.json({ error: "Paper not in collection" }, 404);
     } return c.json({ ok: true });
 });


### PR DESCRIPTION
🧹 [code health improvement] Remove explicit 'as any' in collections route

🎯 What: The explicit `(result as any).meta?.changes` cast was removed in `apps/api/src/routes/collections.ts:446`.
💡 Why: Drizzle ORM's types for Cloudflare D1 natively expose the `meta` property and its `changes` attribute. The type is `D1Result`.
✅ Verification: We ran `cd apps/api && npm run typecheck` which compiled successfully, proving that TS recognizes the `meta` field without issues. `npm run test` and `npm run lint` also ran smoothly.
✨ Result: A safer, cleaner, and fully type-checked `D1Result` access.

---
*PR created automatically by Jules for task [6411328080679569947](https://jules.google.com/task/6411328080679569947) started by @is0692vs*