### PR TITLE
Fix: Codecov PR comment configuration

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -126,7 +126,7 @@ jobs:
         uses: codecov/codecov-action@v5
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
-          disable_search: true
+          disable_search: false
           flags: api
           files: ./coverage-artifacts/api/lcov.info
           fail_ci_if_error: false
@@ -137,7 +137,7 @@ jobs:
         uses: codecov/codecov-action@v5
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
-          disable_search: true
+          disable_search: false
           flags: web
           files: ./coverage-artifacts/web/lcov.info
           fail_ci_if_error: false

--- a/codecov.yml
+++ b/codecov.yml
@@ -2,7 +2,7 @@ codecov:
   require_ci_to_pass: false
   notify:
     wait_for_ci: false
-    after_n_builds: 2
+    # after_n_builds: 2
 
 coverage:
   status:
@@ -17,7 +17,7 @@ coverage:
 comment:
   layout: "reach,diff,flags,files"
   behavior: default
-  require_changes: false
+  require_changes: "false"
 
 flags:
   api:


### PR DESCRIPTION
## Problem
Codecov PR comments are not appearing on open PRs despite successful coverage uploads from both API and Web.

## Solution
- Comment out `codecov.notify.after_n_builds: 2` to allow Codecov to send comment after first upload
- Change `disable_search: true → false` in both ci.yml upload steps
- Stringify `require_changes: false → "false"` in codecov.yml for proper YAML parsing

## Changes
- `codecov.yml`: Disabled after_n_builds, stringified require_changes
- `.github/workflows/ci.yml`: Set disable_search to false for both API and Web uploads

## Testing
- Ran `npm run typecheck && npm run test && npm run lint` - all passed
- No new issues detected (existing 5 lint warnings unchanged)