### PR TITLE
test(api): align slug validation messaging

### DIFF
--- a/apps/api/src/utils/__tests__/validation.test.ts
+++ b/apps/api/src/utils/__tests__/validation.test.ts
@@ -22,8 +22,8 @@ describe("validation utils", () => {
         });
 
         it("rejects leading/trailing hyphens", () => {
-            expect(validateSlug("-invalid")).toBe("slug must contain only lowercase letters, numbers, and hyphens");
-            expect(validateSlug("invalid-")).toBe("slug must contain only lowercase letters, numbers, and hyphens");
+            expect(validateSlug("-invalid")).toBe("slug must not start or end with a hyphen");
+            expect(validateSlug("invalid-")).toBe("slug must not start or end with a hyphen");
         });
 
         it("accepts valid slugs", () => {

--- a/apps/api/src/utils/validation.ts
+++ b/apps/api/src/utils/validation.ts
@@ -4,6 +4,7 @@ export function validateSlug(slug: unknown): string | null {
     if (typeof slug !== "string") return "slug is required";
     const s = slug.trim().toLowerCase();
     if (s.length < 3 || s.length > 40) return "slug must be 3–40 characters";
+    if (s.startsWith("-") || s.endsWith("-")) return "slug must not start or end with a hyphen";
     if (!SLUG_RE.test(s)) return "slug must contain only lowercase letters, numbers, and hyphens";
     if (s.includes("--")) return "slug must not contain consecutive hyphens";
     return null;


### PR DESCRIPTION
## Summary
- align validateSlug length messaging with the existing en-dash expectation
- add focused tests for leading and trailing hyphen rejection

## Validation
- npm run --workspace apps/api test -- src/utils/__tests__/validation.test.ts

Split out of #138 to keep this tiny validation tweak reviewable on its own.

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

このPRは `validateSlug` のエラーメッセージを2点改善しています。①長さエラーのハイフン（`-`）をエンダッシュ（`–`）に統一、②先頭・末尾がハイフンのスラグに対して、従来は誤解を招く "character set" エラーを返していた箇所を専用メッセージ `"slug must not start or end with a hyphen"` に置き換え、それに対応するテストを追加しています。

- `validation.ts`: `"slug must be 3-40 characters"` → `"slug must be 3–40 characters"`（エンダッシュ統一）
- `validation.ts`: `SLUG_RE` チェックの前に `s.startsWith("-") || s.endsWith("-")` の明示的ガードを追加し、より具体的なエラーメッセージを返すように修正
- `validation.test.ts`: 長さバリデーションのテスト期待値をエンダッシュに更新
- `validation.test.ts`: `"rejects leading/trailing hyphens"` テストを新規追加（`"-invalid"` / `"invalid-"` の2ケース）

`SLUG_RE` (`/^[a-z0-9][a-z0-9-]*[a-z0-9]$|^[a-z0-9]$/`) は元々先頭・末尾ハイフンを拒否できていましたが、新しいチェックを前に置くことで **より具体的なエラーメッセージ** を提供できるようになっており、意図的かつ正しい設計変更です。チェックの順序・ロジックに問題はありません。
</details>

<h3>Confidence Score: 5/5</h3>

- 変更は最小限かつ正確で、既存の挙動を壊すリスクはありません。安心してマージできます。
- 変更範囲が小さく（2ファイル、計10行）、エラーメッセージ文字列の修正と新規テストの追加のみ。ロジックの正確性は手動トレースでも確認済みで、テストがその挙動を正しくカバーしています。
- 特に注意が必要なファイルはありません。

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| apps/api/src/utils/validation.ts | エラーメッセージのハイフンをエンダッシュ（–）に変更し、先頭・末尾ハイフン向けの明示的なチェックを SLUG_RE 前に追加。ロジック的に正しく、SLUG_RE との重複は意図的なメッセージ改善のため。 |
| apps/api/src/utils/__tests__/validation.test.ts | 長さエラーメッセージをエンダッシュに揃え、先頭・末尾ハイフン拒否の新テスト（"-invalid" / "invalid-"）を追加。既存テストとの整合性も取れている。 |

</details>

</details>

<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A([validateSlug 呼び出し]) --> B{typeof slug === 'string'?}
    B -- No --> E1["❌ 'slug is required'"]
    B -- Yes --> C[trim + toLowerCase]
    C --> D{length < 3 または > 40?}
    D -- Yes --> E2["❌ 'slug must be 3–40 characters'"]
    D -- No --> F{先頭または末尾が '-' ?}
    F -- Yes --> E3["❌ 'slug must not start or end with a hyphen' 🆕"]
    F -- No --> G{SLUG_RE に一致?}
    G -- No --> E4["❌ 'slug must contain only lowercase letters, numbers, and hyphens'"]
    G -- Yes --> H{'--' を含む?}
    H -- Yes --> E5["❌ 'slug must not contain consecutive hyphens'"]
    H -- No --> OK(["✅ null（有効）"])

    style E3 fill:#d4edda,stroke:#28a745
    style F fill:#d4edda,stroke:#28a745
```

<sub>Last reviewed commit: ee7b03d</sub>

<!-- /greptile_comment -->