### PR TITLE
ci: always retarget main-bound PRs unless stacked

### DIFF
--- a/.github/workflows/enforce-staging-flow.yml
+++ b/.github/workflows/enforce-staging-flow.yml
@@ -18,19 +18,12 @@ jobs:
         env:
           GH_TOKEN: ${{ github.token }}
           GH_REPO: ${{ github.repository }}
-          PR_AUTHOR: ${{ github.event.pull_request.user.login }}
           PR_NUMBER: ${{ github.event.pull_request.number }}
           HEAD_BRANCH: ${{ github.event.pull_request.head.ref }}
           BASE_BRANCH: ${{ github.event.pull_request.base.ref }}
         run: |
           if [ "$HEAD_BRANCH" = "staging" ]; then
             echo "staging -> main PR detected; no retarget needed."
-            exit 0
-          fi
-
-          permission=$(gh api "repos/$GH_REPO/collaborators/$PR_AUTHOR/permission" --jq .permission 2>/dev/null || true)
-          if [ "$permission" = "admin" ]; then
-            echo "PR author has admin permission; leaving target as main."
             exit 0
           fi
 


### PR DESCRIPTION
Remove admin-author bypass so main-target PRs are always retargeted to staging, while stacked PR detection still preserves parent base.

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

本 PR は `main` をターゲットとする全ての PR を強制的に `staging` へリターゲットするワークフローから「管理者バイパス」を削除したものです。スタック PR の検出ロジック（`ahead_by` が最小の候補を親ブランチとして採用）は概念的に正しく実装されています。

主な変更点と課題：

- **変更内容**: 管理者権限を持つ作成者が retarget をスキップできるバイパス条件を削除し、全ての `main` ターゲット PR に対してポリシーを均一に適用するようになった
- **スタック PR 検出**: `gh api compare` を使って `ahead` かつ `behind_by=0` の関係を持つブランチを特定するロジックは正しい
- **P1 問題**: `gh pr list` にデフォルト上限（30件）があるため、オープン PR が多いリポジトリでスタック検出が失敗し、誤って `staging` にリターゲットされるリスクがある（`--limit 1000` の追加で対処可能）
- **P2 問題**: ブランチ名の URL エンコードがスラッシュのみ対応で、特殊文字を含む場合にサイレント失敗する可能性がある
</details>


<h3>Confidence Score: 4/5</h3>

P1 のロジックバグ（`gh pr list` 上限問題）修正後はマージ可能。現状ではスタック PR の誤リターゲットが大規模リポジトリで発生しうる。

ワークフローの全体設計は正しく、意図した機能（管理者バイパス削除）は適切に実装されている。ただし `gh pr list` のデフォルト上限 30件という問題（P1）はリポジトリが成長するにつれて確実に顕在化するバグであり、マージ前の修正が必要なため 4/5 とした。

`.github/workflows/enforce-staging-flow.yml` の 57行目（`gh pr list` への `--limit` 追加）に注意が必要。

<details><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| .github/workflows/enforce-staging-flow.yml | `main` ターゲット PR を強制的に `staging` へリターゲットするワークフロー。管理者バイパスを削除したが、`gh pr list` の上限問題（P1）によりスタック検出が大規模リポジトリで失敗するリスクあり。 |

</details>


</details>


<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant Dev as 開発者
    participant GHA as GitHub Actions
    participant GHAPI as GitHub API (gh CLI)

    Dev->>GHA: main ターゲット PR を open/reopen/edit
    GHA->>GHA: HEAD_BRANCH == staging?
    alt staging→main PR
        GHA-->>Dev: そのまま通過 (exit 0)
    else それ以外
        GHA->>GHAPI: gh pr list (open PRs, デフォルト上限30件⚠️)
        GHAPI-->>GHA: オープン PR 一覧
        loop 各候補ブランチ
            GHA->>GHAPI: gh api compare/candidate...HEAD
            GHAPI-->>GHA: status / ahead_by / behind_by
            GHA->>GHA: ahead かつ behind_by=0 なら stacked_base 候補に
        end
        alt スタック PR 検出 (stacked_base あり)
            GHA->>GHAPI: gh pr edit --base stacked_base
            GHA->>GHAPI: gh pr comment (スタック検知メッセージ)
            GHAPI-->>Dev: ベースを親ブランチに変更
        else スタック PR 未検出
            GHA->>GHAPI: gh pr edit --base staging
            GHA->>GHAPI: gh pr comment (staging 誘導メッセージ)
            GHAPI-->>Dev: ベースを staging に変更
        end
    end
