### PR TITLE
chore: Add contents: read permission to GitHub Actions workflows

### DIFF
--- a/.github/workflows/check-migrations.yml
+++ b/.github/workflows/check-migrations.yml
@@ -5,6 +5,9 @@ on:
       - "apps/api/drizzle/**"
       - "apps/api/migrations/**"
 
+permissions:
+  contents: read
+
 jobs:
   check:
     runs-on: ubuntu-latest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,6 +6,9 @@ on:
   pull_request:
     branches: [main]
 
+permissions:
+  contents: read
+
 jobs:
   setup:
     name: Setup
@@ -18,7 +21,6 @@ jobs:
           cache: npm
       - name: Install dependencies
         run: npm ci
-
   lint:
     name: Lint
     needs: setup
@@ -32,7 +34,6 @@ jobs:
       - run: npm ci
       - name: Lint
         run: npm run lint --if-present
-
   typecheck:
     name: Type Check
     needs: setup
@@ -46,7 +47,6 @@ jobs:
       - run: npm ci
       - name: Type Check
         run: npm run typecheck --workspaces --if-present
-
   test-api:
     name: Test API
     needs: [lint, typecheck]
@@ -74,7 +74,6 @@ jobs:
         with:
           name: coverage-api
           path: apps/api/coverage/
-
   test-web:
     name: Test Web
     needs: [lint, typecheck]
@@ -102,7 +101,6 @@ jobs:
         with:
           name: coverage-web
           path: apps/web/coverage/
-
   upload-coverage:
     name: Upload Coverage
     needs: [build-web-check, e2e]
@@ -144,7 +142,6 @@ jobs:
           override_branch: ${{ env.CODECOV_BRANCH }}
           override_commit: ${{ env.CODECOV_COMMIT_SHA }}
           root_dir: apps/web
-
   build-web-check:
     name: Build Web (Preview Check)
     needs: [test-api, test-web]
@@ -158,7 +155,6 @@ jobs:
       - run: npm ci
       - name: Build web app
         run: npm run build -w apps/web
-
   e2e:
     name: E2E Tests
     needs: [test-api, test-web]
@@ -172,11 +168,9 @@ jobs:
           cache: npm
       - name: Install dependencies
         run: npm ci
-
       - name: Install Playwright Browsers
         run: npx playwright install --with-deps chromium
         working-directory: apps/e2e
-
       - name: Setup local .dev.vars for Worker
         env:
           E2E_JWT_SECRET: ${{ secrets.E2E_JWT_SECRET }}
@@ -184,13 +178,10 @@ jobs:
           echo "JWT_SECRET=${E2E_JWT_SECRET:-e2e-ci-only-secret}" > apps/api/.dev.vars
           echo "FRONTEND_URL=http://localhost:3000" >> apps/api/.dev.vars
           echo "TEST_AUTH_SECRET=e2e-ci-only-secret" >> apps/api/.dev.vars
-
       - name: Set up local D1 schema
         run: npm run db:migrate:local --workspace apps/api
-
       - name: Build web app for E2E
         run: npm run build -w apps/web
-
       - name: Run Playwright tests
         run: npm run test -w apps/e2e
         env:
@@ -198,7 +189,6 @@ jobs:
           TEST_AUTH_SECRET: ${{ secrets.E2E_JWT_SECRET || 'e2e-ci-only-secret' }}
           E2E_API_URL: http://localhost:8787
           NEXT_PUBLIC_API_URL: http://localhost:8787
-
       - name: Upload Playwright Report
         uses: actions/upload-artifact@v4
         if: always()

--- a/.github/workflows/deploy-api.yml
+++ b/.github/workflows/deploy-api.yml
@@ -4,6 +4,9 @@ on:
     branches: [main]
     paths: ["apps/api/**"]
 
+permissions:
+  contents: read
+
 jobs:
   deploy:
     concurrency:


