### PR TITLE
ci(sync): add metadata for automated main->staging PRs

### DIFF
--- a/.github/scripts/sync-main-to-staging.sh
+++ b/.github/scripts/sync-main-to-staging.sh
@@ -7,9 +7,34 @@ HEAD_BRANCH=${HEAD_BRANCH:-main}
 BASE_BRANCH=${BASE_BRANCH:-staging}
 SYNC_SHA=${SYNC_SHA:-}
 DRY_RUN=${DRY_RUN:-0}
+SYNC_PR_LABELS=${SYNC_PR_LABELS:-sync,automated}
+SYNC_PR_ASSIGNEES=${SYNC_PR_ASSIGNEES:-}
+SYNC_PR_REVIEWERS=${SYNC_PR_REVIEWERS:-}
 
 encode_ref() {
   printf '%s' "$1" | jq -sRr @uri
+}
+
+trim() {
+  local value="$1"
+  value="${value#"${value%%[![:space:]]*}"}"
+  value="${value%"${value##*[![:space:]]}"}"
+  printf '%s' "$value"
+}
+
+parse_csv_values() {
+  local csv="$1"
+  local -n output_ref=$2
+  local item
+  output_ref=()
+
+  IFS=',' read -r -a values <<< "$csv"
+  for item in "${values[@]}"; do
+    item="$(trim "$item")"
+    if [ -n "$item" ]; then
+      output_ref+=("$item")
+    fi
+  done
 }
 
 existing_pr_url=$(
@@ -53,17 +78,51 @@ if [ -n "$SYNC_SHA" ]; then
 Source commit: \`${SYNC_SHA}\`"
 fi
 
+declare -a label_values=()
+declare -a assignee_values=()
+declare -a reviewer_values=()
+
+parse_csv_values "$SYNC_PR_LABELS" label_values
+parse_csv_values "$SYNC_PR_ASSIGNEES" assignee_values
+parse_csv_values "$SYNC_PR_REVIEWERS" reviewer_values
+
 if [ "$DRY_RUN" = "1" ]; then
   echo "DRY_RUN=1, skipping PR creation."
   echo "Would create PR: $HEAD_BRANCH -> $BASE_BRANCH"
   echo "Title: $title"
   printf 'Body:\n%s\n' "$body"
+  printf 'Labels: %s\n' "${label_values[*]:-(none)}"
+  printf 'Assignees: %s\n' "${assignee_values[*]:-(none)}"
+  printf 'Reviewers: %s\n' "${reviewer_values[*]:-(none)}"
   exit 0
 fi
 
-gh pr create \
-  --repo "$GH_REPO" \
-  --base "$BASE_BRANCH" \
-  --head "$HEAD_BRANCH" \
-  --title "$title" \
+for label in "${label_values[@]}"; do
+  gh label create "$label" \
+    --repo "$GH_REPO" \
+    --description "Automated main-to-staging sync PR" \
+    --color "1d76db" \
+    --force
+done
+
+create_args=(
+  --repo "$GH_REPO"
+  --base "$BASE_BRANCH"
+  --head "$HEAD_BRANCH"
+  --title "$title"
   --body "$body"
+)
+
+for label in "${label_values[@]}"; do
+  create_args+=(--label "$label")
+done
+
+for assignee in "${assignee_values[@]}"; do
+  create_args+=(--assignee "$assignee")
+done
+
+for reviewer in "${reviewer_values[@]}"; do
+  create_args+=(--reviewer "$reviewer")
+done
+
+gh pr create "${create_args[@]}"

--- a/.github/workflows/sync-main-to-staging.yml
+++ b/.github/workflows/sync-main-to-staging.yml
@@ -11,6 +11,7 @@ concurrency:
 
 permissions:
   contents: read
+  issues: write
   pull-requests: write
 
 jobs:
@@ -26,4 +27,7 @@ jobs:
           HEAD_BRANCH: main
           BASE_BRANCH: staging
           SYNC_SHA: ${{ github.sha }}
+          SYNC_PR_LABELS: ${{ vars.SYNC_PR_LABELS || 'sync,automated' }}
+          SYNC_PR_ASSIGNEES: ${{ vars.SYNC_PR_ASSIGNEES || 'is0692vs' }}
+          SYNC_PR_REVIEWERS: ${{ vars.SYNC_PR_REVIEWERS || 'is0692vs' }}
         run: bash .github/scripts/sync-main-to-staging.sh


### PR DESCRIPTION
## Summary
- add configurable labels, assignees, and reviewers to .github/scripts/sync-main-to-staging.sh
- create or update labels before gh pr create so automation does not fail on missing labels
- grant issues: write in .github/workflows/sync-main-to-staging.yml for label management

## Why
Promotion PR #345 is blocked by a CHANGES_REQUESTED review requesting reviewer, assignee, and label metadata in the auto-sync PR creation flow. This patch implements that feedback directly.

## Defaults
- SYNC_PR_LABELS: sync,automated
- SYNC_PR_ASSIGNEES: is0692vs
- SYNC_PR_REVIEWERS: is0692vs

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

このPRは、`main→staging` の自動同期PRにラベル・アサイニー・レビュアーのメタデータを付与する機能を追加しています。CSV形式での設定可否、ラベルの事前作成（upsert）、`issues: write` 権限の追加など、全体的な方向性は適切です。

主な変更点と注意事項:
- `SYNC_PR_LABELS`（デフォルト: `sync,automated`）・`SYNC_PR_ASSIGNEES`・`SYNC_PR_REVIEWERS` を環境変数で設定可能にし、CSV パースロジック（`trim`・`parse_csv_values`）を追加
- `gh label create --force` により、**既存ラベルの色や説明が `main` へのプッシュのたびに上書きされる**問題があります（P1）
- ワークフローの `SYNC_PR_ASSIGNEES` / `SYNC_PR_REVIEWERS` のフォールバック値に個人ユーザー名 `is0692vs` がハードコードされており、ユーザー離脱時に自動化が壊れる可能性があります（P1）
- `issues: write` の追加はラベル管理に必要であり適切です
</details>

<h3>Confidence Score: 4/5</h3>

P1の問題が2件あるためマージ前に修正を推奨しますが、基本動作は機能します

`--force` による既存ラベルの上書きと個人ユーザー名のハードコードという2件のP1問題があります。ワークフローの基本ロジックは正しく機能しますが、これらを修正してからマージすることを推奨します

`.github/scripts/sync-main-to-staging.sh`（ラベル作成ループの `--force`）および `.github/workflows/sync-main-to-staging.yml`（フォールバックユーザー名）に注意が必要です

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| .github/scripts/sync-main-to-staging.sh | ラベル作成に `--force` を使用しており既存ラベルのメタデータが毎回上書きされる問題あり。CSV パース・トリム・nameref の実装自体は適切。 |
| .github/workflows/sync-main-to-staging.yml | `issues: write` 権限の追加は適切だが、`SYNC_PR_ASSIGNEES`/`SYNC_PR_REVIEWERS` のフォールバックに個人ユーザー名 `is0692vs` がハードコードされており保守性の問題あり。 |

</details>

</details>

<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant GHA as GitHub Actions
    participant Script as sync-main-to-staging.sh
    participant GH as GitHub API

    GHA->>Script: bash sync-main-to-staging.sh
    Script->>GH: gh pr list（既存PR確認）
    GH-->>Script: 既存PRなし
    Script->>GH: gh api compare（ahead_by確認）
    GH-->>Script: ahead_by > 0
    loop 各ラベル（NEW）
        Script->>GH: gh label create --force
        note over GH: ⚠️ 既存ラベルの色・説明を上書き
    end
    Script->>GH: gh pr create --label --assignee --reviewer
    GH-->>Script: PR URL
```

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
This is a comment left during a code review.
Path: .github/workflows/sync-main-to-staging.yml
Line: 31-32

Comment:
**個人ユーザー名のハードコード**

`vars.SYNC_PR_ASSIGNEES` および `vars.SYNC_PR_REVIEWERS` が未設定の場合、フォールバックとして `is0692vs` が使われます。このユーザーがプロジェクトを離れた場合、ワークフローは毎回意図しない相手へのアサインおよびレビューリクエストを送り続けます。スクリプト本体（`sync-main-to-staging.sh` の11〜12行目）のデフォルトは空文字列なので、ワークフロー側のフォールバックとの整合性もとれていません。

リポジトリ変数が未設定のときは空文字列にし、スクリプト側の安全なデフォルト（何も追加しない）に委ねることを推奨します。

```suggestion
          SYNC_PR_ASSIGNEES: ${{ vars.SYNC_PR_ASSIGNEES }}
          SYNC_PR_REVIEWERS: ${{ vars.SYNC_PR_REVIEWERS }}
```

How can I resolve this? If you propose a fix, please make it concise.

---

This is a comment left during a code review.
Path: .github/scripts/sync-main-to-staging.sh
Line: 100-106

Comment:
**`--force` によって既存ラベルのメタデータが毎回上書きされる**

`gh label create --force` は同名ラベルが既に存在する場合でも、色（`1d76db`）と説明文（`Automated main-to-staging sync PR`）を強制的に上書きします。`main` へのプッシュのたびに実行されるため、チームが独自にカスタマイズしたラベルのメタデータが毎回サイレントに破壊されます。

ラベルが存在しない場合のみ作成し、既存ラベルには手を加えないことを推奨します。`set -euo pipefail` が有効なため、単に `--force` を外すだけではラベルが既存の場合にスクリプトが終了してしまいます。存在確認を挟む必要があります。

```bash
for label in "${label_values[@]}"; do
  if ! gh label list --repo "$GH_REPO" --json name --jq '.[].name' | grep -qx "$label"; then
    gh label create "$label" \
      --repo "$GH_REPO" \
      --description "Automated main-to-staging sync PR" \
      --color "1d76db"
  fi
done
```

How can I resolve this? If you propose a fix, please make it concise.
`````

</details>

<sub>Reviews (1): Last reviewed commit: ["ci(sync): add labels and assignee/review..."](https://github.com/hiroki-org/openshelf/commit/8ab071edd15a1fa19bd120f9e0e799876357a8a8) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=27558632)</sub>

> Greptile also left **2 inline comments** on this PR.

<!-- /greptile_comment -->