### PR TITLE
Staging

### DIFF
--- a/.github/scripts/create-staging-to-main-pr.sh
+++ b/.github/scripts/create-staging-to-main-pr.sh
@@ -163,12 +163,19 @@ while IFS= read -r pr_number; do
 done < <(
   git log --pretty=format:'%s' "$base_ref..$head_ref" |
     while IFS= read -r subject; do
-      printf '%s\n' "$subject" | grep -oE '#[0-9]+' | sed 's/#//' || true
+      # Match PR numbers from GitHub merge/squash formats only.
+      printf '%s\n' "$subject" |
+        grep -oE 'Merge pull request #[0-9]+|\(#[0-9]+\)' |
+        grep -oE '[0-9]+' || true
     done |
     awk '!seen[$0]++'
 )
 
-included_pr_lines="$(build_included_pr_lines "${pr_numbers[@]}")"
+if [ "${#pr_numbers[@]}" -eq 0 ]; then
+  included_pr_lines="$(build_included_pr_lines)"
+else
+  included_pr_lines="$(build_included_pr_lines "${pr_numbers[@]}")"
+fi
 body="$(build_body "$included_pr_lines")"
 
 declare -a label_values=()

--- a/.github/scripts/create-staging-to-main-pr.sh
+++ b/.github/scripts/create-staging-to-main-pr.sh
@@ -171,11 +171,7 @@ done < <(
     awk '!seen[$0]++'
 )
 
-if [ "${#pr_numbers[@]}" -eq 0 ]; then
-  included_pr_lines="$(build_included_pr_lines)"
-else
-  included_pr_lines="$(build_included_pr_lines "${pr_numbers[@]}")"
-fi
+included_pr_lines="$(build_included_pr_lines "${pr_numbers[@]}")"
 body="$(build_body "$included_pr_lines")"
 
 declare -a label_values=()

