### PR TITLE
🧹 Code Health: Extract duplicated validation helpers into shared utility

### DIFF
--- a/apps/api/src/routes/collections.ts
+++ b/apps/api/src/routes/collections.ts
@@ -15,36 +15,14 @@ import {
 } from "../db/schema";
 import { authMiddleware } from "../middleware/auth";
 import type { Env, Variables } from "../types";
+import { validateSlug, validateName, validateDescription } from "../utils/validation";
 
 const collectionsRoute = new Hono<{ Bindings: Env; Variables: Variables }>();
 
-const SLUG_RE = /^[a-z0-9][a-z0-9-]*[a-z0-9]$|^[a-z0-9]$/;
 const VALID_VISIBILITY = ["public", "org_only", "private"] as const;
 
 type Visibility = (typeof VALID_VISIBILITY)[number];
 type CurrentUser = { id: string } | null;
-
-function validateSlug(slug: unknown): string | null {
-    if (typeof slug !== "string") return "slug is required";
-    const s = slug.trim().toLowerCase();
-    if (s.length < 3 || s.length > 40) return "slug must be 3-40 characters";
-    if (!SLUG_RE.test(s)) return "slug must contain only lowercase letters, numbers, and hyphens";
-    if (s.includes("--")) return "slug must not contain consecutive hyphens";
-    return null;
-}
-
-function validateName(name: unknown): string | null {
-    if (typeof name !== "string" || name.trim().length === 0) return "name is required";
-    if (name.trim().length > 100) return "name must be 100 characters or less";
-    return null;
-}
-
-function validateDescription(description: unknown): string | null {
-    if (description === undefined || description === null || description === "") return null;
-    if (typeof description !== "string") return "description must be a string";
-    if (description.trim().length > 500) return "description must be 500 characters or less";
-    return null;
-}
 
 function parseVisibility(value: unknown): Visibility | null {
     if (typeof value === "string" && VALID_VISIBILITY.includes(value as Visibility)) {

--- a/apps/api/src/routes/orgs.ts
+++ b/apps/api/src/routes/orgs.ts
@@ -13,33 +13,10 @@ import {
 } from "../db/schema";
 import type { Env, Variables } from "../types";
 import { authMiddleware } from "../middleware/auth";
+import { validateSlug, validateName, validateDescription } from "../utils/validation";
 
 const orgsRoute = new Hono<{ Bindings: Env; Variables: Variables }>();
 
-// ─── Validation helpers ─────────────────────────────────────────
-const SLUG_RE = /^[a-z0-9][a-z0-9-]*[a-z0-9]$|^[a-z0-9]$/;
-
-function validateSlug(slug: unknown): string | null {
-    if (typeof slug !== "string") return "slug is required";
-    const s = slug.trim().toLowerCase();
-    if (s.length < 3 || s.length > 40) return "slug must be 3–40 characters";
-    if (!SLUG_RE.test(s)) return "slug must contain only lowercase letters, numbers, and hyphens";
-    if (s.includes("--")) return "slug must not contain consecutive hyphens";
-    return null;
-}
-
-function validateName(name: unknown): string | null {
-    if (typeof name !== "string" || name.trim().length === 0) return "name is required";
-    if (name.trim().length > 100) return "name must be 100 characters or less";
-    return null;
-}
-
-function validateDescription(description: unknown): string | null {
-    if (description === undefined || description === null || description === "") return null;
-    if (typeof description !== "string") return "description must be a string";
-    if (description.trim().length > 500) return "description must be 500 characters or less";
-    return null;
-}
 
 // ─── Permission helpers ─────────────────────────────────────────
 async function getOrgBySlug(db: ReturnType<typeof drizzle>, slug: string) {

--- a/apps/api/src/utils/validation.ts
+++ b/apps/api/src/utils/validation.ts
@@ -1,0 +1,23 @@
+export const SLUG_RE = /^[a-z0-9][a-z0-9-]*[a-z0-9]$|^[a-z0-9]$/;
+
+export function validateSlug(slug: unknown): string | null {
+    if (typeof slug !== "string") return "slug is required";
+    const s = slug.trim().toLowerCase();
+    if (s.length < 3 || s.length > 40) return "slug must be 3-40 characters";
+    if (!SLUG_RE.test(s)) return "slug must contain only lowercase letters, numbers, and hyphens";
+    if (s.includes("--")) return "slug must not contain consecutive hyphens";
+    return null;
+}
+
+export function validateName(name: unknown): string | null {
+    if (typeof name !== "string" || name.trim().length === 0) return "name is required";
+    if (name.trim().length > 100) return "name must be 100 characters or less";
+    return null;
+}
+
+export function validateDescription(description: unknown): string | null {
+    if (description === undefined || description === null || description === "") return null;
+    if (typeof description !== "string") return "description must be a string";
+    if (description.trim().length > 500) return "description must be 500 characters or less";
+    return null;
+}


### PR DESCRIPTION
🎯 **What:** The validation helper functions (`validateSlug`, `validateName`, `validateDescription`) and the `SLUG_RE` constant were duplicated in both `apps/api/src/routes/orgs.ts` and `apps/api/src/routes/collections.ts`. This PR extracts them into a single utility file at `apps/api/src/utils/validation.ts` and imports them back where they're needed.

💡 **Why:** Centralizing these helpers improves maintainability. Any future changes to validation logic (like updating max lengths or allowed characters in slugs) will now only need to be done in one place, preventing inconsistencies and bugs.

✅ **Verification:** Verified by:
- Creating the `apps/api/src/utils/validation.ts` file and ensuring exports are correct.
- Modifying both route files to use the new imports and stripping out the old duplicated code.
- Running the `npm run lint` linter and resolving any unused variables warnings introduced.
- Running the vitest unit test suite with `npm run test`, specifically checking that the `orgs.test.ts` and `collections.test.ts` API endpoint tests continue passing perfectly.

✨ **Result:** Clean, deduplicated validation code that functions exactly as before but is now easier to maintain and reuse across the API.

---
*PR created automatically by Jules for task [9404474561244069409](https://jules.google.com/task/9404474561244069409) started by @is0692vs*