### PR TITLE
🧪 [testing improvement] Add test for catch block in normalizeOrigin

### DIFF
--- a/apps/api/src/utils/__tests__/origin.test.ts
+++ b/apps/api/src/utils/__tests__/origin.test.ts
@@ -2,6 +2,10 @@ import { describe, expect, it } from "vitest";
 import { isAllowedOrigin, normalizeOrigin } from "../origin";
 
 describe("origin utils", () => {
+    it("returns null for malformed URI components", () => {
+        expect(normalizeOrigin("not-a-url-%E0%A4%A")).toBeNull();
+    });
+
     it("normalizes exact origins before comparison", () => {
         const origin = normalizeOrigin("https://app.example.com")!;
         const frontendOrigin = normalizeOrigin("https://frontend.example.com")!;

--- a/apps/api/src/utils/__tests__/origin.test.ts
+++ b/apps/api/src/utils/__tests__/origin.test.ts
@@ -6,6 +6,10 @@ describe("origin utils", () => {
         expect(normalizeOrigin("not-a-url-%E0%A4%A")).toBeNull();
     });
 
+    it("decodes encoded origins when direct URL parsing fails", () => {
+        expect(normalizeOrigin("https%3A%2F%2Fapp.example.com")).toBe("https://app.example.com");
+    });
+
     it("normalizes exact origins before comparison", () => {
         const origin = normalizeOrigin("https://app.example.com")!;
         const frontendOrigin = normalizeOrigin("https://frontend.example.com")!;


### PR DESCRIPTION
🎯 **What:** The fallback `catch` block in `normalizeOrigin` was not previously tested. It returns `null` if `decodeURIComponent` throws an error on a fallback decode attempt.
📊 **Coverage:** A new test uses `not-a-url-%E0%A4%A`, which first fails `new URL(value)`, then `decodeURIComponent()` throws a URIError, falling into the final catch block to return `null`.
✨ **Result:** Full branch coverage is now achieved for `normalizeOrigin`.

---
*PR created automatically by Jules for task [2577808237896408664](https://jules.google.com/task/2577808237896408664) started by @is0692vs*

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

`normalizeOrigin` の最終 `catch` ブロック（`new URL()` と `decodeURIComponent()` が両方失敗して `null` を返すパス）をカバーするテストを追加しています。入力値 `"not-a-url-%E0%A4%A"` は `%A` が不完全なパーセントエンコードシーケンスであるため `decodeURIComponent` が `URIError` を投げ、意図したパスを正しく踏んでいます。
</details>

<h3>Confidence Score: 5/5</h3>

テストのみの変更で、既存ロジックへの影響はなく、マージ安全です。

変更はテストファイル1つのみで、P0/P1 の問題は一切なし。P2 の指摘（中間成功パスの未テスト）は既存の問題であり、今回のPR起因ではないためスコアに影響しません。

特になし。

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| apps/api/src/utils/__tests__/origin.test.ts | normalizeOrigin の最終 catch ブロックをカバーする新規テストを追加。入力値が正しく URIError を誘発し、null を返すことを検証している。 |

</details>

</details>

<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A["normalizeOrigin(value)"] --> B{value が空?}
    B -- Yes --> C[return null]
    B -- No --> D["new URL(value)"]
    D -- 成功 --> E["return URL.origin ✅ 既存テストでカバー済み"]
    D -- TypeError --> F["decodeURIComponent(value)"]
    F -- 成功 --> G["new URL(decoded).origin ⚠️ 未テスト"]
    F -- "URIError ← %E0%A4%A" --> H["return null ✅ 今回のテストでカバー"]
```

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
This is a comment left during a code review.
Path: apps/api/src/utils/__tests__/origin.test.ts
Line: 5-7

Comment:
**中間成功パスが未テスト**

`new URL(value)` が失敗した後に `decodeURIComponent` が成功し、デコード後のURLが有効なケース（例: `"https%3A%2F%2Fapp.example.com"`）はまだカバーされていません。今回の PR の目的である最終 catch ブロックのカバーとは別の話ですが、`normalizeOrigin` のフォールバック成功パスを将来追加することで完全なブランチカバレッジが達成できます。

How can I resolve this? If you propose a fix, please make it concise.
`````

</details>

<sub>Reviews (1): Last reviewed commit: ["🧪 Add test for catch block in normalize..."](https://github.com/hiroki-org/openshelf/commit/67b1a1a716ca451699d6690a78f9db0bb220ff7f) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=28105180)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->