### PR TITLE
fix(ci): fix Codecov coverage paths and configuration for monorepo

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -128,30 +128,30 @@ jobs:
         with:
           name: coverage-web
           path: ./coverage-artifacts/web
+      - name: Fix coverage paths for monorepo
+        run: |
+          sed -i 's|SF:src/|SF:apps/api/src/|g' ./coverage-artifacts/api/lcov.info
+          sed -i 's|SF:src/|SF:apps/web/src/|g' ./coverage-artifacts/web/lcov.info
       - name: Upload API coverage to Codecov
         uses: codecov/codecov-action@v5
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
-          disable_search: true
           flags: api
           files: ./coverage-artifacts/api/lcov.info
           fail_ci_if_error: false
           override_branch: ${{ env.CODECOV_BRANCH }}
           override_commit: ${{ env.CODECOV_COMMIT_SHA }}
           override_pr: ${{ env.CODECOV_PR }}
-          root_dir: apps/api
       - name: Upload Web coverage to Codecov
         uses: codecov/codecov-action@v5
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
-          disable_search: true
           flags: web
           files: ./coverage-artifacts/web/lcov.info
           fail_ci_if_error: false
           override_branch: ${{ env.CODECOV_BRANCH }}
           override_commit: ${{ env.CODECOV_COMMIT_SHA }}
           override_pr: ${{ env.CODECOV_PR }}
-          root_dir: apps/web
 
   build-web-check:
     name: Build Web (Preview Check)

--- a/codecov.yml
+++ b/codecov.yml
@@ -2,7 +2,6 @@ codecov:
   require_ci_to_pass: false
   notify:
     wait_for_ci: false
-    after_n_builds: 2
 
 coverage:
   status:


### PR DESCRIPTION
This PR aims to fix the missing Codecov PR comments and coverage checks.
It adjusts the paths in  to match the repository root, which is required for monorepos when tests are run in subdirectories.
It also removes  and  from the  configuration to let the action automatically detect the environment correctly.
In ,  is removed to simplify notification timing.

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

このPRは、monorepo 構成での Codecov カバレッジレポートが正しく表示されない問題を修正します。`sed` コマンドで lcov.info のパスをリポジトリルート相対に書き換える方法に切り替え、`root_dir` と `disable_search` を削除してアクションの自動検出に任せる変更です。

**主な変更点：**
- `.github/workflows/ci.yml`: `sed` による lcov.info パス書き換えステップを追加（`SF:src/` → `SF:apps/{api,web}/src/`）、`root_dir` および `disable_search: true` を削除
- `codecov.yml`: `after_n_builds: 2` を削除

**懸念点：**
- `after_n_builds: 2` を削除したことで、API と Web の両カバレッジが揃う前に Codecov が PR コメントを送信してしまう可能性があります（不完全なレポートが表示されるリスク）
- `sed` によるパス置換は lcov.info が相対パス（`SF:src/`）を使用している場合のみ機能し、絶対パスの場合はサイレントに失敗します
</details>

<h3>Confidence Score: 3/5</h3>

- CI設定の修正としては方向性は正しいが、`after_n_builds` の削除と `sed` のサイレント失敗リスクを考慮すると注意が必要です。
- `after_n_builds: 2` の削除が不完全な Codecov 通知を引き起こす可能性があり（意図と逆効果になりうる）、`sed` 置換の信頼性確認が不足している点でスコアを下げています。ただし、本番コードには影響せず CI/CD 設定のみの変更のため最低スコアではありません。
- `codecov.yml` の `after_n_builds` 削除と `.github/workflows/ci.yml` の `sed` ステップに注意してください。

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| .github/workflows/ci.yml | monorepo 向けにカバレッジパスを修正する `sed` ステップを追加し、`root_dir` と `disable_search` を削除。`sed` がサイレント失敗する可能性あり。 |
| codecov.yml | `after_n_builds: 2` を削除。API と Web の 2 回のアップロードを待たずに早期通知が発生する可能性があり、PR コメントに不完全なカバレッジが表示されるリスクがある。 |

