### PR TITLE
🧪 Add explicit edge case test for getRoleBadge

### DIFF
--- a/apps/web/src/lib/__tests__/presentation.test.ts
+++ b/apps/web/src/lib/__tests__/presentation.test.ts
@@ -54,6 +54,7 @@ describe("presentation badge helpers", () => {
       ["uploader", "アップロード者", "info"],
       ["author", "著者", "success"],
       ["reviewer", "reviewer", "neutral"],
+      ["unknown_role", "unknown_role", "neutral"],
       ["", "", "neutral"],
     ] as const)("returns correct badge for %s", (role, label, tone) => {
       expect(getRoleBadge(role)).toEqual({


### PR DESCRIPTION
🎯 **What:** The `getRoleBadge` in `apps/web/src/lib/presentation.ts` lacked explicit testing for edge cases mapping an unknown role string to the default "neutral" badge with the role string directly as the label. Added `unknown_role` case to the table-driven tests.

📊 **Coverage:** The test now completely covers explicit unmatched fallback paths for `getRoleBadge`, explicitly checking that a nonsensical or unknown role string correctly hits the default case in the switch statement.

✨ **Result:** Test robustness and completeness is improved for `getRoleBadge` edge cases, explicitly documenting the behavior for unrecognized strings.

---
*PR created automatically by Jules for task [16008491629262964462](https://jules.google.com/task/16008491629262964462) started by @is0692vs*