### PR TITLE
fix: follow-up to address PR #295 review comments

### DIFF
--- a/apps/api/src/routes/__tests__/auth.test.ts
+++ b/apps/api/src/routes/__tests__/auth.test.ts
@@ -105,10 +105,13 @@ describe("auth routes", () => {
         process.env.NODE_ENV = originalNodeEnv;
     });
 
-    it("GET /api/auth/github persists state in D1 and redirects with client_id", async () => {
+    it("GET /api/auth/github uses request Origin over frontend_origin query when both are present", async () => {
         const app = await createTestApp();
         const oauthStateDb = createOAuthStateDb();
-        const env = createTestEnv({ DB: oauthStateDb.db as any });
+        const env = createTestEnv({
+            DB: oauthStateDb.db as any,
+            ALLOWED_ORIGINS: "https://frontend.example.com,https://staging.example.com",
+        });
 
         const res = await app.request(
             "http://localhost/api/auth/github?frontend_origin=https%3A%2F%2Ffrontend.example.com",
@@ -131,9 +134,28 @@ describe("auth routes", () => {
         expect(state ? oauthStateDb.states.has(state) : false).toBe(true);
         const setCookie = res.headers.get("set-cookie") ?? "";
         expect(setCookie).toContain("oauth_flow_nonce=");
-        expect(setCookie).toContain("oauth_flow_origin=");
+        expect(setCookie).toContain("oauth_flow_origin=https%3A%2F%2Ffrontend.example.com");
         expect(setCookie).toContain("HttpOnly");
         expect(state ? oauthStateDb.states.get(state)?.browserNonce : null).toBeTruthy();
+    });
+
+    it("GET /api/auth/github falls back to query origin when request Origin is missing", async () => {
+        const app = await createTestApp();
+        const oauthStateDb = createOAuthStateDb();
+        const env = createTestEnv({
+            DB: oauthStateDb.db as any,
+            ALLOWED_ORIGINS: "https://frontend.example.com,http://localhost:3000",
+        });
+
+        const res = await app.request(
+            "http://localhost/api/auth/github?frontend_origin=http%3A%2F%2Flocalhost%3A3000",
+            {},
+            env as any,
+        );
+
+        expect(res.status).toBe(302);
+        const setCookie = res.headers.get("set-cookie") ?? "";
+        expect(setCookie).toContain("oauth_flow_origin=http%3A%2F%2Flocalhost%3A3000");
     });
 
     it("GET /api/auth/github/callback returns 400 when state does not exist in D1", async () => {
@@ -329,7 +351,11 @@ describe("auth routes", () => {
         );
 
         const app = await createTestApp();
-        const env = createTestEnv({ DB: oauthStateDb.db as any });
+        const env = createTestEnv({
+            DB: oauthStateDb.db as any,
+            FRONTEND_URL: "https://frontend.example.com",
+            ALLOWED_ORIGINS: "https://frontend.example.com,https://staging.example.com",
+        });
 
         const res = await app.request(
             "http://localhost/api/auth/github/callback?code=code123&state=good-state",
@@ -344,6 +370,61 @@ describe("auth routes", () => {
         expect(res.status).toBe(302);
         const location = res.headers.get("location") ?? "";
         expect(location).toContain("https://staging.example.com/auth/callback#token=");
+    });
+
+    it("GET /api/auth/github/callback falls back to FRONTEND_URL when oauth_flow_origin is not allowlisted", async () => {
+        mockDb.select = vi
+            .fn()
+            .mockImplementationOnce(() => makeQuery({ getResult: { id: "user-1" } }));
+
+        const nowState = new Date().toISOString().replace("T", " " ).slice(0, 19);
+        const oauthStateDb = createOAuthStateDb({
+            "good-state": {
+                createdAt: nowState,
+                browserNonce: "good-nonce",
+            },
+        });
+
+        vi.stubGlobal(
+            "fetch",
+            vi
+                .fn()
+                .mockResolvedValueOnce({
+                    ok: true,
+                    json: async () => ({ access_token: "gh-token" }),
+                })
+                .mockResolvedValueOnce({
+                    ok: true,
+                    json: async () => ({
+                        id: 123,
+                        login: "octocat",
+                        name: "Octo Cat",
+                        avatar_url: "http://avatar",
+                        email: "octo@example.com",
+                    }),
+                }),
+        );
+
+        const app = await createTestApp();
+        const env = createTestEnv({
+            DB: oauthStateDb.db as any,
+            FRONTEND_URL: "https://frontend.example.com",
+            ALLOWED_ORIGINS: "https://frontend.example.com",
+        });
+
+        const res = await app.request(
+            "http://localhost/api/auth/github/callback?code=code123&state=good-state",
+            {
+                headers: {
+                    Cookie: "oauth_flow_nonce=good-nonce; oauth_flow_origin=https://attacker.example.com",
+                },
+            },
+            env as any,
+        );
+
+        expect(res.status).toBe(302);
+        const location = res.headers.get("location") ?? "";
+        expect(location).toContain("https://frontend.example.com/auth/callback#token=");
     });
 
     it("GET /api/auth/github/callback returns 502 when OAuth token exchange fails", async () => {

--- a/apps/api/src/routes/auth.ts
+++ b/apps/api/src/routes/auth.ts
@@ -19,10 +19,10 @@ const OAUTH_FLOW_ORIGIN_COOKIE = "oauth_flow_origin";
 auth.get("/github", async (c) => {
     const state = crypto.randomUUID();
     const flowNonce = crypto.randomUUID();
-    const requestOrigin = c.req.query("frontend_origin");
-    const requestReferer = c.req.header("Origin") ?? c.req.header("Referer");
+    const requestedFrontendOrigin = c.req.query("frontend_origin");
+    const requestSignalOrigin = c.req.header("Origin") ?? c.req.header("Referer");
     const frontendOrigin = resolveAllowedOrigin(
-        [requestOrigin, requestReferer],
+        [requestSignalOrigin, requestedFrontendOrigin],
         c.env.FRONTEND_URL,
         parseOriginList(c.env.ALLOWED_ORIGINS),
     );
@@ -235,7 +235,11 @@ auth.get("/github/callback", async (c) => {
         "HS256",
     );
 
-    const frontendUrl = flowOrigin ?? c.env.FRONTEND_URL;
+    const frontendUrl = resolveAllowedOrigin(
+        [flowOrigin],
+        c.env.FRONTEND_URL,
+        parseOriginList(c.env.ALLOWED_ORIGINS),
+    );
     if (!frontendUrl) {
         console.error("FATAL: FRONTEND_URL environment variable is not set.");
         return c.json({ error: "Server configuration error" }, 500);

--- a/apps/api/src/utils/__tests__/origin.test.ts
+++ b/apps/api/src/utils/__tests__/origin.test.ts
@@ -17,4 +17,24 @@ describe("origin utils", () => {
         expect(isAllowedOrigin(origin, frontendOrigin, ["*"], { allowWildcard: false })).toBe(false);
         expect(isAllowedOrigin(origin, frontendOrigin, ["*"], { allowWildcard: true })).toBe(true);
     });
+
+    it("rejects wildcard subdomain patterns for CSRF checks", () => {
+        const origin = normalizeOrigin("https://app.example.com")!;
+        const frontendOrigin = normalizeOrigin("https://frontend.example.com")!;
+
+        expect(isAllowedOrigin(origin, frontendOrigin, ["https://*.example.com"], { allowWildcard: false })).toBe(false);
+        expect(isAllowedOrigin(origin, frontendOrigin, ["https://*.example.com"], { allowWildcard: true })).toBe(true);
+    });
+
+    it("does not let wildcard cross host boundary", () => {
+        expect(
+            isAllowedOrigin(
+                "https://evil.com/?.example.com",
+                normalizeOrigin("https://frontend.example.com"),
+                ["https://*.example.com"],
+                { allowWildcard: true },
+            ),
+        ).toBe(false);
+    });
+
 });

--- a/apps/api/src/utils/origin.ts
+++ b/apps/api/src/utils/origin.ts
@@ -24,7 +24,9 @@ export function matchesOriginPattern(origin: string, pattern: string): boolean {
     if (pattern === "*") return true;
     if (!pattern.includes("*")) return origin === pattern;
 
-    const escapedPattern = pattern.replace(/[|\\{}()[\]^$+?.]/g, "\\$&").replace(/\*/g, ".*");
+    const escapedPattern = pattern
+        .replace(/[|\\{}()[\]^$+?.]/g, "\\$&")
+        .replace(/\*/g, "[a-zA-Z0-9-]+");
     return new RegExp(`^${escapedPattern}$`).test(origin);
 }
 
@@ -41,7 +43,7 @@ export function isAllowedOrigin(
     return (
         allowedOrigins.some((allowedOrigin) => {
             if (allowedOrigin.includes("*")) {
-                if (allowedOrigin === "*" && !allowWildcard) {
+                if (!allowWildcard) {
                     return false;
                 }
                 return matchesOriginPattern(origin, allowedOrigin);

--- a/apps/web/src/app/orgs/[slug]/__tests__/page-metadata.test.tsx
+++ b/apps/web/src/app/orgs/[slug]/__tests__/page-metadata.test.tsx
@@ -5,11 +5,13 @@ vi.mock("../org-page-client", () => ({
   default: ({ slug }: any) => <div>{`org:${slug}`}</div>,
 }));
 
-import OrgPage, { generateMetadata } from "../page";
-
 describe("orgs/[slug]/page metadata", () => {
+  const originalApiUrl = process.env.API_URL;
+  const originalPublicApiUrl = process.env.NEXT_PUBLIC_API_URL;
   afterEach(() => {
     cleanup();
+    process.env.API_URL = originalApiUrl;
+    process.env.NEXT_PUBLIC_API_URL = originalPublicApiUrl;
   });
 
   beforeEach(() => {
@@ -17,6 +19,11 @@ describe("orgs/[slug]/page metadata", () => {
   });
 
   it("builds org metadata and renders the client page", async () => {
+    process.env.API_URL = "http://internal-api:8787";
+    process.env.NEXT_PUBLIC_API_URL = "https://public-api.example.com";
+    vi.resetModules();
+
+    const { default: OrgPage, generateMetadata } = await import("../page");
     vi.spyOn(global, "fetch").mockResolvedValueOnce(
       new Response(
         JSON.stringify({
@@ -35,8 +42,8 @@ describe("orgs/[slug]/page metadata", () => {
     render(view);
 
     expect(metadata.title).toBe("Research Lab | OpenShelf");
-    expect(metadata.alternates?.types?.["application/atom+xml"]).toContain(
-      "/feed/orgs/lab/atom.xml",
+    expect(metadata.alternates?.types?.["application/atom+xml"]).toBe(
+      "https://public-api.example.com/feed/orgs/lab/atom.xml",
     );
     expect(screen.getByText("org:lab")).toBeInTheDocument();
   });

--- a/apps/web/src/app/orgs/[slug]/page.tsx
+++ b/apps/web/src/app/orgs/[slug]/page.tsx
@@ -17,6 +17,10 @@ const API_BASE =
   process.env.API_URL ??
   process.env.NEXT_PUBLIC_API_URL ??
   "http://localhost:8787";
+const PUBLIC_API_BASE =
+  process.env.NEXT_PUBLIC_API_URL ??
+  process.env.API_URL ??
+  "http://localhost:8787";
 const SITE_BASE =
   process.env.SITE_URL ??
   process.env.NEXT_PUBLIC_SITE_URL ??
@@ -80,7 +84,7 @@ export async function generateMetadata(props: {
     data.org.name,
     data.org.description ?? undefined,
   );
-  const feedUrl = `${API_BASE}/feed/orgs/${slug}/atom.xml`;
+  const feedUrl = `${PUBLIC_API_BASE}/feed/orgs/${slug}/atom.xml`;
 
   return {
     title,

--- a/apps/web/src/app/users/[id]/__tests__/page.test.tsx
+++ b/apps/web/src/app/users/[id]/__tests__/page.test.tsx
@@ -1,9 +1,10 @@
 import {
+  cleanup,
   render,
   screen,
   waitFor,
 } from "@testing-library/react";
-import { beforeEach, describe, expect, it, vi } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import UserPage from "../page";
 import { apiFetch } from "@/lib/api";
 
@@ -31,23 +32,28 @@ describe("UserPage", () => {
     authState = { user: { id: "user-1" } };
   });
 
-  it("renders the user profile and collections", async () => {
-    vi.mocked(apiFetch).mockImplementation(async (url) => {
-      if (url === "/api/users/user-1") {
-        return new Response(
-          JSON.stringify({
-            user: {
-              id: "user-1",
-              name: "Alice",
-              displayName: "Alice A.",
-              avatarUrl: null,
-              githubId: "alice",
-            },
-          }),
-          { status: 200 },
-        );
-      }
+  afterEach(() => {
+    cleanup();
+    vi.restoreAllMocks();
+  });
 
+  it("renders the user profile and collections", async () => {
+    vi.spyOn(global, "fetch").mockResolvedValueOnce(
+      new Response(
+        JSON.stringify({
+          user: {
+            id: "user-1",
+            name: "Alice",
+            displayName: "Alice A.",
+            avatarUrl: null,
+            githubId: "alice",
+          },
+        }),
+        { status: 200 },
+      ) as Response,
+    );
+
+    vi.mocked(apiFetch).mockImplementation(async (url) => {
       if (url === "/api/users/user-1/collections") {
         return new Response(
           JSON.stringify({
@@ -96,9 +102,36 @@ describe("UserPage", () => {
       throw new Error(`Unexpected request: ${String(url)}`);
     });
 
+    vi.spyOn(global, "fetch").mockResolvedValueOnce(
+      new Response(JSON.stringify({ user: null }), { status: 404 }) as Response,
+    );
+
     const view = await UserPage({ params: { id: "user-1" } });
     render(view);
 
     expect(await screen.findByText("ユーザーが見つかりません")).toBeInTheDocument();
+  });
+
+  it("shows generic profile error for non-404 profile responses", async () => {
+    vi.spyOn(global, "fetch").mockResolvedValueOnce(
+      new Response(JSON.stringify({ user: null }), { status: 500 }) as Response,
+    );
+
+    vi.mocked(apiFetch).mockImplementation(async (url) => {
+      if (url === "/api/users/user-1") {
+        return new Response("{}", { status: 500 });
+      }
+
+      if (url === "/api/users/user-1/collections") {
+        return new Response(JSON.stringify({ collections: [] }), { status: 200 });
+      }
+
+      throw new Error(`Unexpected request: ${String(url)}`);
+    });
+
+    const view = await UserPage({ params: { id: "user-1" } });
+    render(view);
+
+    expect(await screen.findByText("ユーザー情報の取得に失敗しました")).toBeInTheDocument();
   });
 });

--- a/apps/web/src/app/users/[id]/page.tsx
+++ b/apps/web/src/app/users/[id]/page.tsx
@@ -5,13 +5,16 @@ import { safePath } from "@/lib/sanitization";
 
 type Params = { id: string };
 
+type UserProfile = {
+  id: string;
+  name: string;
+  displayName: string | null;
+  avatarUrl: string | null;
+  githubId: string;
+};
+
 type UserResponse = {
-  user: {
-    id: string;
-    name: string;
-    displayName: string | null;
-    githubId: string;
-  };
+  user: UserProfile;
 };
 
 const API_FETCH_BASE =
@@ -79,9 +82,11 @@ export default async function UserPage(props: {
     return <div className="text-center py-16">無効な識別子です</div>;
   }
 
+  const data = await fetchUserMetadata(id);
+
   return (
     <Suspense fallback={<div className="text-center py-16">読み込み中...</div>}>
-      <UserPageClient id={id} />
+      <UserPageClient id={id} initialUser={data?.user ?? null} />
     </Suspense>
   );
 }

--- a/apps/web/src/app/users/[id]/user-page-client.tsx
+++ b/apps/web/src/app/users/[id]/user-page-client.tsx
@@ -24,11 +24,12 @@ type Collection = {
 
 type UserPageClientProps = {
   id: string;
+  initialUser?: UserProfile | null;
 };
 
-export default function UserPageClient({ id }: UserPageClientProps) {
+export default function UserPageClient({ id, initialUser = null }: UserPageClientProps) {
   const { user } = useAuth();
-  const [profile, setProfile] = useState<UserProfile | null>(null);
+  const [profile, setProfile] = useState<UserProfile | null>(initialUser);
   const [collections, setCollections] = useState<Collection[]>([]);
   const [error, setError] = useState("");
 
@@ -38,25 +39,34 @@ export default function UserPageClient({ id }: UserPageClientProps) {
   useEffect(() => {
     let cancelled = false;
     setError("");
-    setProfile(null);
+    setProfile(initialUser);
     setCollections([]);
 
     (async () => {
       try {
+        const profileResPromise = initialUser
+          ? Promise.resolve(null)
+          : apiFetch(`/api/users/${encodeURIComponent(id)}`);
         const [profileRes, collectionsRes] = await Promise.all([
-          apiFetch(`/api/users/${encodeURIComponent(id)}`),
+          profileResPromise,
           apiFetch(`/api/users/${encodeURIComponent(id)}/collections`),
         ]);
         if (cancelled) return;
 
-        if (!profileRes.ok) {
-          setError("ユーザーが見つかりません");
-          return;
-        }
+        if (!initialUser) {
+          if (!profileRes || !profileRes.ok) {
+            setError(
+              profileRes?.status === 404
+                ? "ユーザーが見つかりません"
+                : "ユーザー情報の取得に失敗しました",
+            );
+            return;
+          }
 
-        const profileData = await profileRes.json();
-        if (cancelled) return;
-        setProfile(profileData.user);
+          const profileData = await profileRes.json();
+          if (cancelled) return;
+          setProfile(profileData.user);
+        }
 
         if (collectionsRes.ok) {
           const collectionsData = await collectionsRes.json();
@@ -72,7 +82,7 @@ export default function UserPageClient({ id }: UserPageClientProps) {
     return () => {
       cancelled = true;
     };
-  }, [id]);
+  }, [id, initialUser]);
 
   if (error)
     return <div className="text-center py-16 text-red-600">{error}</div>;

--- a/apps/web/src/components/__tests__/feed-button.test.tsx
+++ b/apps/web/src/components/__tests__/feed-button.test.tsx
@@ -30,7 +30,7 @@ describe("FeedButton", () => {
   it("copies the feed URL to the clipboard", async () => {
     render(<FeedButton url="https://api.example/feed.xml" />);
 
-    fireEvent.click(screen.getByRole("button", { name: "📡 RSS" }));
+    fireEvent.click(screen.getByRole("button", { name: "📡 Feed" }));
 
     await waitFor(() => {
       expect(navigator.clipboard.writeText).toHaveBeenCalledWith(
@@ -44,7 +44,7 @@ describe("FeedButton", () => {
     vi.stubGlobal("navigator", {});
 
     render(<FeedButton url="https://api.example/feed.xml" />);
-    fireEvent.click(screen.getByRole("button", { name: "📡 RSS" }));
+    fireEvent.click(screen.getByRole("button", { name: "📡 Feed" }));
 
     await waitFor(() => {
       expect(toastError).toHaveBeenCalledWith(

--- a/apps/web/src/components/feed-button.tsx
+++ b/apps/web/src/components/feed-button.tsx
@@ -11,7 +11,7 @@ type FeedButtonProps = {
 export function FeedButton({
   url,
   className = "rounded-md border border-gray-300 px-3 py-1.5 text-sm hover:bg-gray-50 dark:border-gray-700 dark:hover:bg-gray-800",
-  label = "📡 RSS",
+  label = "📡 Feed",
 }: FeedButtonProps) {
   const handleCopy = async () => {
     if (!navigator.clipboard?.writeText) {


### PR DESCRIPTION
This PR contains minimal follow-up fixes prepared while addressing unresolved review threads on #295.

Includes:
- origin wildcard hardening and CSRF wildcard blocking
- OAuth origin precedence/fallback hardening
- metadata/feed URL public-base fix for org page
- user page duplicate profile fetch reduction + non-404 error UX
- Feed button default label update
- targeted tests for the above

Created because direct push to protected staging is blocked by repository rules.

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

PR #295 のレビューコメントに対するフォローアップ修正です。OAuth リダイレクト先の origin 検証強化、フィード URL の公開ベース URL 修正、ユーザーページのプロファイル重複フェッチ削減、FeedButton のデフォルトラベル更新、および対応するテストが含まれています。

**主な変更点:**
- `isAllowedOrigin` に `allowWildcard` オプションを追加し、CSRF チェックでのワイルドカード拒否を可能に
- `resolveAllowedOrigin` により OAuth フロー中の origin 検証と優先順位制御を統一（`Origin` ヘッダー → クエリパラム → `FRONTEND_URL` の順）
- `apps/web/src/app/orgs/[slug]/page.tsx` および `users/[id]/page.tsx` でフィード URL のベースに `NEXT_PUBLIC_API_URL` を優先使用（内部 `API_URL` ではなく `PUBLIC_API_BASE`）
- `UserPageClient` でサーバーサイドプリフェッチ済みの `initialUser` が渡された場合にクライアントサイドのプロファイルフェッチをスキップ
- 非 404 エラー時の UX 改善（`「ユーザー情報の取得に失敗しました」`）
- 各修正に対応するユニットテストを追加

**要注意点:**
- `resolveAllowedOrigin` はデフォルトで `allowWildcard: true` を使用するため、`ALLOWED_ORIGINS=*` が設定されている場合は任意の origin が OAuth リダイレクト先として許可される可能性があります（設定ミスのリスク）
- `auth.test.ts` の一部テストブロックでインデントの不整合があります（機能上の問題なし）
</details>


<h3>Confidence Score: 5/5</h3>

全ての指摘事項は P2（スタイル・改善提案）レベルであり、マージをブロックする問題はありません

コード変更は概ね堅牢で、セキュリティ上の改善（origin 検証の強化・CSRF ワイルドカードブロック・OAuth リダイレクト検証）が適切に実装されています。ベア * ワイルドカードの懸念は設定ミスのシナリオに限定されており、コードバグではありません。テストカバレッジも各修正に対して適切に追加されています。P2 のみの所見のため 5/5 を付与します。

auth.test.ts のインデント不整合（885行目〜）と user-page-client.tsx のコレクション取得エラーハンドリングに軽微な改善余地があります

<details><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| apps/api/src/utils/origin.ts | origin 検証ユーティリティを新規導入。allowWildcard オプション・matchesOriginPattern・resolveAllowedOrigin を提供するが、ベア * のOAuth利用に懸念 |
| apps/api/src/routes/auth.ts | OAuth フローの origin 検証を resolveAllowedOrigin に統一し、リダイレクト先検証とクッキー永続化を改善 |
| apps/api/src/utils/__tests__/origin.test.ts | allowWildcard の許可/拒否・ホスト境界テストを追加。テストケースが適切 |
| apps/api/src/routes/__tests__/auth.test.ts | OAuthフロー・replay攻撃・fallback動作を網羅するテストを追加。885行目以降でインデント不整合あり |
| apps/web/src/app/orgs/[slug]/page.tsx | フィード URL を PUBLIC_API_BASE（NEXT_PUBLIC_API_URL 優先）に修正。サーバーフェッチは API_BASE（内部 URL）を使用 |
| apps/web/src/app/orgs/[slug]/__tests__/page-metadata.test.tsx | フィード URL が PUBLIC_API_BASE を使うことを検証するテストを追加 |
| apps/web/src/app/users/[id]/page.tsx | サーバーサイドで initialUser をプリフェッチし UserPageClient に渡す。フィード URL も PUBLIC_API_BASE を使用 |
| apps/web/src/app/users/[id]/user-page-client.tsx | initialUser が提供された場合にクライアントサイドのプロファイルフェッチをスキップ。コレクション失敗時の無音エラーに改善余地 |
| apps/web/src/app/users/[id]/__tests__/page.test.tsx | プロファイル重複フェッチ削減・404/非404エラー分岐を正確に検証するテストを追加 |
| apps/web/src/components/feed-button.tsx | デフォルトラベルを '📡 Feed' に更新。変更は最小限で適切 |
| apps/web/src/components/__tests__/feed-button.test.tsx | クリップボードコピー成功・クリップボード未対応ブラウザのエラー処理をテスト |

</details>


</details>


<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant Browser
    participant API as API /api/auth/github
    participant Cookie as Cookie Store
    participant GitHub
    participant CB as API /api/auth/github/callback
    participant FE as Frontend

    Browser->>API: GET /github?frontend_origin=...<br/>Origin: https://staging.example.com
    API->>API: resolveAllowedOrigin([Origin, frontend_origin],<br/>FRONTEND_URL, ALLOWED_ORIGINS)
    Note over API: Origin ヘッダー優先で検証
    API->>Cookie: Set oauth_flow_origin=https://staging.example.com (HttpOnly)
    API->>Cookie: Set oauth_flow_nonce=uuid (HttpOnly)
    API-->>Browser: 302 → GitHub OAuth
    Browser->>GitHub: OAuth Authorization
    GitHub-->>Browser: 302 → /callback?code=&state=
    Browser->>CB: GET /callback?code=&state=<br/>Cookie: nonce + origin
    CB->>CB: state + nonce をD1で検証・削除
    CB->>GitHub: POST token exchange
    GitHub-->>CB: access_token
    CB->>GitHub: GET /user
    GitHub-->>CB: user info
    CB->>CB: Upsert user in DB
    CB->>CB: resolveAllowedOrigin([flowOrigin],<br/>FRONTEND_URL, ALLOWED_ORIGINS)
    Note over CB: 未登録 origin はFRONTEND_URLへ fallback
    CB-->>Browser: 302 → https://staging.example.com/auth/callback#token=JWT
    Browser->>FE: /auth/callback (JWT をハッシュから取得)
```

<!-- greptile_failed_comments -->
<details open><summary><h3>Comments Outside Diff (3)</h3></summary>

1. `apps/api/src/utils/origin.ts`, line 40-56 ([link](https://github.com/hiroki-org/openshelf/blob/5f74a83eb27bd4a6893d190739759bb5cf763d5c/apps/api/src/utils/origin.ts#L40-L56)) 

   <a href="#"><img alt="P2" src="https://greptile-static-assets.s3.amazonaws.com/badges/p2.svg?v=7" align="top"></a> **ベア `*` ワイルドカードが OAuth リダイレクト先として承認される可能性**

   `isAllowedOrigin` の `allowWildcard` は既定値が `true` であり、`resolveAllowedOrigin` はこのオプションを明示的に渡していません。そのため `ALLOWED_ORIGINS=*` が環境変数に設定されている場合、リクエストの `Origin` ヘッダーに含まれる**任意のドメイン**が OAuth リダイレクト先として承認され、JWT がそのドメインに送信される open redirect + JWT 漏洩リスクがあります。

   CSRF チェック向けに `{ allowWildcard: false }` オプションが用意されているのと同様に、`resolveAllowedOrigin` においてもベアの `*`（`https://*.example.com` のようなサブドメインワイルドカードと区別）を明示的にブロックすることを検討してください。例えば、`matchesOriginPattern` 内でパターンが `"*"` の場合に `resolveAllowedOrigin` からは常に `false` を返すか、起動時に `ALLOWED_ORIGINS` にベアの `*` が含まれないことをバリデーションする方法が考えられます。

   <details><summary>Prompt To Fix With AI</summary>

   `````markdown
   This is a comment left during a code review.
   Path: apps/api/src/utils/origin.ts
   Line: 40-56

   Comment:
   **ベア `*` ワイルドカードが OAuth リダイレクト先として承認される可能性**

   `isAllowedOrigin` の `allowWildcard` は既定値が `true` であり、`resolveAllowedOrigin` はこのオプションを明示的に渡していません。そのため `ALLOWED_ORIGINS=*` が環境変数に設定されている場合、リクエストの `Origin` ヘッダーに含まれる**任意のドメイン**が OAuth リダイレクト先として承認され、JWT がそのドメインに送信される open redirect + JWT 漏洩リスクがあります。

   CSRF チェック向けに `{ allowWildcard: false }` オプションが用意されているのと同様に、`resolveAllowedOrigin` においてもベアの `*`（`https://*.example.com` のようなサブドメインワイルドカードと区別）を明示的にブロックすることを検討してください。例えば、`matchesOriginPattern` 内でパターンが `"*"` の場合に `resolveAllowedOrigin` からは常に `false` を返すか、起動時に `ALLOWED_ORIGINS` にベアの `*` が含まれないことをバリデーションする方法が考えられます。

   How can I resolve this? If you propose a fix, please make it concise.
   `````
   </details>


2. `apps/api/src/routes/__tests__/auth.test.ts`, line 885-948 ([link](https://github.com/hiroki-org/openshelf/blob/5f74a83eb27bd4a6893d190739759bb5cf763d5c/apps/api/src/routes/__tests__/auth.test.ts#L885-L948)) 

   <a href="#"><img alt="P2" src="https://greptile-static-assets.s3.amazonaws.com/badges/p2.svg?v=7" align="top"></a> **`it` ブロックのインデントが不整合**

   885〜888行目付近の `});` が 8 スペースでインデントされており（4 スペースが正しい）、それ以降の `it` ブロック（891・914・932行目など）が全体的に 8 スペースインデントになっています。機能的な問題はありませんが、可読性が低下し、`describe` の構造が把握しにくくなります。

   859行目の `it(...)` ブロックの閉じ括弧 `});` を正しい 4 スペースインデントに修正し、後続のテストブロックのインデントも揃えることを推奨します。

   <details><summary>Prompt To Fix With AI</summary>

   `````markdown
   This is a comment left during a code review.
   Path: apps/api/src/routes/__tests__/auth.test.ts
   Line: 885-948

   Comment:
   **`it` ブロックのインデントが不整合**

   885〜888行目付近の `});` が 8 スペースでインデントされており（4 スペースが正しい）、それ以降の `it` ブロック（891・914・932行目など）が全体的に 8 スペースインデントになっています。機能的な問題はありませんが、可読性が低下し、`describe` の構造が把握しにくくなります。

   859行目の `it(...)` ブロックの閉じ括弧 `});` を正しい 4 スペースインデントに修正し、後続のテストブロックのインデントも揃えることを推奨します。

   How can I resolve this? If you propose a fix, please make it concise.
   `````
   </details>

   <sub>Note: If this suggestion doesn't match your team's coding style, reply to this and let me know. I'll remember it for next time!</sub>


3. `apps/web/src/app/users/[id]/user-page-client.tsx`, line 71-75 ([link](https://github.com/hiroki-org/openshelf/blob/5f74a83eb27bd4a6893d190739759bb5cf763d5c/apps/web/src/app/users/[id]/user-page-client.tsx#L71-L75)) 

   <a href="#"><img alt="P2" src="https://greptile-static-assets.s3.amazonaws.com/badges/p2.svg?v=7" align="top"></a> **コレクション取得失敗が無音で無視される**

   `collectionsRes.ok` が `false`（例：500 エラー）の場合、エラー状態が設定されず、コレクションが空のまま表示されます。ユーザーはコレクションが存在しないのかサーバーエラーが発生したのか区別できません。

   コレクション取得失敗時に専用のエラーメッセージを表示するか、少なくともコンソールに記録することを検討してください：

   ```typescript
   if (collectionsRes.ok) {
     const collectionsData = await collectionsRes.json();
     if (cancelled) return;
     setCollections(collectionsData.collections ?? []);
   } else {
     // コレクションの取得に失敗した場合のフィードバックを検討
     // 例: setError("コレクションの取得に失敗しました") や専用の collectionsError 状態
   }
   ```

   <details><summary>Prompt To Fix With AI</summary>

   `````markdown
   This is a comment left during a code review.
   Path: apps/web/src/app/users/[id]/user-page-client.tsx
   Line: 71-75

   Comment:
   **コレクション取得失敗が無音で無視される**

   `collectionsRes.ok` が `false`（例：500 エラー）の場合、エラー状態が設定されず、コレクションが空のまま表示されます。ユーザーはコレクションが存在しないのかサーバーエラーが発生したのか区別できません。

   コレクション取得失敗時に専用のエラーメッセージを表示するか、少なくともコンソールに記録することを検討してください：

   ```typescript
   if (collectionsRes.ok) {
     const collectionsData = await collectionsRes.json();
     if (cancelled) return;
     setCollections(collectionsData.collections ?? []);
   } else {
     // コレクションの取得に失敗した場合のフィードバックを検討
     // 例: setError("コレクションの取得に失敗しました") や専用の collectionsError 状態
   }
   ```

   How can I resolve this? If you propose a fix, please make it concise.
   `````
   </details>

</details>

<!-- /greptile_failed_comments -->

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
This is a comment left during a code review.
Path: apps/api/src/utils/origin.ts
Line: 40-56

Comment:
**ベア `*` ワイルドカードが OAuth リダイレクト先として承認される可能性**

`isAllowedOrigin` の `allowWildcard` は既定値が `true` であり、`resolveAllowedOrigin` はこのオプションを明示的に渡していません。そのため `ALLOWED_ORIGINS=*` が環境変数に設定されている場合、リクエストの `Origin` ヘッダーに含まれる**任意のドメイン**が OAuth リダイレクト先として承認され、JWT がそのドメインに送信される open redirect + JWT 漏洩リスクがあります。

CSRF チェック向けに `{ allowWildcard: false }` オプションが用意されているのと同様に、`resolveAllowedOrigin` においてもベアの `*`（`https://*.example.com` のようなサブドメインワイルドカードと区別）を明示的にブロックすることを検討してください。例えば、`matchesOriginPattern` 内でパターンが `"*"` の場合に `resolveAllowedOrigin` からは常に `false` を返すか、起動時に `ALLOWED_ORIGINS` にベアの `*` が含まれないことをバリデーションする方法が考えられます。

How can I resolve this? If you propose a fix, please make it concise.

---

This is a comment left during a code review.
Path: apps/api/src/routes/__tests__/auth.test.ts
Line: 885-948

Comment:
**`it` ブロックのインデントが不整合**

885〜888行目付近の `});` が 8 スペースでインデントされており（4 スペースが正しい）、それ以降の `it` ブロック（891・914・932行目など）が全体的に 8 スペースインデントになっています。機能的な問題はありませんが、可読性が低下し、`describe` の構造が把握しにくくなります。

859行目の `it(...)` ブロックの閉じ括弧 `});` を正しい 4 スペースインデントに修正し、後続のテストブロックのインデントも揃えることを推奨します。

How can I resolve this? If you propose a fix, please make it concise.

---

This is a comment left during a code review.
Path: apps/web/src/app/users/[id]/user-page-client.tsx
Line: 71-75

Comment:
**コレクション取得失敗が無音で無視される**

`collectionsRes.ok` が `false`（例：500 エラー）の場合、エラー状態が設定されず、コレクションが空のまま表示されます。ユーザーはコレクションが存在しないのかサーバーエラーが発生したのか区別できません。

コレクション取得失敗時に専用のエラーメッセージを表示するか、少なくともコンソールに記録することを検討してください：

```typescript
if (collectionsRes.ok) {
  const collectionsData = await collectionsRes.json();
  if (cancelled) return;
  setCollections(collectionsData.collections ?? []);
} else {
  // コレクションの取得に失敗した場合のフィードバックを検討
  // 例: setError("コレクションの取得に失敗しました") や専用の collectionsError 状態
}
```

How can I resolve this? If you propose a fix, please make it concise.
`````

</details>

<sub>Reviews (1): Last reviewed commit: ["fix: address PR295 security and metadata..."](https://github.com/hiroki-org/openshelf/commit/5f74a83eb27bd4a6893d190739759bb5cf763d5c) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=27380536)</sub>

<!-- /greptile_comment -->