### PR TITLE
fix(deps): resolve undici and minimatch security vulnerabilities

### DIFF
--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -24,7 +24,7 @@
     "drizzle-kit": "^0.31.9",
     "typescript": "^5.9.3",
     "vitest": "^3.2.4",
-    "wrangler": "^4.70.0"
+    "wrangler": "^4.75.0"
   },
   "dependencies": {
     "drizzle-orm": "^0.45.1",

--- a/osv-scanner.toml
+++ b/osv-scanner.toml
@@ -3,33 +3,3 @@
 id = "GHSA-67mh-4wv8-2f99"
 reason = "drizzle-kit 0.31.9 still pulls @esbuild-kit/core-utils with esbuild 0.18.20; package-level overrides do not replace this nested pin in the current lockfile, so we are waiting for an upstream release. Track: https://github.com/drizzle-team/drizzle-orm/issues/5198; Recheck: https://github.com/Hiroki-org/OpenShelf/issues/121"
 ignoreUntil = 2026-04-30
-
-[[IgnoredVulns]]
-id = "GHSA-2mjp-6q6p-2qxm"
-reason = "@cloudflare/vitest-pool-workers and wrangler converge on miniflare, which still pins undici 7.18.2; package-level overrides do not replace this pin in the current lockfile, so we are waiting for an upstream Cloudflare release. Track: https://github.com/cloudflare/workers-sdk/issues/11998; Recheck: https://github.com/Hiroki-org/OpenShelf/issues/121"
-ignoreUntil = 2026-04-30
-
-[[IgnoredVulns]]
-id = "GHSA-4992-7rv2-5pvq"
-reason = "@cloudflare/vitest-pool-workers and wrangler converge on miniflare, which still pins undici 7.18.2; package-level overrides do not replace this pin in the current lockfile, so we are waiting for an upstream Cloudflare release. Track: https://github.com/cloudflare/workers-sdk/issues/11998; Recheck: https://github.com/Hiroki-org/OpenShelf/issues/121"
-ignoreUntil = 2026-04-30
-
-[[IgnoredVulns]]
-id = "GHSA-f269-vfmq-vjvj"
-reason = "@cloudflare/vitest-pool-workers and wrangler converge on miniflare, which still pins undici 7.18.2; package-level overrides do not replace this pin in the current lockfile, so we are waiting for an upstream Cloudflare release. Track: https://github.com/cloudflare/workers-sdk/issues/11998; Recheck: https://github.com/Hiroki-org/OpenShelf/issues/121"
-ignoreUntil = 2026-04-30
-
-[[IgnoredVulns]]
-id = "GHSA-phc3-fgpg-7m6h"
-reason = "@cloudflare/vitest-pool-workers and wrangler converge on miniflare, which still pins undici 7.18.2; package-level overrides do not replace this pin in the current lockfile, so we are waiting for an upstream Cloudflare release. Track: https://github.com/cloudflare/workers-sdk/issues/11998; Recheck: https://github.com/Hiroki-org/OpenShelf/issues/121"
-ignoreUntil = 2026-04-30
-
-[[IgnoredVulns]]
-id = "GHSA-v9p9-hfj2-hcw8"
-reason = "@cloudflare/vitest-pool-workers and wrangler converge on miniflare, which still pins undici 7.18.2; package-level overrides do not replace this pin in the current lockfile, so we are waiting for an upstream Cloudflare release. Track: https://github.com/cloudflare/workers-sdk/issues/11998; Recheck: https://github.com/Hiroki-org/OpenShelf/issues/121"
-ignoreUntil = 2026-04-30
-
-[[IgnoredVulns]]
-id = "GHSA-vrm6-8vpv-qv8q"
-reason = "@cloudflare/vitest-pool-workers and wrangler converge on miniflare, which still pins undici 7.18.2; package-level overrides do not replace this pin in the current lockfile, so we are waiting for an upstream Cloudflare release. Track: https://github.com/cloudflare/workers-sdk/issues/11998; Recheck: https://github.com/Hiroki-org/OpenShelf/issues/121"
-ignoreUntil = 2026-04-30

--- a/package-lock.json
+++ b/package-lock.json
@@ -36,92 +36,7 @@
         "drizzle-kit": "^0.31.9",
         "typescript": "^5.9.3",
         "vitest": "^3.2.4",
-        "wrangler": "^4.70.0"
-      }
-    },
-    "apps/api/node_modules/@cloudflare/workerd-darwin-64": {
-      "version": "1.20260310.1",
-      "resolved": "https://registry.npmjs.org/@cloudflare/workerd-darwin-64/-/workerd-darwin-64-1.20260310.1.tgz",
-      "integrity": "sha512-hF2VpoWaMb1fiGCQJqCY6M8I+2QQqjkyY4LiDYdTL5D/w6C1l5v1zhc0/jrjdD1DXfpJtpcSMSmEPjHse4p9Ig==",
-      "cpu": [
-        "x64"
-      ],
-      "dev": true,
-      "license": "Apache-2.0",
-      "optional": true,
-      "os": [
-        "darwin"
-      ],
-      "engines": {
-        "node": ">=16"
-      }
-    },
-    "apps/api/node_modules/@cloudflare/workerd-darwin-arm64": {
-      "version": "1.20260310.1",
-      "resolved": "https://registry.npmjs.org/@cloudflare/workerd-darwin-arm64/-/workerd-darwin-arm64-1.20260310.1.tgz",
-      "integrity": "sha512-h/Vl3XrYYPI6yFDE27XO1QPq/1G1lKIM8tzZGIWYpntK3IN5XtH3Ee/sLaegpJ49aIJoqhF2mVAZ6Yw+Vk2gJw==",
-      "cpu": [
-        "arm64"
-      ],
-      "dev": true,
-      "license": "Apache-2.0",
-      "optional": true,
-      "os": [
-        "darwin"
-      ],
-      "engines": {
-        "node": ">=16"
-      }
-    },
-    "apps/api/node_modules/@cloudflare/workerd-linux-64": {
-      "version": "1.20260310.1",
-      "resolved": "https://registry.npmjs.org/@cloudflare/workerd-linux-64/-/workerd-linux-64-1.20260310.1.tgz",
-      "integrity": "sha512-XzQ0GZ8G5P4d74bQYOIP2Su4CLdNPpYidrInaSOuSxMw+HamsHaFrjVsrV2mPy/yk2hi6SY2yMbgKFK9YjA7vw==",
-      "cpu": [
-        "x64"
-      ],
-      "dev": true,
-      "license": "Apache-2.0",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">=16"
-      }
-    },
-    "apps/api/node_modules/@cloudflare/workerd-linux-arm64": {
-      "version": "1.20260310.1",
-      "resolved": "https://registry.npmjs.org/@cloudflare/workerd-linux-arm64/-/workerd-linux-arm64-1.20260310.1.tgz",
-      "integrity": "sha512-sxv4CxnN4ZR0uQGTFVGa0V4KTqwdej/czpIc5tYS86G8FQQoGIBiAIs2VvU7b8EROPcandxYHDBPTb+D9HIMPw==",
-      "cpu": [
-        "arm64"
-      ],
-      "dev": true,
-      "license": "Apache-2.0",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">=16"
-      }
-    },
-    "apps/api/node_modules/@cloudflare/workerd-windows-64": {
-      "version": "1.20260310.1",
-      "resolved": "https://registry.npmjs.org/@cloudflare/workerd-windows-64/-/workerd-windows-64-1.20260310.1.tgz",
-      "integrity": "sha512-+1ZTViWKJypLfgH/luAHCqkent0DEBjAjvO40iAhOMHRLYP/SPphLvr4Jpi6lb+sIocS8Q1QZL4uM5Etg1Wskg==",
-      "cpu": [
-        "x64"
-      ],
-      "dev": true,
-      "license": "Apache-2.0",
-      "optional": true,
-      "os": [
-        "win32"
-      ],
-      "engines": {
-        "node": ">=16"
+        "wrangler": "^4.75.0"
       }
     },
     "apps/api/node_modules/@vitest/coverage-v8": {
@@ -314,27 +229,6 @@
         "source-map-js": "^1.2.0"
       }
     },
