### PR TITLE
TSK-368: fix: codecov-action に root_dir を追加してパス解決を修正

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -132,6 +132,7 @@ jobs:
           fail_ci_if_error: false
           override_branch: ${{ env.CODECOV_BRANCH }}
           override_commit: ${{ env.CODECOV_COMMIT_SHA }}
+          root_dir: apps/api
       - name: Upload Web coverage to Codecov
         uses: codecov/codecov-action@v5
         with:
@@ -142,6 +143,7 @@ jobs:
           fail_ci_if_error: false
           override_branch: ${{ env.CODECOV_BRANCH }}
           override_commit: ${{ env.CODECOV_COMMIT_SHA }}
+          root_dir: apps/web
 
   build-web-check:
     name: Build Web (Preview Check)


### PR DESCRIPTION
ref TSK-368

## 概要
- codecov-action の API/Web upload に root_dir を追加
- lcov の相対 SF パスを各アプリのルート基準で解決させるための追加修正

## 変更内容
- API upload に root_dir: apps/api を追加
- Web upload に root_dir: apps/web を追加

## 補足
- 既存の override_commit / override_branch / disable_search は変更していません
- codecov.yml は変更していません
- workflow 設定のみの変更のため、ローカルテストは未実施です
