### PR TITLE
ci: preserve stacked PR base during main retarget

### DIFF
--- a/.github/workflows/enforce-staging-flow.yml
+++ b/.github/workflows/enforce-staging-flow.yml
@@ -14,7 +14,7 @@ jobs:
     name: require-staging-source
     runs-on: ubuntu-latest
     steps:
-      - name: Retarget PR to staging
+      - name: Retarget PR base
         env:
           GH_TOKEN: ${{ github.token }}
           GH_REPO: ${{ github.repository }}
@@ -37,6 +37,36 @@ jobs:
           if [ "$BASE_BRANCH" != "main" ]; then
             echo "Unexpected base branch: $BASE_BRANCH"
             exit 1
+          fi
+
+          stacked_base=""
+          min_ahead=""
+
+          while IFS= read -r candidate; do
+            if [ -z "$candidate" ] || [ "$candidate" = "$HEAD_BRANCH" ] || [ "$candidate" = "main" ] || [ "$candidate" = "staging" ]; then
+              continue
+            fi
+
+            candidate_enc="${candidate//\//%2F}"
+            head_enc="${HEAD_BRANCH//\//%2F}"
+            compare_line=$(gh api "repos/$GH_REPO/compare/$candidate_enc...$head_enc" --jq '"\(.status) \(.ahead_by) \(.behind_by)"' 2>/dev/null || true)
+            if [ -z "$compare_line" ]; then
+              continue
+            fi
+
+            IFS=' ' read -r status ahead_by behind_by <<<"$compare_line"
+            if [ "$status" = "ahead" ] && [ "$behind_by" = "0" ] && [ "${ahead_by:-0}" -gt 0 ]; then
+              if [ -z "$min_ahead" ] || [ "$ahead_by" -lt "$min_ahead" ]; then
+                min_ahead="$ahead_by"
+                stacked_base="$candidate"
+              fi
+            fi
+          done < <(gh pr list --repo "$GH_REPO" --state open --json number,headRefName --jq ".[] | select(.number != $PR_NUMBER) | .headRefName")
+
+          if [ -n "$stacked_base" ]; then
+            gh pr edit "$PR_NUMBER" --repo "$GH_REPO" --base "$stacked_base"
+            gh pr comment "$PR_NUMBER" --repo "$GH_REPO" --body "stacked PR を検知したため、ベースブランチを \`$stacked_base\` に変更しました。"
+            exit 0
           fi
 
           gh pr edit "$PR_NUMBER" --repo "$GH_REPO" --base staging


### PR DESCRIPTION
This PR isolates only the retarget workflow logic so main-target PRs are redirected to staging while preserving stacked PR bases.

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

このPRは、`main` をターゲットとした PR を自動的に `staging` へリターゲットする既存ワークフローに、スタックPR検出ロジックを追加したものです。HEAD ブランチの最も近い祖先ブランチを他のオープンPRから探し、見つかった場合はそちらにリターゲットすることで、スタックPRのベースが失われる問題を解決しています。

- **スタック検出アルゴリズム**: 全オープンPRのブランチと GitHub Compare API を使って「`HEAD_BRANCH` が候補ブランチより前にあり、かつ分岐していない（`status=ahead`, `behind_by=0`）」条件を満たすものを探し、最小 `ahead_by` の候補をベースに設定
- **`gh pr list` のデフォルト件数上限 (30件)**: `--limit` 未指定のため、PR数が多いリポジトリではスタック候補が取得されず誤って `staging` にリターゲットされる P1 の問題があります
- **URL エンコード**: `/` のみ処理しており、他の特殊文字を含むブランチ名に対して脆弱な可能性あり (P2)
- **ステップ名変更**: 「Retarget PR to staging」→「Retarget PR base」は変更内容を正確に表しており適切
</details>

<h3>Confidence Score: 4/5</h3>

`gh pr list` のデフォルト30件制限により、PR数が多い場合にスタック検出が失敗する P1 リスクが存在します。

