### PR TITLE
TSK-364: feat: Codecov導入（カバレッジレポート）

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -59,13 +59,20 @@ jobs:
           cache: npm
       - run: npm ci
       - name: Test
-        run: npm run test:coverage -w apps/api
+        run: npm run test -w apps/api -- --coverage
+      - name: Upload API coverage to Codecov
+        uses: codecov/codecov-action@v5
+        with:
+          token: ${{ secrets.CODECOV_TOKEN }}
+          flags: api
+          files: ./apps/api/coverage/lcov.info
+          fail_ci_if_error: false
       - name: Upload Coverage
         if: always()
         uses: actions/upload-artifact@v4
         with:
           name: coverage-api
-          path: coverage/api/
+          path: apps/api/coverage/
 
   test-web:
     name: Test Web
@@ -79,13 +86,20 @@ jobs:
           cache: npm
       - run: npm ci
       - name: Test
-        run: npm run test:coverage -w apps/web
+        run: npm run test -w apps/web -- --coverage
+      - name: Upload Web coverage to Codecov
+        uses: codecov/codecov-action@v5
+        with:
+          token: ${{ secrets.CODECOV_TOKEN }}
+          flags: web
+          files: ./apps/web/coverage/lcov.info
+          fail_ci_if_error: false
       - name: Upload Coverage
         if: always()
         uses: actions/upload-artifact@v4
         with:
           name: coverage-web
-          path: coverage/web/
+          path: apps/web/coverage/
 
   build-web-check:
     name: Build Web (Preview Check)

--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # OpenShelf
 
+[![codecov](https://codecov.io/gh/Hiroki-org/OpenShelf/graph/badge.svg)](https://codecov.io/gh/Hiroki-org/OpenShelf)
+
 OpenShelf は、研究成果物（論文、プレゼン資料、データセット等）を安全にアップロードし、共有するためのファイルホスティングプラットフォームです。
 
 利用者は GitHub アカウントを用いて安全にログインし、成果物を素早く公開・共有できます。Cloudflare Workers (Hono) と Next.js を組み合わせたモダンな構成で、スケーラビリティとセキュリティを両立しています。

--- a/apps/api/vitest.config.ts
+++ b/apps/api/vitest.config.ts
@@ -5,8 +5,9 @@ export default defineConfig({
         environment: "node",
         include: ["src/**/__tests__/**/*.test.ts"],
         coverage: {
-            reporter: ["text", "html"],
-            reportsDirectory: "../../coverage/api"
+            provider: "v8",
+            reporter: ["text", "lcov"],
+            reportsDirectory: "./coverage"
         }
     }
 });

--- a/apps/web/vitest.config.ts
+++ b/apps/web/vitest.config.ts
@@ -12,8 +12,9 @@ export default defineConfig({
         setupFiles: ["./vitest.setup.ts"],
         include: ["src/**/__tests__/**/*.test.{ts,tsx}"],
         coverage: {
-            reporter: ["text", "html"],
-            reportsDirectory: "../../coverage/web"
+            provider: "v8",
+            reporter: ["text", "lcov"],
+            reportsDirectory: "./coverage"
         }
     }
 });

--- a/codecov.yml
+++ b/codecov.yml
@@ -1,0 +1,27 @@
+codecov:
+  require_ci_to_pass: true
+
+coverage:
+  status:
+    project:
+      default:
+        target: auto
+        threshold: 100%
+    patch:
+      default:
+        target: 0%
+
+comment:
+  layout: "reach,diff,flags,files"
+  behavior: default
+  require_changes: false
+
+flags:
+  api:
+    paths:
+      - apps/api/src/
+    carryforward: true
+  web:
+    paths:
+      - apps/web/src/
+    carryforward: true

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -1,11 +1,15 @@
 import { defineConfig } from "vitest/config";
 
+const coverageEnabled = process.argv.includes("--coverage");
+
 export default defineConfig({
     test: {
         projects: ["apps/api/vitest.config.ts", "apps/web/vitest.config.ts"],
         coverage: {
-            reporter: ["text", "html"],
-            reportsDirectory: "coverage"
+            enabled: coverageEnabled,
+            provider: "v8",
+            reporter: ["text", "lcov"],
+            reportsDirectory: "./coverage"
         }
     }
 });


### PR DESCRIPTION
## 概要
- API/Web の Vitest coverage を `v8 + lcov` に統一
- `codecov.yml` を追加し、api/web フラグを定義
- CI に Codecov アップロードステップを追加
- README に Codecov バッジを追加

## 検証
- `pnpm test -- --coverage`
- `npm run test -w apps/api -- --coverage`
- `npm run test -w apps/web -- --coverage`
- `npm run typecheck`
- `npm run lint`

ref TSK-364