### PR TITLE
perf(api): avoid hex encoding in magic-number checks

### DIFF
--- a/apps/api/src/utils/file.ts
+++ b/apps/api/src/utils/file.ts
@@ -23,6 +23,9 @@ const MAGIC_NUMBER_MAP: ReadonlyArray<
   ],
   [Uint8Array.from([0x50, 0x4b, 0x03, 0x04]), "application/zip"],
 ];
+const MAX_MAGIC_SIZE = Math.max(
+  ...MAGIC_NUMBER_MAP.map(([signature]) => signature.length),
+);
 
 function matchesMagicPrefix(
   bytes: Uint8Array,
@@ -207,7 +210,7 @@ export async function validateMagicNumbers(
   file: File,
   declaredMime: string,
 ): Promise<boolean> {
-  const buffer = await file.slice(0, 8).arrayBuffer();
+  const buffer = await file.slice(0, MAX_MAGIC_SIZE).arrayBuffer();
   const bytes = new Uint8Array(buffer);
   const detectedType =
     MAGIC_NUMBER_MAP.find(([signature]) => matchesMagicPrefix(bytes, signature))


### PR DESCRIPTION
## Summary
- replace magic-number hex string conversion with direct byte-prefix checks
- keep the existing MIME compatibility table and PPT/PPTX deep validation behavior intact
- reduce overhead in the hot path that CodSpeed flagged for PDF validation

## Verification
- `npm run test -w apps/api -- src/utils/__tests__/file.test.ts`
- `npx vitest bench src/utils/__tests__/file.bench.ts --config apps/api/vitest.config.ts`

## Issues
Closes #330

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

このPRは、`validateMagicNumbers` 関数のホットパスにおけるパフォーマンスを改善するリファクタリングです。従来の実装では、ファイル先頭8バイトを16進文字列に変換（`b.toString(16).padStart(2, "0").toUpperCase()`）してから `startsWith` で比較していましたが、CodSpeedのプロファイリングでこの文字列アロケーションがボトルネックとして検出されました。

**主な変更点：**

- `MAGIC_NUMBER_MAP` の型を `string`（hex文字列）から `Uint8Array` に変更し、モジュールロード時に一度だけバイト配列を生成する設計に改めた
- 新関数 `matchesMagicPrefix(bytes, signature)` を追加し、バイト列を直接比較するロジックを実装
- `validateMagicNumbers` 内の hex変換処理を削除し、上記関数を使用するよう変更
- PPT/PPTXの深い検証ロジック（`hasZipEntry` / `hasOleStream`）は変更なし

**正確性の確認：**

新旧の全マジックナンバーを照合した結果、5種類すべてのバイト列が旧来のhex文字列と一致することを確認：
- PDF: `"255044462D"` → `[0x25, 0x50, 0x44, 0x46, 0x2d]` ✓
- PNG: `"89504E470D0A1A0A"` → `[0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a]` ✓
- JPEG: `"FFD8FF"` → `[0xff, 0xd8, 0xff]` ✓
- OLE2: `"D0CF11E0A1B11AE1"` → `[0xd0, 0xcf, 0x11, 0xe0, 0xa1, 0xb1, 0x1a, 0xe1]` ✓
- ZIP: `"504B0304"` → `[0x50, 0x4b, 0x03, 0x04]` ✓

`matchesMagicPrefix` の長さガードも正しく機能しており、ファイルサイズが8バイト未満の場合も安全に `false` を返します。実装に問題は見つかりませんでした。
</details>

<h3>Confidence Score: 5/5</h3>

このPRはマージ可能です。パフォーマンス改善のリファクタリングとして正確に実装されています。

全5種類のマジックナンバーバイト値が旧実装のhex文字列と完全に一致することを確認。matchesMagicPrefix の境界チェックも正しく、P0/P1の問題は一切検出されませんでした。既存の振る舞いは完全に保持されています。

特に注意が必要なファイルはありません。apps/api/src/utils/file.ts の変更は安全です。

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| apps/api/src/utils/file.ts | hex文字列変換をUint8Array直接比較に置き換えるパフォーマンス改善。全マジックナンバーのバイト値が旧hex文字列と一致することを確認済み。既存の深い検証ロジックは変更なし。 |

</details>

</details>

<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[validateMagicNumbers 呼び出し] --> B[file.slice 0-8 arrayBuffer]
    B --> C[new Uint8Array bytes]
    C --> D[MAGIC_NUMBER_MAP.find 探索]
    D --> E{matchesMagicPrefix}
    E -->|長さ不足| F[false 次のエントリへ]
    E -->|バイト列一致| G[detectedType 確定]
    E -->|不一致| F
    F --> D
    D -->|見つからない| H[return false]
    G --> I{MIME_COMPATIBILITY チェック}
    I -->|不一致| H
    I -->|一致| J{PPTX?}
    J -->|Yes| K[hasZipEntry ppt/presentation.xml]
    J -->|No| L{PPT?}
    L -->|Yes| M[hasOleStream PowerPoint Document]
    L -->|No| N[return true]
    K --> O[return 結果]
    M --> O
```

<sub>Reviews (1): Last reviewed commit: ["perf(api): avoid hex encoding in magic-n..."](https://github.com/hiroki-org/openshelf/commit/7058c10ca33fb19e0415f1bd3ce3a761ebcb18ae) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=27406894)</sub>

**Context used:**

- Context used - 日本語で！！！ ([source](https://app.greptile.com/review/custom-context?memory=instruction-0))

<!-- /greptile_comment -->