### PR TITLE
fix(ci): ignore benchmark files in codecov patch coverage

### DIFF
--- a/codecov.yml
+++ b/codecov.yml
@@ -14,6 +14,10 @@ coverage:
       default:
         target: 70%
 
+ignore:
+  - "**/*.bench.ts"
+  - "**/*.bench.tsx"
+
 comment:
   layout: "reach,diff,flags,files"
   behavior: default


### PR DESCRIPTION
## Summary
- add Codecov ignore rules for benchmark source files (*.bench.ts / *.bench.tsx)
- keep existing patch coverage target unchanged

## Why
Patch coverage was reduced by benchmark source files that are not executed in the regular test suite.

Closes #373

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

`codecov.yml` にトップレベルの `ignore` ブロックを追加し、ベンチマークファイル（`*.bench.ts` / `*.bench.tsx`）をカバレッジ計測から除外するCI設定の修正です。通常のテストスイートで実行されないベンチマークファイルがパッチカバレッジを引き下げていた問題（#373）への対応であり、変更内容は最小限かつ意図通りです。
</details>

<h3>Confidence Score: 5/5</h3>

マージして問題ありません。変更は `codecov.yml` の1箇所のみで、副作用のない設定追加です。

P0/P1 の問題はゼロ。`ignore` キーの配置（トップレベル）・グロブパターン（`**/*.bench.ts` / `**/*.bench.tsx`）ともに Codecov の仕様通り正しく、既存の `coverage.status` 設定には影響しません。

特になし。

<details open><summary><h3>Vulnerabilities</h3></summary>

セキュリティ上の懸念は確認されませんでした。
</details>

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| codecov.yml | トップレベルに `ignore` ブロックを追加し、`*.bench.ts` / `*.bench.tsx` ファイルをカバレッジ計測から除外。構文・配置ともに正しく問題なし。 |

</details>

</details>

<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[CI テスト実行] --> B{ファイル種別}
    B -- "*.bench.ts / *.bench.tsx" --> C[Codecov ignore\n対象外として除外]
    B -- "それ以外のソースファイル" --> D[カバレッジ計測対象]
    D --> E{閾値チェック}
    E -- "project ≥ 80%" --> F[✅ project coverage OK]
    E -- "patch ≥ 70%" --> G[✅ patch coverage OK]
```

<sub>Reviews (1): Last reviewed commit: ["fix(ci): ignore benchmark files in codec..."](https://github.com/hiroki-org/openshelf/commit/253ca78f8f08bc6e59d4239cc6dd6ce0c5a26aa8) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=27822909)</sub>

<!-- /greptile_comment -->