### PR TITLE
fix: update hono to 4.12.9 to fix prototype pollution vulnerability

### DIFF
--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -28,6 +28,6 @@
   },
   "dependencies": {
     "drizzle-orm": "^0.45.1",
-    "hono": "4.12.9"
+    "hono": "^4.12.9"
   }
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -27,7 +27,7 @@
       "license": "MIT",
       "dependencies": {
         "drizzle-orm": "^0.45.1",
-        "hono": "4.12.9"
+        "hono": "^4.12.9"
       },
       "devDependencies": {
         "@cloudflare/vitest-pool-workers": "^0.10.12",
@@ -10489,6 +10489,7 @@
       "version": "2.3.2",
       "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
       "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
+      "dev": true,
       "hasInstallScript": true,
       "license": "MIT",
       "optional": true,


### PR DESCRIPTION
This pull request updates the `hono` package in the `apps/api` workspace to version `4.12.9`.

This update resolves a Prototype Pollution vulnerability present in `hono <4.12.6` (CVE/GHSA-v8w9-8mx6-g223) where prototype injection was possible through the `__proto__` key in `parseBody({ dot: true })`.

**Note regarding `esbuild` vulnerability:**
The Dependabot alert also flagged `esbuild <=0.24.2`. This is deeply nested within `drizzle-kit` via `@esbuild-kit/esm-loader` and `@esbuild-kit/core-utils`. Attempting to use `npm` overrides to forcibly upgrade `esbuild` creates strict peer dependency conflicts with `esbuild-register` and `vite` across the workspace. A separate strategy involving a major version update to `drizzle-kit` (which contains breaking changes) or migrating away from `@esbuild-kit` will be required to properly resolve the `esbuild` alert without breaking the build pipeline. This PR isolates and resolves the `hono` security issue safely.

---
*PR created automatically by Jules for task [8050656380368060326](https://jules.google.com/task/8050656380368060326) started by @is0692vs*

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

このPRは、`hono < 4.12.6` に存在するプロトタイプ汚染脆弱性（GHSA-v8w9-8mx6-g223）を修正するため、`apps/api` ワークスペースの `hono` を `^4.12.3` から `^4.12.9` にアップデートするものです。

主な変更点：
- `apps/api/package.json`：`hono` のバージョン範囲を `^4.12.3` → `^4.12.9` に更新
- `package-lock.json`：`hono@4.12.3`（ワークスペースローカルインストール `apps/api/node_modules/hono`）が削除され、`hono@4.12.9` がルートレベルの `node_modules/hono` にホイスティングされて追加された。これは npm が重複排除した結果であり、正常な動作

変更は最小限かつスコープが明確で、セキュリティ修正として適切に実施されています。
</details>

<h3>Confidence Score: 5/5</h3>

このPRはマージして安全です。変更は最小限かつ的確で、セキュリティ脆弱性を正しく修正しています

変更は2ファイルのみで、スコープが明確。`^` によるキャレット形式が維持されており、他の依存と一貫性がある。ロックファイルの変更はnpmのホイスティング動作として正常。CVE対象の `hono < 4.12.6` に対して `4.12.9` への更新は適切

特に注意が必要なファイルはありません

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| apps/api/package.json | `hono` を `^4.12.3` から `^4.12.9` に更新。キャレット形式が維持されており、他の依存パッケージと一貫したスタイルになっている |
| package-lock.json | ロックファイルが正しく更新され、`hono@4.12.3` のワークスペースローカルエントリが削除され、`hono@4.12.9` がルートの `node_modules` にホイスティングされた。整合性ハッシュも含まれており正常 |

</details>

</details>

<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant Client
    participant Hono as Hono (4.12.9)
    participant App as API Application

    Note over Hono: CVE修正済み (GHSA-v8w9-8mx6-g223)

    Client->>Hono: POST /endpoint (body with __proto__ key)
    Note over Hono: parseBody({ dot: true }) の<br/>プロトタイプ汚染を検出・無害化
    Hono->>App: サニタイズ済みリクエストボディを渡す
    App->>Client: 正常レスポンス

    Note over Client,App: 旧バージョン (4.12.3) では<br/>__proto__ キーによるプロトタイプ注入が可能だった
```

<sub>Reviews (2): Last reviewed commit: ["fix: align hono and lockfile"](https://github.com/hiroki-org/openshelf/commit/71abbee9de0e0fe17df381148f30096b33fce558) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=26397549)</sub>

<!-- /greptile_comment -->