### PR TITLE
docs: add staging migration command in agent guide

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -404,7 +404,7 @@ Tests auto-start both frontend (port 3000) and API (port 8787).
 
 - **Frontend**: Vercel or Docker (see `apps/web/Dockerfile`)
 - **API**: Cloudflare Workers via `wrangler deploy`
-- **Database migrations**: Apply staging with `npm run db:migrate:remote`, then production with `npm run db:migrate:remote:production`
+- **Database migrations**: Apply to staging with `npm run db:migrate:remote`, then apply to production with `npm run db:migrate:remote:production`
 
 See `apps/web/README.md` and `apps/api/wrangler.toml` for environment variable requirements.
 


### PR DESCRIPTION
## Summary
- add explicit staging migration command examples (npm run db:migrate:remote) alongside production examples
- align command references in core commands, schema update workflow, and deployment section

## Why
- addresses the remaining unresolved CodeRabbit thread on #295
- prepares staging so the staging-to-main PR can become merge-safe after this lands

## Validation
- npm run lint
- npm run typecheck
- npm run test

Related: #295

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

このPRはエージェント向けガイド（`.github/copilot-instructions.md`）に、ステージング環境用マイグレーションコマンド（`npm run db:migrate:remote`）の明示的な記述を追加し、ドキュメント全体でコマンド参照を整合させるドキュメント変更です。

- **Core Commands** に `db:migrate:remote`（staging env）と `db:migrate:remote:production`（production env）の両コマンドを明示的に追加（lines 58–59）
- **Update Database Schema** のステップ5にステージング→本番の2段階デプロイ手順を追加（line 382）
- **Deployment** セクションにステージング先へのマイグレーション適用コマンドを明記（line 407）
- コードへの影響なし（ドキュメント変更のみ）
- アーキテクチャ概要内の **Migrations** スニペット（lines 124–129）はこのPRで更新されておらず、他のセクションとの軽微な不整合が残っている（P2）
</details>


<h3>Confidence Score: 5/5</h3>

ドキュメントのみの変更であり、コード・DB・デプロイへの影響はなく、安全にマージ可能です

変更はすべて .github/copilot-instructions.md に限定されており、P2レベルの軽微な一貫性の欠如（Migrations スニペットの未更新）のみ確認。P0/P1 の問題はなく、マージをブロックする理由は存在しない

特になし。`.github/copilot-instructions.md` の lines 124–129 を任意で補足すると一貫性がさらに向上する

<details><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| .github/copilot-instructions.md | エージェント向けガイドにステージングマイグレーションコマンドを追加。Core Commands・スキーマ更新ワークフロー・デプロイセクションで一貫して記載。Migrationsスニペット（lines 124–129）のみ未更新のため軽微な一貫性の欠如あり。 |

</details>


</details>


<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[スキーマ変更\napps/api/src/db/schema.ts] --> B[npm run db:generate\nマイグレーションファイル生成]
    B --> C[apps/api/drizzle/ で\nマイグレーションを確認]
    C --> D[npm run db:migrate:local\nローカル D1 でテスト]
    D --> E[npm run db:migrate:remote\nステージング環境へ適用]
    E --> F[npm run db:migrate:remote:production\n本番環境へ適用]
```

<!-- greptile_failed_comments -->
<details open><summary><h3>Comments Outside Diff (1)</h3></summary>

1. `.github/copilot-instructions.md`, line 124-129 ([link](https://github.com/hiroki-org/openshelf/blob/9700a5fd2ddf3544e14ca0d7a6ec819a19c2cdda/.github/copilot-instructions.md#L124-L129)) 

   <a href="#"><img alt="P2" src="https://greptile-static-assets.s3.amazonaws.com/badges/p2.svg?v=7" align="top"></a> **「Migrations」スニペットにリモートコマンドが未記載**

   このPRでは `Core Commands`（line 58–59）、`Update Database Schema`（line 382）、`Deployment`（line 407）の3箇所にステージング用マイグレーションコマンドが追加されましたが、アーキテクチャ概要内のこの **Migrations** スニペットだけ `db:migrate:remote`（staging）と `db:migrate:remote:production`（production）が含まれておらず、他のセクションとの一貫性が損なわれています。

   エージェントがこのスニペットのみを参照した場合、リモートへのデプロイ手順を見落とす可能性があります。以下のように補足することを検討してください。

   bash
   npm run db:generate         # Create migration file
   npm run db:migrate:local    # Test locally
   npm run db:migrate:remote   # Apply to staging
   npm run db:migrate:remote:production  # Apply to production
   ```
   ```

   <details><summary>Prompt To Fix With AI</summary>

   `````markdown
   This is a comment left during a code review.
   Path: .github/copilot-instructions.md
   Line: 124-129

   Comment:
   **「Migrations」スニペットにリモートコマンドが未記載**

   このPRでは `Core Commands`（line 58–59）、`Update Database Schema`（line 382）、`Deployment`（line 407）の3箇所にステージング用マイグレーションコマンドが追加されましたが、アーキテクチャ概要内のこの **Migrations** スニペットだけ `db:migrate:remote`（staging）と `db:migrate:remote:production`（production）が含まれておらず、他のセクションとの一貫性が損なわれています。

   エージェントがこのスニペットのみを参照した場合、リモートへのデプロイ手順を見落とす可能性があります。以下のように補足することを検討してください。

   bash
   npm run db:generate         # Create migration file
   npm run db:migrate:local    # Test locally
   npm run db:migrate:remote   # Apply to staging
   npm run db:migrate:remote:production  # Apply to production
   ```
   ```

   How can I resolve this? If you propose a fix, please make it concise.
   `````
   </details>

</details>

<!-- /greptile_failed_comments -->

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
This is a comment left during a code review.
Path: .github/copilot-instructions.md
Line: 124-129

Comment:
**「Migrations」スニペットにリモートコマンドが未記載**

このPRでは `Core Commands`（line 58–59）、`Update Database Schema`（line 382）、`Deployment`（line 407）の3箇所にステージング用マイグレーションコマンドが追加されましたが、アーキテクチャ概要内のこの **Migrations** スニペットだけ `db:migrate:remote`（staging）と `db:migrate:remote:production`（production）が含まれておらず、他のセクションとの一貫性が損なわれています。

エージェントがこのスニペットのみを参照した場合、リモートへのデプロイ手順を見落とす可能性があります。以下のように補足することを検討してください。

```suggestion
**Migrations**: After schema changes, run:

```bash
npm run db:generate         # Create migration file
npm run db:migrate:local    # Test locally
npm run db:migrate:remote   # Apply to staging
npm run db:migrate:remote:production  # Apply to production
```
```

How can I resolve this? If you propose a fix, please make it concise.
`````

</details>

<sub>Reviews (1): Last reviewed commit: ["docs: add staging migration command exam..."](https://github.com/hiroki-org/openshelf/commit/9700a5fd2ddf3544e14ca0d7a6ec819a19c2cdda) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=27405023)</sub>

<!-- /greptile_comment -->