### PR TITLE
fix: address non-urgent review comments from PR #381

### DIFF
--- a/.github/scripts/create-staging-to-main-pr.sh
+++ b/.github/scripts/create-staging-to-main-pr.sh
@@ -163,12 +163,19 @@ while IFS= read -r pr_number; do
 done < <(
   git log --pretty=format:'%s' "$base_ref..$head_ref" |
     while IFS= read -r subject; do
-      printf '%s\n' "$subject" | grep -oE '#[0-9]+' | sed 's/#//' || true
+      # Match PR numbers from GitHub merge/squash formats only.
+      printf '%s\n' "$subject" |
+        grep -oE 'Merge pull request #[0-9]+|\(#[0-9]+\)' |
+        grep -oE '[0-9]+' || true
     done |
     awk '!seen[$0]++'
 )
 
-included_pr_lines="$(build_included_pr_lines "${pr_numbers[@]}")"
+if [ "${#pr_numbers[@]}" -eq 0 ]; then
+  included_pr_lines="$(build_included_pr_lines)"
+else
+  included_pr_lines="$(build_included_pr_lines "${pr_numbers[@]}")"
+fi
 body="$(build_body "$included_pr_lines")"
 
 declare -a label_values=()

--- a/.github/scripts/create-staging-to-main-pr.sh
+++ b/.github/scripts/create-staging-to-main-pr.sh
@@ -171,11 +171,7 @@ done < <(
     awk '!seen[$0]++'
 )
 
-if [ "${#pr_numbers[@]}" -eq 0 ]; then
-  included_pr_lines="$(build_included_pr_lines)"
-else
-  included_pr_lines="$(build_included_pr_lines "${pr_numbers[@]}")"
-fi
+included_pr_lines="$(build_included_pr_lines "${pr_numbers[@]}")"
 body="$(build_body "$included_pr_lines")"
 
 declare -a label_values=()

--- a/apps/web/src/components/__tests__/feed-button.test.tsx
+++ b/apps/web/src/components/__tests__/feed-button.test.tsx
@@ -45,6 +45,19 @@ describe("FeedButton", () => {
     );
   });
 
