### PR TITLE
ナビゲーション改善: 各ページへ戻るリンクの追加

### DIFF
--- a/apps/web/src/app/collections/new/page.tsx
+++ b/apps/web/src/app/collections/new/page.tsx
@@ -4,6 +4,7 @@ import { useAuth } from "@/components/auth-provider";
 import { apiFetch } from "@/lib/api";
 import { useRouter } from "next/navigation";
 import { useEffect, useMemo, useRef, useState } from "react";
+import Link from "next/link";
 
 function slugify(text: string): string {
   return text
@@ -110,6 +111,15 @@ export default function NewCollectionPage() {
 
   return (
     <div className="max-w-2xl">
+      <div className="mb-6">
+        <Link
+          href="/"
+          className="text-sm text-blue-600 hover:underline dark:text-blue-400"
+        >
+          ← ダッシュボードに戻る
+        </Link>
+      </div>
+
       <h1 className="text-2xl font-bold mb-6">コレクションを作成</h1>
 
       <form

--- a/apps/web/src/app/invites/page.tsx
+++ b/apps/web/src/app/invites/page.tsx
@@ -81,6 +81,15 @@ export default function InvitesPage() {
 
   return (
     <div className="mx-auto max-w-3xl">
+      <div className="mb-6">
+        <Link
+          href="/"
+          className="text-sm text-blue-600 hover:underline dark:text-blue-400"
+        >
+          ← ダッシュボードに戻る
+        </Link>
+      </div>
+
       <div className="mb-8 rounded-3xl border border-gray-200 bg-white px-6 py-6 shadow-sm dark:border-gray-800 dark:bg-gray-950 sm:px-8 sm:py-8">
         <div className="flex flex-col gap-4 sm:flex-row sm:items-start sm:justify-between">
           <div>

--- a/apps/web/src/app/orgs/[slug]/settings/page.tsx
+++ b/apps/web/src/app/orgs/[slug]/settings/page.tsx
@@ -5,6 +5,7 @@ import { apiFetch } from "@/lib/api";
 import { useParams, useRouter, useSearchParams } from "next/navigation";
 import { useEffect, useState, useCallback, useRef } from "react";
 import Image from "next/image";
+import Link from "next/link";
 
 type Org = {
   id: string;
@@ -374,14 +375,15 @@ export default function OrgSettingsPage() {
 
   return (
     <div className="max-w-3xl">
-      <div className="flex items-center gap-2 mb-6">
-        <button
-          type="button"
-          onClick={() => router.push(`/orgs/${slug}`)}
-          className="text-gray-400 hover:text-gray-600"
+      <div className="mb-6">
+        <Link
+          href={`/orgs/${slug}`}
+          className="text-sm text-blue-600 hover:underline dark:text-blue-400"
         >
-          ←
-        </button>
+          ← 組織ページに戻る
+        </Link>
+      </div>
+      <div className="flex items-center gap-2 mb-6">
         <h1 className="text-2xl font-bold">{org.name} — 設定</h1>
       </div>
 

--- a/apps/web/src/app/orgs/new/page.tsx
+++ b/apps/web/src/app/orgs/new/page.tsx
@@ -4,6 +4,7 @@ import { useAuth } from "@/components/auth-provider";
 import { apiFetch } from "@/lib/api";
 import { useRouter } from "next/navigation";
 import { useEffect, useState, useCallback, useRef } from "react";
+import Link from "next/link";
 
 const SLUG_RE = /^[a-z0-9][a-z0-9-]*[a-z0-9]$|^[a-z0-9]$/;
 
@@ -137,6 +138,15 @@ export default function NewOrgPage() {
 
   return (
     <div className="max-w-lg">
+      <div className="mb-6">
+        <Link
+          href="/"
+          className="text-sm text-blue-600 hover:underline dark:text-blue-400"
+        >
+          ← ダッシュボードに戻る
+        </Link>
+      </div>
+
       <h1 className="text-2xl font-bold mb-6">組織を作成</h1>
 
       <form onSubmit={handleSubmit} className="space-y-4">

--- a/apps/web/src/app/settings/page.tsx
+++ b/apps/web/src/app/settings/page.tsx
@@ -4,6 +4,7 @@ import { useAuth } from "@/components/auth-provider";
 import { apiFetch } from "@/lib/api";
 import { useEffect, useMemo, useState } from "react";
 import { useRouter } from "next/navigation";
+import Link from "next/link";
 
 export default function SettingsPage() {
   const { user, loading, refresh } = useAuth();
@@ -75,6 +76,15 @@ export default function SettingsPage() {
 
   return (
     <div className="mx-auto max-w-3xl">
+      <div className="mb-6">
+        <Link
+          href="/"
+          className="text-sm text-blue-600 hover:underline dark:text-blue-400"
+        >
+          ← ダッシュボードに戻る
+        </Link>
+      </div>
+
       <div className="mb-8 rounded-3xl border border-gray-200 bg-white px-6 py-6 shadow-sm dark:border-gray-800 dark:bg-gray-950 sm:px-8 sm:py-8">
         <p className="text-sm font-medium text-gray-500 dark:text-gray-400">
           Profile settings

--- a/apps/web/src/app/upload/page.tsx
+++ b/apps/web/src/app/upload/page.tsx
@@ -4,6 +4,7 @@ import { useAuth } from "@/components/auth-provider";
 import { apiFetch } from "@/lib/api";
 import { useRouter } from "next/navigation";
 import { useEffect, useRef, useState } from "react";
+import Link from "next/link";
 
 const VALID_FILE_TYPES = [
   "paper",
@@ -136,6 +137,15 @@ export default function UploadPage() {
 
   return (
     <div className="mx-auto max-w-3xl">
+      <div className="mb-6">
+        <Link
+          href="/"
+          className="text-sm text-blue-600 hover:underline dark:text-blue-400"
+        >
+          ← ダッシュボードに戻る
+        </Link>
+      </div>
+
       <div className="mb-8 rounded-3xl border border-gray-200 bg-white px-6 py-6 shadow-sm dark:border-gray-800 dark:bg-gray-950 sm:px-8 sm:py-8">
         <div className="flex flex-col gap-4 sm:flex-row sm:items-start sm:justify-between">
           <div>

--- a/package-lock.json
+++ b/package-lock.json
@@ -10405,7 +10405,6 @@
       "version": "2.3.2",
       "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
       "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
-      "dev": true,
       "hasInstallScript": true,
       "license": "MIT",
       "optional": true,


### PR DESCRIPTION
各ページのヘッダー付近に「← 戻る」等のナビゲーションリンクを追加しました。

- `apps/web/src/app/settings/page.tsx`: 「ダッシュボードに戻る」を追加
- `apps/web/src/app/collections/new/page.tsx`: 「ダッシュボードに戻る」を追加
- `apps/web/src/app/upload/page.tsx`: 「ダッシュボードに戻る」を追加
- `apps/web/src/app/orgs/[slug]/settings/page.tsx`: 既存のボタンを `Link` コンポーネントに置き換え、組織ページに戻るように修正
- `apps/web/src/app/orgs/new/page.tsx`: 「ダッシュボードに戻る」を追加
- `apps/web/src/app/invites/page.tsx`: 「ダッシュボードに戻る」を追加

これにより、ユーザーが迷わずに前の画面（またはトップのダッシュボード）へ戻れるようになります。

---
*PR created automatically by Jules for task [12639659391578283992](https://jules.google.com/task/12639659391578283992) started by @is0692vs*