### PR TITLE
🧹 Implement deeper structural file inspection for PPT/PPTX

### DIFF
--- a/apps/api/src/utils/__tests__/file.test.ts
+++ b/apps/api/src/utils/__tests__/file.test.ts
@@ -136,18 +136,17 @@ describe("validateMagicNumbers", () => {
     ).resolves.toBe(true);
   });
 
-  it("rejects legacy PPT files that do not contain the PowerPoint Document stream", async () => {
+  it("rejects legacy PowerPoint files when the PowerPoint Document stream is missing", async () => {
     const ppt = createFile(
       "slides.ppt",
       "application/vnd.ms-powerpoint",
-      createOleWithStream("Word Document"),
+      createOleWithStream("WordDocument"), // Different stream name
     );
 
     await expect(
       validateMagicNumbers(ppt, "application/vnd.ms-powerpoint"),
     ).resolves.toBe(false);
   });
-
 
   it("rejects files with unknown signatures", async () => {
     const file = createFile(

--- a/apps/api/src/utils/file.ts
+++ b/apps/api/src/utils/file.ts
@@ -17,15 +17,10 @@ const MAGIC_NUMBER_MAP: ReadonlyArray<[string, string]> = [
   ["504B0304", "application/zip"],
 ];
 
-const MAX_ZIP_EOCD_SEARCH_WINDOW = 65535 + 22;
-const MAX_ZIP_CENTRAL_DIRECTORY_SIZE = 8 * 1024 * 1024;
-const MIN_OLE_SECTOR_SHIFT = 9;
-const MAX_OLE_SECTOR_SHIFT = 12;
-
-
 // Helper function to check for a specific entry in a ZIP file (Central Directory parsing)
 async function hasZipEntry(file: File, entryName: string): Promise<boolean> {
-  const CHUNK_SIZE = MAX_ZIP_EOCD_SEARCH_WINDOW; // max EOCD comment (65535) + EOCD header (22)
+  const MAX_ZIP_EOCD_SEARCH_WINDOW = 65535 + 22;
+  const CHUNK_SIZE = MAX_ZIP_EOCD_SEARCH_WINDOW;
   const fileSize = file.size;
   const searchEnd = Math.max(0, fileSize - CHUNK_SIZE);
 
@@ -46,8 +41,9 @@ async function hasZipEntry(file: File, entryName: string): Promise<boolean> {
   if (eocdOffset === -1) return false;
 
   // Read Central Directory offset and size
-  const requestedCdSize = view.getUint32(eocdOffset + 12, true);
-  const cdSize = Math.min(requestedCdSize, MAX_ZIP_CENTRAL_DIRECTORY_SIZE);
+  let cdSize = view.getUint32(eocdOffset + 12, true);
+  const MAX_ZIP_CENTRAL_DIRECTORY_SIZE = 10 * 1024 * 1024;
+  cdSize = Math.min(cdSize, MAX_ZIP_CENTRAL_DIRECTORY_SIZE);
   const cdOffset = view.getUint32(eocdOffset + 16, true);
 
   if (cdOffset >= fileSize || cdOffset + cdSize > fileSize) return false;
@@ -99,14 +95,17 @@ async function hasOleStream(file: File, streamName: string): Promise<boolean> {
   }
 
   const sectorShift = headerView.getUint16(30, true);
-  if (sectorShift < MIN_OLE_SECTOR_SHIFT || sectorShift > MAX_OLE_SECTOR_SHIFT) return false;
+  const MIN_OLE_SECTOR_SHIFT = 9;
+  const MAX_OLE_SECTOR_SHIFT = 12;
+  if (sectorShift < MIN_OLE_SECTOR_SHIFT || sectorShift > MAX_OLE_SECTOR_SHIFT)
+    return false;
   const sectorSize = 2 ** sectorShift; // usually 512 or 4096
   const firstDirSector = headerView.getUint32(48, true);
 
   // Simple traversal: assume directory is contiguous or search within first few directory sectors
   // To avoid complex FAT parsing, we just read the first few directory sectors.
   // Each directory sector has (sectorSize / 128) entries.
-  const dirOffset = 512 + firstDirSector * sectorSize;
+  const dirOffset = (firstDirSector + 1) * sectorSize;
   if (dirOffset >= file.size) return false;
 
   // Read up to 4 directory sectors (usually enough for simple PPT files)


### PR DESCRIPTION
🎯 **What:** Replaced the simplistic byte-sequence string search for `ppt/presentation.xml` and `PowerPoint Document` with proper (minimal) structural parsers for ZIP (PPTX) and OLE2 (PPT) file formats.

💡 **Why:** The previous naive byte searching could yield false positives if those exact string bytes appeared randomly in other files, and was inefficient because it blindly chunk-read the entire file. The new approach correctly parses the End of Central Directory (EOCD) for ZIPs to find the specific files, and reads the OLE2 Header and Directory Sector to find the correct streams, massively improving accuracy and performance (especially by skipping directly to relevant offsets) while remaining self-contained within standard Web APIs like `DataView`.

✅ **Verification:** 
1. `npm run test -- apps/api/src/utils/__tests__/file.test.ts`
2. Tests were updated to create minimal valid binary mock structures (instead of just prepending magic numbers to flat strings) to prove the parsers actually work.
3. Code review feedback implemented to ensure `Math.floor` prevents `RangeError` crashes on truncated files.
4. Clean patch verified with no temporary files left in the repo.

✨ **Result:** A far more accurate and professional method for deeply inspecting MS Office binary formats.

---
*PR created automatically by Jules for task [5593825105644636655](https://jules.google.com/task/5593825105644636655) started by @is0692vs*

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

このPRは、PPTX（ZIP形式）とPPT（OLE2形式）のファイル検証を、単純なバイト列検索から適切な構造パーサーに置き換えることで、精度とパフォーマンスを大幅に向上させます。

- **PPTX**: End of Central Directory (EOCD) を正しく解析して Central Directory を特定し、`ppt/presentation.xml` エントリの存在を確認するようになりました
- **PPT**: OLE2 ヘッダー → セクターサイズ → ディレクトリセクターを辿り、UTF-16LE でエンコードされた `PowerPoint Document` ストリーム名を照合するようになりました
- テストも最小限の有効なバイナリ構造を生成するヘルパー関数に刷新され、パーサーの実動作を正しく検証できるようになっています
- `CHUNK_SIZE = 65536` が ZIP 仕様上の最大 EOCD 探索ウィンドウ（65557 バイト）より 1 バイト小さいため、コメントが 65514 バイトを超える ZIP では EOCD が見つからず正当な PPTX が誤拒否される可能性があります（実用上はほぼ起こらない）
- `1 << sectorShift` は JavaScript の 32 ビット符号付き整数演算により `sectorShift ≥ 31` で負値になる可能性があります（実際の挙動は `false` 返却でセーフ）
- PPT の拒否ケースに対するテストが欠落しています
</details>

<h3>Confidence Score: 5/5</h3>

全ての指摘事項は P2（スタイル・将来の堅牢性）であり、現時点でのランタイムエラーや誤動作は発生しないため、マージは安全です。

P0/P1 の問題はなし。CHUNK_SIZE の 1 バイト不足と `1 << sectorShift` の符号問題はいずれも現実のファイルでは影響しない理論上の境界ケースであり、PPT 拒否テストの欠落も機能的な正確性には影響しません。

特に注意が必要なファイルはありません。`file.ts` の 2 点の P2 指摘は品質向上の観点からの提案です。

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| apps/api/src/utils/file.ts | PPTX 用の ZIP Central Directory パーサーと PPT 用の OLE2 ディレクトリパーサーを実装。全体的に正確だが、EOCD 検索ウィンドウが ZIP 仕様の最大コメントサイズ (65535 B) に対し 1 バイト不足、および `1 << sectorShift` の符号付き 32bit 整数問題あり（いずれも実用上は問題になりにくい P2）。 |
| apps/api/src/utils/__tests__/file.test.ts | 最小限の有効なバイナリ構造を生成するヘルパー関数を追加し、テストを大幅に改善。PPT の拒否ケース（"PowerPoint Document" ストリームなし）のテストが欠落。 |

</details>

</details>

<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[validateMagicNumbers] --> B[先頭8バイト読み取り]
    B --> C{マジックナンバー一致?}
    C -- No --> D[false]
    C -- Yes --> E{MIME互換性チェック}
    E -- No --> D
    E -- Yes --> F{MIME種別}
    F -- PPTX --> G[hasZipEntry]
    F -- PPT --> H[hasOleStream]
    F -- PDF/PNG/JPEG --> I[true]
    G --> G1[末尾64KBを読み取り]
    G1 --> G2{EOCDシグネチャ検索}
    G2 -- 見つからない --> D
    G2 -- 見つかった --> G3[CDオフセット・サイズ取得]
    G3 --> G4[Central Directory読み取り]
    G4 --> G5{ppt/presentation.xmlエントリが存在?}
    G5 -- Yes --> I
    G5 -- No --> D
    H --> H1[先頭512バイト読み取り]
    H1 --> H2{OLE2マジック確認}
    H2 -- 不一致 --> D
    H2 -- 一致 --> H3[sectorSize・firstDirSector取得]
    H3 --> H4[ディレクトリセクター読み取り]
    H4 --> H5{PowerPoint DocumentストリームがUTF-16LEで一致?}
    H5 -- Yes --> I
    H5 -- No --> D
```

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
This is a comment left during a code review.
Path: apps/api/src/utils/file.ts
Line: 22

Comment:
**CHUNK_SIZE が 1 バイト足りない可能性**

ZIP 仕様では EOCD の後ろにコメントを最大 65535 バイト付加できます。そのため EOCD の先頭位置は、ファイル末尾から最大 `22 + 65535 = 65557` バイト手前になり得ます。現在の `CHUNK_SIZE = 65536` では **65514 バイト以上のコメントを持つ ZIP** の場合に EOCD がバッファ外となり、正当な PPTX が誤って拒否されます。

現実の PowerPoint ファイルで発生することはほぼありませんが、仕様上の正確性のため修正を推奨します。

```suggestion
  const CHUNK_SIZE = 65536 + 22; // EOCD search window: max comment (65535) + EOCD header (22)
```

How can I resolve this? If you propose a fix, please make it concise.

---

This is a comment left during a code review.
Path: apps/api/src/utils/file.ts
Line: 95

Comment:
**ビット演算による符号付き 32bit 整数オーバーフロー**

JavaScript の `<<` 演算子はオペランドを 32 ビット符号付き整数に変換します。悪意ある OLE2 ファイルが `sectorShift = 31` を持つ場合、`1 << 31 = -2147483648`（負数）となり、`dirOffset` も負数になります。`-2147483648 >= file.size` は `false` なので境界チェックを通過し、以降の `file.slice()` は負の引数を受け取ります（`File.prototype.slice` では負値はファイル末尾からのオフセットとして解釈されます）。

実際には `numEntries = 0` となり `false` を返すため悪用はできませんが、`2 **` 演算子を使うことで意図が明確になり、符号付き整数の問題も回避できます。

```suggestion
  const sectorSize = 2 ** sectorShift; // usually 512 (sectorShift=9) or 4096 (sectorShift=12)
```

How can I resolve this? If you propose a fix, please make it concise.

---

This is a comment left during a code review.
Path: apps/api/src/utils/__tests__/file.test.ts
Line: 127-137

Comment:
**PPT の拒否ケースに対するテストが欠落**

PPTX テストには「受け入れ」と「拒否」の両ケースがありますが、PPT (OLE2) のテストは受け入れケースのみです。`"PowerPoint Document"` ストリームを持たない OLE2 ファイル（例: `"Word Document"` ストリームを持つファイル）が正しく拒否されることを検証するテストを追加することを推奨します。

```ts
it("rejects legacy PPT files that do not contain the PowerPoint Document stream", async () => {
  const ppt = createFile(
    "slides.ppt",
    "application/vnd.ms-powerpoint",
    createOleWithStream("Word Document"),
  );

  await expect(
    validateMagicNumbers(ppt, "application/vnd.ms-powerpoint"),
  ).resolves.toBe(false);
});
```

How can I resolve this? If you propose a fix, please make it concise.
`````

</details>

<sub>Reviews (1): Last reviewed commit: ["refactor(api): implement deeper file ins..."](https://github.com/hiroki-org/openshelf/commit/3ad52d83ecbf5ac2dbbf997363b1d4a4cc171768) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=26668621)</sub>

> Greptile also left **3 inline comments** on this PR.

<!-- /greptile_comment -->