</details>

</details>

<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant TA as test-api job
    participant TW as test-web job
    participant UC as upload-coverage job
    participant CC as Codecov

    TA->>UC: coverage-api artifact をアップロード
    TW->>UC: coverage-web artifact をアップロード
    UC->>UC: Download coverage-api artifact
    UC->>UC: Download coverage-web artifact
    UC->>UC: sed: SF:src/ → SF:apps/api/src/ (lcov.info)
    UC->>UC: sed: SF:src/ → SF:apps/web/src/ (lcov.info)
    UC->>CC: Upload API coverage (flags: api)
    Note over CC: after_n_builds 削除により<br/>この時点で通知が走る可能性
    CC-->>UC: 受付
    UC->>CC: Upload Web coverage (flags: web)
    CC-->>UC: 受付
    CC->>CC: PR コメント送信（全フラグ揃い次第）
```

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
This is a comment left during a code review.
Path: .github/workflows/ci.yml
Line: 133-134

Comment:
**sed がマッチしない場合にサイレント失敗する可能性**

`sed -i 's|SF:src/|...|g'` は、lcov.info 内のパスが `SF:src/` で始まる（相対パス）場合にのみ正しく機能します。Vitest はバージョンや設定によっては絶対パス（例: `SF:/home/runner/work/openshelf/openshelf/apps/api/src/index.ts`）を lcov.info に書き出すことがあります。その場合、`sed` は置換対象を見つけられずに（終了コード 0 で）サイレントに失敗し、Codecov には修正前の不正なパスが送信されます。

置換が実際に行われたかどうかを確認するステップを追加することを検討してください：

```
- name: Fix coverage paths for monorepo
  run: |
    sed -i 's|SF:src/|SF:apps/api/src/|g' ./coverage-artifacts/api/lcov.info
    sed -i 's|SF:src/|SF:apps/web/src/|g' ./coverage-artifacts/web/lcov.info
    grep -m1 "^SF:" ./coverage-artifacts/api/lcov.info || echo "WARNING: No SF: lines found in API lcov.info"
    grep -m1 "^SF:" ./coverage-artifacts/web/lcov.info || echo "WARNING: No SF: lines found in Web lcov.info"
    grep -c "SF:apps/" ./coverage-artifacts/api/lcov.info && echo "API paths look correct" || echo "WARNING: API paths may not have been replaced"
    grep -c "SF:apps/" ./coverage-artifacts/web/lcov.info && echo "Web paths look correct" || echo "WARNING: Web paths may not have been replaced"
```

How can I resolve this? If you propose a fix, please make it concise.

---

This is a comment left during a code review.
Path: codecov.yml
Line: 3-4

Comment:
**`after_n_builds` 削除により早期通知が発生する可能性**

`after_n_builds: 2` は、API と Web の 2 つのカバレッジアップロードが完了するまで Codecov の通知を保留するために設定されていました。これを削除すると、デフォルト値（通常は 1 build）になります。

その結果、`upload-coverage` ジョブで API カバレッジが先にアップロードされた直後に Codecov が PR コメントを送信し、Web カバレッジが含まれない不完全なレポートが表示される可能性があります。その後 Web カバレッジがアップロードされると二度目の通知が来ることもあります。

```yaml
codecov:
  require_ci_to_pass: false
  notify:
    wait_for_ci: false
    after_n_builds: 2  # api と web の両方が揃ってから通知するために残すことを検討
```

`after_n_builds: 2` を維持することで、両フラグのデータが揃った完全なレポートが最初の通知として PR に表示されます。

How can I resolve this? If you propose a fix, please make it concise.
`````

</details>

<sub>Last reviewed commit: 2268c44</sub>

> Greptile also left **2 inline comments** on this PR.

<!-- /greptile_comment -->