### PR TITLE
TSK-368: fix Codecov main branch coverage uploads

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -107,6 +107,9 @@ jobs:
     name: Upload Coverage
     needs: [build-web-check, e2e]
     runs-on: ubuntu-latest
+    env:
+      CODECOV_COMMIT_SHA: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.sha || github.sha }}
+      CODECOV_BRANCH: ${{ github.event_name == 'pull_request' && github.head_ref || github.ref_name }}
     steps:
       - uses: actions/checkout@v4
       - name: Download API coverage artifact
@@ -123,16 +126,22 @@ jobs:
         uses: codecov/codecov-action@v5
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
+          disable_search: true
           flags: api
           files: ./coverage-artifacts/api/lcov.info
           fail_ci_if_error: false
+          override_branch: ${{ env.CODECOV_BRANCH }}
+          override_commit: ${{ env.CODECOV_COMMIT_SHA }}
       - name: Upload Web coverage to Codecov
         uses: codecov/codecov-action@v5
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
+          disable_search: true
           flags: web
           files: ./coverage-artifacts/web/lcov.info
           fail_ci_if_error: false
+          override_branch: ${{ env.CODECOV_BRANCH }}
+          override_commit: ${{ env.CODECOV_COMMIT_SHA }}
 
   build-web-check:
     name: Build Web (Preview Check)


### PR DESCRIPTION
## 概要
- main push 時の Codecov upload で commit と branch を明示するよう修正
- Codecov の自動探索を無効化し、各 step が指定した lcov のみを送るよう修正
- main で 23% に固定される原因だった upload メタデータの曖昧さを解消

## 変更内容
- upload-coverage ジョブに CODECOV_COMMIT_SHA と CODECOV_BRANCH を追加
- API/Web の codecov/codecov-action@v5 に override_commit と override_branch を追加
- API/Web の codecov/codecov-action@v5 に disable_search: true を追加

## ローカル確認
- npm run test -w apps/api -- --coverage
- npm run test -w apps/web -- --coverage
- API line coverage: 80.44%
- Web line coverage: 90.24%
- combined lcov line coverage: 86.33%
