### PR TITLE
TSK-366: Codecov Test Analytics 導入

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -60,6 +60,14 @@ jobs:
       - run: npm ci
       - name: Test
         run: npm run test -w apps/api -- --coverage
+      - name: Upload test results to Codecov
+        if: ${{ !cancelled() }}
+        uses: codecov/test-results-action@v1
+        with:
+          token: ${{ secrets.CODECOV_TOKEN }}
+          files: |
+            apps/api/test-report.junit.xml
+          flags: test-results
       - name: Upload Coverage
         if: always()
         uses: actions/upload-artifact@v4
@@ -80,6 +88,14 @@ jobs:
       - run: npm ci
       - name: Test
         run: npm run test -w apps/web -- --coverage
+      - name: Upload test results to Codecov
+        if: ${{ !cancelled() }}
+        uses: codecov/test-results-action@v1
+        with:
+          token: ${{ secrets.CODECOV_TOKEN }}
+          files: |
+            apps/web/test-report.junit.xml
+          flags: test-results
       - name: Upload Coverage
         if: always()
         uses: actions/upload-artifact@v4

--- a/.gitignore
+++ b/.gitignore
@@ -45,6 +45,7 @@ yarn-error.log*
 .cache/
 *.pem
 coverage/
+test-report.junit.xml
 
 # Playwright
 test-results/

--- a/apps/api/vitest.config.ts
+++ b/apps/api/vitest.config.ts
@@ -4,6 +4,11 @@ export default defineConfig({
     test: {
         environment: "node",
         include: ["src/**/__tests__/**/*.test.ts"],
+        reporters: ["default", "junit"],
+        outputFile: {
+            lcov: "./coverage/lcov.info",
+            junit: "./test-report.junit.xml",
+        },
         coverage: {
             provider: "v8",
             reporter: ["text", "lcov"],

--- a/apps/web/vitest.config.ts
+++ b/apps/web/vitest.config.ts
@@ -11,6 +11,11 @@ export default defineConfig({
         environment: "jsdom",
         setupFiles: ["./vitest.setup.ts"],
         include: ["src/**/__tests__/**/*.test.{ts,tsx}"],
+        reporters: ["default", "junit"],
+        outputFile: {
+            lcov: "./coverage/lcov.info",
+            junit: "./test-report.junit.xml",
+        },
         coverage: {
             provider: "v8",
             reporter: ["text", "lcov"],


### PR DESCRIPTION
## 概要
- API/Web の Vitest 設定に JUnit レポーター出力を追加
- .gitignore に test-report.junit.xml を追加
- CI の API/Web テストジョブに codecov/test-results-action@v1 を追加（if 条件: !cancelled）
- 既存の Codecov カバレッジアップロードは変更なし

## 動作確認
- npm run test -w apps/api で apps/api/test-report.junit.xml 生成を確認
- npm run test -w apps/web で apps/web/test-report.junit.xml 生成を確認
- npm run test -w apps/api -- --coverage
- npm run test -w apps/web -- --coverage
- npm run lint（warningのみ）
- npm run typecheck