### PR TITLE
🧪 [testing improvement] Refactor getRoleBadge, getVisibilityBadge, and getInviteStatusBadge to use table-driven tests

### DIFF
--- a/apps/web/src/lib/__tests__/presentation.test.ts
+++ b/apps/web/src/lib/__tests__/presentation.test.ts
@@ -7,134 +7,149 @@ import {
 
 describe("presentation badge helpers", () => {
   describe("getVisibilityBadge", () => {
-    it("returns a public badge", () => {
-      expect(getVisibilityBadge("public")).toEqual({
-        label: "公開",
-        tone: "success",
-        className:
-          "bg-emerald-50 text-emerald-700 ring-1 ring-inset ring-emerald-200 dark:bg-emerald-950/40 dark:text-emerald-300 dark:ring-emerald-900",
-      });
-    });
-
-    it("returns an org-only badge", () => {
-      expect(getVisibilityBadge("org_only")).toEqual({
-        label: "組織内",
-        tone: "warning",
-        className:
-          "bg-amber-50 text-amber-700 ring-1 ring-inset ring-amber-200 dark:bg-amber-950/40 dark:text-amber-300 dark:ring-amber-900",
-      });
-    });
-
-    it("returns a private badge", () => {
-      expect(getVisibilityBadge("private")).toEqual({
-        label: "非公開",
-        tone: "neutral",
-        className:
-          "bg-slate-100 text-slate-700 ring-1 ring-inset ring-slate-200 dark:bg-slate-800 dark:text-slate-300 dark:ring-slate-700",
-      });
-    });
-
-    it("falls back to the raw label for unknown visibility", () => {
-      expect(getVisibilityBadge("limited")).toEqual({
-        label: "limited",
-        tone: "neutral",
-        className:
-          "bg-slate-100 text-slate-700 ring-1 ring-inset ring-slate-200 dark:bg-slate-800 dark:text-slate-300 dark:ring-slate-700",
-      });
+    it.each([
+      [
+        "public",
+        {
+          label: "公開",
+          tone: "success",
+          className:
+            "bg-emerald-50 text-emerald-700 ring-1 ring-inset ring-emerald-200 dark:bg-emerald-950/40 dark:text-emerald-300 dark:ring-emerald-900",
+        },
+      ],
+      [
+        "org_only",
+        {
+          label: "組織内",
+          tone: "warning",
+          className:
+            "bg-amber-50 text-amber-700 ring-1 ring-inset ring-amber-200 dark:bg-amber-950/40 dark:text-amber-300 dark:ring-amber-900",
+        },
+      ],
+      [
+        "private",
+        {
+          label: "非公開",
+          tone: "neutral",
+          className:
+            "bg-slate-100 text-slate-700 ring-1 ring-inset ring-slate-200 dark:bg-slate-800 dark:text-slate-300 dark:ring-slate-700",
+        },
+      ],
+      [
+        "limited",
+        {
+          label: "limited",
+          tone: "neutral",
+          className:
+            "bg-slate-100 text-slate-700 ring-1 ring-inset ring-slate-200 dark:bg-slate-800 dark:text-slate-300 dark:ring-slate-700",
+        },
+      ],
+    ] as const)("returns the correct badge for %s", (visibility, expected) => {
+      expect(getVisibilityBadge(visibility)).toEqual(expected);
     });
   });
 
   describe("getInviteStatusBadge", () => {
-    it("returns a pending badge", () => {
-      expect(getInviteStatusBadge("pending")).toEqual({
-        label: "保留中",
-        tone: "warning",
-        className:
-          "bg-amber-50 text-amber-700 ring-1 ring-inset ring-amber-200 dark:bg-amber-950/40 dark:text-amber-300 dark:ring-amber-900",
-      });
-    });
-
-    it("returns an accepted badge", () => {
-      expect(getInviteStatusBadge("accepted")).toEqual({
-        label: "承認済み",
-        tone: "success",
-        className:
-          "bg-emerald-50 text-emerald-700 ring-1 ring-inset ring-emerald-200 dark:bg-emerald-950/40 dark:text-emerald-300 dark:ring-emerald-900",
-      });
-    });
-
-    it("returns a declined badge", () => {
-      expect(getInviteStatusBadge("declined")).toEqual({
-        label: "拒否済み",
-        tone: "danger",
-        className:
-          "bg-rose-50 text-rose-700 ring-1 ring-inset ring-rose-200 dark:bg-rose-950/40 dark:text-rose-300 dark:ring-rose-900",
-      });
-    });
-
-    it("falls back to a neutral badge for unknown invite status", () => {
-      expect(getInviteStatusBadge("expired")).toEqual({
-        label: "expired",
-        tone: "neutral",
-        className:
-          "bg-slate-100 text-slate-700 ring-1 ring-inset ring-slate-200 dark:bg-slate-800 dark:text-slate-300 dark:ring-slate-700",
-      });
+    it.each([
+      [
+        "pending",
+        {
+          label: "保留中",
+          tone: "warning",
+          className:
+            "bg-amber-50 text-amber-700 ring-1 ring-inset ring-amber-200 dark:bg-amber-950/40 dark:text-amber-300 dark:ring-amber-900",
+        },
+      ],
+      [
+        "accepted",
+        {
+          label: "承認済み",
+          tone: "success",
+          className:
+            "bg-emerald-50 text-emerald-700 ring-1 ring-inset ring-emerald-200 dark:bg-emerald-950/40 dark:text-emerald-300 dark:ring-emerald-900",
+        },
+      ],
+      [
+        "declined",
+        {
+          label: "拒否済み",
+          tone: "danger",
+          className:
+            "bg-rose-50 text-rose-700 ring-1 ring-inset ring-rose-200 dark:bg-rose-950/40 dark:text-rose-300 dark:ring-rose-900",
+        },
+      ],
+      [
+        "expired",
+        {
+          label: "expired",
+          tone: "neutral",
+          className:
+            "bg-slate-100 text-slate-700 ring-1 ring-inset ring-slate-200 dark:bg-slate-800 dark:text-slate-300 dark:ring-slate-700",
+        },
+      ],
+    ] as const)("returns the correct badge for %s", (status, expected) => {
+      expect(getInviteStatusBadge(status)).toEqual(expected);
     });
   });
 
   describe("getRoleBadge", () => {
-    it("returns an owner badge", () => {
-      expect(getRoleBadge("owner")).toEqual({
-        label: "オーナー",
-        tone: "info",
-        className:
-          "bg-sky-50 text-sky-700 ring-1 ring-inset ring-sky-200 dark:bg-sky-950/40 dark:text-sky-300 dark:ring-sky-900",
-      });
-    });
-
-    it("returns an admin badge", () => {
-      expect(getRoleBadge("admin")).toEqual({
-        label: "管理者",
-        tone: "warning",
-        className:
-          "bg-amber-50 text-amber-700 ring-1 ring-inset ring-amber-200 dark:bg-amber-950/40 dark:text-amber-300 dark:ring-amber-900",
-      });
-    });
-
-    it("returns a member badge", () => {
-      expect(getRoleBadge("member")).toEqual({
-        label: "メンバー",
-        tone: "neutral",
-        className:
-          "bg-slate-100 text-slate-700 ring-1 ring-inset ring-slate-200 dark:bg-slate-800 dark:text-slate-300 dark:ring-slate-700",
-      });
-    });
-
-    it("returns an uploader badge", () => {
-      expect(getRoleBadge("uploader")).toEqual({
-        label: "アップロード者",
-        tone: "info",
-        className:
-          "bg-sky-50 text-sky-700 ring-1 ring-inset ring-sky-200 dark:bg-sky-950/40 dark:text-sky-300 dark:ring-sky-900",
-      });
-    });
-
-    it("returns an author badge", () => {
-      expect(getRoleBadge("author")).toEqual({
-        label: "著者",
-        tone: "success",
-        className:
-          "bg-emerald-50 text-emerald-700 ring-1 ring-inset ring-emerald-200 dark:bg-emerald-950/40 dark:text-emerald-300 dark:ring-emerald-900",
-      });
-    });
-
-    it("falls back to a neutral badge for unknown roles", () => {
-      expect(getRoleBadge("reviewer")).toEqual({
-        label: "reviewer",
-        tone: "neutral",
-        className:
-          "bg-slate-100 text-slate-700 ring-1 ring-inset ring-slate-200 dark:bg-slate-800 dark:text-slate-300 dark:ring-slate-700",
-      });
+    it.each([
+      [
+        "owner",
+        {
+          label: "オーナー",
+          tone: "info",
+          className:
+            "bg-sky-50 text-sky-700 ring-1 ring-inset ring-sky-200 dark:bg-sky-950/40 dark:text-sky-300 dark:ring-sky-900",
+        },
+      ],
+      [
+        "admin",
+        {
+          label: "管理者",
+          tone: "warning",
+          className:
+            "bg-amber-50 text-amber-700 ring-1 ring-inset ring-amber-200 dark:bg-amber-950/40 dark:text-amber-300 dark:ring-amber-900",
+        },
+      ],
+      [
+        "member",
+        {
+          label: "メンバー",
+          tone: "neutral",
+          className:
+            "bg-slate-100 text-slate-700 ring-1 ring-inset ring-slate-200 dark:bg-slate-800 dark:text-slate-300 dark:ring-slate-700",
+        },
+      ],
+      [
+        "uploader",
+        {
+          label: "アップロード者",
+          tone: "info",
+          className:
+            "bg-sky-50 text-sky-700 ring-1 ring-inset ring-sky-200 dark:bg-sky-950/40 dark:text-sky-300 dark:ring-sky-900",
+        },
+      ],
+      [
+        "author",
+        {
+          label: "著者",
+          tone: "success",
+          className:
+            "bg-emerald-50 text-emerald-700 ring-1 ring-inset ring-emerald-200 dark:bg-emerald-950/40 dark:text-emerald-300 dark:ring-emerald-900",
+        },
+      ],
+      [
+        "reviewer",
+        {
+          label: "reviewer",
+          tone: "neutral",
+          className:
+            "bg-slate-100 text-slate-700 ring-1 ring-inset ring-slate-200 dark:bg-slate-800 dark:text-slate-300 dark:ring-slate-700",
+        },
+      ],
+    ] as const)("returns the correct badge for %s", (role, expected) => {
+      expect(getRoleBadge(role)).toEqual(expected);
     });
   });
 });

--- a/package-lock.json
+++ b/package-lock.json
@@ -10487,7 +10487,6 @@
       "version": "2.3.2",
       "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
       "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
-      "dev": true,
       "hasInstallScript": true,
       "license": "MIT",
       "optional": true,


### PR DESCRIPTION
🎯 **What:** The testing gap addressed
The previous unit tests for `getRoleBadge`, `getVisibilityBadge`, and `getInviteStatusBadge` relied on repetitive individual test blocks. I refactored these units to utilize Vitest's `it.each` capability (table-driven tests) to consolidate duplicate test structures and improve maintainability as directed in project documentation.

📊 **Coverage:** What scenarios are now tested
The exact same cases as before have been migrated to the table structure, ensuring complete coverage. The tested methods map various identifiers mapping to distinct badge presentations. Tested paths including happy, alternate, and error fallback paths.

✨ **Result:** The improvement in test coverage
Although overall numerical coverage did not increase because they were already tested, the *quality* and *maintainability* of the test suite is substantially improved. Future engineers will simply add a tuple to the `it.each` array for testing new role, visibility, or invite status configurations.

---
*PR created automatically by Jules for task [3157147507440421944](https://jules.google.com/task/3157147507440421944) started by @is0692vs*