### PR TITLE
🧹 Remove outdated TODO comment for PPT/PPTX inspection

### DIFF
--- a/apps/api/src/utils/file.ts
+++ b/apps/api/src/utils/file.ts
@@ -2,7 +2,6 @@ const MIME_COMPATIBILITY: Record<string, readonly string[]> = {
     "application/pdf": ["application/pdf"],
     "image/png": ["image/png"],
     "image/jpeg": ["image/jpeg"],
-    // TODO: For deeper inspection of PPT/PPTX, parse OLE2 streams or check for specific ZIP entries like "ppt/presentation.xml"
     "application/vnd.ms-powerpoint": ["application/x-ole-storage"],
     "application/vnd.openxmlformats-officedocument.presentationml.presentation": ["application/zip"],
 };


### PR DESCRIPTION
🎯 **What:** Removed the actionable TODO comment regarding OLE2 streams parsing and ZIP entry checking for PPT/PPTX files in `apps/api/src/utils/file.ts`.

💡 **Why:** The TODO comment suggests implementing deep inspection for PPT/PPTX files. However, the `validateMagicNumbers` function in the same file already contains the implementation to check for `ppt/presentation.xml` in `.pptx` files and the UTF-16LE `PowerPoint Document` string in `.ppt` files. The TODO is outdated and no longer relevant, making the code misleading. Removing it improves maintainability and code readability.

✅ **Verification:**
1. Manually verified `validateMagicNumbers` function in `apps/api/src/utils/file.ts` to confirm it handles deeper inspection of PPT/PPTX.
2. Ran tests using `npm run test -- ./apps/api/src/utils/__tests__/file.test.ts` to ensure everything works correctly. All 6 tests in `file.test.ts` pass, confirming the inspection logic is active.
3. Ran `npm run lint` and `npm run typecheck` across the workspaces to ensure no other regressions were introduced.

✨ **Result:** Cleaned up outdated documentation, making the code easier to follow for developers without any behavioral changes.

---
*PR created automatically by Jules for task [15457423527613240224](https://jules.google.com/task/15457423527613240224) started by @is0692vs*