### PR TITLE
🧪 Add tests for MarkdownRenderer component

### DIFF
--- a/apps/web/src/components/__tests__/markdown-renderer.test.tsx
+++ b/apps/web/src/components/__tests__/markdown-renderer.test.tsx
@@ -1,6 +1,11 @@
-import { render, screen } from "@testing-library/react";
-import { describe, it, expect } from "vitest";
+import { render, screen, cleanup } from "@testing-library/react";
+import { describe, it, expect, afterEach } from "vitest";
 import { MarkdownRenderer } from "../markdown-renderer";
+
+
+afterEach(() => {
+  cleanup();
+});
 
 describe("MarkdownRenderer", () => {
   it("renders plain text correctly", () => {
@@ -12,7 +17,7 @@ describe("MarkdownRenderer", () => {
     const { container } = render(
       <MarkdownRenderer markdown="Text" className="custom-class" />
     );
-    expect(container.firstChild).toHaveClass("custom-class");
+    expect(container.firstElementChild).toHaveClass("custom-class");
   });
 
   it("renders headers correctly", () => {
@@ -56,6 +61,8 @@ describe("MarkdownRenderer", () => {
     expect(pre).toHaveClass("overflow-x-auto rounded-md bg-gray-950 p-3 text-sm text-gray-100");
     const code = container.querySelector("code");
     expect(code).toBeInTheDocument();
+    expect(code).toHaveClass("language-javascript");
+    expect(container.querySelector("span[class^=\"hljs\"], span[class*=\" hljs\"]")).toBeInTheDocument();
   });
 
   it("supports GitHub Flavored Markdown (tables)", () => {
@@ -88,6 +95,7 @@ describe("MarkdownRenderer", () => {
 <script>alert('xss')</script>
 <iframe src="javascript:alert('xss')"></iframe>
 [Safe link](javascript:alert('xss'))
+<a href="javascript:alert('xss')">Unsafe anchor</a>
     `;
     const { container } = render(<MarkdownRenderer markdown={unsafeMarkdown} />);
 
@@ -102,5 +110,11 @@ describe("MarkdownRenderer", () => {
     // unsafe link should have href removed or sanitized to empty string or #
     const link = screen.queryByRole("link", { name: "Safe link" });
     expect(link).toBeNull();
+
+    const unsafeAnchorText = screen.queryByText("Unsafe anchor");
+    if (unsafeAnchorText) {
+      const anchor = unsafeAnchorText.closest("a");
+      expect(anchor).not.toHaveAttribute("href");
+    }
   });
 });


### PR DESCRIPTION
🎯 **What:** The `MarkdownRenderer` component in the `apps/web` workspace previously lacked test coverage. This PR introduces a test file for the component to improve testing reliability and coverage.

📊 **Coverage:** The new test suite covers:
- Plain markdown rendering
- Application of `className` prop
- Proper rendering of headers
- Custom component overrides for `a` tags (checking `target="_blank"` and `rel="noopener noreferrer"`)
- Custom component overrides for `img` tags (checking lazy loading attributes)
- Inline and block code rendering
- GitHub Flavored Markdown (tables support)
- HTML sanitization (stripping unsafe `script` tags, `iframe` embeds, and `javascript:` protocol links to prevent XSS)

✨ **Result:** The `MarkdownRenderer` component is now fully tested, preventing potential regressions in markdown rendering, custom styles, and HTML security (sanitization). All tests are passing successfully.

---
*PR created automatically by Jules for task [3571802183508350307](https://jules.google.com/task/3571802183508350307) started by @is0692vs*

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

`MarkdownRenderer` コンポーネントに対するテストスイートを新規追加するPRです。プレーンテキスト・ヘッダー・カスタムアンカー・画像・インラインコード・コードブロック・GFMテーブル・HTMLサニタイズ（XSS対策）など、主要なレンダリング動作を8つのテストケースで網羅しており、コンポーネントのリグレッション防止に貢献します。

主な変更点と所見：
- `script` タグ、`iframe`、`javascript:` プロトコルリンクに対するXSSサニタイズ検証を含む
- サニタイズテストのアサーション（`queryByRole("link")` が `null` であること）は、ARIA ロールセマンティクスに依存した間接的な検証であり、より直接的な `href` 属性チェックを追加することで堅牢性が向上する
- 既存のテストファイル（`header.test.tsx` 等）が持つ `afterEach(cleanup)` パターンが欠落しており、一貫性の観点から追加を推奨

</details>

<h3>Confidence Score: 5/5</h3>

テストのみの変更であり、プロダクションコードへの影響はなく、マージは安全です

新規テストファイルの追加のみで、指摘事項はすべてP2（スタイル・堅牢性の改善提案）です。テストカバレッジは適切であり、機能的・セキュリティ上の問題はありません。P2のみのためスコアは5/5とします

特に注意が必要なファイルはありませんが、`markdown-renderer.test.tsx` のサニタイズテストの堅牢性向上を推奨します

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| apps/web/src/components/__tests__/markdown-renderer.test.tsx | MarkdownRendererコンポーネントのテストファイルを新規追加。8つのテストケースで主要機能を網羅しているが、サニタイズテストのアサーションとafterEachの欠落に軽微な改善余地あり |

</details>

</details>

<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant Test as テストコード
    participant MR as MarkdownRenderer
    participant RM as react-markdown
    participant RG as remarkGfm
    participant RH as rehypeHighlight
    participant RS as rehypeSanitize
    participant DOM as DOM出力

    Test->>MR: markdown文字列を渡す
    MR->>RM: remarkPlugins=[remarkGfm]<br/>rehypePlugins=[rehypeHighlight, rehypeSanitize]
    RM->>RG: Markdownをパース（GFMサポート）
    RG-->>RM: ASTを返す
    RM->>RH: ハイライト処理
    RH-->>RM: ハイライト済みAST
    RM->>RS: サニタイズ処理（javascript:等を除去）
    RS-->>RM: 安全なAST
    RM->>MR: カスタムコンポーネント（a, img, code, pre, table等）でレンダリング
    MR->>DOM: HTMLを出力
    DOM-->>Test: アサーション実行
```

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
This is a comment left during a code review.
Path: apps/web/src/components/__tests__/markdown-renderer.test.tsx
Line: 83-105

Comment:
**サニタイズテストのアサーションが間接的**

`queryByRole("link", { name: "Safe link" })` が `null` を返すのは、`rehype-sanitize` が `javascript:` の `href` 属性を削除したことで `<a>` 要素の ARIA ロールが `link` から `generic` に変わるためです。これは「偶然正しい」アサーションであり、サニタイズ機構が実際に `href` を取り除いたかどうかを**直接**検証していません。

将来的に `href="#"` などのフォールバック値が設定された場合、リンクが再び `link` ロールになるため `queryByRole` がヒットし、このアサーションは失敗します（これは望ましい）。一方で、`href` が別の安全でない形式で残った場合は検出できない恐れがあります。

より明示的な検証として、以下の追加を検討してください：

```tsx
// unsafe link should have href removed or sanitized
const link = screen.queryByRole("link", { name: "Safe link" });
expect(link).toBeNull();

// href属性が実際に取り除かれていることを直接確認する
const anchor = screen.queryByText("Safe link");
if (anchor) {
  expect(anchor.closest("a")).not.toHaveAttribute("href");
}
```

How can I resolve this? If you propose a fix, please make it concise.

---

This is a comment left during a code review.
Path: apps/web/src/components/__tests__/markdown-renderer.test.tsx
Line: 1-3

Comment:
**`afterEach(cleanup)` が欠落**

既存のテストファイル（例：`header.test.tsx`、`toast.test.tsx` 等）では、各テスト後に明示的に `cleanup()` を呼び出すパターンが採用されています：

```tsx
afterEach(() => {
  cleanup();
});
```

このファイルには同様の `afterEach` がありません。`@testing-library/react` のオートクリーンアップ機能により実害は生じませんが、コードベース全体の一貫性を保つために追加することを推奨します。

```suggestion
import { render, screen, cleanup } from "@testing-library/react";
import { describe, it, expect, afterEach } from "vitest";
import { MarkdownRenderer } from "../markdown-renderer";
```

How can I resolve this? If you propose a fix, please make it concise.
`````

</details>

<sub>Reviews (1): Last reviewed commit: ["test(web): add tests for MarkdownRendere..."](https://github.com/hiroki-org/openshelf/commit/6708854f918118c69220a033ba8a2cf21436ce74) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=27376574)</sub>

> Greptile also left **2 inline comments** on this PR.

<!-- /greptile_comment -->