### PR TITLE
🧹 [Code Health] Remove leftover console.error in CSRF middleware

### DIFF
--- a/apps/api/src/index.ts
+++ b/apps/api/src/index.ts
@@ -64,8 +64,8 @@ app.use("/api/*", async (c, next) => {
         if (isAllowedOrigin || isAllowedReferer) return await next();
 
 
-    } catch {
-        // Ignore CSRF check error
+    } catch (err) {
+        console.error(`CSRF check error: ${err}`);
     }
 
     return c.text("Forbidden", 403);


### PR DESCRIPTION
🎯 **What:** CSRFミドルウェア（`apps/api/src/index.ts`）に残っていた不要な `console.error` を削除しました。
💡 **Why:** エラーが発生してもアプリケーションログを不必要に汚染しないようにし、保守性と可読性を向上させるためです。これらはデバッグ用のコードであり、本番環境には不要なものです。
✅ **Verification:**
  - ローカルで `npm test` と `npm run typecheck` を実行し、すべてのテストがパスすることを確認しました。
  - CSRFチェック自体を扱うテスト（`csrf.test.ts`）を実行し、問題なく機能していることを確認しました。
✨ **Result:** CSRFエラー時に不要なログ出力が行われなくなり、コードがすっきりしました。機能上の変更はありません。

---
*PR created automatically by Jules for task [11466854655525274342](https://jules.google.com/task/11466854655525274342) started by @is0692vs*

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

このPRは `apps/api/src/index.ts` のCSRFミドルウェアからデバッグ用の `console.error` 呼び出しを2箇所削除することで、本番ログのノイズを減らすことを目的としています。方向性は正しいですが、**`catch` ブロックが完全に空になってしまった**点が懸念事項です。

主な変更点と問題点:

- `console.error("CSRF check failed: ...")` の削除 — Originや Refererなど機密性のある情報のログ出力を止める点では良い変更です。
- `console.error("CSRF check error: ...")` の削除 + `catch (err)` → `catch {}` への変更 — `new URL(c.env.FRONTEND_URL)` や `new URL(referer)` が例外を投げた場合（設定ミスや不正なヘッダーなど）に、エラーが完全に握りつぶされ、ログに何も残りません。本番環境での問題調査が困難になる可能性があります。
</details>

<h3>Confidence Score: 3/5</h3>

- 機能への直接的な影響はないが、空の catch ブロックが本番環境での可観測性を損なうため、マージ前の修正を推奨します。
- CSRF 自体の動作ロジックに変更はなく、テストもパスしているとのことで機能上のリグレッションはほぼありません。一方、`catch` ブロックを完全に空にしたことで、URL パースエラーなどの設定ミスが本番で完全にサイレントになり、デバッグコストが増大するリスクがあります。
- apps/api/src/index.ts の `catch` ブロック（67〜69行目）に注意が必要です。

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| apps/api/src/index.ts | CSRFミドルウェアの `console.error` を2箇所削除。エラーログの除去は良い方向だが、`catch` ブロックが完全に空になったため、URL解析エラーなどが発生しても一切ログに残らない問題がある。 |

</details>

</details>

<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[Request] --> B{GET/HEAD/OPTIONS/TRACE?}
    B -- Yes --> C[Call next]
    B -- No --> D{Bearer token or test auth?}
    D -- Yes --> C
    D -- No --> E[Try: Validate URL]
    E --> F{Origin/Referer allowed?}
    F -- Yes --> C
    F -- No --> H[Return 403 Forbidden]
    E -- Exception --> G[catch block - EMPTY - error silenced]
    G --> H
```

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
This is a comment left during a code review.
Path: apps/api/src/index.ts
Line: 67-69

Comment:
**空の `catch` ブロックでエラーが完全に握りつぶされる**

`console.error` を削除すること自体は理解できますが、`catch` ブロックを完全に空にしてしまうと、例えば `new URL(c.env.FRONTEND_URL)` が無効なURLで例外を投げた場合や、`new URL(referer)` がマルフォームされた Referer ヘッダーでエラーになった場合に、**その事実がまったくログに残りません**。

その結果、本番環境でCSRF設定に問題が発生しても、アプリが黙ってクライアントに `403` を返すだけとなり、原因の調査が非常に困難になります。

`console.error` を使いたくない場合でも、構造化ログや専用のロガーを使用して最低限のエラー情報を残すことを推奨します。

```suggestion
    } catch (err) {
        // TODO: 本番用ロガーへの差し替えを検討してください
        // 例: logger.error("CSRF check error", { error: err });
    }
```

How can I resolve this? If you propose a fix, please make it concise.
`````

</details>

<sub>Last reviewed commit: ["🧹 chore: remove lef..."](https://github.com/hiroki-org/openshelf/commit/708804ea903e0168caafedca36a7152ff3c2a7e9)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->