### PR TITLE
fix(ci): restore main CodeQL workflow parsing

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -30,7 +30,6 @@ jobs:
         with:
           languages: ${{ matrix.language }}
       - name: Autobuild
-      - name: Autobuild
         # actions 言語はワークフローファイルを静的解析するためビルド不要
         if: matrix.language == 'javascript-typescript'
         uses: github/codeql-action/autobuild@v3


### PR DESCRIPTION
## Summary
- fix malformed `.github/workflows/codeql.yml` on `main`
- remove duplicated empty `Autobuild` step that made the workflow file invalid at runtime

## Root cause
A stray duplicated step entry (`- name: Autobuild`) was present without action fields, so the run failed immediately with a workflow-file issue and created zero jobs.

## Validation
- confirmed only this line is removed
- branch pushed and PR opened for immediate merge to unblock main

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

このPRは、`.github/workflows/codeql.yml`に存在していた無効な重複ステップエントリを削除することで、壊れていたCodeQLワークフローを修復します。

主な変更点：
- `- name: Autobuild` のみが記述された（`uses` や `run` キーを持たない）孤立したステップエントリを1行削除
- 残存する `Autobuild` ステップは正しく `github/codeql-action/autobuild@v3` を参照しており、`javascript-typescript` 言語にのみ実行される条件も正常
- ワークフロー全体の構造（`checkout` → `Initialize CodeQL` → `Autobuild`（条件付き）→ `Perform CodeQL Analysis`）は修正後も意図通り
- 修正はシンプルかつ最小限であり、他のロジックへの影響はなし
</details>

<h3>Confidence Score: 5/5</h3>

即マージ可能。変更は1行削除のみで、ワークフローの正確性を回復する明確な修正。

変更内容は `uses`/`run` キーを持たない無効な重複ステップの削除1行のみ。修正後のYAMLは構文的・論理的に正しく、P1以上の問題は一切存在しない。

特に注意が必要なファイルはありません。

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| .github/workflows/codeql.yml | 重複した不完全な `Autobuild` ステップエントリ（`uses`/`run` なし）を削除。修正後のファイルは構文的に正しく、ワークフローが正常に動作する |

</details>

</details>

<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant GH as GitHub Actions
    participant Checkout as actions/checkout@v4
    participant Init as codeql-action/init@v3
    participant Build as codeql-action/autobuild@v3
    participant Analyze as codeql-action/analyze@v3

    GH->>Checkout: (matrix: javascript-typescript / actions)
    Checkout-->>GH: done
    GH->>Init: Initialize CodeQL (languages: matrix.language)
    Init-->>GH: done
    alt matrix.language == 'javascript-typescript'
        GH->>Build: Autobuild
        Build-->>GH: done
    else matrix.language == 'actions'
        GH-->>GH: Autobuild スキップ（静的解析のみ）
    end
    GH->>Analyze: Perform CodeQL Analysis (category: /language:matrix.language)
    Analyze-->>GH: 解析完了・セキュリティイベント送信
```

<sub>Reviews (1): Last reviewed commit: ["fix(ci): remove stray CodeQL autobuild s..."](https://github.com/hiroki-org/openshelf/commit/e5693efa38f4e19844b1348218ce36fbe746b931) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=26645520)</sub>

<!-- /greptile_comment -->