--- a/apps/api/src/routes/__tests__/feed.test.ts
+++ b/apps/api/src/routes/__tests__/feed.test.ts
@@ -336,6 +336,7 @@ describe("feed routes", () => {
         const text = await res.text();
         expect(text).toContain("User Paper");
         expect(text).toContain("<author><name>OpenShelf</name></author>");
+        expect(text).not.toMatch(/<author><name>\s+<\/name><\/author>/);
     });
 
     it("GET /feed/users/:id/atom.xml de-duplicates repeated paper rows", async () => {

--- a/apps/api/src/routes/__tests__/feed.test.ts
+++ b/apps/api/src/routes/__tests__/feed.test.ts
@@ -250,6 +250,94 @@ describe("feed routes", () => {
         expect(text).toContain("User Paper");
     });
 
+    it("GET /feed/users/:id/atom.xml returns 404 when user is missing", async () => {
+        mockDb.select = vi.fn(() => makeQuery({ getResult: null }));
+
+        const app = await createTestApp();
+        const env = createTestEnv();
+
+        const res = await app.request("http://localhost/feed/users/missing/atom.xml", {}, env as any);
+
+        expect(res.status).toBe(404);
+        await expect(res.json()).resolves.toEqual({ error: "User not found" });
+    });
+
+    it("GET /feed/users/:id/atom.xml falls back to user name when displayName is null", async () => {
+        mockDb.select = vi
+            .fn()
+            .mockImplementationOnce(() => makeQuery({
+                getResult: {
+                    id: "user-1",
+                    name: "Alice",
+                    displayName: null,
+                    githubId: "alice",
+                    updatedAt: "2026-01-02 00:00:00",
+                },
+            }))
+            .mockImplementationOnce(() => makeQuery({
+                allResult: [
+                    {
+                        id: "paper-1",
+                        title: "User Paper",
+                        abstract: null,
+                        category: null,
+                        createdAt: "2026-01-03 00:00:00",
+                        updatedAt: "2026-01-04 00:00:00",
+                    },
+                ],
+            }))
+            .mockImplementationOnce(() => makeQuery({ allResult: [] }))
+            .mockImplementationOnce(() => makeQuery({ allResult: [] }));
+
+        const app = await createTestApp();
+        const env = createTestEnv();
+
+        const res = await app.request("http://localhost/feed/users/user-1/atom.xml", {}, env as any);
+
+        expect(res.status).toBe(200);
+        const text = await res.text();
+        expect(text).toContain("<title>Alice - OpenShelf</title>");
+        expect(text).toContain("<author><name>Alice</name></author>");
+    });
+
+    it("GET /feed/users/:id/atom.xml falls back to OpenShelf when feed author is blank", async () => {
+        mockDb.select = vi
+            .fn()
+            .mockImplementationOnce(() => makeQuery({
+                getResult: {
+                    id: "user-1",
+                    name: "   ",
+                    displayName: null,
+                    githubId: "alice",
+                    updatedAt: "2026-01-02 00:00:00",
+                },
+            }))
+            .mockImplementationOnce(() => makeQuery({
+                allResult: [
+                    {
+                        id: "paper-1",
+                        title: "User Paper",
+                        abstract: null,
+                        category: null,
+                        createdAt: "2026-01-03 00:00:00",
+                        updatedAt: "2026-01-04 00:00:00",
+                    },
+                ],
+            }))
+            .mockImplementationOnce(() => makeQuery({ allResult: [] }))
+            .mockImplementationOnce(() => makeQuery({ allResult: [] }));
+
+        const app = await createTestApp();
+        const env = createTestEnv();
+
+        const res = await app.request("http://localhost/feed/users/user-1/atom.xml", {}, env as any);
+
+        expect(res.status).toBe(200);
+        const text = await res.text();
+        expect(text).toContain("User Paper");
+        expect(text).toContain("<author><name>OpenShelf</name></author>");
+    });
+
     it("GET /feed/users/:id/atom.xml de-duplicates repeated paper rows", async () => {
         mockDb.select = vi
             .fn()
@@ -443,6 +531,75 @@ describe("feed routes", () => {
         const text = await res.text();
         expect(text).toContain("<title>Featured - Lab - OpenShelf</title>");
         expect(text).toContain("Collection Paper");
+    });
+
+    it("GET /feed/orgs/:slug/collections/:cSlug/atom.xml returns 404 when collection is missing", async () => {
+        mockDb.select = vi
+            .fn()
+            .mockImplementationOnce(() => makeQuery({
+                getResult: {
+                    id: "org-1",
+                    slug: "lab",
+                    name: "Lab",
+                    description: null,
+                    createdAt: "2026-01-01 00:00:00",
+                    updatedAt: "2026-01-02 00:00:00",
+                },
+            }))
+            .mockImplementationOnce(() => makeQuery({ getResult: null }));
+
+        const app = await createTestApp();
+        const env = createTestEnv();
+
+        const res = await app.request(
+            "http://localhost/feed/orgs/lab/collections/missing/atom.xml",
+            {},
+            env as any,
+        );
+
+        expect(res.status).toBe(404);
+        await expect(res.json()).resolves.toEqual({ error: "Collection not found" });
+    });
+
+    it("GET /feed/orgs/:slug/collections/:cSlug/atom.xml returns 404 when collection is private", async () => {
+        mockDb.select = vi
+            .fn()
+            .mockImplementationOnce(() => makeQuery({
+                getResult: {
+                    id: "org-1",
+                    slug: "lab",
+                    name: "Lab",
+                    description: null,
+                    createdAt: "2026-01-01 00:00:00",
+                    updatedAt: "2026-01-02 00:00:00",
+                },
+            }))
+            .mockImplementationOnce(() => makeQuery({
+                getResult: {
+                    id: "col-1",
+                    ownerType: "org",
+                    ownerId: "org-1",
+                    orgSlug: "lab",
+                    slug: "featured",
+                    name: "Featured",
+                    description: null,
+                    visibility: "private",
+                    createdAt: "2026-01-01 00:00:00",
+                    updatedAt: "2026-01-02 00:00:00",
+                },
+            }));
+
+        const app = await createTestApp();
+        const env = createTestEnv();
+
+        const res = await app.request(
+            "http://localhost/feed/orgs/lab/collections/featured/atom.xml",
+            {},
+            env as any,
+        );
+
+        expect(res.status).toBe(404);
+        await expect(res.json()).resolves.toEqual({ error: "Collection not found" });
     });
 
     it("GET /feed/users/:id/collections/:cSlug/atom.xml returns atom xml for public collection papers", async () => {

--- a/apps/api/src/routes/feed.ts
+++ b/apps/api/src/routes/feed.ts
@@ -316,13 +316,14 @@ async function buildFeedResponse(
         loadPaperAuthors(db, paperIds),
         loadPaperFiles(db, paperIds),
     ]);
+    const authorName = meta.authorName.trim() || "OpenShelf";
     const entries = buildPaperEntries(
         papersRows,
         authorsByPaperId,
         filesByPaperId,
         c.env.FRONTEND_URL,
         new URL(c.req.url).origin,
-        meta.authorName,
+        authorName,
     );
     const xml = buildAtomFeed(
         {
@@ -331,7 +332,7 @@ async function buildFeedResponse(
             selfLink: meta.selfLink,
             id: meta.id,
             updated: toIsoString(latestTimestamp(papersRows, meta.updatedFallback)),
-            authorName: meta.authorName,
+            authorName,
         },
         entries,
     );

--- a/apps/web/package-lock.json
+++ b/apps/web/package-lock.json
@@ -11,7 +11,7 @@
       "dependencies": {
         "@vercel/analytics": "^2.0.1",
         "@vercel/speed-insights": "^2.0.0",
-        "next": "16.2.1",
+        "next": "16.2.3",
         "react": "19.2.3",
         "react-dom": "19.2.3",
         "react-markdown": "^10.1.0",
@@ -2100,9 +2100,9 @@
       }
     },
     "node_modules/@next/env": {
-      "version": "16.2.1",
-      "resolved": "https://registry.npmjs.org/@next/env/-/env-16.2.1.tgz",
-      "integrity": "sha512-n8P/HCkIWW+gVal2Z8XqXJ6aB3J0tuM29OcHpCsobWlChH/SITBs1DFBk/HajgrwDkqqBXPbuUuzgDvUekREPg==",
+      "version": "16.2.3",
+      "resolved": "https://registry.npmjs.org/@next/env/-/env-16.2.3.tgz",
+      "integrity": "sha512-ZWXyj4uNu4GCWQw9cjRxWlbD+33mcDszIo9iQxFnBX3Wmgq9ulaSJcl6VhuWx5pCWqqD+9W6Wfz7N0lM5lYPMA==",
       "license": "MIT"
     },
     "node_modules/@next/eslint-plugin-next": {
@@ -2116,9 +2116,9 @@
       }
     },
     "node_modules/@next/swc-darwin-arm64": {
-      "version": "16.2.1",
-      "resolved": "https://registry.npmjs.org/@next/swc-darwin-arm64/-/swc-darwin-arm64-16.2.1.tgz",
-      "integrity": "sha512-BwZ8w8YTaSEr2HIuXLMLxIdElNMPvY9fLqb20LX9A9OMGtJilhHLbCL3ggyd0TwjmMcTxi0XXt+ur1vWUoxj2Q==",
+      "version": "16.2.3",
+      "resolved": "https://registry.npmjs.org/@next/swc-darwin-arm64/-/swc-darwin-arm64-16.2.3.tgz",
+      "integrity": "sha512-u37KDKTKQ+OQLvY+z7SNXixwo4Q2/IAJFDzU1fYe66IbCE51aDSAzkNDkWmLN0yjTUh4BKBd+hb69jYn6qqqSg==",
       "cpu": [
         "arm64"
       ],
@@ -2132,9 +2132,9 @@
       }
     },
     "node_modules/@next/swc-darwin-x64": {
-      "version": "16.2.1",
-      "resolved": "https://registry.npmjs.org/@next/swc-darwin-x64/-/swc-darwin-x64-16.2.1.tgz",
-      "integrity": "sha512-/vrcE6iQSJq3uL3VGVHiXeaKbn8Es10DGTGRJnRZlkNQQk3kaNtAJg8Y6xuAlrx/6INKVjkfi5rY0iEXorZ6uA==",
+      "version": "16.2.3",
+      "resolved": "https://registry.npmjs.org/@next/swc-darwin-x64/-/swc-darwin-x64-16.2.3.tgz",
+      "integrity": "sha512-gHjL/qy6Q6CG3176FWbAKyKh9IfntKZTB3RY/YOJdDFpHGsUDXVH38U4mMNpHVGXmeYW4wj22dMp1lTfmu/bTQ==",
       "cpu": [
         "x64"
       ],
@@ -2148,9 +2148,9 @@
       }
     },
     "node_modules/@next/swc-linux-arm64-gnu": {
-      "version": "16.2.1",
-      "resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-gnu/-/swc-linux-arm64-gnu-16.2.1.tgz",
-      "integrity": "sha512-uLn+0BK+C31LTVbQ/QU+UaVrV0rRSJQ8RfniQAHPghDdgE+SlroYqcmFnO5iNjNfVWCyKZHYrs3Nl0mUzWxbBw==",
+      "version": "16.2.3",
+      "resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-gnu/-/swc-linux-arm64-gnu-16.2.3.tgz",
+      "integrity": "sha512-U6vtblPtU/P14Y/b/n9ZY0GOxbbIhTFuaFR7F4/uMBidCi2nSdaOFhA0Go81L61Zd6527+yvuX44T4ksnf8T+Q==",
       "cpu": [
         "arm64"
       ],
@@ -2164,9 +2164,9 @@
       }
     },
     "node_modules/@next/swc-linux-arm64-musl": {
-      "version": "16.2.1",
-      "resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-musl/-/swc-linux-arm64-musl-16.2.1.tgz",
-      "integrity": "sha512-ssKq6iMRnHdnycGp9hCuGnXJZ0YPr4/wNwrfE5DbmvEcgl9+yv97/Kq3TPVDfYome1SW5geciLB9aiEqKXQjlQ==",
+      "version": "16.2.3",
+      "resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-musl/-/swc-linux-arm64-musl-16.2.3.tgz",
+      "integrity": "sha512-/YV0LgjHUmfhQpn9bVoGc4x4nan64pkhWR5wyEV8yCOfwwrH630KpvRg86olQHTwHIn1z59uh6JwKvHq1h4QEw==",
       "cpu": [
         "arm64"
       ],
@@ -2180,9 +2180,9 @@
       }
     },
     "node_modules/@next/swc-linux-x64-gnu": {
-      "version": "16.2.1",
-      "resolved": "https://registry.npmjs.org/@next/swc-linux-x64-gnu/-/swc-linux-x64-gnu-16.2.1.tgz",
-      "integrity": "sha512-HQm7SrHRELJ30T1TSmT706IWovFFSRGxfgUkyWJZF/RKBMdbdRWJuFrcpDdE5vy9UXjFOx6L3mRdqH04Mmx0hg==",
+      "version": "16.2.3",
+      "resolved": "https://registry.npmjs.org/@next/swc-linux-x64-gnu/-/swc-linux-x64-gnu-16.2.3.tgz",
+      "integrity": "sha512-/HiWEcp+WMZ7VajuiMEFGZ6cg0+aYZPqCJD3YJEfpVWQsKYSjXQG06vJP6F1rdA03COD9Fef4aODs3YxKx+RDQ==",
       "cpu": [
         "x64"
       ],
@@ -2196,9 +2196,9 @@
       }
     },
     "node_modules/@next/swc-linux-x64-musl": {
-      "version": "16.2.1",
-      "resolved": "https://registry.npmjs.org/@next/swc-linux-x64-musl/-/swc-linux-x64-musl-16.2.1.tgz",
-      "integrity": "sha512-aV2iUaC/5HGEpbBkE+4B8aHIudoOy5DYekAKOMSHoIYQ66y/wIVeaRx8MS2ZMdxe/HIXlMho4ubdZs/J8441Tg==",
+      "version": "16.2.3",
+      "resolved": "https://registry.npmjs.org/@next/swc-linux-x64-musl/-/swc-linux-x64-musl-16.2.3.tgz",
+      "integrity": "sha512-Kt44hGJfZSefebhk/7nIdivoDr3Ugp5+oNz9VvF3GUtfxutucUIHfIO0ZYO8QlOPDQloUVQn4NVC/9JvHRk9hw==",
       "cpu": [
         "x64"
       ],
@@ -2212,9 +2212,9 @@
       }
     },
     "node_modules/@next/swc-win32-arm64-msvc": {
-      "version": "16.2.1",
-      "resolved": "https://registry.npmjs.org/@next/swc-win32-arm64-msvc/-/swc-win32-arm64-msvc-16.2.1.tgz",
-      "integrity": "sha512-IXdNgiDHaSk0ZUJ+xp0OQTdTgnpx1RCfRTalhn3cjOP+IddTMINwA7DXZrwTmGDO8SUr5q2hdP/du4DcrB1GxA==",
+      "version": "16.2.3",
+      "resolved": "https://registry.npmjs.org/@next/swc-win32-arm64-msvc/-/swc-win32-arm64-msvc-16.2.3.tgz",
+      "integrity": "sha512-O2NZ9ie3Tq6xj5Z5CSwBT3+aWAMW2PIZ4egUi9MaWLkwaehgtB7YZjPm+UpcNpKOme0IQuqDcor7BsW6QBiQBw==",
       "cpu": [
         "arm64"
       ],
@@ -2228,9 +2228,9 @@
       }
     },
     "node_modules/@next/swc-win32-x64-msvc": {
-      "version": "16.2.1",
-      "resolved": "https://registry.npmjs.org/@next/swc-win32-x64-msvc/-/swc-win32-x64-msvc-16.2.1.tgz",
-      "integrity": "sha512-qvU+3a39Hay+ieIztkGSbF7+mccbbg1Tk25hc4JDylf8IHjYmY/Zm64Qq1602yPyQqvie+vf5T/uPwNxDNIoeg==",
+      "version": "16.2.3",
+      "resolved": "https://registry.npmjs.org/@next/swc-win32-x64-msvc/-/swc-win32-x64-msvc-16.2.3.tgz",
+      "integrity": "sha512-Ibm29/GgB/ab5n7XKqlStkm54qqZE8v2FnijUPBgrd67FWrac45o/RsNlaOWjme/B5UqeWt/8KM4aWBwA1D2Kw==",
       "cpu": [
         "x64"
       ],
@@ -8536,12 +8536,12 @@
       "license": "MIT"
     },
     "node_modules/next": {
-      "version": "16.2.1",
-      "resolved": "https://registry.npmjs.org/next/-/next-16.2.1.tgz",
-      "integrity": "sha512-VaChzNL7o9rbfdt60HUj8tev4m6d7iC1igAy157526+cJlXOQu5LzsBXNT+xaJnTP/k+utSX5vMv7m0G+zKH+Q==",
+      "version": "16.2.3",
+      "resolved": "https://registry.npmjs.org/next/-/next-16.2.3.tgz",
+      "integrity": "sha512-9V3zV4oZFza3PVev5/poB9g0dEafVcgNyQ8eTRop8GvxZjV2G15FC5ARuG1eFD42QgeYkzJBJzHghNP8Ad9xtA==",
       "license": "MIT",
       "dependencies": {
-        "@next/env": "16.2.1",
+        "@next/env": "16.2.3",
         "@swc/helpers": "0.5.15",
         "baseline-browser-mapping": "^2.9.19",
         "caniuse-lite": "^1.0.30001579",
@@ -8555,14 +8555,14 @@
         "node": ">=20.9.0"
       },
       "optionalDependencies": {
-        "@next/swc-darwin-arm64": "16.2.1",
-        "@next/swc-darwin-x64": "16.2.1",
-        "@next/swc-linux-arm64-gnu": "16.2.1",
-        "@next/swc-linux-arm64-musl": "16.2.1",
-        "@next/swc-linux-x64-gnu": "16.2.1",
-        "@next/swc-linux-x64-musl": "16.2.1",
-        "@next/swc-win32-arm64-msvc": "16.2.1",
-        "@next/swc-win32-x64-msvc": "16.2.1",
+        "@next/swc-darwin-arm64": "16.2.3",
+        "@next/swc-darwin-x64": "16.2.3",
+        "@next/swc-linux-arm64-gnu": "16.2.3",
+        "@next/swc-linux-arm64-musl": "16.2.3",
+        "@next/swc-linux-x64-gnu": "16.2.3",
+        "@next/swc-linux-x64-musl": "16.2.3",
+        "@next/swc-win32-arm64-msvc": "16.2.3",
+        "@next/swc-win32-x64-msvc": "16.2.3",
         "sharp": "^0.34.5"
       },
       "peerDependencies": {

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -15,7 +15,7 @@
   "dependencies": {
     "@vercel/analytics": "^2.0.1",
     "@vercel/speed-insights": "^2.0.0",
-    "next": "16.2.1",
+    "next": "16.2.3",
     "react": "19.2.3",
     "react-dom": "19.2.3",
     "react-markdown": "^10.1.0",

--- a/apps/web/src/components/__tests__/feed-button.test.tsx
+++ b/apps/web/src/components/__tests__/feed-button.test.tsx
@@ -45,6 +45,19 @@ describe("FeedButton", () => {
     );
   });
 
+  it("renders custom label and className", () => {
+    render(
+      <FeedButton
+        url="https://api.example/feed.xml"
+        label="Feed URL を表示"
+        className="custom-trigger"
+      />,
+    );
+
+    const trigger = screen.getByRole("button", { name: "Feed URL を表示" });
+    expect(trigger).toHaveClass("custom-trigger");
+  });
+
   it("moves focus into the dialog when it opens", async () => {
     render(<FeedButton url="https://api.example/feed.xml" />);
 
@@ -58,7 +71,8 @@ describe("FeedButton", () => {
   it("closes the dialog when clicking outside with pointer events", async () => {
     render(<FeedButton url="https://api.example/feed.xml" />);
 
-    fireEvent.click(screen.getByRole("button", { name: "📡 Feed" }));
+    const trigger = screen.getByRole("button", { name: "📡 Feed" });
+    fireEvent.click(trigger);
     expect(screen.getByRole("dialog", { name: "フィード URL" })).toBeInTheDocument();
 
     fireEvent.pointerDown(document.body);
@@ -67,6 +81,7 @@ describe("FeedButton", () => {
       expect(
         screen.queryByRole("dialog", { name: "フィード URL" }),
       ).not.toBeInTheDocument();
+      expect(trigger).toHaveFocus();
     });
   });
 
@@ -94,6 +109,20 @@ describe("FeedButton", () => {
     });
   });
 
+  it("keeps focus trapped when tabbing from the dialog container", async () => {
+    render(<FeedButton url="https://api.example/feed.xml" />);
+
+    fireEvent.click(screen.getByRole("button", { name: "📡 Feed" }));
+
+    const dialog = await screen.findByRole("dialog", { name: "フィード URL" });
+    const textbox = screen.getByRole("textbox", { name: "フィード URL" });
+
+    dialog.focus();
+    fireEvent.keyDown(document, { key: "Tab" });
+
+    expect(textbox).toHaveFocus();
+  });
+
   it("copies the feed URL from the popover", async () => {
     render(<FeedButton url="https://api.example/feed.xml" />);
 
@@ -105,6 +134,38 @@ describe("FeedButton", () => {
         "https://api.example/feed.xml",
       );
       expect(toastSuccess).toHaveBeenCalledWith("コピーしました");
+    });
+  });
+
+  it("shows an error when clipboard write fails", async () => {
+    vi.stubGlobal("navigator", {
+      clipboard: {
+        writeText: vi.fn(async () => {
+          throw new Error("clipboard write failed");
+        }),
+      },
+    });
+
+    render(<FeedButton url="https://api.example/feed.xml" />);
+    fireEvent.click(screen.getByRole("button", { name: "📡 Feed" }));
+    fireEvent.click(screen.getByRole("button", { name: "コピー" }));
+
+    await waitFor(() => {
+      expect(toastError).toHaveBeenCalledWith("クリップボードへのコピーに失敗しました");
+    });
+  });
+
+  it("shows an error when clipboard.writeText is unavailable", async () => {
+    vi.stubGlobal("navigator", { clipboard: {} });
+
+    render(<FeedButton url="https://api.example/feed.xml" />);
+    fireEvent.click(screen.getByRole("button", { name: "📡 Feed" }));
+    fireEvent.click(screen.getByRole("button", { name: "コピー" }));
+
+    await waitFor(() => {
+      expect(toastError).toHaveBeenCalledWith(
+        "このブラウザではクリップボード機能を利用できません",
+      );
     });
   });
 

--- a/apps/web/src/components/feed-button.tsx
+++ b/apps/web/src/components/feed-button.tsx
@@ -23,7 +23,7 @@ export function FeedButton({
     if (!open) return;
 
     const focusableSelector =
-      'button:not([tabindex="-1"]), [href]:not([tabindex="-1"]), input:not([tabindex="-1"]), textarea:not([tabindex="-1"]), select:not([tabindex="-1"]), [tabindex]:not([tabindex="-1"])';
+      'button:not([tabindex="-1"]), [href]:not([tabindex="-1"]), input:not([tabindex="-1"]), textarea:not([tabindex="-1"]), select:not([tabindex="-1"]), [contenteditable]:not([contenteditable="false"]):not([tabindex="-1"]), [tabindex]:not([tabindex="-1"])';
     const getFocusableElements = () =>
       Array.from(
         dialogRef.current?.querySelectorAll<HTMLElement>(focusableSelector) ??
@@ -78,7 +78,7 @@ export function FeedButton({
         return;
       }
 
-      if (activeElement === last) {
+      if (activeElement === last || activeElement === dialogRef.current) {
         event.preventDefault();
         first.focus();
       }

--- a/package-lock.json
+++ b/package-lock.json
@@ -696,7 +696,7 @@
       "dependencies": {
         "@vercel/analytics": "^2.0.1",
         "@vercel/speed-insights": "^2.0.0",
-        "next": "16.2.1",
+        "next": "^16.2.3",
         "react": "19.2.3",
         "react-dom": "19.2.3",
         "react-markdown": "^10.1.0",
@@ -2861,9 +2861,9 @@
       }
     },
     "node_modules/@next/env": {
-      "version": "16.2.1",
-      "resolved": "https://registry.npmjs.org/@next/env/-/env-16.2.1.tgz",
-      "integrity": "sha512-n8P/HCkIWW+gVal2Z8XqXJ6aB3J0tuM29OcHpCsobWlChH/SITBs1DFBk/HajgrwDkqqBXPbuUuzgDvUekREPg==",
+      "version": "16.2.3",
+      "resolved": "https://registry.npmjs.org/@next/env/-/env-16.2.3.tgz",
+      "integrity": "sha512-ZWXyj4uNu4GCWQw9cjRxWlbD+33mcDszIo9iQxFnBX3Wmgq9ulaSJcl6VhuWx5pCWqqD+9W6Wfz7N0lM5lYPMA==",
       "license": "MIT"
     },
     "node_modules/@next/eslint-plugin-next": {
@@ -2877,9 +2877,9 @@
       }
     },
     "node_modules/@next/swc-darwin-arm64": {
-      "version": "16.2.1",
-      "resolved": "https://registry.npmjs.org/@next/swc-darwin-arm64/-/swc-darwin-arm64-16.2.1.tgz",
-      "integrity": "sha512-BwZ8w8YTaSEr2HIuXLMLxIdElNMPvY9fLqb20LX9A9OMGtJilhHLbCL3ggyd0TwjmMcTxi0XXt+ur1vWUoxj2Q==",
+      "version": "16.2.3",
+      "resolved": "https://registry.npmjs.org/@next/swc-darwin-arm64/-/swc-darwin-arm64-16.2.3.tgz",
+      "integrity": "sha512-u37KDKTKQ+OQLvY+z7SNXixwo4Q2/IAJFDzU1fYe66IbCE51aDSAzkNDkWmLN0yjTUh4BKBd+hb69jYn6qqqSg==",
       "cpu": [
         "arm64"
       ],
@@ -2893,9 +2893,9 @@
       }
     },
     "node_modules/@next/swc-darwin-x64": {
-      "version": "16.2.1",
-      "resolved": "https://registry.npmjs.org/@next/swc-darwin-x64/-/swc-darwin-x64-16.2.1.tgz",
-      "integrity": "sha512-/vrcE6iQSJq3uL3VGVHiXeaKbn8Es10DGTGRJnRZlkNQQk3kaNtAJg8Y6xuAlrx/6INKVjkfi5rY0iEXorZ6uA==",
+      "version": "16.2.3",
+      "resolved": "https://registry.npmjs.org/@next/swc-darwin-x64/-/swc-darwin-x64-16.2.3.tgz",
+      "integrity": "sha512-gHjL/qy6Q6CG3176FWbAKyKh9IfntKZTB3RY/YOJdDFpHGsUDXVH38U4mMNpHVGXmeYW4wj22dMp1lTfmu/bTQ==",
       "cpu": [
         "x64"
       ],
@@ -2909,9 +2909,9 @@
       }
     },
     "node_modules/@next/swc-linux-arm64-gnu": {
-      "version": "16.2.1",
-      "resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-gnu/-/swc-linux-arm64-gnu-16.2.1.tgz",
-      "integrity": "sha512-uLn+0BK+C31LTVbQ/QU+UaVrV0rRSJQ8RfniQAHPghDdgE+SlroYqcmFnO5iNjNfVWCyKZHYrs3Nl0mUzWxbBw==",
+      "version": "16.2.3",
+      "resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-gnu/-/swc-linux-arm64-gnu-16.2.3.tgz",
+      "integrity": "sha512-U6vtblPtU/P14Y/b/n9ZY0GOxbbIhTFuaFR7F4/uMBidCi2nSdaOFhA0Go81L61Zd6527+yvuX44T4ksnf8T+Q==",
       "cpu": [
         "arm64"
       ],
@@ -2925,9 +2925,9 @@
       }
     },
     "node_modules/@next/swc-linux-arm64-musl": {
-      "version": "16.2.1",
-      "resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-musl/-/swc-linux-arm64-musl-16.2.1.tgz",
-      "integrity": "sha512-ssKq6iMRnHdnycGp9hCuGnXJZ0YPr4/wNwrfE5DbmvEcgl9+yv97/Kq3TPVDfYome1SW5geciLB9aiEqKXQjlQ==",
+      "version": "16.2.3",
+      "resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-musl/-/swc-linux-arm64-musl-16.2.3.tgz",
+      "integrity": "sha512-/YV0LgjHUmfhQpn9bVoGc4x4nan64pkhWR5wyEV8yCOfwwrH630KpvRg86olQHTwHIn1z59uh6JwKvHq1h4QEw==",
       "cpu": [
         "arm64"
       ],
@@ -2941,9 +2941,9 @@
       }
     },
     "node_modules/@next/swc-linux-x64-gnu": {
-      "version": "16.2.1",
-      "resolved": "https://registry.npmjs.org/@next/swc-linux-x64-gnu/-/swc-linux-x64-gnu-16.2.1.tgz",
-      "integrity": "sha512-HQm7SrHRELJ30T1TSmT706IWovFFSRGxfgUkyWJZF/RKBMdbdRWJuFrcpDdE5vy9UXjFOx6L3mRdqH04Mmx0hg==",
+      "version": "16.2.3",
+      "resolved": "https://registry.npmjs.org/@next/swc-linux-x64-gnu/-/swc-linux-x64-gnu-16.2.3.tgz",
+      "integrity": "sha512-/HiWEcp+WMZ7VajuiMEFGZ6cg0+aYZPqCJD3YJEfpVWQsKYSjXQG06vJP6F1rdA03COD9Fef4aODs3YxKx+RDQ==",
       "cpu": [
         "x64"
       ],
@@ -2957,9 +2957,9 @@
       }
     },
     "node_modules/@next/swc-linux-x64-musl": {
-      "version": "16.2.1",
-      "resolved": "https://registry.npmjs.org/@next/swc-linux-x64-musl/-/swc-linux-x64-musl-16.2.1.tgz",
-      "integrity": "sha512-aV2iUaC/5HGEpbBkE+4B8aHIudoOy5DYekAKOMSHoIYQ66y/wIVeaRx8MS2ZMdxe/HIXlMho4ubdZs/J8441Tg==",
+      "version": "16.2.3",
+      "resolved": "https://registry.npmjs.org/@next/swc-linux-x64-musl/-/swc-linux-x64-musl-16.2.3.tgz",
+      "integrity": "sha512-Kt44hGJfZSefebhk/7nIdivoDr3Ugp5+oNz9VvF3GUtfxutucUIHfIO0ZYO8QlOPDQloUVQn4NVC/9JvHRk9hw==",
       "cpu": [
         "x64"
       ],
@@ -2973,9 +2973,9 @@
       }
     },
     "node_modules/@next/swc-win32-arm64-msvc": {
-      "version": "16.2.1",
-      "resolved": "https://registry.npmjs.org/@next/swc-win32-arm64-msvc/-/swc-win32-arm64-msvc-16.2.1.tgz",
-      "integrity": "sha512-IXdNgiDHaSk0ZUJ+xp0OQTdTgnpx1RCfRTalhn3cjOP+IddTMINwA7DXZrwTmGDO8SUr5q2hdP/du4DcrB1GxA==",
+      "version": "16.2.3",
+      "resolved": "https://registry.npmjs.org/@next/swc-win32-arm64-msvc/-/swc-win32-arm64-msvc-16.2.3.tgz",
+      "integrity": "sha512-O2NZ9ie3Tq6xj5Z5CSwBT3+aWAMW2PIZ4egUi9MaWLkwaehgtB7YZjPm+UpcNpKOme0IQuqDcor7BsW6QBiQBw==",
       "cpu": [
         "arm64"
       ],
@@ -2989,9 +2989,9 @@
       }
     },
     "node_modules/@next/swc-win32-x64-msvc": {
-      "version": "16.2.1",
-      "resolved": "https://registry.npmjs.org/@next/swc-win32-x64-msvc/-/swc-win32-x64-msvc-16.2.1.tgz",
-      "integrity": "sha512-qvU+3a39Hay+ieIztkGSbF7+mccbbg1Tk25hc4JDylf8IHjYmY/Zm64Qq1602yPyQqvie+vf5T/uPwNxDNIoeg==",
+      "version": "16.2.3",
+      "resolved": "https://registry.npmjs.org/@next/swc-win32-x64-msvc/-/swc-win32-x64-msvc-16.2.3.tgz",
+      "integrity": "sha512-Ibm29/GgB/ab5n7XKqlStkm54qqZE8v2FnijUPBgrd67FWrac45o/RsNlaOWjme/B5UqeWt/8KM4aWBwA1D2Kw==",
       "cpu": [
         "x64"
       ],
@@ -9912,12 +9912,12 @@
       "license": "MIT"
     },
     "node_modules/next": {
-      "version": "16.2.1",
-      "resolved": "https://registry.npmjs.org/next/-/next-16.2.1.tgz",
-      "integrity": "sha512-VaChzNL7o9rbfdt60HUj8tev4m6d7iC1igAy157526+cJlXOQu5LzsBXNT+xaJnTP/k+utSX5vMv7m0G+zKH+Q==",
+      "version": "16.2.3",
+      "resolved": "https://registry.npmjs.org/next/-/next-16.2.3.tgz",
+      "integrity": "sha512-9V3zV4oZFza3PVev5/poB9g0dEafVcgNyQ8eTRop8GvxZjV2G15FC5ARuG1eFD42QgeYkzJBJzHghNP8Ad9xtA==",
       "license": "MIT",
       "dependencies": {
-        "@next/env": "16.2.1",
+        "@next/env": "16.2.3",
         "@swc/helpers": "0.5.15",
         "baseline-browser-mapping": "^2.9.19",
         "caniuse-lite": "^1.0.30001579",
@@ -9931,14 +9931,14 @@
         "node": ">=20.9.0"
       },
       "optionalDependencies": {
-        "@next/swc-darwin-arm64": "16.2.1",
-        "@next/swc-darwin-x64": "16.2.1",
-        "@next/swc-linux-arm64-gnu": "16.2.1",
-        "@next/swc-linux-arm64-musl": "16.2.1",
-        "@next/swc-linux-x64-gnu": "16.2.1",
-        "@next/swc-linux-x64-musl": "16.2.1",
-        "@next/swc-win32-arm64-msvc": "16.2.1",
-        "@next/swc-win32-x64-msvc": "16.2.1",
+        "@next/swc-darwin-arm64": "16.2.3",
+        "@next/swc-darwin-x64": "16.2.3",
+        "@next/swc-linux-arm64-gnu": "16.2.3",
+        "@next/swc-linux-arm64-musl": "16.2.3",
+        "@next/swc-linux-x64-gnu": "16.2.3",
+        "@next/swc-linux-x64-musl": "16.2.3",
+        "@next/swc-win32-arm64-msvc": "16.2.3",
+        "@next/swc-win32-x64-msvc": "16.2.3",
         "sharp": "^0.34.5"
       },
       "peerDependencies": {


### PR DESCRIPTION
<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

このPRはstagingからmainへのプロモーションPRで、(1) フィードのAtom XMLで空白のみの著者名が出力されないよう修正（`trim() || "OpenShelf"` フォールバック）、(2) `FeedButton` コンポーネントのフォーカストラップのアクセシビリティ改善、(3) PR番号抽出ロジックをGitHub公式のマージ/スカッシュ形式のみに限定するシェルスクリプト修正、(4) Next.js を 16.2.1 → 16.2.3 へのバージョンアップが含まれています。
</details>


<h3>Confidence Score: 5/5</h3>

マージ可能。残存する指摘はすべて P2 レベルのスタイル・一貫性の改善提案です。

P0/P1 の問題は見当たりません。eslint-config-next のバージョン不一致とフィードタイトルのトリミング未適用はどちらも P2 相当であり、マージを妨げるものではありません。

apps/web/package.json（eslint-config-next バージョン不一致）、apps/api/src/routes/feed.ts（タイトル文字列のトリミング）

<details><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| apps/api/src/routes/feed.ts | 空白のみの著者名を `trim() || "OpenShelf"` でフォールバックする修正。タイトル文字列では同様のトリミングが未適用だが実害は限定的。 |
| apps/api/src/routes/__tests__/feed.test.ts | 404ケース、displayName=null フォールバック、空白著者名フォールバック、コレクション404など新テストを追加。カバレッジは十分。 |
| apps/web/src/components/feed-button.tsx | フォーカストラップにダイアログコンテナからの Tab 前進ケースと `contenteditable` セレクタを追加するアクセシビリティ修正。 |
| apps/web/package.json | next を 16.2.3 に更新したが eslint-config-next は 16.2.1 のままでバージョン不一致。 |
| .github/scripts/create-staging-to-main-pr.sh | PR番号抽出をGitHub公式マージ/スカッシュ形式のみに絞り込み、誤検知を防止する改善。 |
| apps/web/src/components/__tests__/feed-button.test.tsx | FeedButton の各インタラクション（フォーカス、Escape、Tab トラップ、クリップボード）を網羅するテストが追加されている。 |

</details>


</details>


<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[FeedButton クリック] --> B[open = true]
    B --> C[ダイアログ表示]
    C --> D[最初のフォーカス可能要素にフォーカス移動]
    D --> E{ユーザー操作}
    E -->|Escape キー| F[open = false\nトリガーにフォーカス戻す]
    E -->|ダイアログ外をクリック| F
    E -->|Tab キー\n最後の要素 or ダイアログコンテナ| G[最初の要素にフォーカス]
    E -->|Shift+Tab\n最初の要素 or ダイアログコンテナ| H[最後の要素にフォーカス]
    E -->|コピーボタン| I{Clipboard API 利用可能?}
    I -->|Yes| J[navigator.clipboard.writeText]
    J -->|成功| K[toast.success]
    J -->|失敗| L[toast.error]
    I -->|No| L
    E -->|開くリンク| M[新タブで Feed URL を開く]
    F --> N[ダイアログ非表示]
```

<!-- greptile_failed_comments -->
<details open><summary><h3>Comments Outside Diff (2)</h3></summary>

1. `apps/web/package.json`, line 38 ([link](https://github.com/hiroki-org/openshelf/blob/242725630d818a37251fbaec9de6a58b32a48c7d/apps/web/package.json#L38)) 

   <a href="#"><img alt="P2" src="https://greptile-static-assets.s3.amazonaws.com/badges/p2.svg?v=7" align="top"></a> **eslint-config-next のバージョン不一致**

   `next` が 16.2.3 に更新されましたが、`eslint-config-next` は 16.2.1 のままです。`eslint-config-next` は対応する Next.js バージョン用のルールを提供するため、バージョンを揃えておくことが推奨されます。

   

   <details><summary>Prompt To Fix With AI</summary>

   `````markdown
   This is a comment left during a code review.
   Path: apps/web/package.json
   Line: 38

   Comment:
   **eslint-config-next のバージョン不一致**

   `next` が 16.2.3 に更新されましたが、`eslint-config-next` は 16.2.1 のままです。`eslint-config-next` は対応する Next.js バージョン用のルールを提供するため、バージョンを揃えておくことが推奨されます。

   

   How can I resolve this? If you propose a fix, please make it concise.
   `````
   </details>


2. `apps/api/src/routes/feed.ts`, line 403 ([link](https://github.com/hiroki-org/openshelf/blob/242725630d818a37251fbaec9de6a58b32a48c7d/apps/api/src/routes/feed.ts#L403)) 

   <a href="#"><img alt="P2" src="https://greptile-static-assets.s3.amazonaws.com/badges/p2.svg?v=7" align="top"></a> **フィードタイトルへのトリミング未適用**

   `authorName` は `buildFeedResponse` で `.trim() || "OpenShelf"` が適用されますが、`title` の構築には同じ正規化が行われていません。`user.displayName` が空文字列 `""` の場合（`null` ではないため `??` でフォールバックされない）、タイトルが `" - OpenShelf"` になります。同様に `displayName` が null で `user.name` が空白のみの場合は `"    - OpenShelf"` になります。

   

   <details><summary>Prompt To Fix With AI</summary>

   `````markdown
   This is a comment left during a code review.
   Path: apps/api/src/routes/feed.ts
   Line: 403

   Comment:
   **フィードタイトルへのトリミング未適用**

   `authorName` は `buildFeedResponse` で `.trim() || "OpenShelf"` が適用されますが、`title` の構築には同じ正規化が行われていません。`user.displayName` が空文字列 `""` の場合（`null` ではないため `??` でフォールバックされない）、タイトルが `" - OpenShelf"` になります。同様に `displayName` が null で `user.name` が空白のみの場合は `"    - OpenShelf"` になります。

   

   How can I resolve this? If you propose a fix, please make it concise.
   `````
   </details>

</details>

<!-- /greptile_failed_comments -->

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
This is a comment left during a code review.
Path: apps/web/package.json
Line: 38

Comment:
**eslint-config-next のバージョン不一致**

`next` が 16.2.3 に更新されましたが、`eslint-config-next` は 16.2.1 のままです。`eslint-config-next` は対応する Next.js バージョン用のルールを提供するため、バージョンを揃えておくことが推奨されます。

```suggestion
    "eslint-config-next": "16.2.3",
```

How can I resolve this? If you propose a fix, please make it concise.

---

This is a comment left during a code review.
Path: apps/api/src/routes/feed.ts
Line: 403

Comment:
**フィードタイトルへのトリミング未適用**

`authorName` は `buildFeedResponse` で `.trim() || "OpenShelf"` が適用されますが、`title` の構築には同じ正規化が行われていません。`user.displayName` が空文字列 `""` の場合（`null` ではないため `??` でフォールバックされない）、タイトルが `" - OpenShelf"` になります。同様に `displayName` が null で `user.name` が空白のみの場合は `"    - OpenShelf"` になります。

```suggestion
        title: `${(user.displayName?.trim() || user.name?.trim() || "OpenShelf")} - OpenShelf`,
```

How can I resolve this? If you propose a fix, please make it concise.
`````

</details>

<sub>Reviews (1): Last reviewed commit: ["Merge pull request #391 from Hiroki-org/..."](https://github.com/hiroki-org/openshelf/commit/242725630d818a37251fbaec9de6a58b32a48c7d) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=28077139)</sub>

<!-- /greptile_comment -->