### PR TITLE
fix: Correct `github.paginate` call signature in codeql-alerts-to-issues workflow

### DIFF
--- a/.github/workflows/codeql-alerts-to-issues.yml
+++ b/.github/workflows/codeql-alerts-to-issues.yml
@@ -191,7 +191,6 @@ jobs:
             await ensureLabel(scopedLabel, "5319e7", "Workflow permissions alerts from CodeQL");
 
             const openAlerts = await github.paginate(
-              github.request,
               "GET /repos/{owner}/{repo}/code-scanning/alerts",
               {
                 owner,


### PR DESCRIPTION
The `Sync alerts and issues` job in `.github/workflows/codeql-alerts-to-issues.yml` was failing with a `404 Not Found` error on the `GET /repos///code-scanning/alerts` endpoint.

The error occurred because `github.paginate` was incorrectly called with `github.request` as its first argument and the route string as its second argument. The `paginate` function expects either `(route, parameters)` or `(EndpointMethod, parameters)`. When `github.request` was provided as the first argument, `paginate` treated the route string as the parameters object and the actual parameters as a mapping function. This prevented Octokit from interpolating `{owner}` and `{repo}` into the request URL.

The fix removes the `github.request` argument so that the route string is correctly passed as the first argument.

---
*PR created automatically by Jules for task [2184127735942370046](https://jules.google.com/task/2184127735942370046) started by @is0692vs*

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

このPRは `.github/workflows/codeql-alerts-to-issues.yml` 内の `github.paginate` 呼び出しの引数ミスを修正します。`github.request` を第一引数として渡していたため、Octokit が URL テンプレート (`{owner}`, `{repo}`) を正しく補間できず `404 Not Found` エラーが発生していた問題を解消します。

**変更内容:**
- `github.paginate(github.request, "GET /repos/{owner}/{repo}/code-scanning/alerts", { ... })` という誤った3引数の呼び出しから、`github.request` を削除し、正しい2引数形式 `github.paginate("GET /repos/{owner}/{repo}/code-scanning/alerts", { ... })` に修正

**補足:**
- 同ファイル内の `listManagedIssues` 関数（121行目）では `github.paginate(github.rest.issues.listForRepo, { ... })` という形式で `EndpointMethod` を正しく使用しており、今回の修正後のパターンと合わせて Octokit の公式な使い方に準拠しています。
- 変更は最小限かつピンポイントで、副作用はありません。
</details>

<h3>Confidence Score: 5/5</h3>

- 変更は明確で安全です。即座にマージ可能です。
- 1行の削除のみで、Octokit の公式ドキュメント通りの正しいシグネチャへの修正です。PR説明のエラー原因分析も正確で、既存のコードベース内の他のpaginateの使い方とも一貫しています。リグレッションリスクはほぼゼロです。
- 特に注意が必要なファイルはありません。

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| .github/workflows/codeql-alerts-to-issues.yml | `github.paginate` の呼び出しシグネチャを修正 — `github.request` を第一引数から削除し、ルート文字列が正しく第一引数として渡されるように変更。ロジックは正しく、副作用なし。 |

</details>

</details>

<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant WF as GitHub Actions Workflow
    participant Octokit as github.paginate (Octokit)
    participant API as GitHub API

    Note over WF,API: 修正前（誤ったシグネチャ）
    WF->>Octokit: paginate(github.request, "GET /repos/{owner}/{repo}/...", params)
    Note over Octokit: routeが github.request と解釈され<br/>文字列がparamsとして誤認識
    Octokit->>API: GET /repos///code-scanning/alerts
    API-->>Octokit: 404 Not Found

    Note over WF,API: 修正後（正しいシグネチャ）
    WF->>Octokit: paginate("GET /repos/{owner}/{repo}/...", params)
    Note over Octokit: routeが正しく解釈され<br/>{owner}/{repo}が補間される
    Octokit->>API: GET /repos/hiroki-org/openshelf/code-scanning/alerts
    API-->>Octokit: 200 OK + alerts[]
    Octokit-->>WF: openAlerts[]
```

<sub>Reviews (1): Last reviewed commit: ["fix: Correct \`github.paginate\` call sign..."](https://github.com/hiroki-org/openshelf/commit/3970ee489c91c3ec252a39341fc1620a52e1b22c) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=26165211)</sub>

<!-- /greptile_comment -->