### PR DESCRIPTION
Resolves multiple CodeQL alerts regarding missing `permissions` declarations in three GitHub Actions workflow files (`ci.yml`, `deploy-api.yml`, and `check-migrations.yml`) by setting explicitly defined permissions to `contents: read` at the top level of each workflow.

---
*PR created automatically by Jules for task [5416421552970130426](https://jules.google.com/task/5416421552970130426) started by @is0692vs*

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

3 つの GitHub Actions ワークフローファイル（`ci.yml`、`deploy-api.yml`、`check-migrations.yml`）に対して、CodeQL のアラートで指摘されていた `permissions` 宣言の欠落を解消するため、ワークフローのトップレベルに `permissions: contents: read` を追加しています。また `ci.yml` ではジョブ間の不要な空行が整理されています。

**主な変更点:**
- `.github/workflows/check-migrations.yml`：トップレベルに `permissions: contents: read` を追加
- `.github/workflows/ci.yml`：トップレベルに `permissions: contents: read` を追加、ジョブ間の余分な空行を削除
- `.github/workflows/deploy-api.yml`：トップレベルに `permissions: contents: read` を追加

**評価:**
各ワークフローの実際の処理内容（コードのチェックアウト、npm ビルド、Cloudflare へのデプロイ、マイグレーション確認）に対して、`contents: read` は必要十分な最小権限です。`actions/upload-artifact@v4` や `actions/download-artifact@v4` は `ACTIONS_RUNTIME_TOKEN` を内部的に使用するため、`GITHUB_TOKEN` の追加権限は不要です。Cloudflare Wrangler のデプロイも専用のシークレットトークンを使用するため問題ありません。変更は安全かつ適切です。
</details>

<h3>Confidence Score: 5/5</h3>

変更は最小限かつ正確で、すぐにマージ可能です。

3 ファイルすべてに対して CodeQL アラートの根本原因である権限宣言の欠落を正しく修正しています。各ワークフローで必要な権限は `contents: read` のみであり、アーティファクト操作・外部デプロイともに別のトークン機構を使用するため、追加の権限は不要です。ロジックの変更は一切なく、セキュリティを強化する純粋な修正です。

特に注意が必要なファイルはありません。

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| .github/workflows/ci.yml | トップレベルに `permissions: contents: read` を追加し、ジョブ間の不要な空行を削除。権限の設定内容はワークフローの各ステップに必要な最低限の権限として適切。 |
| .github/workflows/deploy-api.yml | トップレベルに `permissions: contents: read` を追加。Cloudflare へのデプロイはシークレット経由の API トークンを使用するため GITHUB_TOKEN の追加権限は不要で変更は適切。 |
| .github/workflows/check-migrations.yml | トップレベルに `permissions: contents: read` を追加。`git diff` による変更検知のみを行うワークフローに対して必要十分な権限設定。 |

</details>

</details>

<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    subgraph ci["ci.yml (push/pull_request → main)"]
        direction TB
        P1["permissions: contents: read ✅"] --> J1[setup] --> J2[lint] & J3[typecheck]
        J2 & J3 --> J4[test-api] & J5[test-web]
        J4 & J5 --> J6[build-web-check] & J7[e2e]
        J6 & J7 --> J8[upload-coverage]
    end

    subgraph deploy["deploy-api.yml (push → main, apps/api/**)"]
        direction TB
        P2["permissions: contents: read ✅"] --> D1[checkout] --> D2["Apply D1 migrations (wrangler)"] --> D3["Deploy Workers (wrangler)"]
    end

    subgraph migrate["check-migrations.yml (pull_request, drizzle/**/migrations/**)"]
        direction TB
        P3["permissions: contents: read ✅"] --> M1["checkout (fetch-depth: 0)"] --> M2["Check migration immutability (git diff)"]
    end
```

<sub>Reviews (1): Last reviewed commit: ["chore: Add contents: read permission to ..."](https://github.com/hiroki-org/openshelf/commit/e4b24ba761a5e7f1b410cf0dbfc2b6b034041a5e) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=26395149)</sub>

<!-- /greptile_comment -->