### PR TITLE
fix(ci): make coverage upload resilient to missing artifacts

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -120,18 +120,28 @@ jobs:
       - uses: actions/checkout@v4
       - name: Download API coverage artifact
         uses: actions/download-artifact@v4
+        continue-on-error: true
         with:
           name: coverage-api
           path: ./coverage-artifacts/api
       - name: Download Web coverage artifact
         uses: actions/download-artifact@v4
+        continue-on-error: true
         with:
           name: coverage-web
           path: ./coverage-artifacts/web
       - name: Fix coverage paths for monorepo
         run: |
-          sed -i 's|SF:src/|SF:apps/api/src/|g' ./coverage-artifacts/api/lcov.info
-          sed -i 's|SF:src/|SF:apps/web/src/|g' ./coverage-artifacts/web/lcov.info
+          if [[ -f ./coverage-artifacts/api/lcov.info ]]; then
+            sed -i 's|SF:src/|SF:apps/api/src/|g' ./coverage-artifacts/api/lcov.info
+          else
+            echo "::warning::Missing ./coverage-artifacts/api/lcov.info"
+          fi
+          if [[ -f ./coverage-artifacts/web/lcov.info ]]; then
+            sed -i 's|SF:src/|SF:apps/web/src/|g' ./coverage-artifacts/web/lcov.info
+          else
+            echo "::warning::Missing ./coverage-artifacts/web/lcov.info"
+          fi
       - name: Upload API coverage to Codecov
         uses: codecov/codecov-action@v5
         with:


### PR DESCRIPTION
Addressing resilience in ci.yml as requested in issue 147. Tolerates missing artifacts and checks for lcov.info existence before sed.