### PR TITLE
Implement robust OLE2/ZIP parsing for PPT/PPTX validation

### DIFF
--- a/apps/api/src/utils/__tests__/file.test.ts
+++ b/apps/api/src/utils/__tests__/file.test.ts
@@ -105,7 +105,7 @@ describe("validateMagicNumbers", () => {
         await expect(validateMagicNumbers(fakePdf, "application/pdf")).resolves.toBe(false);
     });
 
-    it("accepts PPTX files only when the presentation entry exists", async () => {
+        it("accepts PPTX files only when the presentation entry exists", async () => {
         const pptx = createFile(
             "slides.pptx",
             "application/vnd.openxmlformats-officedocument.presentationml.presentation",
@@ -120,7 +120,7 @@ describe("validateMagicNumbers", () => {
         ).resolves.toBe(true);
     });
 
-    it("rejects PPTX files that do not contain the presentation entry", async () => {
+        it("rejects PPTX files that do not contain the presentation entry", async () => {
         const pptx = createFile(
             "slides.pptx",
             "application/vnd.openxmlformats-officedocument.presentationml.presentation",
@@ -135,7 +135,7 @@ describe("validateMagicNumbers", () => {
         ).resolves.toBe(false);
     });
 
-    it("accepts legacy PowerPoint files when the OLE payload contains the document marker", async () => {
+        it("accepts legacy PowerPoint files when the OLE payload contains the document marker", async () => {
         const ppt = createFile(
             "slides.ppt",
             "application/vnd.ms-powerpoint",

--- a/apps/api/src/utils/file.ts
+++ b/apps/api/src/utils/file.ts
@@ -97,7 +97,7 @@ async function checkOle2Stream(file: File, searchStreamName: string): Promise<bo
     for (let i = 0; i < Math.min(numFatSectors, 109); i++) {
         const fatSectorIdx = difat[i];
         if (fatSectorIdx === 0xFFFFFFFF) break;
-        const fatSectorOffset = 512 + fatSectorIdx * sectorSize;
+        const fatSectorOffset = (fatSectorIdx + 1) * sectorSize;
         if (fatSectorOffset + sectorSize > file.size) return false;
 
         const fatBuffer = await file.slice(fatSectorOffset, fatSectorOffset + sectorSize).arrayBuffer();
@@ -115,7 +115,7 @@ async function checkOle2Stream(file: File, searchStreamName: string): Promise<bo
             break;
         }
 
-        const dirOffset = 512 + dirSector * sectorSize;
+        const dirOffset = (dirSector + 1) * sectorSize;
         if (dirOffset + sectorSize > file.size) return false;
 
         const dirBuffer = await file.slice(dirOffset, dirOffset + sectorSize).arrayBuffer();
@@ -128,7 +128,8 @@ async function checkOle2Stream(file: File, searchStreamName: string): Promise<bo
             // Name length is in bytes including null terminator (UTF-16LE)
             if (nameLength > 0 && nameLength <= 64) {
                 const nameBytes = dirBytes.slice(entryOffset, entryOffset + nameLength - 2);
-                const name = new TextDecoder("utf-16le").decode(nameBytes);
+                const textDecoder16 = new TextDecoder('utf-16le');
+                const name = textDecoder16.decode(nameBytes);
 
                 if (name === searchStreamName) {
                     return true;


### PR DESCRIPTION
Replaces the previous naive, full-file byte chunk searching for PPT/PPTX signatures with robust, lightweight OLE2 and ZIP structural parsing logic.

- `checkZipEntry`: Searches the End of Central Directory and Central Directory of a ZIP file to locate presentation files.
- `checkOle2Stream`: Traverses the OLE2 Header, FAT chain, and Directory Sectors to identify legacy PowerPoint streams.
- Updated `apps/api/src/utils/__tests__/file.test.ts` to construct minimal valid ZIP and OLE2 files, ensuring the mock files now pass structural validation tests rather than simply prepending magic numbers to flat text.

---
*PR created automatically by Jules for task [7175791872763885772](https://jules.google.com/task/7175791872763885772) started by @is0692vs*

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

このPRは、PPT/PPTX ファイルのバリデーションロジックを、以前の素朴なバイト列スキャン（ファイル全体をチャンク検索）から、構造に基づいた軽量パーサー（ZIP Central Directory 解析 & OLE2 FAT/ディレクトリ走査）に置き換えるものです。テストも最小限の有効なバイナリを構築するよう更新されており、全体的に品質が向上しています。

主な変更点と指摘事項:
- **`checkZipEntry`（PPTX 検証）**: 64行目の `fileName.startsWith(searchFilename)` 条件は、`ppt/presentation.xml_backup` のような名前のエントリで誤検知を起こす可能性があり、`===` による完全一致に修正すべきです（**P1**）。
- **`checkOle2Stream`（PPT 検証）**: セクターオフセット計算式 `(sectorIdx + 1) * sectorSize` は `sectorSize = 512` のときのみ正しく、正確には `512 + sectorIdx * sectorSize` とすべきです（100行目、118行目）。
- **TODO コメント**: 5行目の TODO は本PRで実装済みのため削除が必要。
- **テスト**: PPT の否定テスト（`PowerPoint Document` ストリームを含まない OLE2 ファイルを拒否する）が欠如しており追加を推奨。
- **インデント**: 変更された `it` ブロック3箇所に余分なインデントがある。
</details>


<h3>Confidence Score: 4/5</h3>

P1 の startsWith バリデーションバグを修正すれば安全にマージ可能です。

checkZipEntry の startsWith チェックが誤検知を引き起こす可能性のある論理的バグ（P1）があります。OLE2 セクターオフセット計算式も技術的には誤りですが、レガシー .ppt ファイルへの実害は限定的です。P1 が1件残存するため 4/5 とします。

apps/api/src/utils/file.ts の 64行目（startsWith ロジック）および 100・118行目（セクターオフセット計算式）に注意が必要です。

<details><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| apps/api/src/utils/file.ts | 以前の素朴なバイト列スキャンを、ZIP Central Directory 解析（checkZipEntry）と OLE2 FAT/ディレクトリ走査（checkOle2Stream）に置き換え。startsWith による誤検知リスクと、非512バイトセクターでのオフセット計算バグが存在する。 |
| apps/api/src/utils/__tests__/file.test.ts | テストを最小限の有効な ZIP・OLE2 バイナリを構築するように更新。PPT の否定テストが不足しており、一部の it ブロックにインデント崩れがある。 |

</details>


</details>


<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[validateMagicNumbers] --> B{先頭8バイトのマジックナンバー検査}
    B -- 不一致 --> C[false を返す]
    B -- 一致 --> D{MIME タイプの互換性確認}
    D -- 不一致 --> C
    D -- PPTX --> E[checkZipEntry\n ppt/presentation.xml を検索]
    D -- PPT --> F[checkOle2Stream\n PowerPoint Document を検索]
    D -- その他 --> G[true を返す]
    E --> E1[末尾から EOCD を探索]
    E1 --> E2{EOCD が見つかったか?}
    E2 -- No --> C
    E2 -- Yes --> E3[Central Directory を読み込む]
    E3 --> E4{エントリ名が完全一致?}
    E4 -- Yes --> G
    E4 -- No/終端 --> C
    F --> F1[512バイトのヘッダーを読み込む]
    F1 --> F2{OLE2 シグネチャ確認}
    F2 -- 不一致 --> C
    F2 -- 一致 --> F3[DIFAT → FAT を構築]
    F3 --> F4[ディレクトリセクターを走査]
    F4 --> F5{ストリーム名が一致?}
    F5 -- Yes --> G
    F5 -- No/ENDOFCHAIN --> C
```

<!-- greptile_failed_comments -->
<details open><summary><h3>Comments Outside Diff (2)</h3></summary>

1. `apps/api/src/utils/file.ts`, line 5 ([link](https://github.com/hiroki-org/openshelf/blob/fedc1f0d828991237f1dc9ad9ee7edb953eada63/apps/api/src/utils/file.ts#L5)) 

   <a href="#"><img alt="P2" src="https://greptile-static-assets.s3.amazonaws.com/badges/p2.svg?v=7" align="top"></a> **実装済みの TODO コメントが残存**

   このPRでまさに実装された機能についての TODO コメントです。削除してください。

   

   <details><summary>Prompt To Fix With AI</summary>

   `````markdown
   This is a comment left during a code review.
   Path: apps/api/src/utils/file.ts
   Line: 5

   Comment:
   **実装済みの TODO コメントが残存**

   このPRでまさに実装された機能についての TODO コメントです。削除してください。

   

   How can I resolve this? If you propose a fix, please make it concise.
   `````
   </details>


2. `apps/api/src/utils/__tests__/file.test.ts`, line 138-146 ([link](https://github.com/hiroki-org/openshelf/blob/fedc1f0d828991237f1dc9ad9ee7edb953eada63/apps/api/src/utils/__tests__/file.test.ts#L138-L146)) 

   <a href="#"><img alt="P2" src="https://greptile-static-assets.s3.amazonaws.com/badges/p2.svg?v=7" align="top"></a> **PPT 否定テストケースの欠如**

   PPTX には「エントリが存在しない場合に拒否する」テストがありますが、PPT（OLE2）には対応するテストがありません。`PowerPoint Document` ストリームを含まない OLE2 ファイルが正しく `false` を返すことを検証するテストを追加することを推奨します。

   例:
   ```typescript
   it("rejects legacy PowerPoint files that do not contain the document marker", async () => {
       const ppt = createFile(
           "slides.ppt",
           "application/vnd.ms-powerpoint",
           createMinimalOle2("SomeOtherStream"),
       );
       await expect(validateMagicNumbers(ppt, "application/vnd.ms-powerpoint")).resolves.toBe(false);
   });
   ```

   <details><summary>Prompt To Fix With AI</summary>

   `````markdown
   This is a comment left during a code review.
   Path: apps/api/src/utils/__tests__/file.test.ts
   Line: 138-146

   Comment:
   **PPT 否定テストケースの欠如**

   PPTX には「エントリが存在しない場合に拒否する」テストがありますが、PPT（OLE2）には対応するテストがありません。`PowerPoint Document` ストリームを含まない OLE2 ファイルが正しく `false` を返すことを検証するテストを追加することを推奨します。

   例:
   ```typescript
   it("rejects legacy PowerPoint files that do not contain the document marker", async () => {
       const ppt = createFile(
           "slides.ppt",
           "application/vnd.ms-powerpoint",
           createMinimalOle2("SomeOtherStream"),
       );
       await expect(validateMagicNumbers(ppt, "application/vnd.ms-powerpoint")).resolves.toBe(false);
   });
   ```

   How can I resolve this? If you propose a fix, please make it concise.
   `````
   </details>

</details>

<!-- /greptile_failed_comments -->

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
This is a comment left during a code review.
Path: apps/api/src/utils/file.ts
Line: 64

Comment:
**`startsWith` による誤検知の可能性**

`fileName.startsWith(searchFilename)` の条件は、`ppt/presentation.xml_backup` や `ppt/presentation.xmlFOO` のようなエントリ名でも `true` を返してしまいます。実際の PPTX ファイルには正確に `ppt/presentation.xml` という名前のエントリが存在するため、完全一致 `===` だけで十分です。`startsWith` を残しておくと、本来は無効な ZIP ファイルがバリデーションを通過してしまう恐れがあります。

```suggestion
        if (fileName === searchFilename) {
```

How can I resolve this? If you propose a fix, please make it concise.

---

This is a comment left during a code review.
Path: apps/api/src/utils/file.ts
Line: 100

Comment:
**OLE2 セクターオフセット計算式のバグ（非512バイトセクター時）**

`(fatSectorIdx + 1) * sectorSize` という式は、`sectorSize = 512` のときのみ正しい値になります。OLE2 仕様（MS-CFB）でのセクター N の絶対オフセットは `512 + N * sectorSize` です。これら2式が一致するのは `sectorSize == 512` の場合だけです。

たとえば `sectorShift = 12`（4096バイトセクター）の場合:
- 正しい計算: セクター0 → `512 + 0 * 4096 = 512`
- 現在の計算: セクター0 → `(0 + 1) * 4096 = 4096`（**誤り**）

同様の問題が `dirOffset` 計算（118行目）にも存在します。

```suggestion
        const fatSectorOffset = 512 + fatSectorIdx * sectorSize;
```

How can I resolve this? If you propose a fix, please make it concise.

---

This is a comment left during a code review.
Path: apps/api/src/utils/file.ts
Line: 118

Comment:
**dirOffset の計算式も同様のバグ**

100行目と同じ問題です。`sectorSize = 512` 以外では誤ったオフセットを参照します。

```suggestion
        const dirOffset = 512 + dirSector * sectorSize;
```

How can I resolve this? If you propose a fix, please make it concise.

---

This is a comment left during a code review.
Path: apps/api/src/utils/file.ts
Line: 5

Comment:
**実装済みの TODO コメントが残存**

このPRでまさに実装された機能についての TODO コメントです。削除してください。

```suggestion

```

How can I resolve this? If you propose a fix, please make it concise.

---

This is a comment left during a code review.
Path: apps/api/src/utils/__tests__/file.test.ts
Line: 108

Comment:
**インデント崩れ**

変更された3つの `it` ブロック（108行目、123行目、138行目）に余分なインデント（4スペース）が入っています。他のテストブロック（88行目、98行目、148行目）と統一してください。

```suggestion
    it("accepts PPTX files only when the presentation entry exists", async () => {
```

How can I resolve this? If you propose a fix, please make it concise.

---

This is a comment left during a code review.
Path: apps/api/src/utils/__tests__/file.test.ts
Line: 138-146

Comment:
**PPT 否定テストケースの欠如**

PPTX には「エントリが存在しない場合に拒否する」テストがありますが、PPT（OLE2）には対応するテストがありません。`PowerPoint Document` ストリームを含まない OLE2 ファイルが正しく `false` を返すことを検証するテストを追加することを推奨します。

例:
```typescript
it("rejects legacy PowerPoint files that do not contain the document marker", async () => {
    const ppt = createFile(
        "slides.ppt",
        "application/vnd.ms-powerpoint",
        createMinimalOle2("SomeOtherStream"),
    );
    await expect(validateMagicNumbers(ppt, "application/vnd.ms-powerpoint")).resolves.toBe(false);
});
```

How can I resolve this? If you propose a fix, please make it concise.
`````

</details>

<sub>Reviews (1): Last reviewed commit: ["feat(api): implement robust ole2 and zip..."](https://github.com/hiroki-org/openshelf/commit/fedc1f0d828991237f1dc9ad9ee7edb953eada63) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=26666776)</sub>

> Greptile also left **4 inline comments** on this PR.

<!-- /greptile_comment -->