コアロジック（Compare API を使ったスタック検出、最小 ahead_by の選択）は正しく、ステップ名変更も適切です。ただし `--limit` 未指定の問題はマージ前に修正が推奨されるため 4/5 とします。

`.github/workflows/enforce-staging-flow.yml` の64行目（`gh pr list` への `--limit 200` 追加）

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| .github/workflows/enforce-staging-flow.yml | スタックPRベース保持ロジックを追加。ただし `gh pr list` のデフォルト30件制限による検出漏れリスク（P1）あり。 |

</details>

</details>

<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant GH as GitHub Event
    participant WF as Workflow
    participant API as GitHub API

    GH->>WF: pull_request_target (opened/edited/reopened) → main
    WF->>WF: HEAD_BRANCH = staging? → exit 0
    WF->>API: GET collaborators/{author}/permission
    API-->>WF: permission
    WF->>WF: admin? → exit 0 (keep main)
    WF->>WF: BASE_BRANCH != main? → exit 1

    WF->>API: gh pr list (open PRs, デフォルト30件)
    API-->>WF: [headRefName list]

    loop 各候補ブランチ
        WF->>API: compare/candidate...HEAD
        API-->>WF: status, ahead_by, behind_by
        WF->>WF: status=ahead and behind_by=0? → update min_ahead
    end

    alt stacked_base が見つかった場合
        WF->>API: gh pr edit --base stacked_base
        WF->>API: gh pr comment (スタック検知メッセージ)
        WF->>WF: exit 0
    else 見つからなかった場合
        WF->>API: gh pr edit --base staging
        WF->>API: gh pr comment (stagingフローメッセージ)
    end
```

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
This is a comment left during a code review.
Path: .github/workflows/enforce-staging-flow.yml
Line: 64

Comment:
**`gh pr list` のデフォルト上限によるスタック検出漏れ**

`gh pr list` は `--limit` を指定しない場合、デフォルトで **30件** しか返しません。オープンPRが30件を超えると、スタック候補ブランチが取得されずに `staging` に誤ってリターゲットされる恐れがあります。

```suggestion
          done < <(gh pr list --repo "$GH_REPO" --state open --limit 200 --json number,headRefName --jq ".[] | select(.number != $PR_NUMBER) | .headRefName")
```

How can I resolve this? If you propose a fix, please make it concise.

---

This is a comment left during a code review.
Path: .github/workflows/enforce-staging-flow.yml
Line: 50-51

Comment:
**ブランチ名の URL エンコードが不完全**

現在は `/` → `%2F` のみエンコードしていますが、ブランチ名に `#`・`?`・`&`・`%` などが含まれる場合、`gh api` の URL が壊れる可能性があります。`jq -Rr @uri` を使ってより堅牢にエンコードできます。

```suggestion
            candidate_enc=$(printf '%s' "$candidate" | jq -Rr @uri)
            head_enc=$(printf '%s' "$HEAD_BRANCH" | jq -Rr @uri)
```

How can I resolve this? If you propose a fix, please make it concise.

---

This is a comment left during a code review.
Path: .github/workflows/enforce-staging-flow.yml
Line: 66-70

Comment:
**スタックベースブランチ自体が `main` をターゲットにしている可能性**

`stacked_base` として選ばれた候補ブランチの PR が、まだこのワークフローによってリターゲットされていない（レース条件などで `main` を向いたまま）ケースが考えられます。その場合、スタックの連鎖が正しく機能しない恐れがあります。リターゲット前に候補PRのベースブランチも確認する防御ガードを追加することを検討してください。

How can I resolve this? If you propose a fix, please make it concise.
`````

</details>

<sub>Reviews (1): Last reviewed commit: ["ci: preserve stacked PR base during main..."](https://github.com/hiroki-org/openshelf/commit/c21a074ddb5c9cd6deefc46b6eb4bb2cf85a962e) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=27401343)</sub>

> Greptile also left **3 inline comments** on this PR.

**Context used:**

- Context used - 日本語で！！！ ([source](https://app.greptile.com/review/custom-context?memory=instruction-0))

<!-- /greptile_comment -->