### PR TITLE
ci(sync): remove hardcoded assignee/reviewer fallback

### DIFF
--- a/.github/workflows/sync-main-to-staging.yml
+++ b/.github/workflows/sync-main-to-staging.yml
@@ -28,6 +28,6 @@ jobs:
           BASE_BRANCH: staging
           SYNC_SHA: ${{ github.sha }}
           SYNC_PR_LABELS: ${{ vars.SYNC_PR_LABELS || 'sync,automated' }}
-          SYNC_PR_ASSIGNEES: ${{ vars.SYNC_PR_ASSIGNEES || 'is0692vs' }}
-          SYNC_PR_REVIEWERS: ${{ vars.SYNC_PR_REVIEWERS || 'is0692vs' }}
+          SYNC_PR_ASSIGNEES: ${{ vars.SYNC_PR_ASSIGNEES || '' }}
+          SYNC_PR_REVIEWERS: ${{ vars.SYNC_PR_REVIEWERS || '' }}
         run: bash .github/scripts/sync-main-to-staging.sh


### PR DESCRIPTION
## Summary
- remove hardcoded is0692vs fallback for sync PR assignees/reviewers
- keep values driven by repository variables (or empty)

## Why
Follow-up CodeRabbit review on PR #345 requested that sync PR assignee/reviewer defaults not be tied to a fixed username.

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

このPRは、sync PRの自動生成時に `SYNC_PR_ASSIGNEES` および `SYNC_PR_REVIEWERS` のフォールバック値としてハードコードされていたユーザー名 `is0692vs` を削除し、空文字列 `''` へ変更します。PR #345 に対する CodeRabbit のレビュー指摘を受けたフォローアップです。

- `.github/workflows/sync-main-to-staging.yml` の `SYNC_PR_ASSIGNEES` と `SYNC_PR_REVIEWERS` のフォールバックを `'is0692vs'` → `''` に変更
- ラベルのフォールバック (`sync,automated`) は汎用的なため引き続き維持
- `sync-main-to-staging.sh` 内の `parse_csv_values` 関数は空文字列を正しく処理するため、スクリプト側の変更は不要
- リポジトリ変数 (`vars.SYNC_PR_ASSIGNEES` / `vars.SYNC_PR_REVIEWERS`) が設定されていない場合、assignee・reviewer なしで PR が作成される
</details>

<h3>Confidence Score: 5/5</h3>

変更は最小限かつ安全で、マージに問題なし。

ハードコードされたユーザー名を空文字列へ置き換えるだけのシンプルな1行変更が2箇所。シェルスクリプト側の空値ハンドリング（parse_csv_values）も適切に実装されており、P1以上の問題は見当たらない。

特になし。

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| .github/workflows/sync-main-to-staging.yml | ハードコードされた `is0692vs` フォールバックを削除し空文字列に変更。スクリプトの動作に影響なし。 |

</details>

</details>

<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant GH as GitHub Actions
    participant WF as sync-main-to-staging.yml
    participant SH as sync-main-to-staging.sh
    participant API as GitHub API

    GH->>WF: push to main / workflow_dispatch
    WF->>WF: 環境変数を設定<br/>SYNC_PR_ASSIGNEES = vars.SYNC_PR_ASSIGNEES \|\| ''<br/>SYNC_PR_REVIEWERS = vars.SYNC_PR_REVIEWERS \|\| ''
    WF->>SH: bash スクリプト実行
    SH->>API: 既存 PR を確認
    alt 既存 PR なし かつ コミット差分あり
        SH->>API: gh pr create<br/>(変数が空の場合 --assignee / --reviewer はスキップ)
    else 既存 PR あり または 差分なし
        SH-->>GH: exit 0
    end
```

<sub>Reviews (1): Last reviewed commit: ["ci(sync): remove hardcoded sync assignee..."](https://github.com/hiroki-org/openshelf/commit/a5538a94964e04ff88395ae93e4d857aadc1cd5d) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=27559572)</sub>

<!-- /greptile_comment -->