### PR TITLE
test: add feed edge-case coverage for Codecov follow-ups

### DIFF
--- a/apps/api/src/routes/__tests__/feed.test.ts
+++ b/apps/api/src/routes/__tests__/feed.test.ts
@@ -336,6 +336,7 @@ describe("feed routes", () => {
         const text = await res.text();
         expect(text).toContain("User Paper");
         expect(text).toContain("<author><name>OpenShelf</name></author>");
+        expect(text).not.toMatch(/<author><name>\s+<\/name><\/author>/);
     });
 
     it("GET /feed/users/:id/atom.xml de-duplicates repeated paper rows", async () => {

--- a/apps/api/src/routes/__tests__/feed.test.ts
+++ b/apps/api/src/routes/__tests__/feed.test.ts
@@ -250,6 +250,94 @@ describe("feed routes", () => {
         expect(text).toContain("User Paper");
     });
 
+    it("GET /feed/users/:id/atom.xml returns 404 when user is missing", async () => {
+        mockDb.select = vi.fn(() => makeQuery({ getResult: null }));
+
+        const app = await createTestApp();
+        const env = createTestEnv();
+
+        const res = await app.request("http://localhost/feed/users/missing/atom.xml", {}, env as any);
+
+        expect(res.status).toBe(404);
+        await expect(res.json()).resolves.toEqual({ error: "User not found" });
+    });
+
+    it("GET /feed/users/:id/atom.xml falls back to user name when displayName is null", async () => {
+        mockDb.select = vi
+            .fn()
+            .mockImplementationOnce(() => makeQuery({
+                getResult: {
+                    id: "user-1",
+                    name: "Alice",
+                    displayName: null,
+                    githubId: "alice",
+                    updatedAt: "2026-01-02 00:00:00",
+                },
+            }))
+            .mockImplementationOnce(() => makeQuery({
+                allResult: [
+                    {
+                        id: "paper-1",
+                        title: "User Paper",
+                        abstract: null,
+                        category: null,
+                        createdAt: "2026-01-03 00:00:00",
+                        updatedAt: "2026-01-04 00:00:00",
+                    },
+                ],
+            }))
+            .mockImplementationOnce(() => makeQuery({ allResult: [] }))
+            .mockImplementationOnce(() => makeQuery({ allResult: [] }));
+
+        const app = await createTestApp();
+        const env = createTestEnv();
+
+        const res = await app.request("http://localhost/feed/users/user-1/atom.xml", {}, env as any);
+
+        expect(res.status).toBe(200);
+        const text = await res.text();
+        expect(text).toContain("<title>Alice - OpenShelf</title>");
+        expect(text).toContain("<author><name>Alice</name></author>");
+    });
+
+    it("GET /feed/users/:id/atom.xml falls back to OpenShelf when feed author is blank", async () => {
+        mockDb.select = vi
+            .fn()
+            .mockImplementationOnce(() => makeQuery({
+                getResult: {
+                    id: "user-1",
+                    name: "   ",
+                    displayName: null,
+                    githubId: "alice",
+                    updatedAt: "2026-01-02 00:00:00",
+                },
+            }))
+            .mockImplementationOnce(() => makeQuery({
+                allResult: [
+                    {
+                        id: "paper-1",
+                        title: "User Paper",
+                        abstract: null,
+                        category: null,
+                        createdAt: "2026-01-03 00:00:00",
+                        updatedAt: "2026-01-04 00:00:00",
+                    },
+                ],
+            }))
+            .mockImplementationOnce(() => makeQuery({ allResult: [] }))
+            .mockImplementationOnce(() => makeQuery({ allResult: [] }));
+
+        const app = await createTestApp();
+        const env = createTestEnv();
+
+        const res = await app.request("http://localhost/feed/users/user-1/atom.xml", {}, env as any);
+
+        expect(res.status).toBe(200);
+        const text = await res.text();
+        expect(text).toContain("User Paper");
+        expect(text).toContain("<author><name>OpenShelf</name></author>");
+    });
+
     it("GET /feed/users/:id/atom.xml de-duplicates repeated paper rows", async () => {
         mockDb.select = vi
             .fn()
@@ -443,6 +531,75 @@ describe("feed routes", () => {
         const text = await res.text();
         expect(text).toContain("<title>Featured - Lab - OpenShelf</title>");
         expect(text).toContain("Collection Paper");
+    });
+
+    it("GET /feed/orgs/:slug/collections/:cSlug/atom.xml returns 404 when collection is missing", async () => {
+        mockDb.select = vi
+            .fn()
+            .mockImplementationOnce(() => makeQuery({
+                getResult: {
+                    id: "org-1",
+                    slug: "lab",
+                    name: "Lab",
+                    description: null,
+                    createdAt: "2026-01-01 00:00:00",
+                    updatedAt: "2026-01-02 00:00:00",
+                },
+            }))
+            .mockImplementationOnce(() => makeQuery({ getResult: null }));
+
+        const app = await createTestApp();
+        const env = createTestEnv();
+
+        const res = await app.request(
+            "http://localhost/feed/orgs/lab/collections/missing/atom.xml",
+            {},
+            env as any,
+        );
+
+        expect(res.status).toBe(404);
+        await expect(res.json()).resolves.toEqual({ error: "Collection not found" });
+    });
+
+    it("GET /feed/orgs/:slug/collections/:cSlug/atom.xml returns 404 when collection is private", async () => {
+        mockDb.select = vi
+            .fn()
+            .mockImplementationOnce(() => makeQuery({
+                getResult: {
+                    id: "org-1",
+                    slug: "lab",
+                    name: "Lab",
+                    description: null,
+                    createdAt: "2026-01-01 00:00:00",
+                    updatedAt: "2026-01-02 00:00:00",
+                },
+            }))
+            .mockImplementationOnce(() => makeQuery({
+                getResult: {
+                    id: "col-1",
+                    ownerType: "org",
+                    ownerId: "org-1",
+                    orgSlug: "lab",
+                    slug: "featured",
+                    name: "Featured",
+                    description: null,
+                    visibility: "private",
+                    createdAt: "2026-01-01 00:00:00",
+                    updatedAt: "2026-01-02 00:00:00",
+                },
+            }));
+
+        const app = await createTestApp();
+        const env = createTestEnv();
+
+        const res = await app.request(
+            "http://localhost/feed/orgs/lab/collections/featured/atom.xml",
+            {},
+            env as any,
+        );
+
+        expect(res.status).toBe(404);
+        await expect(res.json()).resolves.toEqual({ error: "Collection not found" });
     });
 
     it("GET /feed/users/:id/collections/:cSlug/atom.xml returns atom xml for public collection papers", async () => {

--- a/apps/api/src/routes/feed.ts
+++ b/apps/api/src/routes/feed.ts
@@ -316,13 +316,14 @@ async function buildFeedResponse(
         loadPaperAuthors(db, paperIds),
         loadPaperFiles(db, paperIds),
     ]);
+    const authorName = meta.authorName.trim() || "OpenShelf";
     const entries = buildPaperEntries(
         papersRows,
         authorsByPaperId,
         filesByPaperId,
         c.env.FRONTEND_URL,
         new URL(c.req.url).origin,
-        meta.authorName,
+        authorName,
     );
     const xml = buildAtomFeed(
         {
@@ -331,7 +332,7 @@ async function buildFeedResponse(
             selfLink: meta.selfLink,
             id: meta.id,
             updated: toIsoString(latestTimestamp(papersRows, meta.updatedFallback)),
-            authorName: meta.authorName,
+            authorName,
         },
         entries,
     );


### PR DESCRIPTION
## Summary
- add user feed 404 test when user is missing
- verify user feed title/author fallback when `displayName` is null
- verify entry author fallback to `OpenShelf` when feed author name is blank
- add org collection feed 404 tests for missing and private collections

## Linked issues
- Closes #373
- Closes #352

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

フィードルートのエッジケースカバレッジを強化するテストを5件追加しています。ユーザーフィードの 404・`displayName` null フォールバック・空白著者フォールバック・org コレクションフィードの存在しない/非公開コレクション 404 をそれぞれ検証しており、モックの設定・ルートの期待動作との整合性はいずれも正確です。
</details>

<h3>Confidence Score: 5/5</h3>

テストのみの変更であり、本番コードへの影響はなく、マージは安全です。

5つの新規テストはいずれもルートの実際の動作と整合しており、モック設定も正確です。唯一の指摘（フィードレベルの blank author アサーション欠落）は P2 のスタイル提案であり、マージをブロックするものではありません。

特に注意が必要なファイルはありません。

<details open><summary><h3>Vulnerabilities</h3></summary>

セキュリティ上の懸念は見当たりません。変更はテストファイルのみで、本番コードへの影響はありません。
</details>

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| apps/api/src/routes/__tests__/feed.test.ts | ユーザーフィード 404・displayName null フォールバック・空白著者フォールバック・org コレクション 404（存在しない/非公開）の5つのテストを追加。モックの呼び出し順序・ルートの動作との整合性はいずれも正しい。フィードレベルの author 要素が空白になるケースがアサートされていない点のみ P2 指摘あり。 |

</details>

</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
This is a comment left during a code review.
Path: apps/api/src/routes/__tests__/feed.test.ts
Line: 303-339

Comment:
**フィードレベルの `<author>` が空白のまま検証されていない**

このテストはエントリレベルの `<author><name>OpenShelf</name></author>` フォールバックを検証していますが、フィードレベルの `<author>` 要素（`buildAtomFeed` が `meta.authorName` を直接使用して生成する部分）は検証されていません。

`buildUserFeedResponse` では `authorName: user.displayName ?? user.name` = `"   "` がそのまま渡され、`buildAtomFeed` は `escapeXml(meta.authorName)` を使うため、フィードレベルには `<author><name>   </name></author>`（空白3文字）が出力されます。一方、`buildPaperEntries` では `fallbackAuthorName.trim() || "OpenShelf"` でフォールバックが機能しています。

この非対称性を明示するアサーションを追加することで、フィードレベルの挙動が未検証であることが明確になります：

```suggestion
        expect(res.status).toBe(200);
        const text = await res.text();
        expect(text).toContain("User Paper");
        expect(text).toContain("<author><name>OpenShelf</name></author>");
        // フィードレベルの <author> も空白名にならないことを確認する場合は以下を追加:
        // expect(text).not.toMatch(/<author><name>\s+<\/name><\/author>/);
```

How can I resolve this? If you propose a fix, please make it concise.
`````

</details>

<sub>Reviews (1): Last reviewed commit: ["test: expand feed route edge-case covera..."](https://github.com/hiroki-org/openshelf/commit/cd68821d9af37c7a3af12a76e07eeb5d9747bcc4) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=27868690)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->