### PR TITLE
chore: temporary retarget verification

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -52,3 +52,4 @@ test-results/
 playwright-report/
 blob-report/
 playwright/.cache/
+retarget-check-1775407239


### PR DESCRIPTION
Temporary PR to verify Enforce Staging Flow retarget behavior. Will close after verification.

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

このPRは「Enforce Staging Flow のリターゲット動作を検証する」ための一時的な変更です。`.gitignore` に `retarget-check-1775407239` という1行が追加されています。

- `.gitignore` への追加エントリはリポジトリ内の実際のファイル・ディレクトリに対応しておらず、純粋に CI/CD ワークフローの動作確認用のものです
- PR説明に「確認後クローズ」と記載されているため、`main` にマージする場合はこのエントリの削除が必要です
- コードロジックへの影響はなく、リスクは極めて低い変更です
</details>

<h3>Confidence Score: 5/5</h3>

コードロジックへの影響がなく、マージしても安全です。ただし一時エントリの削除を忘れずに。

変更は .gitignore への1行追加のみで、機能的・セキュリティ的なリスクはありません。P2のスタイル指摘のみのためスコアは5/5です。

.gitignore — 一時エントリが残存しないよう確認が必要

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| .gitignore | retarget-check-1775407239 という一時的な検証用エントリが1行追加されている |

</details>

</details>

<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[PR #317 作成] --> B[.gitignore に retarget-check-1775407239 追加]
    B --> C{Staging Flow\nリターゲット動作確認}
    C -->|確認完了| D[PR クローズ / エントリ削除]
    C -->|確認未完了| E[エントリ維持]
```

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
This is a comment left during a code review.
Path: .gitignore
Line: 55

Comment:
**一時的なエントリの混入**

`retarget-check-1775407239` はリポジトリ内の実際のファイルやディレクトリに対応しておらず、PR説明にも「確認後にクローズする」と明記されています。このエントリは `.gitignore` に永続的に残すべきものではなく、`main` ブランチにマージする場合はこのエントリを削除してください。

How can I resolve this? If you propose a fix, please make it concise.
`````

</details>

<sub>Reviews (1): Last reviewed commit: ["chore: temporary retarget verification m..."](https://github.com/hiroki-org/openshelf/commit/b620f9ba767d20c38592b013cece91f3a33c5863) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=27401549)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->