### PR TITLE
docs: issue→PR→review loop 運用ランブック

### DIFF
--- a/.github/issue-pr-review-loop-runbook.md
+++ b/.github/issue-pr-review-loop-runbook.md
@@ -43,7 +43,7 @@ issue ごとに以下を繰り返します。
 
    ```bash
    git checkout main
-   git pull --ff-only
+   git pull --rebase
    git checkout -b feat/issue-<number>-<short-topic>
    ```
 
@@ -73,10 +73,10 @@ issue ごとに以下を繰り返します。
 
 `open` な全PRに対して、以下をループします。
 
-1. PRの未解決レビュー会話を取得
+1. PRのレビュー会話・通常コメント・CI状態を取得
 
    ```bash
-   gh pr view <PR_NUMBER> --json reviews,comments,statusCheckRollup
+   gh pr view <PR_NUMBER> --json number,state,mergeStateStatus,reviewDecision,reviews,comments,latestReviews,headRefName,baseRefName,statusCheckRollup
    ```
 
 2. 各スレッドを判定
@@ -92,16 +92,16 @@ issue ごとに以下を繰り返します。
    gh pr checks <PR_NUMBER> --required --watch --interval 10
    ```
 
-5. しばらく待って再取得（例: 300秒）
+5. CI完了後に即時で再取得（新規レビュー/返信も確認）
 
    ```bash
-   sleep 300
-   gh pr view <PR_NUMBER> --json reviews,statusCheckRollup
+   gh pr view <PR_NUMBER> --json number,state,mergeStateStatus,reviewDecision,reviews,comments,latestReviews,statusCheckRollup
    ```
 
 6. 停止条件
    - unresolved conversation = 0
    - required checks = 全て success
+   - ループ安全上限: 最大 20 イテレーション（到達時は停止してブロッカー報告）
 
 ## 判定ポリシー
 
@@ -109,6 +109,14 @@ issue ごとに以下を繰り返します。
 - `IGNORE_WITH_REASON` は以下を満たす場合のみ許可
   - 明確な仕様・要件根拠がある
   - 返信で根拠を明示した
+
+## エスカレーション条件
+
+以下のいずれかに該当する場合、ループを止めて人間に判断を依頼する。
+
+- レビューリクエストがプロダクト要件と競合する
+- 提案修正が広範なリファクタリングを要する
+- 権限不足などで作者がスレッドを解決できない
 
 ## 運用テンプレート
 
@@ -125,7 +133,6 @@ issue ごとに以下を繰り返します。
 - [ ] open issue の本文+コメントを確認した
 - [ ] issue ごとに 1PR 以上作成した
 - [ ] すべてのPRで `Closes #<issue>` を付けた
-- [ ] 各レビュー会話に返信した
+- [ ] 各レビュー会話・通常コメントに返信した
 - [ ] unresolved threads が 0
 - [ ] required checks が green
-


### PR DESCRIPTION
## Summary
- add .github/issue-pr-review-loop-runbook.md
- define operational flow for open issues to implementation PRs to review closure loop
- document stop conditions, decision policy, and command templates aligned with existing agent playbooks

## Validation
- docs-only change (no code execution required)

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

このPRは、OpenShelfにおける **open issue → 実装PR → レビュークローズのループ** を運用するためのランブック (`.github/issue-pr-review-loop-runbook.md`) を新規追加するドキュメントのみの変更です。既存の `pr-review-closure-loop.md` と `copilot-instructions.md` の内容を、実行フェーズ順（棚卸し・PR作成・レビュークローズ）に再整理しており、エージェントや開発者が手順に沿って操作できる形にまとめられています。

主な変更内容と指摘事項：

- **フェーズ1〜3の構成**はわかりやすく整理されており、コマンドテンプレートも実用的
- **ループ安全上限（最大20イテレーション）の記載が欠落** — `pr-review-closure-loop.md` で定義されている重要な安全ガードが反映されていないため、エージェントが無限ループに陥るリスクがある
- **フェーズ3のステップ1の `gh pr view` コマンドの `--json` フィールドが不完全** — `mergeStateStatus`・`reviewDecision`・`latestReviews` など重要フィールドが省略されており、マージ可否の正確な判断ができない
- **エスカレーション手順が欠落** — 要件競合・広範なリファクタリング要求・権限制限などの状況で人間にエスカレーションすべき条件の記述がなく、完全性の観点で参照元プレイブックとの乖離がある
</details>

<h3>Confidence Score: 3/5</h3>

- ドキュメントのみの変更のためコードへの直接的な影響はないが、参照元プレイブックとの重要な差異（ループ上限欠落・コマンド不完全）がある
- ドキュメントのみの変更なのでランタイムリスクはゼロだが、エージェントがこのランブックに従って動作した場合にループ安全上限の欠落が問題になる可能性があること、またフェーズ3の `gh pr view` コマンドのフィールド不足がエージェントの正確な判断を妨げる可能性があることから、3点とした
- .github/issue-pr-review-loop-runbook.md — ループ安全上限と `gh pr view` の `--json` フィールドの修正が必要

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| .github/issue-pr-review-loop-runbook.md | 新規ランブックとして概ね既存プレイブックの内容を適切に整理しているが、ループ安全上限の欠落・`gh pr view` の `--json` フィールド不完全・エスカレーション手順の欠如という3点の問題がある |

