### PR TITLE
🧪 Add try/catch in validateMagicNumbers to handle corrupt files

### DIFF
--- a/apps/api/src/utils/__tests__/file.test.ts
+++ b/apps/api/src/utils/__tests__/file.test.ts
@@ -195,17 +195,15 @@ describe("validateMagicNumbers", () => {
   });
 
   it("returns false when DataView throws a RangeError for a corrupt file", async () => {
+    const zipHeader = new Uint8Array([0x50, 0x4b, 0x03, 0x04, 0, 0, 0, 0]);
     const corruptFile = {
       size: 100000,
       type: "application/vnd.openxmlformats-officedocument.presentationml.presentation",
       slice(start?: number, end?: number) {
-        if (start === 0 && end === 8) {
+        if (start === 0 && end === zipHeader.byteLength) {
           // Pass the magic number check for ZIP
           return {
-            arrayBuffer: () =>
-              Promise.resolve(
-                new Uint8Array([0x50, 0x4b, 0x03, 0x04, 0, 0, 0, 0]).buffer,
-              ),
+            arrayBuffer: () => Promise.resolve(zipHeader.buffer),
           };
         }
         // Throw a RangeError when hasZipEntry calls slice(start).arrayBuffer()

--- a/apps/api/src/utils/__tests__/file.test.ts
+++ b/apps/api/src/utils/__tests__/file.test.ts
@@ -189,8 +189,40 @@ describe("validateMagicNumbers", () => {
       new Uint8Array([0x89, 0x50, 0x4e, 0x47]),
     );
 
+    await expect(validateMagicNumbers(truncatedPng, "image/png")).resolves.toBe(
+      false,
+    );
+  });
+
+  it("returns false when DataView throws a RangeError for a corrupt file", async () => {
+    const corruptFile = {
+      size: 100000,
+      type: "application/vnd.openxmlformats-officedocument.presentationml.presentation",
+      slice(start?: number, end?: number) {
+        if (start === 0 && end === 8) {
+          // Pass the magic number check for ZIP
+          return {
+            arrayBuffer: () =>
+              Promise.resolve(
+                new Uint8Array([0x50, 0x4b, 0x03, 0x04, 0, 0, 0, 0]).buffer,
+              ),
+          };
+        }
+        // Throw a RangeError when hasZipEntry calls slice(start).arrayBuffer()
+        return {
+          arrayBuffer: () =>
+            Promise.reject(
+              new RangeError("Offset is outside the bounds of the DataView"),
+            ),
+        };
+      },
+    } as any as File;
+
     await expect(
-      validateMagicNumbers(truncatedPng, "image/png"),
+      validateMagicNumbers(
+        corruptFile,
+        "application/vnd.openxmlformats-officedocument.presentationml.presentation",
+      ),
     ).resolves.toBe(false);
   });
 });

--- a/apps/api/src/utils/file.ts
+++ b/apps/api/src/utils/file.ts
@@ -214,54 +214,11 @@ export async function validateMagicNumbers(
     const bytes = new Uint8Array(buffer);
 
     let detectedType: string | null = null;
-    if (
-      bytes.length >= 5 &&
-      bytes[0] === 0x25 &&
-      bytes[1] === 0x50 &&
-      bytes[2] === 0x44 &&
-      bytes[3] === 0x46 &&
-      bytes[4] === 0x2d
-    ) {
-      detectedType = "application/pdf";
-    } else if (
-      bytes.length >= 8 &&
-      bytes[0] === 0x89 &&
-      bytes[1] === 0x50 &&
-      bytes[2] === 0x4e &&
-      bytes[3] === 0x47 &&
-      bytes[4] === 0x0d &&
-      bytes[5] === 0x0a &&
-      bytes[6] === 0x1a &&
-      bytes[7] === 0x0a
-    ) {
-      detectedType = "image/png";
-    } else if (
-      bytes.length >= 3 &&
-      bytes[0] === 0xff &&
-      bytes[1] === 0xd8 &&
-      bytes[2] === 0xff
-    ) {
-      detectedType = "image/jpeg";
-    } else if (
-      bytes.length >= 8 &&
-      bytes[0] === 0xd0 &&
-      bytes[1] === 0xcf &&
-      bytes[2] === 0x11 &&
-      bytes[3] === 0xe0 &&
-      bytes[4] === 0xa1 &&
-      bytes[5] === 0xb1 &&
-      bytes[6] === 0x1a &&
-      bytes[7] === 0xe1
-    ) {
-      detectedType = "application/x-ole-storage";
-    } else if (
-      bytes.length >= 4 &&
-      bytes[0] === 0x50 &&
-      bytes[1] === 0x4b &&
-      bytes[2] === 0x03 &&
-      bytes[3] === 0x04
-    ) {
-      detectedType = "application/zip";
+    for (const [signature, mimeType] of MAGIC_NUMBER_MAP) {
+      if (matchesMagicPrefix(bytes, signature)) {
+        detectedType = mimeType;
+        break;
+      }
     }
 
     if (!detectedType) return false;
@@ -282,7 +239,10 @@ export async function validateMagicNumbers(
     }
 
     return true;
-  } catch {
-    return false;
+  } catch (error) {
+    if (error instanceof RangeError || error instanceof TypeError) {
+      return false;
+    }
+    throw error;
   }
 }

--- a/apps/api/src/utils/file.ts
+++ b/apps/api/src/utils/file.ts
@@ -8,21 +8,20 @@ const MIME_COMPATIBILITY: Record<string, readonly string[]> = {
   ],
 };
 
-const MAGIC_NUMBER_MAP: ReadonlyArray<
-  readonly [Readonly<Uint8Array>, string]
-> = [
-  [Uint8Array.from([0x25, 0x50, 0x44, 0x46, 0x2d]), "application/pdf"],
+const MAGIC_NUMBER_MAP: ReadonlyArray<readonly [Readonly<Uint8Array>, string]> =
   [
-    Uint8Array.from([0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a]),
-    "image/png",
-  ],
-  [Uint8Array.from([0xff, 0xd8, 0xff]), "image/jpeg"],
-  [
-    Uint8Array.from([0xd0, 0xcf, 0x11, 0xe0, 0xa1, 0xb1, 0x1a, 0xe1]),
-    "application/x-ole-storage",
-  ],
-  [Uint8Array.from([0x50, 0x4b, 0x03, 0x04]), "application/zip"],
-];
+    [Uint8Array.from([0x25, 0x50, 0x44, 0x46, 0x2d]), "application/pdf"],
+    [
+      Uint8Array.from([0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a]),
+      "image/png",
+    ],
+    [Uint8Array.from([0xff, 0xd8, 0xff]), "image/jpeg"],
+    [
+      Uint8Array.from([0xd0, 0xcf, 0x11, 0xe0, 0xa1, 0xb1, 0x1a, 0xe1]),
+      "application/x-ole-storage",
+    ],
+    [Uint8Array.from([0x50, 0x4b, 0x03, 0x04]), "application/zip"],
+  ];
 const MAX_MAGIC_SIZE = Math.max(
   ...MAGIC_NUMBER_MAP.map(([signature]) => signature.length),
 );
