### PR TITLE
🧪 [test] add test for orgs POST unique constraint race condition

### DIFF
--- a/apps/api/src/routes/__tests__/orgs.test.ts
+++ b/apps/api/src/routes/__tests__/orgs.test.ts
@@ -40,10 +40,12 @@ describe("orgs routes", () => {
 
             mockDb.insert = vi.fn()
                 .mockImplementationOnce(() => ({
-                    values: vi.fn().mockRejectedValue(new Error("UNIQUE constraint failed: orgs.slug")),
+                    values: vi.fn(async () => {
+                        throw new Error("UNIQUE constraint failed: orgs.slug");
+                    })
                 }))
                 .mockImplementation(() => ({
-                    values: vi.fn(async () => undefined),
+                    values: vi.fn(async () => undefined)
                 }));
 
             const app = await createTestApp();


### PR DESCRIPTION
🎯 **What:** The testing gap addressed was missing coverage for the race condition when creating an organization, specifically when two requests simultaneously attempt to claim the same slug resulting in a UNIQUE constraint violation from the database.

📊 **Coverage:** A test case has been added in `apps/api/src/routes/__tests__/orgs.test.ts` to mock the D1 `db.insert` function throwing a UNIQUE constraint violation error (`"UNIQUE constraint failed: orgs.slug"`).

✨ **Result:** The test successfully verifies that the API catches the error and responds correctly with a `409 Conflict` status code and the `{"error": "slug already in use"}` payload, improving code coverage for edge cases on this endpoint.

---
*PR created automatically by Jules for task [17692736200744204508](https://jules.google.com/task/17692736200744204508) started by @is0692vs*

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

組織作成時のスラグ重複レースコンディション（DB の UNIQUE 制約違反）に対するテストカバレッジを追加するPRです。既存の「アプリケーション層での重複チェック（select → 409）」とは異なり、チェック通過後に DB がエラーを投げるケースを検証しています。

- `apps/api/src/routes/__tests__/orgs.test.ts` に `\"returns 409 for UNIQUE constraint violation race condition\"` テストを追加
- `mockDb.select` を `null` 返却（スラグ未使用を偽装）、`mockDb.insert` を UNIQUE 制約エラーでスローするようにモック
- `orgs.ts` の `POST /api/orgs` ハンドラが持つ `catch` ブロック（レースコンディション対策）のコードパスを正しくカバーしている
- 軽微な点として、`insert` モックがすべての挿入呼び出しを失敗させる汎用的な設定になっているが、今回はルート内の最初のインサートで例外が投げられるため実用上は問題なし
</details>

<h3>Confidence Score: 5/5</h3>

テスト追加のみのPRであり、プロダクションコードへの変更はなし。安全にマージ可能。

追加されたテストは論理的に正確で、既存のモックパターンとも一致しており、意図したコードパス（レースコンディション時の catch ブロック）を正しくカバーしている。P1以上の問題は存在しない。

特に注意が必要なファイルはありません。

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| apps/api/src/routes/__tests__/orgs.test.ts | POSTエンドポイントのUNIQUE制約違反（スラグのレースコンディション）を検証する新しいテストケースを追加。テストロジックは正確で既存のモックパターンとも一致している。 |

</details>

</details>

<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant Test as テストケース
    participant App as POST /api/orgs
    participant DB as mockDb

    Test->>App: POST /api/orgs (slug: "race-lab")
    App->>DB: select (slug存在チェック)
    DB-->>App: null (スラグ未使用)
    App->>DB: insert(orgs).values(...)
    DB-->>App: throw Error("UNIQUE constraint failed: orgs.slug")
    Note over App: catch ブロックで UNIQUE を検知
    App-->>Test: 409 {"error": "slug already in use"}
    Note over DB: insert(orgMembers) は到達しない
```

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
This is a comment left during a code review.
Path: apps/api/src/routes/__tests__/orgs.test.ts
Line: 41-45

Comment:
**`insert` モックがすべての挿入を無差別に失敗させる**

現在のモックは `db.insert(orgs)` と `db.insert(orgMembers)` の両方を同じエラーでスローします。今回のテストではルートコードの最初のインサート（`orgs`）が例外を投げた時点で `orgMembers` への挿入には到達しないため、テスト結果は正しいです。

ただし、将来的にルートのロジックが変わった場合（例：try ブロックの前に別の `insert` が追加された場合など）、意図しない挿入が失敗してしまうリスクがあります。より正確にするなら、最初の呼び出しのみ失敗させ、2回目は成功させる形にすると堅牢になります。

```suggestion
            mockDb.insert = vi.fn()
                .mockImplementationOnce(() => ({
                    values: vi.fn(async () => {
                        throw new Error("UNIQUE constraint failed: orgs.slug");
                    })
                }))
                .mockImplementation(() => ({
                    values: vi.fn(async () => undefined),
                }));
```

How can I resolve this? If you propose a fix, please make it concise.
`````

</details>

<sub>Reviews (1): Last reviewed commit: ["test: add test for UNIQUE constraint vio..."](https://github.com/hiroki-org/openshelf/commit/d3520e12eefeb7cd71c446caaa8f555cab1b259a) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=26668534)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->