</details>

</details>

<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A([開始]) --> B[フェーズ1: open issue 棚卸し]
    B --> B1["gh issue list --state open"]
    B1 --> B2["gh issue view &lt;NUM&gt; --comments\n完了条件を明文化"]
    B2 --> C[フェーズ2: issue ごとに実装PR作成]
    C --> C1["main からブランチ作成\ngit checkout -b feat/issue-&lt;N&gt;-..."]
    C1 --> C2["実装 + テスト追加"]
    C2 --> C3["npm run typecheck && test && lint"]
    C3 --> C4["git add -A / commit / push"]
    C4 --> C5["gh pr create ... Closes #&lt;ISSUE&gt;"]
    C5 --> D{未処理 issue あり?}
    D -- Yes --> C
    D -- No --> E[フェーズ3: open PR review closure loop]
    E --> E1["gh pr view &lt;PR&gt; --json reviews,comments,statusCheckRollup"]
    E1 --> E2{未解決スレッドあり?}
    E2 -- Yes --> E3{ADDRESS or\nIGNORE_WITH_REASON}
    E3 -- ADDRESS --> E4["修正実装 → push"]
    E3 -- IGNORE --> E5["仕様根拠付きで返信"]
    E4 --> E6["返信してスレッドをresolve"]
    E5 --> E6
    E6 --> E7["gh pr checks &lt;PR&gt; --required --watch --interval 10"]
    E7 --> E8["sleep 300 → 再取得"]
    E8 --> E9{停止条件\nunresolved=0\nchecks=green?}
    E9 -- No --> E2
    E9 -- Yes --> F([完了])
    E2 -- No --> E9
```

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
This is a comment left during a code review.
Path: .github/issue-pr-review-loop-runbook.md
Line: 96-98

Comment:
**ループ安全上限（Safety Cap）の記載が欠落**

`pr-review-closure-loop.md` には **最大20イテレーション** というループ安全上限が明示的に定義されています（`Loop safety cap: Maximum 20 iterations. If cap is reached, stop and report blockers.`）。しかしこのランブックには対応する記載がなく、エージェントが上限なしにループし続けるリスクがあります。

フェーズ3のループ手順に上限とキャップ到達時の対応を追加することを推奨します：

```suggestion
6. 停止条件
   - unresolved conversation = 0
   - required checks = 全て success
   - **ループ安全上限: 最大 20 イテレーション。上限に達した場合はループを停止してブロッカーを報告する**
```

How can I resolve this? If you propose a fix, please make it concise.

---

This is a comment left during a code review.
Path: .github/issue-pr-review-loop-runbook.md
Line: 63

Comment:
**`--json` フィールドが不完全で重要情報が取得できない**

`pr-review-closure-loop.md` の推奨コマンドには以下のフィールドが含まれています：

```
gh pr view <PR_NUMBER> --json number,state,mergeStateStatus,reviewDecision,reviews,comments,latestReviews,headRefName,baseRefName,statusCheckRollup
```

このランブックのコマンドは `reviews,comments,statusCheckRollup` のみで、`mergeStateStatus`（マージ可否の判定）、`reviewDecision`（レビュー承認状態）、`latestReviews`（最新レビュー）などの重要フィールドが欠落しています。これらがないと、マージ可否の正確な判断ができません。

```suggestion
   gh pr view <PR_NUMBER> --json number,state,mergeStateStatus,reviewDecision,reviews,comments,latestReviews,headRefName,baseRefName,statusCheckRollup
```

How can I resolve this? If you propose a fix, please make it concise.

---

This is a comment left during a code review.
Path: .github/issue-pr-review-loop-runbook.md
Line: 101-113

Comment:
**エスカレーション手順の欠如**

`pr-review-closure-loop.md` には以下のエスカレーション条件が定義されていますが、このランブックには対応するセクションがありません：

- レビューリクエストがプロダクト要件と競合する場合
- 提案された修正が広範なリファクタリングを必要とする場合
- スレッドが作者権限では解決できない場合

エージェントがどのような状況で人間にエスカレーションすべきかを明示することで、自動化ループの暴走を防ぐことができます。チェックリストか「判定ポリシー」セクションに `## エスカレーション条件` を追加することを推奨します。

How can I resolve this? If you propose a fix, please make it concise.
`````

</details>

<sub>Last reviewed commit: ["docs: add issue-to-p..."](https://github.com/hiroki-org/openshelf/commit/e4ca157f3999fc7f3097eeb6eefe529cde59e40f)</sub>

> Greptile also left **3 inline comments** on this PR.

<!-- /greptile_comment -->