### PR TITLE
🧪 test: add test coverage for tag parsing logic

### DIFF
--- a/apps/api/src/utils/__tests__/tags.test.ts
+++ b/apps/api/src/utils/__tests__/tags.test.ts
@@ -3,61 +3,61 @@ import { parseStoredTags } from "../tags";
 
 describe("parseStoredTags", () => {
     it("returns an empty array for null input", () => {
-      expect(parseStoredTags(null)).toEqual([]);
+        expect(parseStoredTags(null)).toEqual([]);
     });
 
     it("returns an empty array for an empty string", () => {
-      expect(parseStoredTags("")).toEqual([]);
-    });
-
-    it("parses a valid JSON array of strings", () => {
-      expect(parseStoredTags('["tag1", "tag2", "tag3"]')).toEqual([
-        "tag1",
-        "tag2",
-        "tag3",
-      ]);
-    });
-
-    it("trims whitespace from tags", () => {
-      expect(parseStoredTags('[" tag1 ", "tag2  ", "  tag3"]')).toEqual([
-        "tag1",
-        "tag2",
-        "tag3",
-      ]);
-    });
-
-    it("filters out empty tags after trimming", () => {
-      expect(parseStoredTags('["tag1", "", "  ", "tag2"]')).toEqual([
-        "tag1",
-        "tag2",
-      ]);
-    });
-
-    it("filters out non-string items", () => {
-      expect(parseStoredTags('["tag1", 42, null, {}, "tag2"]')).toEqual([
-        "tag1",
-        "tag2",
-      ]);
-    });
-
-    it("returns an empty array if the parsed JSON is a plain object", () => {
-      expect(parseStoredTags('{"tag": "value"}')).toEqual([]);
-    });
-
-    it("returns an empty array if the parsed JSON is a string", () => {
-      expect(parseStoredTags('"just a string"')).toEqual([]);
-    });
-
-    it("returns an empty array if the parsed JSON is a number", () => {
-      expect(parseStoredTags("42")).toEqual([]);
-    });
-
-    it("returns an empty array and catches errors for invalid JSON", () => {
-      expect(parseStoredTags("invalid-json")).toEqual([]);
-      expect(parseStoredTags('["unclosed", "array"')).toEqual([]);
+        expect(parseStoredTags("")).toEqual([]);
     });
 
     it("returns an empty array for an empty JSON array", () => {
-      expect(parseStoredTags("[]")).toEqual([]);
+        expect(parseStoredTags("[]")).toEqual([]);
+    });
+
+    it("parses a valid JSON array of strings", () => {
+        expect(parseStoredTags('["tag1", "tag2", "tag3"]')).toEqual([
+            "tag1",
+            "tag2",
+            "tag3",
+        ]);
+    });
+
+    it("trims whitespace from tags", () => {
+        expect(parseStoredTags('[" tag1 ", "tag2  ", "  tag3"]')).toEqual([
+            "tag1",
+            "tag2",
+            "tag3",
+        ]);
+    });
+
+    it("filters out empty tags after trimming", () => {
+        expect(parseStoredTags('["tag1", "", "  ", "tag2"]')).toEqual([
+            "tag1",
+            "tag2",
+        ]);
+    });
+
+    it("filters out non-string items", () => {
+        expect(parseStoredTags('["tag1", 42, null, {}, "tag2"]')).toEqual([
+            "tag1",
+            "tag2",
+        ]);
+    });
+
+    it("returns an empty array if the parsed JSON is an object", () => {
+        expect(parseStoredTags('{"tag": "value"}')).toEqual([]);
+    });
+
+    it("returns an empty array if the parsed JSON is a string", () => {
+        expect(parseStoredTags('"just a string"')).toEqual([]);
+    });
+
+    it("returns an empty array if the parsed JSON is a number", () => {
+        expect(parseStoredTags("42")).toEqual([]);
+    });
+
+    it("returns an empty array and catches errors for invalid JSON", () => {
+        expect(parseStoredTags("invalid-json")).toEqual([]);
+        expect(parseStoredTags('["unclosed", "array"')).toEqual([]);
     });
 });

--- a/package-lock.json
+++ b/package-lock.json
@@ -10828,6 +10828,7 @@
       "version": "2.3.2",
       "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
       "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
+      "dev": true,
       "hasInstallScript": true,
       "license": "MIT",
       "optional": true,


### PR DESCRIPTION
🎯 **What:** Added tests for the `parseStoredTags` function in `apps/api/src/utils/tags.ts` to test tag parsing and its `try/catch` block handling `JSON.parse` errors.

📊 **Coverage:** Covered following scenarios:
*   Null or empty strings (return empty array).
*   Valid JSON array of strings (return parsed strings, trimmed).
*   Valid JSON array of strings with empty strings or spaces (filter out empty strings after trimming).
*   Valid JSON array containing non-strings (filter out non-strings).
*   Valid JSON object or string (not an array - return empty array).
*   Invalid JSON (trigger the catch block - return empty array).

✨ **Result:** Improved test coverage and reliability for metadata parsing logic in the API workspace.

