### PR TITLE
ci: pin checkout in sync workflow

### DIFF
--- a/.github/workflows/sync-main-to-staging.yml
+++ b/.github/workflows/sync-main-to-staging.yml
@@ -18,7 +18,7 @@ jobs:
     name: Open Main -> Staging Sync PR
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
       - name: Create or reuse main -> staging sync PR
         env:
           GH_TOKEN: ${{ github.token }}


### PR DESCRIPTION
Summary:
- pin actions/checkout in the main-to-staging sync workflow
- address the security review on the staging-to-main promotion PR

Notes:
- follow-up to review feedback on #345
- after merging this PR, #345 will pick up the pinned workflow reference automatically

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

このPRは `sync-main-to-staging.yml` の `actions/checkout` を SHA `11bd71901bbe5b1630ceea73d27597364c9af683`（v4.2.2）にピン留めし、サプライチェーン攻撃リスクを軽減しています。PR #345 のセキュリティレビューへのフォローアップとして適切な対応です。

- `actions/checkout` の SHA ピン（`11bd71901bbe5b1630ceea73d27597364c9af683`、v4.2.2）を `sync-main-to-staging.yml` に適用
- ピンされた SHA が `actions/checkout@v4.2.2` の正しい値であることを確認済み
- `# v4` コメントにより人間による可読性も維持されている
- **フォローアップ推奨：** `ci.yml`（9箇所）、`deploy-api.yml`、`enforce-staging-flow.yml`（`pull_request_target` 使用のため最高リスク）、`check-migrations.yml` の計12箇所にも同様の SHA ピンを適用することを推奨
</details>


<h3>Confidence Score: 5/5</h3>

このPRの変更自体は安全にマージ可能です

変更は1ファイル1行のみで、SHAが正確（v4.2.2）であることを確認済み。残存する未ピン参照はすべてP2レベルの改善提案であり、このPRのマージをブロックするものではありません。

このPR自体は問題なし。フォローアップとして `.github/workflows/enforce-staging-flow.yml`（最高リスク）、`.github/workflows/ci.yml`（9箇所）、`.github/workflows/deploy-api.yml`、`.github/workflows/check-migrations.yml` への対応を推奨します。

<details><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| .github/workflows/sync-main-to-staging.yml | `actions/checkout` を SHA `11bd71901bbe5b1630ceea73d27597364c9af683`（v4.2.2）にピン留め。変更は正確かつ安全で、他のワークフローへの同様対応をフォローアップとして推奨。 |

</details>


</details>


<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant Main as mainブランチ
    participant GHA as GitHub Actions
    participant CO as actions/checkout
    participant Script as sync-main-to-staging.sh
    participant PR as Sync PR (main→staging)

    Main->>GHA: pushイベント発火
    GHA->>GHA: concurrencyグループ確認
    Note over GHA: cancel-in-progress: true
    GHA->>CO: チェックアウト実行
    Note over CO: SHA固定: 11bd71901...
    CO-->>GHA: コード取得完了
    GHA->>Script: bash実行
    Note over Script: GH_TOKEN, SYNC_SHA注入
    Script->>PR: 同期PRを作成または再利用
    PR-->>Main: PRレビュー待ち
```

<!-- greptile_failed_comments -->
<details open><summary><h3>Comments Outside Diff (1)</h3></summary>

1. `.github/workflows/ci.yml`, line 17 ([link](https://github.com/hiroki-org/openshelf/blob/52a66d8361643dfbab6527aeef8f893863f5e4fb/.github/workflows/ci.yml#L17)) 

   <a href="#"><img alt="P2" src="https://greptile-static-assets.s3.amazonaws.com/badges/p2.svg?v=7" align="top"></a> **他のワークフローでも未ピンの `actions/checkout@v4` が使用されています**

   このPRでは `sync-main-to-staging.yml` にSHAピンが適用されましたが、以下のファイルでも同様の対応が必要です：

   - `.github/workflows/ci.yml`: 17, 29, 42, 55, 82, 113, 151, 175, 232行目
   - `.github/workflows/deploy-api.yml`: 19行目
   - `.github/workflows/enforce-staging-flow.yml`: 24行目（`pull_request_target` トリガー使用のため**最高リスク**）
   - `.github/workflows/check-migrations.yml`: 15行目

   特に `enforce-staging-flow.yml` は `pull_request_target` トリガーを使用しており、フォークからの悪意あるコードがリポジトリの書き込み権限で実行されるリスクがあります。すべてのワークフローに以下のように適用することを推奨します：

   

   <details><summary>Prompt To Fix With AI</summary>

   `````markdown
   This is a comment left during a code review.
   Path: .github/workflows/ci.yml
   Line: 17

   Comment:
   **他のワークフローでも未ピンの `actions/checkout@v4` が使用されています**

   このPRでは `sync-main-to-staging.yml` にSHAピンが適用されましたが、以下のファイルでも同様の対応が必要です：

   - `.github/workflows/ci.yml`: 17, 29, 42, 55, 82, 113, 151, 175, 232行目
   - `.github/workflows/deploy-api.yml`: 19行目
   - `.github/workflows/enforce-staging-flow.yml`: 24行目（`pull_request_target` トリガー使用のため**最高リスク**）
   - `.github/workflows/check-migrations.yml`: 15行目

   特に `enforce-staging-flow.yml` は `pull_request_target` トリガーを使用しており、フォークからの悪意あるコードがリポジトリの書き込み権限で実行されるリスクがあります。すべてのワークフローに以下のように適用することを推奨します：

   

   How can I resolve this? If you propose a fix, please make it concise.
   `````
   </details>

</details>

<!-- /greptile_failed_comments -->

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
This is a comment left during a code review.
Path: .github/workflows/ci.yml
Line: 17

Comment:
**他のワークフローでも未ピンの `actions/checkout@v4` が使用されています**

このPRでは `sync-main-to-staging.yml` にSHAピンが適用されましたが、以下のファイルでも同様の対応が必要です：

- `.github/workflows/ci.yml`: 17, 29, 42, 55, 82, 113, 151, 175, 232行目
- `.github/workflows/deploy-api.yml`: 19行目
- `.github/workflows/enforce-staging-flow.yml`: 24行目（`pull_request_target` トリガー使用のため**最高リスク**）
- `.github/workflows/check-migrations.yml`: 15行目

特に `enforce-staging-flow.yml` は `pull_request_target` トリガーを使用しており、フォークからの悪意あるコードがリポジトリの書き込み権限で実行されるリスクがあります。すべてのワークフローに以下のように適用することを推奨します：

```suggestion
      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
```

How can I resolve this? If you propose a fix, please make it concise.
`````

</details>

<sub>Reviews (1): Last reviewed commit: ["ci: pin checkout in sync workflow"](https://github.com/hiroki-org/openshelf/commit/52a66d8361643dfbab6527aeef8f893863f5e4fb) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=27552427)</sub>

<!-- /greptile_comment -->