```

<!-- greptile_failed_comments -->
<details open><summary><h3>Comments Outside Diff (2)</h3></summary>

1. `.github/workflows/enforce-staging-flow.yml`, line 57 ([link](https://github.com/hiroki-org/openshelf/blob/51b2da863d1f48b1407c8d5a6bc245f59b76543d/.github/workflows/enforce-staging-flow.yml#L57)) 

   <a href="#"><img alt="P1" src="https://greptile-static-assets.s3.amazonaws.com/badges/p1.svg?v=7" align="top"></a> **`gh pr list` のデフォルト上限により、スタック検出がサイレントに失敗する**

   `gh pr list` は `--limit` を指定しない場合、デフォルトで最大 **30件** しか取得しません。オープン PR が 30件を超えるリポジトリでは、親ブランチ（スタックベース）が一覧に含まれない場合があり、スタック検出がサイレントに失敗します。結果として、本来スタック PR として処理されるべき PR が誤って `staging` にリターゲットされてしまいます。

   `--limit 1000` を追加して対処してください：

   

   <details><summary>Prompt To Fix With AI</summary>

   `````markdown
   This is a comment left during a code review.
   Path: .github/workflows/enforce-staging-flow.yml
   Line: 57

   Comment:
   **`gh pr list` のデフォルト上限により、スタック検出がサイレントに失敗する**

   `gh pr list` は `--limit` を指定しない場合、デフォルトで最大 **30件** しか取得しません。オープン PR が 30件を超えるリポジトリでは、親ブランチ（スタックベース）が一覧に含まれない場合があり、スタック検出がサイレントに失敗します。結果として、本来スタック PR として処理されるべき PR が誤って `staging` にリターゲットされてしまいます。

   `--limit 1000` を追加して対処してください：

   

   How can I resolve this? If you propose a fix, please make it concise.
   `````
   </details>


2. `.github/workflows/enforce-staging-flow.yml`, line 43-44 ([link](https://github.com/hiroki-org/openshelf/blob/51b2da863d1f48b1407c8d5a6bc245f59b76543d/.github/workflows/enforce-staging-flow.yml#L43-L44)) 

   <a href="#"><img alt="P2" src="https://greptile-static-assets.s3.amazonaws.com/badges/p2.svg?v=7" align="top"></a> **URL エンコードがスラッシュのみ対応で他の特殊文字が未処理**

   現在の実装はブランチ名中の `/` を `%2F` に置換するのみで、スペース・`?`・`#`・`%`・`+` などの文字はエンコードされません。これらを含むブランチ名では GitHub API への URL が不正な形式になり、`2>/dev/null || true` によりサイレントに無視されるため、スタック PR が検出されないまま誤ったリターゲットが発生する可能性があります。

   Python を使ったパーセントエンコードへの変更を検討してください：

   ```
               candidate_enc=$(python3 -c "import urllib.parse, sys; print(urllib.parse.quote(sys.argv[1], safe=''))" "$candidate")
               head_enc=$(python3 -c "import urllib.parse, sys; print(urllib.parse.quote(sys.argv[1], safe=''))" "$HEAD_BRANCH")
   ```

   <details><summary>Prompt To Fix With AI</summary>

   `````markdown
   This is a comment left during a code review.
   Path: .github/workflows/enforce-staging-flow.yml
   Line: 43-44

   Comment:
   **URL エンコードがスラッシュのみ対応で他の特殊文字が未処理**

   現在の実装はブランチ名中の `/` を `%2F` に置換するのみで、スペース・`?`・`#`・`%`・`+` などの文字はエンコードされません。これらを含むブランチ名では GitHub API への URL が不正な形式になり、`2>/dev/null || true` によりサイレントに無視されるため、スタック PR が検出されないまま誤ったリターゲットが発生する可能性があります。

   Python を使ったパーセントエンコードへの変更を検討してください：

   ```
               candidate_enc=$(python3 -c "import urllib.parse, sys; print(urllib.parse.quote(sys.argv[1], safe=''))" "$candidate")
               head_enc=$(python3 -c "import urllib.parse, sys; print(urllib.parse.quote(sys.argv[1], safe=''))" "$HEAD_BRANCH")
   ```

   How can I resolve this? If you propose a fix, please make it concise.
   `````
   </details>

</details>

<!-- /greptile_failed_comments -->

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
This is a comment left during a code review.
Path: .github/workflows/enforce-staging-flow.yml
Line: 57

Comment:
**`gh pr list` のデフォルト上限により、スタック検出がサイレントに失敗する**

`gh pr list` は `--limit` を指定しない場合、デフォルトで最大 **30件** しか取得しません。オープン PR が 30件を超えるリポジトリでは、親ブランチ（スタックベース）が一覧に含まれない場合があり、スタック検出がサイレントに失敗します。結果として、本来スタック PR として処理されるべき PR が誤って `staging` にリターゲットされてしまいます。

`--limit 1000` を追加して対処してください：

```suggestion
          done < <(gh pr list --repo "$GH_REPO" --state open --limit 1000 --json number,headRefName --jq ".[] | select(.number != $PR_NUMBER) | .headRefName")
```

How can I resolve this? If you propose a fix, please make it concise.

---

This is a comment left during a code review.
Path: .github/workflows/enforce-staging-flow.yml
Line: 43-44

Comment:
**URL エンコードがスラッシュのみ対応で他の特殊文字が未処理**

現在の実装はブランチ名中の `/` を `%2F` に置換するのみで、スペース・`?`・`#`・`%`・`+` などの文字はエンコードされません。これらを含むブランチ名では GitHub API への URL が不正な形式になり、`2>/dev/null || true` によりサイレントに無視されるため、スタック PR が検出されないまま誤ったリターゲットが発生する可能性があります。

Python を使ったパーセントエンコードへの変更を検討してください：

```
            candidate_enc=$(python3 -c "import urllib.parse, sys; print(urllib.parse.quote(sys.argv[1], safe=''))" "$candidate")
            head_enc=$(python3 -c "import urllib.parse, sys; print(urllib.parse.quote(sys.argv[1], safe=''))" "$HEAD_BRANCH")
```

How can I resolve this? If you propose a fix, please make it concise.
`````

</details>

<sub>Reviews (1): Last reviewed commit: ["ci: always retarget main-bound PRs unles..."](https://github.com/hiroki-org/openshelf/commit/51b2da863d1f48b1407c8d5a6bc245f59b76543d) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=27401774)</sub>

<!-- /greptile_comment -->