### PR TITLE
🧪 test: add coverage for parseStoredTags utility

### DIFF
--- a/apps/api/src/utils/__tests__/tags.test.ts
+++ b/apps/api/src/utils/__tests__/tags.test.ts
@@ -1,0 +1,39 @@
+import { describe, it, expect } from "vitest";
+import { parseStoredTags } from "../tags";
+
+describe("parseStoredTags", () => {
+    it("returns an empty array for null input", () => {
+        expect(parseStoredTags(null)).toEqual([]);
+    });
+
+    it("returns an empty array for empty string input", () => {
+        expect(parseStoredTags("")).toEqual([]);
+    });
+
+    it("parses a valid JSON array of strings", () => {
+        expect(parseStoredTags('["tag1", "tag2"]')).toEqual(["tag1", "tag2"]);
+    });
+
+    it("filters out non-string elements", () => {
+        expect(parseStoredTags('["tag1", 123, "tag2", null, {}, []]')).toEqual(["tag1", "tag2"]);
+    });
+
+    it("trims whitespace from strings", () => {
+        expect(parseStoredTags('["  tag1  ", "tag2", "\\t tag3 \\n"]')).toEqual(["tag1", "tag2", "tag3"]);
+    });
+
+    it("filters out empty strings or strings that become empty after trimming", () => {
+        expect(parseStoredTags('["tag1", "", "  ", "tag2"]')).toEqual(["tag1", "tag2"]);
+    });
+
+    it("returns an empty array for valid JSON that is not an array", () => {
+        expect(parseStoredTags('{"tag": "value"}')).toEqual([]);
+        expect(parseStoredTags('"just a string"')).toEqual([]);
+        expect(parseStoredTags('123')).toEqual([]);
+    });
+
+    it("returns an empty array for invalid JSON (catches the error)", () => {
+        expect(parseStoredTags('invalid json')).toEqual([]);
+        expect(parseStoredTags('["unclosed string')).toEqual([]);
+    });
+});


### PR DESCRIPTION
🎯 **What:** Added tests for the `parseStoredTags` function in `apps/api/src/utils/tags.ts` to cover the tag parsing logic and its JSON `try/catch` block.
📊 **Coverage:** The new test file (`apps/api/src/utils/__tests__/tags.test.ts`) covers 100% of statements and branches. It tests null inputs, empty strings, valid JSON string arrays, mixed type arrays, whitespace trimming, empty string filtering, valid non-array JSON objects, and malformed invalid JSON that triggers the catch block.
✨ **Result:** Increased test coverage and confidence in the tag parsing utility's resilience to bad inputs.

---
*PR created automatically by Jules for task [17862465612812719727](https://jules.google.com/task/17862465612812719727) started by @is0692vs*

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

このPRは `apps/api/src/utils/tags.ts` の `parseStoredTags` 関数に対するテストファイル（`apps/api/src/utils/__tests__/tags.test.ts`）を追加するものです。null入力・空文字・正常なJSON配列・混在型配列・空白トリミング・非配列JSON・不正なJSONなど、関数の全ブランチを網羅しており、カバレッジ100%を達成しています。

- 実装の全ブランチ（`!rawTags` ガード・`!Array.isArray` チェック・`catch` ブロック）をテストでカバーしている
- Vitest の `describe`/`it`/`expect` を正しくインポートし、対象モジュールのインポートパスも正確
- 軽微な点として、`returns an empty array for valid JSON that is not an array` のテストケースが1つの `it` ブロックに複数の `expect` をまとめているが、機能的な問題はない
</details>

<h3>Confidence Score: 5/5</h3>

テストのみの変更であり、プロダクションコードへの影響はなく、マージしても安全です。

変更はテストファイルの追加のみで、実装コードへの影響はありません。テストは正確に実装の全ブランチをカバーしており、P1/P0の問題は見つかりませんでした。

特に注目が必要なファイルはありません。

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| apps/api/src/utils/__tests__/tags.test.ts | parseStoredTags の全ブランチを網羅する新規テストファイル。ロジックに問題なし。 |

</details>

</details>

<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[parseStoredTags 呼び出し] --> B{rawTags が falsy?}
    B -- はい --> C[空配列を返す]
    B -- いいえ --> D[JSON.parse を試みる]
    D -- 失敗 catch --> C
    D -- 成功 --> E{Array.isArray?}
    E -- いいえ --> C
    E -- はい --> F[string のみフィルタ]
    F --> G[各要素を trim]
    G --> H[空文字列をフィルタ]
    H --> I[文字列配列を返す]
```

<sub>Reviews (1): Last reviewed commit: ["test: add coverage for parseStoredTags u..."](https://github.com/hiroki-org/openshelf/commit/2d5e5e1ca8aa467efb83253afb954b4f8064fcb3) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=27376573)</sub>

<!-- /greptile_comment -->