### PR TITLE
🧹 [Code Health] Remove deprecated snake_case backward compatibility field

### DIFF
--- a/apps/api/src/routes/__tests__/papers.test.ts
+++ b/apps/api/src/routes/__tests__/papers.test.ts
@@ -977,7 +977,6 @@ describe("papers routes", () => {
         expect(body.id).toBe("paper-1");
         expect(body.description).toBe("## Updated");
         expect(body.descriptionUpdatedAt).toBe("2026-04-01T12:00:00.000Z");
-        expect(body.description_updated_at).toBe("2026-04-01T12:00:00.000Z");
     });
 
     it("PUT /api/papers/:id/description rejects non-author", async () => {

--- a/apps/api/src/routes/papers.ts
+++ b/apps/api/src/routes/papers.ts
@@ -1374,8 +1374,6 @@ papersRoute.put("/:id/description", authMiddleware, async (c) => {
         id: updatedPaper.id,
         description: updatedPaper.description,
         descriptionUpdatedAt: normalizedDescriptionUpdatedAt,
-        // Backward compatibility for existing clients expecting snake_case.
-        description_updated_at: normalizedDescriptionUpdatedAt,
     });
 });
 


### PR DESCRIPTION
### 🎯 **What:** The code health issue addressed
Removed the `description_updated_at` backward compatibility field and its corresponding explanatory comment from the `apps/api/src/routes/papers.ts` file. Also removed the corresponding test assertion from `apps/api/src/routes/__tests__/papers.test.ts`.

### 💡 **Why:** How this improves maintainability
The codebase has moved to standard `camelCase` response payloads (like `descriptionUpdatedAt`). Removing this deprecated field cleans up the response object, avoids dead code, and reduces mental overhead for future developers navigating the API route logic. It enforces a single source of truth for the payload's structure.

### ✅ **Verification:** How you confirmed the change is safe
- Used `npm run test --workspaces --if-present` to verify the test suite passes successfully.
- Tests in `apps/api` and `apps/web` passed correctly, indicating no regression or broken dependencies. (Note: `e2e` failing locally is expected due to the local server environment).

### ✨ **Result:** The improvement achieved
A cleaner API payload that accurately reflects the codebase's conventions, without the tech debt of maintaining stale client backward compatibility logic.

---
*PR created automatically by Jules for task [6665081687148056512](https://jules.google.com/task/6665081687148056512) started by @is0692vs*

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

このPRは `PUT /api/papers/:id/description` エンドポイントのレスポンスペイロードから、非推奨の snake_case 後方互換フィールド `description_updated_at` を削除するコードクリーンアップです。

**主な変更内容:**
- `apps/api/src/routes/papers.ts`: レスポンスオブジェクトから `description_updated_at` フィールドおよびその説明コメント（後方互換のための snake_case 対応）を削除
- `apps/api/src/routes/__tests__/papers.test.ts`: 削除されたフィールドに対応する `expect(body.description_updated_at)...` アサーションを1行削除
- `apps/web` 側は既に `descriptionUpdatedAt`（camelCase）のみを参照しており、リポジトリ内に `description_updated_at` への API レスポンス依存は残っていないことを確認済み
- DBスキーマ・マイグレーションファイル内の `description_updated_at` はカラム名として残っているが、これはAPIレスポンスとは無関係で影響なし

**問題点:** 特になし。変更は最小限かつ安全で、コードの一貫性が向上します。
</details>

<h3>Confidence Score: 5/5</h3>

マージ安全。変更は最小限で、既存クライアントへの影響もなく、テストも整合している。

変更が2行の削除のみであり、webフロントエンドは既に camelCase フィールドのみを使用しておりP1以上の問題は存在しない。

特になし

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| apps/api/src/routes/papers.ts | PUT /:id/description レスポンスから非推奨の snake_case フィールド `description_updated_at` を削除 |
| apps/api/src/routes/__tests__/papers.test.ts | `description_updated_at` テストアサーションを削除し、新しいレスポンス構造と整合 |

</details>

</details>

<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant Client
    participant API as PUT /api/papers/:id/description
    participant DB

    Client->>API: PUT リクエスト (description)
    API->>DB: UPDATE papers SET description, descriptionUpdatedAt
    DB-->>API: updatedPaper
    API-->>Client: { id, description, descriptionUpdatedAt } ✅
    Note over Client,API: description_updated_at (snake_case) は削除済み
```

<sub>Reviews (1): Last reviewed commit: ["🧹 Remove deprecated \`description\_update..."](https://github.com/hiroki-org/openshelf/commit/6d7a830e890c14cff5d8e032cb2d034706d7410c) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=27376608)</sub>

<!-- /greptile_comment -->