### PR TITLE
TSK-368: fix: codecov.yml から carryforward を削除

### DIFF
--- a/codecov.yml
+++ b/codecov.yml
@@ -23,8 +23,6 @@ flags:
   api:
     paths:
       - apps/api/src/
-    carryforward: true
   web:
     paths:
       - apps/web/src/
-    carryforward: true


### PR DESCRIPTION
ref TSK-368

## 概要
- codecov.yml の flags 設定から carryforward を削除
- 古い main ブランチ coverage が持ち越され続ける状態を解消するための追加修正

## 変更内容
- api flag の carryforward を削除
- web flag の carryforward を削除

## 補足
- ci.yml は変更していません
- 設定ファイルのみの変更のため、ローカルテストは未実施です