+  it("renders custom label and className", () => {
+    render(
+      <FeedButton
+        url="https://api.example/feed.xml"
+        label="Feed URL を表示"
+        className="custom-trigger"
+      />,
+    );
+
+    const trigger = screen.getByRole("button", { name: "Feed URL を表示" });
+    expect(trigger).toHaveClass("custom-trigger");
+  });
+
   it("moves focus into the dialog when it opens", async () => {
     render(<FeedButton url="https://api.example/feed.xml" />);
 
@@ -58,7 +71,8 @@ describe("FeedButton", () => {
   it("closes the dialog when clicking outside with pointer events", async () => {
     render(<FeedButton url="https://api.example/feed.xml" />);
 
-    fireEvent.click(screen.getByRole("button", { name: "📡 Feed" }));
+    const trigger = screen.getByRole("button", { name: "📡 Feed" });
+    fireEvent.click(trigger);
     expect(screen.getByRole("dialog", { name: "フィード URL" })).toBeInTheDocument();
 
     fireEvent.pointerDown(document.body);
@@ -67,6 +81,7 @@ describe("FeedButton", () => {
       expect(
         screen.queryByRole("dialog", { name: "フィード URL" }),
       ).not.toBeInTheDocument();
+      expect(trigger).toHaveFocus();
     });
   });
 
@@ -94,6 +109,20 @@ describe("FeedButton", () => {
     });
   });
 
+  it("keeps focus trapped when tabbing from the dialog container", async () => {
+    render(<FeedButton url="https://api.example/feed.xml" />);
+
+    fireEvent.click(screen.getByRole("button", { name: "📡 Feed" }));
+
+    const dialog = await screen.findByRole("dialog", { name: "フィード URL" });
+    const textbox = screen.getByRole("textbox", { name: "フィード URL" });
+
+    dialog.focus();
+    fireEvent.keyDown(document, { key: "Tab" });
+
+    expect(textbox).toHaveFocus();
+  });
+
   it("copies the feed URL from the popover", async () => {
     render(<FeedButton url="https://api.example/feed.xml" />);
 
@@ -105,6 +134,38 @@ describe("FeedButton", () => {
         "https://api.example/feed.xml",
       );
       expect(toastSuccess).toHaveBeenCalledWith("コピーしました");
+    });
+  });
+
+  it("shows an error when clipboard write fails", async () => {
+    vi.stubGlobal("navigator", {
+      clipboard: {
+        writeText: vi.fn(async () => {
+          throw new Error("clipboard write failed");
+        }),
+      },
+    });
+
+    render(<FeedButton url="https://api.example/feed.xml" />);
+    fireEvent.click(screen.getByRole("button", { name: "📡 Feed" }));
+    fireEvent.click(screen.getByRole("button", { name: "コピー" }));
+
+    await waitFor(() => {
+      expect(toastError).toHaveBeenCalledWith("クリップボードへのコピーに失敗しました");
+    });
+  });
+
+  it("shows an error when clipboard.writeText is unavailable", async () => {
+    vi.stubGlobal("navigator", { clipboard: {} });
+
+    render(<FeedButton url="https://api.example/feed.xml" />);
+    fireEvent.click(screen.getByRole("button", { name: "📡 Feed" }));
+    fireEvent.click(screen.getByRole("button", { name: "コピー" }));
+
+    await waitFor(() => {
+      expect(toastError).toHaveBeenCalledWith(
+        "このブラウザではクリップボード機能を利用できません",
+      );
     });
   });
 

--- a/apps/web/src/components/feed-button.tsx
+++ b/apps/web/src/components/feed-button.tsx
@@ -23,7 +23,7 @@ export function FeedButton({
     if (!open) return;
 
     const focusableSelector =
-      'button:not([tabindex="-1"]), [href]:not([tabindex="-1"]), input:not([tabindex="-1"]), textarea:not([tabindex="-1"]), select:not([tabindex="-1"]), [tabindex]:not([tabindex="-1"])';
+      'button:not([tabindex="-1"]), [href]:not([tabindex="-1"]), input:not([tabindex="-1"]), textarea:not([tabindex="-1"]), select:not([tabindex="-1"]), [contenteditable]:not([contenteditable="false"]):not([tabindex="-1"]), [tabindex]:not([tabindex="-1"])';
     const getFocusableElements = () =>
       Array.from(
         dialogRef.current?.querySelectorAll<HTMLElement>(focusableSelector) ??
@@ -78,7 +78,7 @@ export function FeedButton({
         return;
       }
 
-      if (activeElement === last) {
+      if (activeElement === last || activeElement === dialogRef.current) {
         event.preventDefault();
         first.focus();
       }


### PR DESCRIPTION
## Summary
- tighten promotion script PR-number parsing to GitHub merge/squash commit formats only
- make included PR rendering robust when no PR numbers are collected
- include `[contenteditable]` elements in the feed dialog focus trap selector
- make forward Tab trapping symmetric with Shift+Tab when dialog container has focus
- extend feed button tests for focus restoration, dialog-container tabbing, clipboard error branches, and custom props

## Linked issues
- Closes #384
- Closes #383
- Closes #382

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

PR #381 での指摘事項を対応したフォローアップ PR です。主な変更は3つのファイルにまたがります。

- **シェルスクリプト**: PR番号の抽出正規表現を GitHub の merge/squash コミット形式（`Merge pull request #NNN` または `(#NNN)`）に限定し、`set -u` 環境での空配列展開を安全に処理するよう修正。`build_included_pr_lines` にゼロ引数ガードを追加。
- **`feed-button.tsx`**: フォーカストラップセレクターに `[contenteditable]` 要素を追加し、ダイアログコンテナにフォーカスがある状態での前進 Tab を Shift+Tab と対称に修正（`activeElement === dialogRef.current` 条件を追加）。
- **テスト**: フォーカス復元・ダイアログコンテナのタブ操作・クリップボードエラー・カスタム props の各ブランチをカバーするテストを追加。
</details>


<h3>Confidence Score: 5/5</h3>

P2 の軽微な提案のみで、マージに支障となる問題はありません。

全変更が正確で、フォーカストラップの対称性修正・シェルスクリプトの堅牢化・テスト拡充はすべて正しく実装されています。残っている指摘は `waitFor` ラッピングの提案（スタイル/安定性）のみであり P2 相当です。

特に注意が必要なファイルはありません。

<details open><summary><h3>Vulnerabilities</h3></summary>

セキュリティ上の懸念は特に見当たりません。
</details>


<details><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| .github/scripts/create-staging-to-main-pr.sh | PR番号抽出を GitHub merge/squash コミット形式に限定し、空配列の `nounset` 対応と `build_included_pr_lines` のゼロ引数ガードを追加。変更は正確でロジックの問題なし。 |
| apps/web/src/components/feed-button.tsx | `[contenteditable]` をフォーカストラップセレクターに追加し、ダイアログコンテナへのフォーカス時の前進タブ挙動を Shift+Tab と対称になるよう修正。変更は正確。 |
| apps/web/src/components/__tests__/feed-button.test.tsx | フォーカス復元、ダイアログコンテナのタブ操作、クリップボードエラー分岐、カスタム props のテストを追加。一部フォーカスアサーションで `waitFor` が欠けている可能性あり。 |

</details>


</details>


<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[keydown イベント] --> B{key === Escape?}
    B -- Yes --> C[setOpen false\ntriggerRef.focus]
    B -- No --> D{key === Tab?}
    D -- No --> E[処理なし]
    D -- Yes --> F[getFocusableElements]
    F --> G{要素数 === 0?}
    G -- Yes --> H[preventDefault\ndialogRef.focus]
    G -- No --> I{shiftKey?}
    I -- Yes --> J{activeElement ===\nfirst OR dialogRef?}
    J -- Yes --> K[preventDefault\nlast.focus]
    J -- No --> L[処理なし]
    I -- No --> M{activeElement ===\nlast OR dialogRef?}
    M -- Yes --> N[preventDefault\nfirst.focus]
    M -- No --> O[処理なし]
```

<!-- greptile_failed_comments -->
<details open><summary><h3>Comments Outside Diff (1)</h3></summary>

1. `apps/web/src/components/__tests__/feed-button.test.tsx`, line 98-102 ([link](https://github.com/hiroki-org/openshelf/blob/63d37bf6a5c3273a057c580c896eadf626915b1d/apps/web/src/components/__tests__/feed-button.test.tsx#L98-L102)) 

   <a href="#"><img alt="P2" src="https://greptile-static-assets.s3.amazonaws.com/badges/p2.svg?v=7" align="top"></a> **テスト内の Tab キー操作後のフォーカス確認に `await` がない**

   `fireEvent.keyDown` はイベントを同期的に発火しますが、コンポーネント内の `.focus()` 呼び出しが jsdom で非同期に処理される場合、`expect(link).toHaveFocus()` と `expect(textbox).toHaveFocus()` が即座に評価されてフォーカスがまだ移動していないタイミングでアサーションが走る可能性があります。既存の「dialog container からタブ操作」テストと整合させるため、フォーカスアサーションを `waitFor` で囲むことを検討してください。

   

   <details><summary>Prompt To Fix With AI</summary>

   `````markdown
   This is a comment left during a code review.
   Path: apps/web/src/components/__tests__/feed-button.test.tsx
   Line: 98-102

   Comment:
   **テスト内の Tab キー操作後のフォーカス確認に `await` がない**

   `fireEvent.keyDown` はイベントを同期的に発火しますが、コンポーネント内の `.focus()` 呼び出しが jsdom で非同期に処理される場合、`expect(link).toHaveFocus()` と `expect(textbox).toHaveFocus()` が即座に評価されてフォーカスがまだ移動していないタイミングでアサーションが走る可能性があります。既存の「dialog container からタブ操作」テストと整合させるため、フォーカスアサーションを `waitFor` で囲むことを検討してください。

   

   How can I resolve this? If you propose a fix, please make it concise.
   `````
   </details>

</details>

<!-- /greptile_failed_comments -->

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
This is a comment left during a code review.
Path: apps/web/src/components/__tests__/feed-button.test.tsx
Line: 98-102

Comment:
**テスト内の Tab キー操作後のフォーカス確認に `await` がない**

`fireEvent.keyDown` はイベントを同期的に発火しますが、コンポーネント内の `.focus()` 呼び出しが jsdom で非同期に処理される場合、`expect(link).toHaveFocus()` と `expect(textbox).toHaveFocus()` が即座に評価されてフォーカスがまだ移動していないタイミングでアサーションが走る可能性があります。既存の「dialog container からタブ操作」テストと整合させるため、フォーカスアサーションを `waitFor` で囲むことを検討してください。

```suggestion
    textbox.focus();
    fireEvent.keyDown(document, { key: "Tab", shiftKey: true });
    await waitFor(() => expect(link).toHaveFocus());

    fireEvent.keyDown(document, { key: "Tab" });
    await waitFor(() => expect(textbox).toHaveFocus());
```

How can I resolve this? If you propose a fix, please make it concise.
`````

</details>

<sub>Reviews (1): Last reviewed commit: ["fix: address non-urgent PR #381 review n..."](https://github.com/hiroki-org/openshelf/commit/63d37bf6a5c3273a057c580c896eadf626915b1d) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=27868441)</sub>

<!-- /greptile_comment -->