---
*PR created automatically by Jules for task [12552816604811663943](https://jules.google.com/task/12552816604811663943) started by @is0692vs*

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

このPRは `apps/api/src/utils/tags.ts` の `parseStoredTags` 関数に対するテストカバレッジを追加するものです。null・空文字・有効なJSON配列・無効なJSON・配列以外のJSONなど主要なシナリオを網羅しており、品質向上として好ましい変更です。

**主な変更点と気になる点:**

- `apps/api/src/utils/__tests__/tags.test.ts`（新規）: `parseStoredTags` の8つのテストケースを追加。カバレッジは全体的に十分。
- `package-lock.json`: `fsevents` から `"dev": true` フラグが削除されており、テスト追加とは無関係な変更が混在している点が懸念される。
- 新規テストファイルのインデント（2スペース）が既存の `__tests__/` ファイル（4スペース）と一致していない。
- 1つのテストブロックに複数のアサーションが混在しており、障害発生時の原因特定がやや困難。
- `parseStoredTags("[]")` のエッジケースが未テスト。
</details>

<h3>Confidence Score: 5/5</h3>

マージは安全です。残っている指摘はすべてP2（スタイル・カバレッジの改善提案）であり、ブロッカーはありません。

テスト自体のロジックは正確で、実装の全主要パスをカバーしています。`package-lock.json` の変更は `optional: true` のため実害はなく、インデントや複数アサーションの問題もスタイル上の改善提案に留まります。

`package-lock.json` の `fsevents` の `dev` フラグ削除が意図的かどうか確認してください。

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| apps/api/src/utils/__tests__/tags.test.ts | 新規テストファイル。parseStoredTags の主要パスを網羅しており品質は高いが、インデントが既存ファイルと不一致（2スペース vs 4スペース） |
| package-lock.json | fsevents から "dev": true が削除されており、テスト追加とは無関係な意図しない変更の可能性あり |

</details>

</details>

<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A([parseStoredTags 呼び出し]) --> B{rawTags が null
または空文字?}
    B -- Yes --> C([空配列を返す])
    B -- No --> D[JSON.parse 実行]
    D --> E{パース成功?}
    E -- No: 例外 --> F([空配列を返す catch])
    E -- Yes --> G{Array.isArray?}
    G -- No --> H([空配列を返す])
    G -- Yes --> I[string のみフィルタ]
    I --> J[各要素を trim]
    J --> K[空文字を除外]
    K --> L([フィルタ済み配列を返す])
```

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
This is a comment left during a code review.
Path: package-lock.json
Line: 10828-10833

Comment:
**`fsevents` の `"dev": true` が意図せず削除されています**

`package-lock.json` から `fsevents` の `"dev": true` フラグが削除されています。これはテストの追加とは無関係な変更であり、`fsevents`（macOS のファイル監視ネイティブモジュール）が開発依存ではなく本番依存として扱われることを意味します。

`vitest` などの devDependency のインストール時に `npm install` の実行方法が変わり、ロックファイルが再生成された可能性があります。`fsevents` は `"optional": true` のため本番ビルドが壊れることはありませんが、この変更は意図的なものでしょうか？

本来 devDependency のみに紐づくはずのモジュールが本番扱いになるため、確認をお勧めします。

How can I resolve this? If you propose a fix, please make it concise.

---

This is a comment left during a code review.
Path: apps/api/src/utils/__tests__/tags.test.ts
Line: 1-3

Comment:
**インデントがリポジトリの規約と異なります**

このファイルはスペース2つのインデントを使用していますが、同じ `__tests__/` ディレクトリ内の既存ファイル（`citation.test.ts`、`file.test.ts`）はスペース4つのインデントを使用しています。コードベース全体で一貫したスタイルを保つため、4スペースインデントに統一することをお勧めします。

How can I resolve this? If you propose a fix, please make it concise.

---

This is a comment left during a code review.
Path: apps/api/src/utils/__tests__/tags.test.ts
Line: 43-47

Comment:
**1つのテストブロックに複数のアサーション**

「JSONが配列でない場合」のテストにオブジェクト・文字列・数値の3パターンが混在しています。1つが失敗したときに原因の特定が難しくなるため、それぞれ独立した `it` ブロックに分割するとより可読性が高まります。

```suggestion
  it("returns an empty array if the parsed JSON is a plain object", () => {
    expect(parseStoredTags('{"tag": "value"}')).toEqual([]);
  });

  it("returns an empty array if the parsed JSON is a string", () => {
    expect(parseStoredTags('"just a string"')).toEqual([]);
  });

  it("returns an empty array if the parsed JSON is a number", () => {
    expect(parseStoredTags("42")).toEqual([]);
  });
```

How can I resolve this? If you propose a fix, please make it concise.

---

This is a comment left during a code review.
Path: apps/api/src/utils/__tests__/tags.test.ts
Line: 49-52

Comment:
**空配列 `"[]"` の入力ケースが未テスト**

`parseStoredTags("[]")` は空の JSON 配列を受け取り `[]` を返す想定ですが、そのケースがテストされていません。エッジケースとして追加することでカバレッジが向上します。

```suggestion
  it("returns an empty array and catches errors for invalid JSON", () => {
    expect(parseStoredTags("invalid-json")).toEqual([]);
    expect(parseStoredTags('["unclosed", "array"')).toEqual([]);
  });

  it("returns an empty array for an empty JSON array", () => {
    expect(parseStoredTags("[]")).toEqual([]);
  });
```

How can I resolve this? If you propose a fix, please make it concise.
`````

</details>

<sub>Reviews (1): Last reviewed commit: ["test(api): add tests for tag parsing and..."](https://github.com/hiroki-org/openshelf/commit/7cdfccaa059f0e90c4c814b0526b7ee6fc5d130c) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=27376543)</sub>

> Greptile also left **4 inline comments** on this PR.

<!-- /greptile_comment -->