### PR TITLE
chore: update hono to ^4.12.9 to address vulnerabilities

### DIFF
--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -28,6 +28,6 @@
   },
   "dependencies": {
     "drizzle-orm": "^0.45.1",
-    "hono": "^4.12.3"
+    "hono": "^4.12.9"
   }
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -27,7 +27,7 @@
       "license": "MIT",
       "dependencies": {
         "drizzle-orm": "^0.45.1",
-        "hono": "^4.12.3"
+        "hono": "^4.12.9"
       },
       "devDependencies": {
         "@cloudflare/vitest-pool-workers": "^0.10.12",
@@ -1600,13 +1600,6 @@
       },
       "funding": {
         "url": "https://github.com/privatenumber/get-tsconfig?sponsor=1"
-      }
-    },
-    "apps/api/node_modules/hono": {
-      "version": "4.12.3",
-      "license": "MIT",
-      "engines": {
-        "node": ">=16.9.0"
       }
     },
     "apps/api/node_modules/miniflare": {
@@ -9561,6 +9554,15 @@
       "license": "MIT",
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/hono": {
+      "version": "4.12.9",
+      "resolved": "https://registry.npmjs.org/hono/-/hono-4.12.9.tgz",
+      "integrity": "sha512-wy3T8Zm2bsEvxKZM5w21VdHDDcwVS1yUFFY6i8UobSsKfFceT7TOwhbhfKsDyx7tYQlmRM5FLpIuYvNFyjctiA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=16.9.0"
       }
     },
     "node_modules/html-encoding-sniffer": {


### PR DESCRIPTION
This updates `hono` to `^4.12.9` to address security vulnerabilities reported by Dependabot.

Specifically, it bumps `hono` in `apps/api/package.json` to version `4.12.9` to patch:
- Hono Vulnerable to Cookie Attribute Injection via Unsanitized domain and path in setCookie()
- Hono Vulnerable to SSE Control Field Injection via CR/LF in writeSSE()
- Hono vulnerable to arbitrary file access via serveStatic vulnerability
- Hono vulnerable to Prototype Pollution possible through __proto__ key allowed in parseBody({ dot: true })

Tests successfully passed and the `package-lock.json` file changes have been staged.
Fixes #32.

---
*PR created automatically by Jules for task [12086687047734052529](https://jules.google.com/task/12086687047734052529) started by @is0692vs*

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

このPRは `hono` を `^4.12.3` から `^4.12.9` にバンプし、Dependabot が報告した複数のセキュリティ脆弱性を修正します。\n\n主な変更点：\n- `apps/api/package.json` の `hono` バージョン要件を `^4.12.9` に更新\n- `package-lock.json` の解決バージョンを `4.12.9` に更新（npm レジストリの整合性ハッシュと一致確認済み）\n- パッケージがモノレポのルート `node_modules/hono` に巻き上げられた（以前は `apps/api/node_modules/hono` にネストされていた）\n\n修正された脆弱性：\n- `setCookie()` の `domain`/`path` 未サニタイズによる Cookie 属性インジェクション\n- `writeSSE()` の CR/LF による SSE コントロールフィールドインジェクション\n- `serveStatic` による任意ファイルアクセス\n- `parseBody({ dot: true })` での `__proto__` キーを介した Prototype Pollution\n\n`apps/api` 以外に `hono` を使用しているパッケージはなく、影響範囲は API アプリのみです。
</details>

<h3>Confidence Score: 5/5</h3>

セキュリティパッチのみを含むシンプルな依存関係更新であり、マージは安全です。

変更は `hono` のマイナーバージョンバンプのみで、破壊的変更なし。npm レジストリの整合性ハッシュと一致していることを確認済み。`hono` を使用しているのは `apps/api` のみで影響範囲が明確。テストも通過しており、コード品質上の問題は一切見当たらない。

特に注意が必要なファイルはありません。

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| apps/api/package.json | `hono` のバージョンを `^4.12.3` から `^4.12.9` に更新。セキュリティ脆弱性（Cookie インジェクション、SSE インジェクション、serveStatic 任意ファイルアクセス、Prototype Pollution）を修正。 |
| package-lock.json | `hono` のロックエントリを `4.12.9` に更新。パッケージが `apps/api/node_modules/hono`（ネスト）から `node_modules/hono`（ルートへの巻き上げ）に移動し、正しい `resolved` URL と整合性ハッシュ（npm レジストリと一致）が付与されている。 |

</details>

</details>

<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[Dependabot アラート検知] --> B[hono 4.12.3\n脆弱性あり]
    B --> C1[Cookie 属性インジェクション\nCVE: setCookie domain/path]
    B --> C2[SSE インジェクション\nCVE: writeSSE CR/LF]
    B --> C3[任意ファイルアクセス\nCVE: serveStatic]
    B --> C4[Prototype Pollution\nCVE: parseBody dot:true]
    C1 & C2 & C3 & C4 --> D[hono 4.12.9 へアップデート]
    D --> E[apps/api/package.json 更新]
    D --> F[package-lock.json 更新\n整合性ハッシュ検証済み]
    E & F --> G[脆弱性修正完了]
```

<sub>Reviews (1): Last reviewed commit: ["chore: update hono to ^4.12.9 to address..."](https://github.com/hiroki-org/openshelf/commit/1431022d6f6ec26f8d25932c58cc00ea0a1926e8) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=26394834)</sub>

<!-- /greptile_comment -->