### PR TITLE
🧹 [code health] Refactor unsafe `any` types in orgs API request bodies

### DIFF
--- a/apps/api/src/routes/orgs.ts
+++ b/apps/api/src/routes/orgs.ts
@@ -23,9 +23,6 @@ interface OrgBody {
     description?: unknown;
 }
 
-type CreateOrgBody = OrgBody;
-type UpdateOrgBody = OrgBody;
-
 interface AddMemberBody {
     userId?: unknown;
     role?: unknown;
@@ -41,6 +38,21 @@ interface AssociatePaperBody {
 
 
 // ─── Validation helpers ─────────────────────────────────────────
+
+function parseMemberRole(role: unknown): "admin" | "member" | null {
+    if (role === undefined || role === null) return "member";
+    if (typeof role === "string" && (role === "admin" || role === "member")) {
+        return role;
+    }
+    return null;
+}
+
+function parseRequiredMemberRole(role: unknown): "admin" | "member" | null {
+    if (typeof role === "string" && (role === "admin" || role === "member")) {
+        return role;
+    }
+    return null;
+}
 const SLUG_RE = /^[a-z0-9][a-z0-9-]*[a-z0-9]$|^[a-z0-9]$/;
 
 function validateSlug(slug: unknown): string | null {
@@ -63,17 +75,6 @@ function validateDescription(description: unknown): string | null {
     if (typeof description !== "string") return "description must be a string";
     if (description.trim().length > 500) return "description must be 500 characters or less";
     return null;
-}
-
-function parseMemberRole(rawRole: unknown): "admin" | "member" | null {
-    if (rawRole === undefined || rawRole === null) return "member";
-    if (typeof rawRole !== "string") return null;
-    return rawRole === "admin" || rawRole === "member" ? rawRole : null;
-}
-
-function parseRequiredMemberRole(rawRole: unknown): "admin" | "member" | null {
-    if (typeof rawRole !== "string") return null;
-    return rawRole === "admin" || rawRole === "member" ? rawRole : null;
 }
 
 // ─── Permission helpers ─────────────────────────────────────────
@@ -117,7 +118,7 @@ async function isPaperAuthor(db: ReturnType<typeof drizzle>, paperId: string, us
 
 // POST /api/orgs — create org
 orgsRoute.post("/", authMiddleware, async (c) => {
-    let body: CreateOrgBody;
+    let body: OrgBody;
     try {
         body = await c.req.json();
     } catch {
@@ -206,7 +207,7 @@ orgsRoute.patch("/:slug", authMiddleware, async (c) => {
     const adminCheck = await requireOrgAdmin(db, org.id, userId);
     if (!adminCheck.ok) return c.json({ error: adminCheck.error }, 403);
 
-    let body: UpdateOrgBody;
+    let body: OrgBody;
     try {
         body = await c.req.json();
     } catch {


### PR DESCRIPTION
🎯 **What:** The code health issue addressed
Removed unsafe `any` typing for request bodies (`let body: any`) and replaced it with dedicated interfaces (`CreateOrgBody`, `UpdateOrgBody`, etc.) where properties are explicitly typed as `unknown` to enforce type narrowing and validation logic before assignment. Also properly typed `Record<string, unknown>` and `JwtPayload` usage.

💡 **Why:** How this improves maintainability
Using `any` inherently defeats TypeScript's static analysis, making it easier to slip through silent errors or assume properties exist when they don't. By typing payloads with explicit interfaces using `unknown`, we ensure developers handle untrusted external input defensively via explicit casting and validations.

✅ **Verification:** How you confirmed the change is safe
Ran `npm run typecheck`, `npm run lint`, and unit tests within the `apps/api` workspace (`npm run test -w apps/api`) successfully without regressions. Note that `e2e` tests had pre-existing environment teardowns related to db connection that were ignored, as unit tests were fully isolated and passed correctly.

✨ **Result:** The improvement achieved
A fully type-safe `apps/api/src/routes/orgs.ts` request processing layer.

---
*PR created automatically by Jules for task [6979562157640414327](https://jules.google.com/task/6979562157640414327) started by @is0692vs*

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

このPRは `apps/api/src/routes/orgs.ts` における `any` 型を一掃し、リクエストボディに専用インターフェース（`CreateOrgBody` など）を導入することでコード品質を向上させます。変更は局所的で既存の動作を変えず、既存のバリデーションロジックとの整合性も保たれています。

**主な変更点:**
- `let body: any` → 5 つの専用インターフェース (`CreateOrgBody`, `UpdateOrgBody`, `AddMemberBody`, `ChangeRoleBody`, `AssociatePaperBody`) に置き換え。各フィールドを `unknown` で定義し、バリデーション前の型ナローイングを強制
- `Record<string, any>` → `Record<string, unknown>` に変更
- JWT ペイロードの `as any` キャストを既存の `JwtPayload` 型で置き換え
- `body?.role` の扱いで `typeof` ガードなしの型アサーション (`as \"admin\" | \"member\" | undefined`) が使われており、ランタイム検証は後続の `includes()` チェックに依存している（動作に問題はないが意図が不明確）
- `CreateOrgBody` と `UpdateOrgBody` が完全に同一の定義となっており、重複している
</details>

<h3>Confidence Score: 5/5</h3>

軽微なスタイル改善点はあるがマージ可能。既存の動作は変わらない。

P0/P1 の問題はなし。指摘は型アサーションの書き方の改善提案と重複インターフェースの統合提案のみ（P2）。実際のランタイム動作は変わらず、型チェックもパスしている。

apps/api/src/routes/orgs.ts の `role` バリデーション付近（line 314, 365）

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| apps/api/src/routes/orgs.ts | `any` 型から専用インターフェース (`unknown` フィールド) への置き換え、`Record<string, unknown>` への変更、JWT ペイロードへの `JwtPayload` 型適用。型アサーション (`as "admin" | "member" | undefined`) が実行時ガードなしに使われている点と、`CreateOrgBody`/`UpdateOrgBody` が重複している点が改善余地。 |

</details>

</details>

<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[リクエスト受信] --> B[c.req.json\n型: CreateOrgBody / UpdateOrgBody\n/ AddMemberBody など]
    B --> C{JSON パース成功?}
    C -- No --> D[400 Invalid JSON body]
    C -- Yes --> E[フィールドごとのバリデーション\nvalidateSlug / validateName\n/ validateDescription]
    E --> F{バリデーション通過?}
    F -- No --> G[400 エラーレスポンス]
    F -- Yes --> H[型アサーション\n例: body.slug as string]
    H --> I[DB 操作\ndrizzle ORM]
    I --> J[201 / 200 レスポンス]

    style B fill:#d4edda,stroke:#28a745
    style D fill:#f8d7da,stroke:#dc3545
    style G fill:#f8d7da,stroke:#dc3545
    style H fill:#fff3cd,stroke:#ffc107
```

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
This is a comment left during a code review.
Path: apps/api/src/routes/orgs.ts
Line: 314-316

Comment:
**`role` の型アサーションは実行時の検証を伴わない**

`body?.role as "admin" | "member" | undefined` は TypeScript にコンパイラを信頼させるだけで、ランタイムでは何も検証しません。`body.role` が例えば数値 `1` だった場合、アサーション後も `1` のままであり、`?? "member"` が適用されないため（`1` は nullish でないため）、`includes(role)` が `false` を返してエラーになるだけです。

現状はこの後の `!["admin", "member"].includes(role)` でランタイム検証が行われているため実害はありませんが、アサーションが型安全性の向上という目的に反しています。`typeof` ガードを用いた方が意図が明確になります。

```suggestion
    const rawRole = body?.role;
    const role = (rawRole === undefined || rawRole === null) ? "member" : rawRole;
    if (!role || typeof role !== "string" || !["admin", "member"].includes(role)) {
```

同様のパターンが `PATCH /:slug/members/:userId` (line 365) にも存在します。

How can I resolve this? If you propose a fix, please make it concise.

---

This is a comment left during a code review.
Path: apps/api/src/routes/orgs.ts
Line: 365-367

Comment:
**`newRole` の型アサーションが `unknown` を検証せずにキャストしている**

`body?.role as "admin" | "member" | undefined` はランタイムで何も検証せず、TypeScript の型チェッカーを欺くだけです。`body.role` が `unknown` である以上、`typeof` によるナローイングを先に行ってから判定する方が意図が明確です。

```suggestion
    const newRole = typeof body?.role === "string" ? body.role as "admin" | "member" | undefined : undefined;
    if (!newRole || !["admin", "member"].includes(newRole)) {
```

How can I resolve this? If you propose a fix, please make it concise.

---

This is a comment left during a code review.
Path: apps/api/src/routes/orgs.ts
Line: 20-30

Comment:
**`CreateOrgBody` と `UpdateOrgBody` が完全に同一**

2 つのインターフェースのメンバーが一致しています。現時点では Create と Update で許可フィールドが同じですが、将来的に一方だけ変更する際に同期漏れが生じるリスクがあります。共通の基底型を定義してどちらかが継承するか、一方の型エイリアスにすることを検討してください。

```suggestion
interface OrgBody {
    slug?: unknown;
    name?: unknown;
    description?: unknown;
}

type CreateOrgBody = OrgBody;
type UpdateOrgBody = OrgBody;
```

How can I resolve this? If you propose a fix, please make it concise.
`````

</details>

<sub>Reviews (1): Last reviewed commit: ["refactor(api): remove unsafe \`any\` types..."](https://github.com/hiroki-org/openshelf/commit/23157e7a2c4a03d2ae080bf31b18586fae195a9f) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=26668900)</sub>

> Greptile also left **3 inline comments** on this PR.

<!-- /greptile_comment -->