### PR TITLE
fix: resolve #219, #241, and Dependabot alert #2

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -26,7 +26,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
         with:
-          fetch-depth: 0
+          fetch-depth: 2
       - name: Initialize CodeQL
         uses: github/codeql-action/init@v3
         with:

--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -20,7 +20,7 @@
   "type": "commonjs",
   "devDependencies": {
     "@cloudflare/workers-types": "^4.20260218.0",
-    "drizzle-kit": "^1.0.0-beta.9-e89174b",
+    "drizzle-kit": "1.0.0-beta.9-e89174b",
     "typescript": "^5.9.3",
     "vitest": "^3.2.4",
     "wrangler": "^4.78.0"

--- a/apps/web/src/app/__tests__/collections-new.test.tsx
+++ b/apps/web/src/app/__tests__/collections-new.test.tsx
@@ -107,6 +107,41 @@ describe("NewCollectionPage", () => {
     expect(submit).not.toBeDisabled();
   });
 
+  it("resets slug availability when switching from user to org ownership", async () => {
+    vi.mocked(apiFetch).mockImplementation(async (url) => {
+      if (url === "/api/users/user-1/collections") {
+        return new Response(JSON.stringify({ collections: [] }), { status: 200 });
+      }
+
+      if (url === "/api/orgs/example-org/collections") {
+        return new Response(JSON.stringify({ collections: [] }), { status: 200 });
+      }
+
+      throw new Error(`Unexpected request: ${String(url)}`);
+    });
+
+    render(<NewCollectionPage />);
+
+    fireEvent.change(screen.getByLabelText("name"), {
+      target: { value: "Lab Picks" },
+    });
+
+    const submit = screen.getByRole("button", { name: "作成" });
+    await waitFor(() => expect(screen.getByText("✓ 使用可能")).toBeInTheDocument());
+    expect(submit).not.toBeDisabled();
+
+    fireEvent.click(screen.getByLabelText(/^org$/));
+
+    expect(submit).toBeDisabled();
+
+    fireEvent.change(screen.getByLabelText("org slug"), {
+      target: { value: "example-org" },
+    });
+
+    await waitFor(() => expect(screen.getByText("✓ 使用可能")).toBeInTheDocument());
+    expect(submit).not.toBeDisabled();
+  });
+
   it("requires an org slug for org-owned collections", async () => {
     vi.mocked(apiFetch).mockImplementation(async (url) => {
       if (url === "/api/orgs/example-org/collections") {

--- a/apps/web/src/app/collections/new/page.tsx
+++ b/apps/web/src/app/collections/new/page.tsx
@@ -55,6 +55,11 @@ export default function NewCollectionPage() {
   }, [ownerType, orgSlug]);
 
   useEffect(() => {
+    slugCheckRef.current += 1;
+    setSlugStatus("idle");
+  }, [ownerType]);
+
+  useEffect(() => {
     if (!slug) {
       setSlugStatus("idle");
       return;

--- a/package-lock.json
+++ b/package-lock.json
@@ -32,7 +32,7 @@
       },
       "devDependencies": {
         "@cloudflare/workers-types": "^4.20260218.0",
-        "drizzle-kit": "^1.0.0-beta.9-e89174b",
+        "drizzle-kit": "1.0.0-beta.9-e89174b",
         "typescript": "^5.9.3",
         "vitest": "^3.2.4",
         "wrangler": "^4.78.0"


### PR DESCRIPTION
## Summary
- Fixes #219 by preventing collection creation while slug availability is still unresolved (`idle`) and by removing dead slug-check code in the debounce path.
- Fixes #241 by adding `fetch-depth: 0` to the CodeQL workflow checkout step.
- Addresses Dependabot alert https://github.com/Hiroki-org/OpenShelf/security/dependabot/2 by upgrading `apps/api` `drizzle-kit` to `1.0.0-beta.9-e89174b`, removing the vulnerable `@esbuild-kit/core-utils -> esbuild@0.18.20` chain.

## Details
- `apps/web/src/app/collections/new/page.tsx`
  - Block submit when `slugStatus` is `idle` or `checking`.
  - Disable submit button while `slugStatus` is `idle`.
  - Remove unreachable `if (!user) return` from slug debounce check and replace with a safe `url` null guard.
- `apps/web/src/app/__tests__/collections-new.test.tsx`
  - Added/updated tests for idle debounce behavior and org-owned form behavior.
- `.github/workflows/codeql.yml`
  - Added `fetch-depth: 0` under checkout.
- `apps/api/package.json`, `package-lock.json`
  - Upgraded `drizzle-kit` to `1.0.0-beta.9-e89174b`.

## Validation
- `npm run typecheck`
- `npm run lint`
- `npm run test`
- `npm audit --json` => total vulnerabilities: 0

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

このPRは3つの独立した問題（Issue #219・#241・Dependabot アラート #2）をまとめて修正しています。コレクション作成フォームのスラッグ確認が完了していない状態での誤送信を防ぐロジック修正、CodeQLワークフローへの `fetch-depth: 0` 追加、そして脆弱な `esbuild@0.18.20` を含む依存チェーンを解消する `drizzle-kit` のアップグレードが含まれます。

- **`page.tsx`**: `slugStatus === \"idle\"` をボタンの `disabled` 条件に追加し、`onSubmit` でも同ガードを設けることで二重防止を実現。デバウンスパス内のデッドコード（`if (!user) return`）を削除し、`url` の null ガードに置き換えた点も適切。
- **テスト**: idle 状態での無効化と org オーナーフォームの挙動を検証する 2 テストを追加。実タイマーを使った `waitFor` アプローチは一貫性があり、既存のフェイクタイマーを使ったテストと共存できる設計。
- **CodeQL**: `fetch-depth: 0` は全履歴をフェッチするため、大規模リポジトリでは CI が遅くなる可能性があります（P2）。
- **drizzle-kit**: `^1.0.0-beta.9-e89174b` の `^` プレフィックスは将来的な意図しないアップグレードを許容する可能性があります（P2）。
- **`ownerType` 切替時の slugStatus**: 400ms のデバウンス期間中に送信ボタンが一瞬有効になりますが、`onSubmit` のガードで実害はありません（P2）。
</details>


<h3>Confidence Score: 5/5</h3>

全ての残存指摘が P2（スタイル・ベストプラクティス）であり、マージをブロックする問題はありません。

3つの修正はそれぞれ独立しており、ロジック変更は `onSubmit` と `disabled` の両方でガードされています。テストも追加されており動作が検証済みです。残る指摘（`fetch-depth: 0`・`^` プレフィックス・ownerType 切替時の一瞬の enabled 状態）はすべて P2 レベルであり、本番環境のクリティカルパスに影響しません。

特に注意が必要なファイルはありません。`codeql.yml` と `apps/api/package.json` の P2 指摘を任意で確認してください。

<details><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| apps/web/src/app/collections/new/page.tsx | slugStatus が `idle` / `checking` の間は送信ボタンを無効化し、デバウンスパス内のデッドコードを削除して `url` の null ガードに置き換えた正しい修正。 |
| apps/web/src/app/__tests__/collections-new.test.tsx | idle 状態でのボタン無効化と org オーナー時の挙動を検証する 2 つのテストを追加。既存テストとの一貫性あり。 |
| .github/workflows/codeql.yml | checkout に `fetch-depth: 0` を追加。CodeQL の JavaScript 解析では通常フル履歴は不要であり、CI が遅くなる可能性がある。 |
| apps/api/package.json | drizzle-kit を `^1.0.0-beta.9-e89174b` にアップグレードしてセキュリティ脆弱性を解消。`^` プレフィックスの使用が意図しないアップグレードを招く可能性あり。 |
| package-lock.json | drizzle-kit アップグレードに伴うロックファイルの更新。依存チェーンから脆弱な esbuild@0.18.20 が除去されている。 |

</details>


</details>


<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[slug 入力 / name 変更] --> B{slug が空?}
    B -- はい --> C[slugStatus = idle\nボタン無効]
    B -- いいえ --> D{フォーマット検証\n長さ 3-40 / 正規表現 / -- なし}
    D -- 不正 --> E[slugStatus = invalid\nボタン無効]
    D -- 正常 --> F[400ms デバウンス開始]
    F --> G[slugStatus = checking\nボタン無効]
    G --> H{ownerType = org かつ\norgSlug が空?}
    H -- はい --> C
    H -- いいえ --> I{url を決定\nuser.id or orgSlug}
    I -- url = null --> C
    I -- url あり --> J[apiFetch でコレクション一覧取得]
    J -- エラー / !res.ok --> C
    J -- 成功 --> K{slug が既存に存在?}
    K -- あり --> L[slugStatus = taken\nボタン無効]
    K -- なし --> M[slugStatus = available\nボタン有効]
    M --> N[送信ボタンクリック]
    N --> O{onSubmit ガード確認}
    O -- NG --> P[エラー表示]
    O -- OK --> Q[POST /api/collections]
    Q -- 成功 --> R[router.push でリダイレクト]
    Q -- 失敗 --> P
```

<!-- greptile_failed_comments -->
<details open><summary><h3>Comments Outside Diff (1)</h3></summary>

1. `apps/web/src/app/collections/new/page.tsx`, line 57-113 ([link](https://github.com/hiroki-org/openshelf/blob/f90d7134bd630b330ce0d635df9f48cfb214a531/apps/web/src/app/collections/new/page.tsx#L57-L113)) 

   <a href="#"><img alt="P2" src="https://greptile-static-assets.s3.amazonaws.com/badges/p2.svg?v=7" align="top"></a> **`ownerType` 切替直後に `slugStatus` が一瞬 "available" のまま残ります**

   `ownerType` が `"user"` → `"org"` に切り替わると、`useEffect` の依存配列に `ownerType` が含まれているため再実行されますが、既存のスラッグ確認タイムアウト（400ms）が開始されるまでの間、`slugStatus` は直前の `"available"` のまま維持されます。

   この 400ms のウィンドウ中に `orgSlug` が空のまま送信ボタンが有効になりますが、`onSubmit` 内の `if (ownerType === "org" && !orgSlug.trim())` ガードが機能するため実際の送信は防がれています。ただし、UX の一貫性を高めるために `ownerType` 変更時に即座に `slugStatus` をリセットする `useEffect` を追加することを検討してください。

   ```ts
   useEffect(() => {
     setSlugStatus("idle");
   }, [ownerType]);
   ```

   これにより、切替と同時にボタンが無効化され、デバウンスが完了するまで "確認中..." の状態が適切に表示されます。

   <details><summary>Prompt To Fix With AI</summary>

   `````markdown
   This is a comment left during a code review.
   Path: apps/web/src/app/collections/new/page.tsx
   Line: 57-113

   Comment:
   **`ownerType` 切替直後に `slugStatus` が一瞬 "available" のまま残ります**

   `ownerType` が `"user"` → `"org"` に切り替わると、`useEffect` の依存配列に `ownerType` が含まれているため再実行されますが、既存のスラッグ確認タイムアウト（400ms）が開始されるまでの間、`slugStatus` は直前の `"available"` のまま維持されます。

   この 400ms のウィンドウ中に `orgSlug` が空のまま送信ボタンが有効になりますが、`onSubmit` 内の `if (ownerType === "org" && !orgSlug.trim())` ガードが機能するため実際の送信は防がれています。ただし、UX の一貫性を高めるために `ownerType` 変更時に即座に `slugStatus` をリセットする `useEffect` を追加することを検討してください。

   ```ts
   useEffect(() => {
     setSlugStatus("idle");
   }, [ownerType]);
   ```

   これにより、切替と同時にボタンが無効化され、デバウンスが完了するまで "確認中..." の状態が適切に表示されます。

   How can I resolve this? If you propose a fix, please make it concise.
   `````
   </details>

</details>

<!-- /greptile_failed_comments -->

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
This is a comment left during a code review.
Path: .github/workflows/codeql.yml
Line: 28-29

Comment:
**`fetch-depth: 0` は CodeQL に不要で CI を遅くする可能性があります**

GitHub の CodeQL 公式スターターワークフローは shallow clone（デフォルト `fetch-depth: 1`）を使用しており、JavaScript/TypeScript の静的解析にコミット履歴は必要ありません。`fetch-depth: 0` を指定するとリポジトリの全履歴を取得するため、リポジトリが成長するにつれて CI の checkout ステップが著しく遅くなります。

Issue #241 の根本原因が「git blame / 履歴ベースの解析」でなければ、デフォルトの shallow clone で十分なはずです。修正が不要だった場合は削除を検討してください。

```suggestion
      - uses: actions/checkout@v4
```

How can I resolve this? If you propose a fix, please make it concise.

---

This is a comment left during a code review.
Path: apps/api/package.json
Line: 23

Comment:
**セキュリティ修正版は `^` なしの固定バージョンが安全です**

`^1.0.0-beta.9-e89174b` という指定は semver の互換範囲 `>=1.0.0-beta.9-e89174b <2.0.0` を許可します。将来 `npm update` を実行した際、まだテストされていない新しい pre-release や安定版 `1.0.0` に自動アップグレードされる可能性があります。

Dependabot アラートに対応する特定のコミット（`e89174b`）を固定するなら、キャレットを外して完全固定にする方が意図を明確にできます。

```suggestion
    "drizzle-kit": "1.0.0-beta.9-e89174b",
```

How can I resolve this? If you propose a fix, please make it concise.

---

This is a comment left during a code review.
Path: apps/web/src/app/collections/new/page.tsx
Line: 57-113

Comment:
**`ownerType` 切替直後に `slugStatus` が一瞬 "available" のまま残ります**

`ownerType` が `"user"` → `"org"` に切り替わると、`useEffect` の依存配列に `ownerType` が含まれているため再実行されますが、既存のスラッグ確認タイムアウト（400ms）が開始されるまでの間、`slugStatus` は直前の `"available"` のまま維持されます。

この 400ms のウィンドウ中に `orgSlug` が空のまま送信ボタンが有効になりますが、`onSubmit` 内の `if (ownerType === "org" && !orgSlug.trim())` ガードが機能するため実際の送信は防がれています。ただし、UX の一貫性を高めるために `ownerType` 変更時に即座に `slugStatus` をリセットする `useEffect` を追加することを検討してください。

```ts
useEffect(() => {
  setSlugStatus("idle");
}, [ownerType]);
```

これにより、切替と同時にボタンが無効化され、デバウンスが完了するまで "確認中..." の状態が適切に表示されます。

How can I resolve this? If you propose a fix, please make it concise.
`````

</details>

<sub>Reviews (1): Last reviewed commit: ["fix: address #219, #241, and Dependabot ..."](https://github.com/hiroki-org/openshelf/commit/f90d7134bd630b330ce0d635df9f48cfb214a531) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=26646100)</sub>

> Greptile also left **2 inline comments** on this PR.

<!-- /greptile_comment -->