### PR TITLE
🧹 Remove unused imports orgs and orgMembers from auth.ts

### DIFF
--- a/apps/api/src/routes/auth.ts
+++ b/apps/api/src/routes/auth.ts
@@ -3,7 +3,7 @@ import { deleteCookie, getCookie, setCookie } from "hono/cookie";
 import { sign } from "hono/jwt";
 import { drizzle } from "drizzle-orm/d1";
 import { eq } from "drizzle-orm";
-import { users, orgs, orgMembers, enableForeignKeys, touchUpdatedAt } from "../db/schema";
+import { users, enableForeignKeys, touchUpdatedAt } from "../db/schema";
 import type { Env, Variables } from "../types";
 import { authMiddleware } from "../middleware/auth";
 import { parseOriginList, resolveAllowedOrigin } from "../utils/origin";


### PR DESCRIPTION
🎯 **What:** Removed unused imports `orgs` and `orgMembers` from `apps/api/src/routes/auth.ts`.
💡 **Why:** `orgs` and `orgMembers` were imported from `../db/schema` but never used anywhere in `apps/api/src/routes/auth.ts`. Removing unused imports reduces clutter, improves code readability, and prevents confusion regarding the module's database dependencies.
✅ **Verification:**
1. Ran `npm run typecheck` across all workspaces — passed with no new errors.
2. Ran `npm run lint` — passed without error.
3. Ran `npm run test -w apps/api` — the unit test suite for the api workspace passed completely (239 tests).
✨ **Result:** The `auth.ts` file now has cleaner imports, improving overall code health and maintainability.

---
*PR created automatically by Jules for task [5794247403456287704](https://jules.google.com/task/5794247403456287704) started by @is0692vs*

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

`apps/api/src/routes/auth.ts` から未使用のインポート `orgs` と `orgMembers` を削除するシンプルなクリーンアップ変更です。ファイル内でこれらのシンボルは一切参照されておらず、削除は安全です。
</details>

<h3>Confidence Score: 5/5</h3>

安全にマージ可能です。未使用インポートの削除のみで、ロジックへの影響はありません。

変更は1行のインポート削除のみ。`orgs` と `orgMembers` がファイル全体で使用されていないことを確認済み。P0/P1の問題は存在しません。

特に注意が必要なファイルはありません。

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| apps/api/src/routes/auth.ts | 未使用のインポート `orgs`・`orgMembers` を削除。残存するインポートはすべて使用されており問題なし。 |

</details>

</details>

<sub>Reviews (1): Last reviewed commit: ["🧹 Remove unused imports in auth.ts"](https://github.com/hiroki-org/openshelf/commit/96d783b36a42f4a80834a7b580a37f301894dd02) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=28105234)</sub>

<!-- /greptile_comment -->