### PR TITLE
fix(ci): restore Codecov monorepo path normalization

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -121,28 +121,28 @@ jobs:
         with:
           name: coverage-web
           path: ./coverage-artifacts/web
+      - name: Normalize coverage source paths for monorepo
+        run: |
+          sed -i 's|SF:src/|SF:apps/api/src/|g' ./coverage-artifacts/api/lcov.info
+          sed -i 's|SF:src/|SF:apps/web/src/|g' ./coverage-artifacts/web/lcov.info
       - name: Upload API coverage to Codecov
         uses: codecov/codecov-action@v5
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
-          disable_search: true
           flags: api
           files: ./coverage-artifacts/api/lcov.info
           fail_ci_if_error: false
           override_branch: ${{ env.CODECOV_BRANCH }}
           override_commit: ${{ env.CODECOV_COMMIT_SHA }}
-          root_dir: apps/api
       - name: Upload Web coverage to Codecov
         uses: codecov/codecov-action@v5
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
-          disable_search: true
           flags: web
           files: ./coverage-artifacts/web/lcov.info
           fail_ci_if_error: false
           override_branch: ${{ env.CODECOV_BRANCH }}
           override_commit: ${{ env.CODECOV_COMMIT_SHA }}
-          root_dir: apps/web
   build-web-check:
     name: Build Web (Preview Check)
     needs: [test-api, test-web]


### PR DESCRIPTION
## Summary
- restore lcov source path normalization in upload-coverage
- remove disable_search and root_dir overrides that regressed coverage display to 0%
- keep existing API and Web split uploads with commit and branch overrides

## Why
Recent CI runs uploaded coverage artifacts successfully, but Codecov branch badges for both main and staging stayed at 0%. The regression started after the normalization step was removed from .github/workflows/ci.yml, breaking monorepo path mapping in coverage processing.

## Validation
- root lint/typecheck/test completed successfully
- upload logs show Codecov accepted both lcov files, so the issue is mapping after upload

## Notes
This PR targets staging per repository flow.

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

Codecovのモノレポパスマッピングが壊れ、mainおよびstagingブランチのバッジが0%を表示していた問題を修正するCIワークフローの変更です。

- `upload-coverage`ジョブに`sed`を使ったlcovソースパス正規化ステップを復元（`SF:src/` → `SF:apps/api/src/` および `SF:apps/web/src/`）
- `codecov/codecov-action`の`disable_search: true`オプションを両アップロードステップから削除
- `root_dir: apps/api`および`root_dir: apps/web`オプションを両アップロードステップから削除
- Vitestは各アプリディレクトリからの相対パス（例：`SF:src/some/file.ts`）でlcov.infoを生成します。Codecovがリポジトリルートからのパスとして正しく認識するためには、`SF:apps/api/src/some/file.ts` のように正規化する必要があります。この復元によって、モノレポ構成でのカバレッジ表示が正常に動作するようになります。
</details>

<h3>Confidence Score: 5/5</h3>

このPRはマージしても安全です。CIカバレッジ表示の既知のリグレッションを正確に修正しています。

変更は単一ファイル（.github/workflows/ci.yml）のみで、以前動作していたsedによるパス正規化を復元する内容です。Vitestの設定（apps/api/vitest.config.ts, apps/web/vitest.config.ts）を確認したところ、両アプリともlcovレポーターを使用しており、sed置換パターン（SF:src/ → SF:apps/api/src/）は正確です。P1以上の問題は見つかりません。

特に注意が必要なファイルはありません。

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| .github/workflows/ci.yml | upload-coverageジョブにlcovパス正規化ステップを復元し、disable_searchとroot_dirオプションを削除。Codecovのモノレポパスマッピングの0%リグレッションを修正。 |

</details>

</details>

<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
  participant API as test-api job
  participant Web as test-web job
  participant Art as GitHub Artifacts
  participant Upload as upload-coverage job
  participant CC as Codecov

  API->>Art: coverage-api をアップロード (SF:src/...)
  Web->>Art: coverage-web をアップロード (SF:src/...)

  Upload->>Art: coverage-api をダウンロード
  Upload->>Art: coverage-web をダウンロード
  Note over Upload: sed: SF:src/ → SF:apps/api/src/
  Note over Upload: sed: SF:src/ → SF:apps/web/src/
  Upload->>CC: API lcov.info をアップロード（正規化済みパス）
  Upload->>CC: Web lcov.info をアップロード（正規化済みパス）
  Note over CC: モノレポパスマッピング正常動作 ✓
```

<sub>Reviews (1): Last reviewed commit: ["fix(ci): restore monorepo path normaliza..."](https://github.com/hiroki-org/openshelf/commit/46aa3cd27d45f0ad59900c65bd9db9e152ec5810) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=27530053)</sub>

<!-- /greptile_comment -->