### PR TITLE
fix(ci): add actions:write permission for cancel-in-progress

### DIFF
--- a/.github/workflows/deploy-api.yml
+++ b/.github/workflows/deploy-api.yml
@@ -6,6 +6,7 @@ on:
 
 permissions:
   contents: read
+  actions: write
 
 jobs:
   deploy:


### PR DESCRIPTION
Closes #129. Adds explicit `actions: write` permission to `deploy-api.yml` to allow `cancel-in-progress: true` to function correctly via `GITHUB_TOKEN`.

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

`deploy-api.yml` の `permissions` ブロックに `actions: write` を追加し、`cancel-in-progress: true` が `GITHUB_TOKEN` 経由で正しく動作するよう修正した PR です。変更は1行のみで、影響範囲は非常に限定的です。

- **修正内容**: `permissions.actions: write` を追加することで、GitHub Actions が同一 concurrency グループ内の実行中ワークフローをキャンセルできるようになる
- **影響範囲**: `deploy-api.yml` ワークフローのみ。他のワークフロー（`ci.yml`、`check-migrations.yml` など）には影響なし
- **権限の妥当性**: `actions: write` はデプロイワークフローの目的（重複デプロイの防止）に対して適切かつ必要最小限の追加権限であり、既存の `contents: read` との組み合わせも問題なし
</details>

<h3>Confidence Score: 5/5</h3>

- このPRはマージしても安全です。1行の権限追加のみで、副作用のリスクはほぼありません。
- 変更はワークフローの `permissions` ブロックへの1行追加のみ。`actions: write` は `cancel-in-progress: true` に必要な標準的な権限であり、意図・実装ともに正確。既存の動作を壊すリスクはなく、セキュリティ上の懸念もない。
- 特に注意が必要なファイルはありません。

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| .github/workflows/deploy-api.yml | `permissions` ブロックに `actions: write` を1行追加。`cancel-in-progress: true` の動作に必要な権限を明示的に付与する、最小限かつ正確な修正。 |

</details>

</details>

<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant Dev as 開発者
    participant GH as GitHub (push to main)
    participant Runner1 as 実行中の deploy ジョブ
    participant Runner2 as 新しい deploy ジョブ

    Dev->>GH: push to main (apps/api/**)
    GH->>Runner1: ワークフロー実行中 (concurrency group: deploy-api-refs/heads/main)

    Dev->>GH: 追加の push to main (apps/api/**)
    Note over GH: concurrency group で競合検出
    GH->>Runner1: キャンセル要求 (GITHUB_TOKEN / actions:write が必要)
    Note over Runner1: actions:write がない場合はキャンセル失敗
    Runner1-->>GH: キャンセル完了
    GH->>Runner2: 新しい deploy ジョブ開始
    Runner2->>Runner2: npm ci → D1 migrations → wrangler deploy
    Runner2-->>GH: デプロイ完了
```

<sub>Last reviewed commit: 607ba0a</sub>

<!-- /greptile_comment -->