### PR TITLE
🧪 Add test for invalid JSON in POST /api/orgs

### DIFF
--- a/apps/api/src/routes/__tests__/orgs.test.ts
+++ b/apps/api/src/routes/__tests__/orgs.test.ts
@@ -135,6 +135,29 @@ describe("orgs routes", () => {
 
             expect(res.status).toBe(400);
         });
+
+        it("returns 400 for invalid JSON bodies", async () => {
+            const token = await createTestJWT({ sub: "user-1", githubId: "123", name: "Tester" });
+
+            const app = await createTestApp();
+            const env = createTestEnv();
+
+            const res = await app.request(
+                "http://localhost/api/orgs",
+                {
+                    method: "POST",
+                    headers: {
+                        Authorization: `Bearer ${token}`,
+                        "Content-Type": "application/json",
+                    },
+                    body: "{",
+                },
+                env as any,
+            );
+
+            expect(res.status).toBe(400);
+            await expect(res.json()).resolves.toEqual({ error: "Invalid JSON body" });
+        });
     });
 
     // ─── GET /api/orgs/:slug ──────────────────────────────────


### PR DESCRIPTION
🎯 **What:** The testing gap addressed
Added a missing test case in `POST /api/orgs` to verify the error handling when an invalid JSON payload is sent to the endpoint.

📊 **Coverage:** What scenarios are now tested
- The scenario where the request body contains a malformed JSON string (e.g., `"{""`). The endpoint should correctly return a `400 Bad Request` with the error message `"Invalid JSON body"`.

✨ **Result:** The improvement in test coverage
This increases API robustness by ensuring the JSON parsing error catch block in the `POST /api/orgs` route is fully verified, guarding against regressions.

---
*PR created automatically by Jules for task [12046890148991268090](https://jules.google.com/task/12046890148991268090) started by @is0692vs*

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

このPRは `POST /api/orgs` エンドポイントへ不正な JSON ボディを送信した際のエラーハンドリングを検証するテストケースを追加します。既存のルート実装（`orgs.ts` 84〜90行目）には `c.req.json()` 呼び出しを try/catch で囲んで `{ error: "Invalid JSON body" }` を 400 で返す処理がありましたが、このパスに対するテストが欠落していました。

- ステータスコード `400` とレスポンスボディ `{ error: "Invalid JSON body" }` の両方を検証しており、カバレッジが充実している
- `PATCH /api/orgs/:slug` の既存の不正 JSON テスト（243〜268行目）と同じスタイルで一貫性がある
- `authMiddleware` は JWT のみで検証を行い DB アクセスがないため、テスト内で `mockDb` の追加セットアップが不要な点も正しく判断されている
- 不正 JSON として `"{"` を使用しており、JSON パースエラーを確実に発生させる最小限かつ明確なボディである
</details>

<h3>Confidence Score: 5/5</h3>

テスト追加のみのシンプルな変更であり、マージに問題はない

変更は 1 ファイルの純粋なテスト追加のみ。実装ロジックに触れておらず、新テストは既存パターンと整合し正しく動作する。P1 以上の問題なし。

特になし

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| apps/api/src/routes/__tests__/orgs.test.ts | `POST /api/orgs` に不正な JSON ボディを送った場合の 400 エラー処理を検証するテストケースを追加。実装パターンは既存の同様テスト（PATCH の不正 JSON テストなど）と整合している。 |

</details>

</details>

<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant T as テスト
    participant A as POST /api/orgs
    participant Auth as authMiddleware
    participant JSON as JSON パーサー

    T->>A: POST /api/orgs<br/>body: "{"
    A->>Auth: JWT 検証
    Auth-->>A: OK (DB アクセスなし)
    A->>JSON: c.req.json() を試みる
    JSON-->>A: SyntaxError をスロー
    A-->>T: 400 { error: "Invalid JSON body" }
```

<sub>Reviews (1): Last reviewed commit: ["test(api): add test for invalid JSON bod..."](https://github.com/hiroki-org/openshelf/commit/ad39540c7b7cb6df78dee6929ae5901c26515f85) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=26668598)</sub>

<!-- /greptile_comment -->