### PR TITLE
Fix feed button accessibility and add file validation coverage

### DIFF
--- a/apps/api/src/utils/__tests__/file.test.ts
+++ b/apps/api/src/utils/__tests__/file.test.ts
@@ -83,31 +83,37 @@ function createFile(name: string, type: string, bytes: Uint8Array) {
   return new File([Uint8Array.from(bytes)], name, { type });
 }
 
-function withText(bytes: number[], text: string) {
-  const textBytes = new TextEncoder().encode(text);
-  return new Uint8Array([...bytes, ...textBytes]);
-}
-
-function toUtf16Le(text: string) {
-  const bytes = new Uint8Array(text.length * 2);
-  for (let index = 0; index < text.length; index++) {
-    bytes[index * 2] = text.charCodeAt(index);
-    bytes[index * 2 + 1] = 0;
-  }
-  return bytes;
-}
-
 describe("validateMagicNumbers", () => {
-  it("accepts valid PDF files", async () => {
-    const pdf = createFile(
-      "paper.pdf",
-      "application/pdf",
-      new Uint8Array([0x25, 0x50, 0x44, 0x46, 0x2d, 0x31, 0x2e, 0x37]),
-    );
-
-    await expect(validateMagicNumbers(pdf, "application/pdf")).resolves.toBe(
-      true,
-    );
+  it.each([
+    {
+      label: "PDF",
+      file: createFile(
+        "paper.pdf",
+        "application/pdf",
+        new Uint8Array([0x25, 0x50, 0x44, 0x46, 0x2d, 0x31, 0x2e, 0x37]),
+      ),
+      declaredMime: "application/pdf",
+    },
+    {
+      label: "PNG",
+      file: createFile(
+        "cover.png",
+        "image/png",
+        new Uint8Array([0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a]),
+      ),
+      declaredMime: "image/png",
+    },
+    {
+      label: "JPEG",
+      file: createFile(
+        "photo.jpg",
+        "image/jpeg",
+        new Uint8Array([0xff, 0xd8, 0xff, 0xdb]),
+      ),
+      declaredMime: "image/jpeg",
+    },
+  ])("accepts valid $label files", async ({ file, declaredMime }) => {
+    await expect(validateMagicNumbers(file, declaredMime)).resolves.toBe(true);
   });
 
   it("rejects files whose magic number does not match the declared type", async () => {
@@ -153,9 +159,6 @@ describe("validateMagicNumbers", () => {
   });
 
   it("accepts legacy PowerPoint files when the OLE payload contains the document marker", async () => {
-    const header = new Uint8Array([
-      0xd0, 0xcf, 0x11, 0xe0, 0xa1, 0xb1, 0x1a, 0xe1,
-    ]);
     const ppt = createFile(
       "slides.ppt",
       "application/vnd.ms-powerpoint",
@@ -176,6 +179,18 @@ describe("validateMagicNumbers", () => {
 
     await expect(
       validateMagicNumbers(file, "application/octet-stream"),
+    ).resolves.toBe(false);
+  });
+
+  it("rejects files whose content ends before a full signature match", async () => {
+    const truncatedPng = createFile(
+      "cover.png",
+      "image/png",
+      new Uint8Array([0x89, 0x50, 0x4e, 0x47]),
+    );
+
+    await expect(
+      validateMagicNumbers(truncatedPng, "image/png"),
     ).resolves.toBe(false);
   });
 });

--- a/apps/web/src/components/__tests__/feed-button.test.tsx
+++ b/apps/web/src/components/__tests__/feed-button.test.tsx
@@ -45,6 +45,55 @@ describe("FeedButton", () => {
     );
   });
 
+  it("moves focus into the dialog when it opens", async () => {
+    render(<FeedButton url="https://api.example/feed.xml" />);
+
+    fireEvent.click(screen.getByRole("button", { name: "📡 Feed" }));
+
+    await waitFor(() => {
+      expect(screen.getByRole("textbox", { name: "フィード URL" })).toHaveFocus();
+    });
+  });
+
+  it("closes the dialog when clicking outside with pointer events", async () => {
+    render(<FeedButton url="https://api.example/feed.xml" />);
+
+    fireEvent.click(screen.getByRole("button", { name: "📡 Feed" }));
+    expect(screen.getByRole("dialog", { name: "フィード URL" })).toBeInTheDocument();
+
+    fireEvent.pointerDown(document.body);
+
+    await waitFor(() => {
+      expect(
+        screen.queryByRole("dialog", { name: "フィード URL" }),
+      ).not.toBeInTheDocument();
+    });
+  });
+
+  it("traps focus inside the dialog and returns focus on escape", async () => {
+    render(<FeedButton url="https://api.example/feed.xml" />);
+
+    const trigger = screen.getByRole("button", { name: "📡 Feed" });
+    fireEvent.click(trigger);
+
+    const textbox = await screen.findByRole("textbox", { name: "フィード URL" });
+    const link = screen.getByRole("link", { name: "開く" });
+
+    textbox.focus();
+    fireEvent.keyDown(document, { key: "Tab", shiftKey: true });
+    expect(link).toHaveFocus();
+
+    fireEvent.keyDown(document, { key: "Tab" });
+    expect(textbox).toHaveFocus();
+
+    fireEvent.keyDown(document, { key: "Escape" });
+
+    await waitFor(() => {
+      expect(screen.queryByRole("dialog", { name: "フィード URL" })).not.toBeInTheDocument();
+      expect(trigger).toHaveFocus();
+    });
+  });
+
   it("copies the feed URL from the popover", async () => {
     render(<FeedButton url="https://api.example/feed.xml" />);
 

--- a/apps/web/src/components/feed-button.tsx
+++ b/apps/web/src/components/feed-button.tsx
@@ -23,7 +23,7 @@ export function FeedButton({
     if (!open) return;
 
     const focusableSelector =
-      'button, [href], input, textarea, select, [tabindex]:not([tabindex="-1"])';
+      'button:not([tabindex="-1"]), [href]:not([tabindex="-1"]), input:not([tabindex="-1"]), textarea:not([tabindex="-1"]), select:not([tabindex="-1"]), [tabindex]:not([tabindex="-1"])';
     const getFocusableElements = () =>
       Array.from(
         dialogRef.current?.querySelectorAll<HTMLElement>(focusableSelector) ??
@@ -44,6 +44,7 @@ export function FeedButton({
         !containerRef.current?.contains(target)
       ) {
         setOpen(false);
+        triggerRef.current?.focus();
       }
     };
 
@@ -65,11 +66,8 @@ export function FeedButton({
         return;
       }
 
-      const first = focusable[0];
-      const last = focusable[focusable.length - 1];
-      if (!first || !last) {
-        return;
-      }
+      const first = focusable[0]!;
+      const last = focusable[focusable.length - 1]!;
 
       const activeElement = document.activeElement;
       if (event.shiftKey) {

--- a/apps/web/src/components/feed-button.tsx
+++ b/apps/web/src/components/feed-button.tsx
@@ -16,12 +16,33 @@ export function FeedButton({
 }: FeedButtonProps) {
   const [open, setOpen] = useState(false);
   const containerRef = useRef<HTMLDivElement>(null);
+  const triggerRef = useRef<HTMLButtonElement>(null);
+  const dialogRef = useRef<HTMLDivElement>(null);
 
   useEffect(() => {
     if (!open) return;
 
-    const handlePointerDown = (event: MouseEvent) => {
-      if (!containerRef.current?.contains(event.target as Node)) {
+    const focusableSelector =
+      'button, [href], input, textarea, select, [tabindex]:not([tabindex="-1"])';
+    const getFocusableElements = () =>
+      Array.from(
+        dialogRef.current?.querySelectorAll<HTMLElement>(focusableSelector) ??
+          [],
+      ).filter(
+        (element) =>
+          !element.hasAttribute("disabled") &&
+          element.getAttribute("aria-hidden") !== "true",
+      );
+
+    const firstFocusable = getFocusableElements()[0];
+    (firstFocusable ?? dialogRef.current)?.focus();
+
+    const handlePointerDown = (event: PointerEvent) => {
+      const target = event.target;
+      if (
+        target instanceof Node &&
+        !containerRef.current?.contains(target)
+      ) {
         setOpen(false);
       }
     };
@@ -29,14 +50,47 @@ export function FeedButton({
     const handleKeyDown = (event: KeyboardEvent) => {
       if (event.key === "Escape") {
         setOpen(false);
+        triggerRef.current?.focus();
+        return;
+      }
+
+      if (event.key !== "Tab") {
+        return;
+      }
+
+      const focusable = getFocusableElements();
+      if (focusable.length === 0) {
+        event.preventDefault();
+        dialogRef.current?.focus();
+        return;
+      }
+
+      const first = focusable[0];
+      const last = focusable[focusable.length - 1];
+      if (!first || !last) {
+        return;
+      }
+
+      const activeElement = document.activeElement;
+      if (event.shiftKey) {
+        if (activeElement === first || activeElement === dialogRef.current) {
+          event.preventDefault();
+          last.focus();
+        }
+        return;
+      }
+
+      if (activeElement === last) {
+        event.preventDefault();
+        first.focus();
       }
     };
 
-    document.addEventListener("mousedown", handlePointerDown);
+    document.addEventListener("pointerdown", handlePointerDown);
     document.addEventListener("keydown", handleKeyDown);
 
     return () => {
-      document.removeEventListener("mousedown", handlePointerDown);
+      document.removeEventListener("pointerdown", handlePointerDown);
       document.removeEventListener("keydown", handleKeyDown);
     };
   }, [open]);
@@ -58,6 +112,7 @@ export function FeedButton({
   return (
     <div ref={containerRef} className="relative inline-block">
       <button
+        ref={triggerRef}
         type="button"
         className={className}
         aria-haspopup="dialog"
@@ -68,9 +123,11 @@ export function FeedButton({
       </button>
       {open && (
         <div
+          ref={dialogRef}
           role="dialog"
           aria-modal="true"
           aria-label="フィード URL"
+          tabIndex={-1}
           className="absolute right-0 top-full z-20 mt-2 w-80 rounded-md border border-gray-200 bg-white p-3 shadow-lg dark:border-gray-700 dark:bg-gray-900"
         >
           <p className="text-xs font-medium text-gray-500 dark:text-gray-400">


### PR DESCRIPTION
## Summary
- switch the feed popover close handler from `mousedown` to `pointerdown`
- move focus into the feed dialog, trap `Tab` navigation while it is open, and restore focus to the trigger on `Escape`
- add regression tests for the feed dialog interaction flow and broaden `validateMagicNumbers` test coverage

## Issues
Closes #353
Closes #354

## Notes
- Issue #368 and issue #369 appear to already be resolved on `main`, so this PR does not include closing keywords for them.
- The extra `validateMagicNumbers` tests help reduce the coverage gap called out in issue #373, but this PR does not close #373 directly.

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

フィードダイアログのアクセシビリティを改善するPRです。`mousedown` を `pointerdown` に切り替え、ダイアログオープン時のフォーカス移動・Tab トラップ・Escape によるフォーカス復元を実装しています。また、`validateMagicNumbers` のテストを `it.each` でリファクタリングし、切り捨てファイルの拒否ケースを追加しています。
</details>

<h3>Confidence Score: 5/5</h3>

すべての指摘が P2（スタイル提案）であり、マージ可能です。

実装は正しく、フォーカス移動・Tab トラップ・Escape 復元がすべて適切に動作します。外部クリック時のフォーカス復元が未実装という ARIA 推奨事項の P2 がありますが、機能上の障害はありません。テストカバレッジも十分です。

apps/web/src/components/feed-button.tsx — 外部クリック閉じ時のフォーカス復元（P2）

<details open><summary><h3>Vulnerabilities</h3></summary>

セキュリティ上の懸念は確認されませんでした。
</details>

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| apps/web/src/components/feed-button.tsx | `mousedown` → `pointerdown` への切り替え、ダイアログオープン時のフォーカス移動、Tab トラップ、Escape 時のフォーカス復元を実装。外部クリック閉じ時のフォーカス復元（ARIA 推奨）が未実装という P2 がある。 |
| apps/web/src/components/__tests__/feed-button.test.tsx | フォーカス移動・外部クリック閉じ・Tab トラップ・Escape フォーカス復元の各シナリオをカバーする新規テストを追加。実装の挙動と整合しており問題なし。 |
| apps/api/src/utils/__tests__/file.test.ts | `it.each` を使って PDF/PNG/JPEG の有効ファイルテストを統合し、切り捨てられた PNG シグネチャの拒否テストを追加。不要な `withText` / `toUtf16Le` ヘルパーも削除されており、クリーンな改善。 |

</details>

</details>

<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[ユーザーがトリガーボタンをクリック] --> B[setOpen: true]
    B --> C[ダイアログ表示]
    C --> D[useEffect: 最初のフォーカス可能要素にフォーカス移動]
    D --> E{ユーザー操作}

    E -->|Escape キー| F[setOpen: false\ntriggerRef.focus]
    E -->|Tab キー| G{現在フォーカス位置}
    E -->|ダイアログ外 pointerdown| H[setOpen: false\n※フォーカス未復元 P2]

    G -->|最後の要素 + Tab| I[最初の要素へ wrap]
    G -->|最初の要素 + Shift+Tab| J[最後の要素へ wrap]
    G -->|中間要素| K[デフォルト Tab 動作]

    F --> L[ダイアログ非表示\nフォーカス: トリガーボタン]
    H --> M[ダイアログ非表示\nフォーカス: 不定]
    I --> D
    J --> D
    K --> D
```

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
This is a comment left during a code review.
Path: apps/web/src/components/feed-button.tsx
Line: 40-47

Comment:
**外部クリック時のフォーカス復元が未実装**

ダイアログ外のクリック (`pointerdown`) で閉じた場合、フォーカスがトリガーボタンに戻りません。WAI-ARIA のダイアログパターンでは、ダイアログを閉じた際は必ずトリガー要素にフォーカスを戻すことが推奨されています。クリック先の要素がフォーカスを受け取らないケース（例：テキストノードや背景）では、フォーカスが失われてキーボードユーザーが操作不能になる可能性があります。

```suggestion
    const handlePointerDown = (event: PointerEvent) => {
      const target = event.target;
      if (
        target instanceof Node &&
        !containerRef.current?.contains(target)
      ) {
        setOpen(false);
        triggerRef.current?.focus();
      }
    };
```

How can I resolve this? If you propose a fix, please make it concise.
`````

</details>

<sub>Reviews (1): Last reviewed commit: ["fix: improve feed dialog accessibility"](https://github.com/hiroki-org/openshelf/commit/260512dc9612ebd358ed2fb2bbd814e247d745e2) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=27818039)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->