-    "apps/api/node_modules/miniflare": {
-      "version": "4.20260310.0",
-      "resolved": "https://registry.npmjs.org/miniflare/-/miniflare-4.20260310.0.tgz",
-      "integrity": "sha512-uC5vNPenFpDSj5aUU3wGSABG6UUqMr+Xs1m4AkCrTHo37F4Z6xcQw5BXqViTfPDVT/zcYH1UgTVoXhr1l6ZMXw==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@cspotcode/source-map-support": "0.8.1",
-        "sharp": "^0.34.5",
-        "undici": "7.18.2",
-        "workerd": "1.20260310.1",
-        "ws": "8.18.0",
-        "youch": "4.1.0-beta.10"
-      },
-      "bin": {
-        "miniflare": "bootstrap.js"
-      },
-      "engines": {
-        "node": ">=18.0.0"
-      }
-    },
     "apps/api/node_modules/std-env": {
       "version": "3.10.0",
       "resolved": "https://registry.npmjs.org/std-env/-/std-env-3.10.0.tgz",
@@ -357,16 +251,6 @@
       "license": "MIT",
       "engines": {
         "node": ">=14.0.0"
-      }
-    },
-    "apps/api/node_modules/undici": {
-      "version": "7.18.2",
-      "resolved": "https://registry.npmjs.org/undici/-/undici-7.18.2.tgz",
-      "integrity": "sha512-y+8YjDFzWdQlSE9N5nzKMT3g4a5UBX1HKowfdXh0uvAnTaqqwqB92Jt4UXBAeKekDs5IaDKyJFR4X1gYVCgXcw==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=20.18.1"
       }
     },
     "apps/api/node_modules/vite": {
@@ -513,62 +397,6 @@
           "optional": true
         },
         "jsdom": {
-          "optional": true
-        }
-      }
-    },
-    "apps/api/node_modules/workerd": {
-      "version": "1.20260310.1",
-      "resolved": "https://registry.npmjs.org/workerd/-/workerd-1.20260310.1.tgz",
-      "integrity": "sha512-yawXhypXXHtArikJj15HOMknNGikpBbSg2ZDe6lddUbqZnJXuCVSkgc/0ArUeVMG1jbbGvpst+REFtKwILvRTQ==",
-      "dev": true,
-      "hasInstallScript": true,
-      "license": "Apache-2.0",
-      "bin": {
-        "workerd": "bin/workerd"
-      },
-      "engines": {
-        "node": ">=16"
-      },
-      "optionalDependencies": {
-        "@cloudflare/workerd-darwin-64": "1.20260310.1",
-        "@cloudflare/workerd-darwin-arm64": "1.20260310.1",
-        "@cloudflare/workerd-linux-64": "1.20260310.1",
-        "@cloudflare/workerd-linux-arm64": "1.20260310.1",
-        "@cloudflare/workerd-windows-64": "1.20260310.1"
-      }
-    },
-    "apps/api/node_modules/wrangler": {
-      "version": "4.72.0",
-      "resolved": "https://registry.npmjs.org/wrangler/-/wrangler-4.72.0.tgz",
-      "integrity": "sha512-bKkb8150JGzJZJWiNB2nu/33smVfawmfYiecA6rW4XH7xS23/jqMbgpdelM34W/7a1IhR66qeQGVqTRXROtAZg==",
-      "dev": true,
-      "license": "MIT OR Apache-2.0",
-      "dependencies": {
-        "@cloudflare/kv-asset-handler": "0.4.2",
-        "@cloudflare/unenv-preset": "2.15.0",
-        "blake3-wasm": "2.1.5",
-        "esbuild": "0.27.3",
-        "miniflare": "4.20260310.0",
-        "path-to-regexp": "6.3.0",
-        "unenv": "2.0.0-rc.24",
-        "workerd": "1.20260310.1"
-      },
-      "bin": {
-        "wrangler": "bin/wrangler.js",
-        "wrangler2": "bin/wrangler.js"
-      },
-      "engines": {
-        "node": ">=20.0.0"
-      },
-      "optionalDependencies": {
-        "fsevents": "~2.3.2"
-      },
-      "peerDependencies": {
-        "@cloudflare/workers-types": "^4.20260310.1"
-      },
-      "peerDependenciesMeta": {
-        "@cloudflare/workers-types": {
           "optional": true
         }
       }
@@ -1238,6 +1066,91 @@
         "workerd": {
           "optional": true
         }
+      }
+    },
+    "node_modules/@cloudflare/workerd-darwin-64": {
+      "version": "1.20260317.1",
+      "resolved": "https://registry.npmjs.org/@cloudflare/workerd-darwin-64/-/workerd-darwin-64-1.20260317.1.tgz",
+      "integrity": "sha512-8hjh3sPMwY8M/zedq3/sXoA2Q4BedlGufn3KOOleIG+5a4ReQKLlUah140D7J6zlKmYZAFMJ4tWC7hCuI/s79g==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=16"
+      }
+    },
+    "node_modules/@cloudflare/workerd-darwin-arm64": {
+      "version": "1.20260317.1",
+      "resolved": "https://registry.npmjs.org/@cloudflare/workerd-darwin-arm64/-/workerd-darwin-arm64-1.20260317.1.tgz",
+      "integrity": "sha512-M/MnNyvO5HMgoIdr3QHjdCj2T1ki9gt0vIUnxYxBu9ISXS/jgtMl6chUVPJ7zHYBn9MyYr8ByeN6frjYxj0MGg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=16"
+      }
+    },
+    "node_modules/@cloudflare/workerd-linux-64": {
+      "version": "1.20260317.1",
+      "resolved": "https://registry.npmjs.org/@cloudflare/workerd-linux-64/-/workerd-linux-64-1.20260317.1.tgz",
+      "integrity": "sha512-1ltuEjkRcS3fsVF7CxsKlWiRmzq2ZqMfqDN0qUOgbUwkpXsLVJsXmoblaLf5OP00ELlcgF0QsN0p2xPEua4Uug==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=16"
+      }
+    },
+    "node_modules/@cloudflare/workerd-linux-arm64": {
+      "version": "1.20260317.1",
+      "resolved": "https://registry.npmjs.org/@cloudflare/workerd-linux-arm64/-/workerd-linux-arm64-1.20260317.1.tgz",
+      "integrity": "sha512-3QrNnPF1xlaNwkHpasvRvAMidOvQs2NhXQmALJrEfpIJ/IDL2la8g499yXp3eqhG3hVMCB07XVY149GTs42Xtw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=16"
+      }
+    },
+    "node_modules/@cloudflare/workerd-windows-64": {
+      "version": "1.20260317.1",
+      "resolved": "https://registry.npmjs.org/@cloudflare/workerd-windows-64/-/workerd-windows-64-1.20260317.1.tgz",
+      "integrity": "sha512-MfZTz+7LfuIpMGTa3RLXHX8Z/pnycZLItn94WRdHr8LPVet+C5/1Nzei399w/jr3+kzT4pDKk26JF/tlI5elpQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=16"
       }
     },
     "node_modules/@cloudflare/workers-types": {
@@ -9638,6 +9551,27 @@
         "node": ">=4"
       }
     },
