### PR TITLE
🧪 [Testing] Add edge case tests for getRoleBadge

### DIFF
--- a/apps/web/src/lib/__tests__/presentation.test.ts
+++ b/apps/web/src/lib/__tests__/presentation.test.ts
@@ -54,6 +54,7 @@ describe("presentation badge helpers", () => {
       ["uploader", "アップロード者", "info"],
       ["author", "著者", "success"],
       ["reviewer", "reviewer", "neutral"],
+      ["", "", "neutral"],
     ] as const)("returns correct badge for %s", (role, label, tone) => {
       expect(getRoleBadge(role)).toEqual({
         label,


### PR DESCRIPTION
🎯 **What:** The `getRoleBadge` tests already existed, but did not have an explicit test case for empty/falsy strings handling via the switch default statement.

📊 **Coverage:** The empty string `""` now explicitly triggers and validates the `default` fallback statement branch.

✨ **Result:** Enhanced unit test robustness and determinism for presentation functions.

---
*PR created automatically by Jules for task [8240409957331497842](https://jules.google.com/task/8240409957331497842) started by @is0692vs*

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

このPRは `getRoleBadge` 関数のテストスイートに、空文字列 `""` を渡した場合の `default` ブランチ動作を検証するテストケース1行を追加するものです。

主な変更点：
- `presentation.test.ts` の `getRoleBadge` テーブルテストに `["", "", "neutral"]` のケースを追加
- 実装側の `default: return createBadge(role, "neutral")` が空文字を受け取ると `{ label: "", tone: "neutral", className: ... }` を返すことを明示的に検証
- `getInviteStatusBadge` のテストに既に同じパターン（`["", "", "neutral"]`）が存在しており、一貫性のある追加となっている

特筆すべき問題点は見当たらず、実装との整合性も正しいです。
</details>

<h3>Confidence Score: 5/5</h3>

- テストコードのみの変更であり、本番コードへの影響はなく安全にマージ可能です。
- 変更は1行のテストケース追加のみ。実装の `default` ブランチの動作（空文字をそのまま label として返し、tone は neutral）と期待値が正確に一致しており、論理的・構文的なエラーはありません。
- 特に注意が必要なファイルはありません。

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| apps/web/src/lib/__tests__/presentation.test.ts | getRoleBadge の default ブランチを空文字列でカバーするテストケースを1行追加。既存の getInviteStatusBadge と同様のパターンで一貫性があり、実装との整合性も正しい。 |

</details>

</details>

<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[getRoleBadge role] --> B{switch role}
    B -->|owner| C[createBadge オーナー info]
    B -->|admin| D[createBadge 管理者 warning]
    B -->|member| E[createBadge メンバー neutral]
    B -->|uploader| F[createBadge アップロード者 info]
    B -->|author| G[createBadge 著者 success]
    B -->|default reviewer 空文字など| H[createBadge role neutral]
    H --> I[新テスト role=空文字 → label=空文字 tone=neutral]
```

<sub>Last reviewed commit: 887aa29</sub>

<!-- /greptile_comment -->