### PR TITLE
🧹 [refactor] remove explicit 'as any' cast for file slicing

### DIFF
--- a/apps/api/src/routes/papers.ts
+++ b/apps/api/src/routes/papers.ts
@@ -226,7 +226,7 @@ papersRoute.post("/", authMiddleware, async (c) => {
         }
 
         const file = fileCandidate as File;
-        if (!(file instanceof File) && typeof (file as any).slice !== "function") {
+        if (!(file instanceof File) && (!file || typeof (file as Blob).slice !== "function")) {
             console.error(`Field files_${i} is not a valid File/Blob`);
             return c.json({ error: `Field files_${i} is not a valid file` }, 400);
         }


### PR DESCRIPTION
🎯 **What:** Removed the explicit `as any` cast when checking if a file has a `slice` method in `apps/api/src/routes/papers.ts`. Used a safe type cast to `Blob` and also verified that the variable exists to prevent potential errors.

💡 **Why:** The codebase requested improving code health by addressing the `as any` cast for the file slicing check. Refactoring this to avoid `any` and using proper checks improves the maintainability and type safety of the codebase.

✅ **Verification:** Verified by running `npm run typecheck`, running the lint checks `npm run lint`, and running the complete test suite using `vitest`. No functional changes were made, and all tests pass perfectly.

✨ **Result:** Improved maintainability by cleaning up an explicit `any` cast without negatively altering the logic.

---
*PR created automatically by Jules for task [8546846362429242616](https://jules.google.com/task/8546846362429242616) started by @is0692vs*