+    "node_modules/miniflare": {
+      "version": "4.20260317.0",
+      "resolved": "https://registry.npmjs.org/miniflare/-/miniflare-4.20260317.0.tgz",
+      "integrity": "sha512-xuwk5Kjv+shi5iUBAdCrRl9IaWSGnTU8WuTQzsUS2GlSDIMCJuu8DiF/d9ExjMXYiQG5ml+k9SVKnMj8cRkq0w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@cspotcode/source-map-support": "0.8.1",
+        "sharp": "^0.34.5",
+        "undici": "7.24.4",
+        "workerd": "1.20260317.1",
+        "ws": "8.18.0",
+        "youch": "4.1.0-beta.10"
+      },
+      "bin": {
+        "miniflare": "bootstrap.js"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
     "node_modules/minimatch": {
       "version": "10.2.4",
       "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-10.2.4.tgz",
@@ -12242,6 +12176,62 @@
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/workerd": {
+      "version": "1.20260317.1",
+      "resolved": "https://registry.npmjs.org/workerd/-/workerd-1.20260317.1.tgz",
+      "integrity": "sha512-ZuEq1OdrJBS+NV+L5HMYPCzVn49a2O60slQiiLpG44jqtlOo+S167fWC76kEXteXLLLydeuRrluRel7WdOUa4g==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "workerd": "bin/workerd"
+      },
+      "engines": {
+        "node": ">=16"
+      },
+      "optionalDependencies": {
+        "@cloudflare/workerd-darwin-64": "1.20260317.1",
+        "@cloudflare/workerd-darwin-arm64": "1.20260317.1",
+        "@cloudflare/workerd-linux-64": "1.20260317.1",
+        "@cloudflare/workerd-linux-arm64": "1.20260317.1",
+        "@cloudflare/workerd-windows-64": "1.20260317.1"
+      }
+    },
+    "node_modules/wrangler": {
+      "version": "4.75.0",
+      "resolved": "https://registry.npmjs.org/wrangler/-/wrangler-4.75.0.tgz",
+      "integrity": "sha512-Efk1tcnm4eduBYpH1sSjMYydXMnIFPns/qABI3+fsbDrUk5GksNYX8nYGVP4sFygvGPO7kJc36YJKB5ooA7JAg==",
+      "dev": true,
+      "license": "MIT OR Apache-2.0",
+      "dependencies": {
+        "@cloudflare/kv-asset-handler": "0.4.2",
+        "@cloudflare/unenv-preset": "2.15.0",
+        "blake3-wasm": "2.1.5",
+        "esbuild": "0.27.3",
+        "miniflare": "4.20260317.0",
+        "path-to-regexp": "6.3.0",
+        "unenv": "2.0.0-rc.24",
+        "workerd": "1.20260317.1"
+      },
+      "bin": {
+        "wrangler": "bin/wrangler.js",
+        "wrangler2": "bin/wrangler.js"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      },
+      "optionalDependencies": {
+        "fsevents": "~2.3.2"
+      },
+      "peerDependencies": {
+        "@cloudflare/workers-types": "^4.20260317.1"
+      },
+      "peerDependenciesMeta": {
+        "@cloudflare/workers-types": {
+          "optional": true
+        }
       }
     },
     "node_modules/wrap-ansi": {

--- a/package.json
+++ b/package.json
@@ -26,6 +26,7 @@
   "overrides": {
     "undici": "7.24.4",
     "flatted": "3.4.1",
+    "minimatch@3": "3.1.5",
     "miniflare": {
       "undici": "7.24.4"
     },


### PR DESCRIPTION
## Summary

Resolves open Dependabot security alerts by upgrading transitive dependencies to patched versions.

### Changes

| Change | Detail |
|--------|--------|
| **wrangler** | `^4.70.0` → `^4.75.0` (pulls `miniflare@4.20260317.0` → `undici@7.24.4`) |
| **minimatch override** | Added `"minimatch@3": "3.1.5"` to `overrides` (ensures >= 3.1.3 fix for CVE-2026-27903/26996) |
| **osv-scanner.toml** | Removed 6 resolved undici ignore entries (GHSA-2mjp, GHSA-4992, GHSA-f269, GHSA-phc3, GHSA-v9p9, GHSA-vrm6) |

### Security Impact

| Before | After |
|--------|-------|
| 7 vulnerabilities (3 high, 4 moderate) | 4 vulnerabilities (0 high, 4 moderate) |
| undici 7.0.0–7.23.0 via miniflare | undici 7.24.4 (patched) |

**Remaining**: 4 moderate esbuild alerts (upstream `drizzle-kit` dependency, tracked in #121, ignored in `osv-scanner.toml` until 2026-04-30)

### Regarding alerts mentioned in the issue

The serialize-javascript, minimatch, and diff (jsdiff) alerts referenced in the original request are **not present** in the current Dependabot alert list — they may have been auto-resolved or from a previous state. This PR addresses all currently open and actionable alerts.

### Verification

- ✅ `npm audit` — only esbuild moderate alerts remain (already ignored)
- ✅ `npm run test` — 288 tests pass across 39 files
- ✅ `npm run lint` — 0 errors (3 pre-existing warnings)

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

このPRは、`undici` および `minimatch` に関するセキュリティ脆弱性を解消するため、推移的な依存パッケージをパッチ済みバージョンへアップグレードするものです。`wrangler` を `^4.70.0` → `^4.75.0` へ更新することで `miniflare` 経由の `undici` が `7.18.2`（脆弱）→ `7.24.4`（パッチ済み）へ更新され、`osv-scanner.toml` の対応する6件の無視エントリが削除されています。また `minimatch@3` に対するオーバーライドが追加されています。

主な変更点：

- **`apps/api/package.json`**: `wrangler` を `^4.75.0` へ更新
- **`package.json`**: `overrides` に `"minimatch@3": "3.1.5"` を追加（CVE-2026-27903/26996 対応）
- **`osv-scanner.toml`**: パッチ済みとなった undici 関連の 6 件の `IgnoredVulns` エントリを削除
- **`package-lock.json`**: wrangler/miniflare/undici/workerd の各バージョンが更新され、app スコープから root へのホイスティングが行われた

### 軽微な観察事項

1. **`undici` オーバーライドの冗長性**: `package.json` の `overrides` にはグローバルな `"undici": "7.24.4"` と、スコープ付きの `"miniflare": { "undici": "7.24.4" }` の両方が存在します。グローバルオーバーライドがあれば後者は不要ですが、動作への影響はなく、以前から存在するものです。

2. **`minimatch@3` オーバーライドの実効性**: 現在の依存ツリーに `minimatch@3.x` が含まれていない場合、このオーバーライドは実質的に無効（no-op）になりますが、将来的な依存追加に備えた予防策として有害ではありません。PR説明にも「Dependabot アラートには現在存在しない」と記載されており、整合性があります。
</details>

<h3>Confidence Score: 4/5</h3>

- セキュリティ上のリスクを適切に軽減しており、マージ可能な状態です。
- wrangler のアップグレードにより undici が 7.24.4 にパッチされており、lockfile の整合性も確認できます。minimatch@3 オーバーライドが現在の依存ツリーに実際に影響を与えるかどうかの確認が取れないため、完全な 5/5 ではありませんが、動作への悪影響はなく安全なPRです。
- 特に注意が必要なファイルはありません。package.json の冗長なオーバーライドは軽微な技術的負債ですが、ブロッカーではありません。

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| apps/api/package.json | `wrangler` を `^4.70.0` から `^4.75.0` へ更新。問題なし。 |
| package.json | `overrides` に `"minimatch@3": "3.1.5"` を追加。`undici` のグローバルオーバーライドと `miniflare` スコープの両方が共存しており、軽微な冗長性がある。 |
| osv-scanner.toml | undici に関する 6 件の既知脆弱性無視エントリを削除。パッチ適用済みのため適切な対応。 |
| package-lock.json | wrangler/miniflare/undici/workerd のバージョンが更新され、undici が 7.18.2 → 7.24.4 に修正。app レベルから root へのホイスティング変更も適切。 |

</details>

</details>

<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A["package.json\noverrides"] -->|"minimatch@3 → 3.1.5\nundici → 7.24.4"| B["npm install"]
    C["apps/api/package.json\nwrangler ^4.75.0"] --> B

    B --> D["node_modules/wrangler@4.75.0"]
    D --> E["node_modules/miniflare@4.20260317.0"]
    E --> F["node_modules/undici@7.24.4 ✅ (patched)"]

    B --> G["minimatch@3.x → 3.1.5 ✅ (patched)"]

    F -->|"CVE resolved"| H["GHSA-2mjp\nGHSA-4992\nGHSA-f269\nGHSA-phc3\nGHSA-v9p9\nGHSA-vrm6"]
    H -->|"removed from"| I["osv-scanner.toml"]

    style F fill:#90EE90
    style G fill:#90EE90
    style H fill:#FFD700
    style I fill:#87CEEB
```

<sub>Last reviewed commit: ["fix(deps): resolve u..."](https://github.com/hiroki-org/openshelf/commit/bb210c59618cb04fd695ff2424918cc4a1135f8a)</sub>

<!-- /greptile_comment -->