@@ -210,38 +209,80 @@ export async function validateMagicNumbers(
   file: File,
   declaredMime: string,
 ): Promise<boolean> {
-  const buffer = await file.slice(0, MAX_MAGIC_SIZE).arrayBuffer();
-  const bytes = new Uint8Array(buffer);
+  try {
+    const buffer = await file.slice(0, MAX_MAGIC_SIZE).arrayBuffer();
+    const bytes = new Uint8Array(buffer);
 
-  let detectedType: string | null = null;
-  if (bytes.length >= 5 && bytes[0] === 0x25 && bytes[1] === 0x50 && bytes[2] === 0x44 && bytes[3] === 0x46 && bytes[4] === 0x2d) {
-    detectedType = "application/pdf";
-  } else if (bytes.length >= 8 && bytes[0] === 0x89 && bytes[1] === 0x50 && bytes[2] === 0x4e && bytes[3] === 0x47 && bytes[4] === 0x0d && bytes[5] === 0x0a && bytes[6] === 0x1a && bytes[7] === 0x0a) {
-    detectedType = "image/png";
-  } else if (bytes.length >= 3 && bytes[0] === 0xff && bytes[1] === 0xd8 && bytes[2] === 0xff) {
-    detectedType = "image/jpeg";
-  } else if (bytes.length >= 8 && bytes[0] === 0xd0 && bytes[1] === 0xcf && bytes[2] === 0x11 && bytes[3] === 0xe0 && bytes[4] === 0xa1 && bytes[5] === 0xb1 && bytes[6] === 0x1a && bytes[7] === 0xe1) {
-    detectedType = "application/x-ole-storage";
-  } else if (bytes.length >= 4 && bytes[0] === 0x50 && bytes[1] === 0x4b && bytes[2] === 0x03 && bytes[3] === 0x04) {
-    detectedType = "application/zip";
+    let detectedType: string | null = null;
+    if (
+      bytes.length >= 5 &&
+      bytes[0] === 0x25 &&
+      bytes[1] === 0x50 &&
+      bytes[2] === 0x44 &&
+      bytes[3] === 0x46 &&
+      bytes[4] === 0x2d
+    ) {
+      detectedType = "application/pdf";
+    } else if (
+      bytes.length >= 8 &&
+      bytes[0] === 0x89 &&
+      bytes[1] === 0x50 &&
+      bytes[2] === 0x4e &&
+      bytes[3] === 0x47 &&
+      bytes[4] === 0x0d &&
+      bytes[5] === 0x0a &&
+      bytes[6] === 0x1a &&
+      bytes[7] === 0x0a
+    ) {
+      detectedType = "image/png";
+    } else if (
+      bytes.length >= 3 &&
+      bytes[0] === 0xff &&
+      bytes[1] === 0xd8 &&
+      bytes[2] === 0xff
+    ) {
+      detectedType = "image/jpeg";
+    } else if (
+      bytes.length >= 8 &&
+      bytes[0] === 0xd0 &&
+      bytes[1] === 0xcf &&
+      bytes[2] === 0x11 &&
+      bytes[3] === 0xe0 &&
+      bytes[4] === 0xa1 &&
+      bytes[5] === 0xb1 &&
+      bytes[6] === 0x1a &&
+      bytes[7] === 0xe1
+    ) {
+      detectedType = "application/x-ole-storage";
+    } else if (
+      bytes.length >= 4 &&
+      bytes[0] === 0x50 &&
+      bytes[1] === 0x4b &&
+      bytes[2] === 0x03 &&
+      bytes[3] === 0x04
+    ) {
+      detectedType = "application/zip";
+    }
+
+    if (!detectedType) return false;
+
+    const isValidBasic = (MIME_COMPATIBILITY[declaredMime] ?? []).includes(
+      detectedType,
+    );
+    if (!isValidBasic) return false;
+
+    // Deeper inspection of PPT/PPTX files
+    if (
+      declaredMime ===
+      "application/vnd.openxmlformats-officedocument.presentationml.presentation"
+    ) {
+      return await hasZipEntry(file, "ppt/presentation.xml");
+    } else if (declaredMime === "application/vnd.ms-powerpoint") {
+      return await hasOleStream(file, "PowerPoint Document");
+    }
+
+    return true;
+  } catch {
+    return false;
   }
-
-  if (!detectedType) return false;
-
-  const isValidBasic = (MIME_COMPATIBILITY[declaredMime] ?? []).includes(
-    detectedType,
-  );
-  if (!isValidBasic) return false;
-
-  // Deeper inspection of PPT/PPTX files
-  if (
-    declaredMime ===
-    "application/vnd.openxmlformats-officedocument.presentationml.presentation"
-  ) {
-    return hasZipEntry(file, "ppt/presentation.xml");
-  } else if (declaredMime === "application/vnd.ms-powerpoint") {
-    return hasOleStream(file, "PowerPoint Document");
-  }
-
-  return true;
 }


### PR DESCRIPTION
🎯 **What:** Added a `try/catch` block to the body of `validateMagicNumbers` and `await` keywords before calling deep inspection helpers like `hasZipEntry` and `hasOleStream`.
📊 **Coverage:** A test was added to explicitly simulate a corrupt ZIP file (`DataView` operations throwing `RangeError` indirectly via underlying mocked buffers), which previously caused unhandled promise rejections.
✨ **Result:** Corrupt files that cause bounds violations during magical number inspection or file parsing inside DataView now safely return `false` instead of crashing the process, making the function significantly more robust against invalid or manipulated file structures.

---
*PR created automatically by Jules for task [15001162983394736675](https://jules.google.com/task/15001162983394736675) started by @is0692vs*

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

`validateMagicNumbers` の関数本体全体を `try/catch` で囲み、壊れたファイルによる DataView の境界違反（`RangeError`）が未処理の Promise リジェクションとなる問題を修正しています。また、`hasZipEntry`・`hasOleStream` の呼び出しに欠けていた `await` を追加することで、非同期エラーが `catch` ブロックで正しく捕捉されるようになりました。残りの指摘はすべて P2 (スタイル・改善提案) です。
</details>

<h3>Confidence Score: 5/5</h3>

マージ可能。すべての残存指摘は P2（スタイル・改善提案）であり、ブロッカーはありません。

主要な修正（try/catch の追加と await の欠落修正）は正確で意図した動作を達成しており、新テストも追加されています。残る指摘は catch ブロックの粒度とテストモックのハードコード値に関する P2 レベルのみです。

特になし。2 ファイルとも変更内容は適切です。

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| apps/api/src/utils/file.ts | `validateMagicNumbers` 全体を `try/catch` で囲み、`hasZipEntry`・`hasOleStream` の呼び出しに `await` を追加。`catch {}` が全エラーを無音で飲み込む点は軽微な懸念。 |
| apps/api/src/utils/__tests__/file.test.ts | 壊れた ZIP ファイルを模擬した新テストを追加。モック内の `end === 8` が `MAX_MAGIC_SIZE` にハードコードされている点は若干脆弱。 |

</details>

</details>

<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[validateMagicNumbers 開始] --> B[try ブロック]
    B --> C[await arrayBuffer]
    C -- 成功 --> D[マジックナンバー判定]
    C -- 例外 --> Z[catch: return false]
    D -- 不明 --> E[return false]
    D -- 検出 --> F[MIME_COMPATIBILITY チェック]
    F -- 不一致 --> E
    F -- PPTX --> G[await hasZipEntry]
    F -- PPT --> H[await hasOleStream]
    F -- その他 --> I[return true]
    G --> I
    G -- 例外 --> Z
    H --> I
    H -- 例外 --> Z
```

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
This is a comment left during a code review.
Path: apps/api/src/utils/file.ts
Line: 285-287

Comment:
**catch ブロックが広すぎる（エラーの無音スワロー）**

すべての例外を無条件で捕捉しているため、`hasZipEntry` や `hasOleStream` 内のプログラミングバグ（例: `TypeError`）もサイレントに `false` を返して隠蔽されます。本来のターゲットは `RangeError`（DataView 境界違反）と `TypeError`（壊れたバッファ操作）に限定し、それ以外は再スローするか、少なくともエラーをログ出力することを推奨します。

```suggestion
  } catch (error) {
    if (error instanceof RangeError || error instanceof TypeError) {
      return false;
    }
    throw error;
  }
```

How can I resolve this? If you propose a fix, please make it concise.

---

This is a comment left during a code review.
Path: apps/api/src/utils/__tests__/file.test.ts
Line: 202

Comment:
**テストモックの条件が `MAX_MAGIC_SIZE` の値にハードコードされている**

`end === 8` は現在の `MAX_MAGIC_SIZE`（PNG シグネチャ 8 バイト）に依存しており、将来より長いシグネチャが追加された場合にテストが壊れます。`MAX_MAGIC_SIZE` を直接インポートして比較するか、コメントで依存関係を明示することを推奨します。

```suggestion
        if (start === 0 && end === 8) { // MAX_MAGIC_SIZE = 8 に依存
```

How can I resolve this? If you propose a fix, please make it concise.
`````

</details>

<sub>Reviews (1): Last reviewed commit: ["🧪 add try/catch in validateMagicNumbers..."](https://github.com/hiroki-org/openshelf/commit/252236a391221649679cfe91b3fe2f4cb9de90ad) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=28105488)</sub>

> Greptile also left **2 inline comments** on this PR.

<!-- /greptile_comment -->