### PR TITLE
fix(ci): keep OSV scan green on main updates

### DIFF
--- a/.github/workflows/osv-scanner.yml
+++ b/.github/workflows/osv-scanner.yml
@@ -7,6 +7,7 @@ on:
     branches: [main]
   schedule:
     - cron: '15 13 * * 1'
+  workflow_dispatch:
   push:
     branches: [main]
 
@@ -17,8 +18,11 @@ permissions:
 
 jobs:
   scan-scheduled:
-    if: ${{ github.event_name == 'push' || github.event_name == 'schedule' }}
+    if: ${{ github.event_name == 'push' || github.event_name == 'schedule' || github.event_name == 'workflow_dispatch' }}
     uses: "google/osv-scanner-action/.github/workflows/osv-scanner-reusable.yml@v2.3.5"
+    with:
+      # Keep scheduled scans blocking on known vulns, but do not fail main push runs.
+      fail-on-vuln: ${{ github.event_name == 'schedule' }}
   scan-pr:
     if: ${{ github.event_name == 'pull_request' || github.event_name == 'merge_group' }}
     uses: "google/osv-scanner-action/.github/workflows/osv-scanner-reusable-pr.yml@v2.3.5"


### PR DESCRIPTION
Summary:
- stop failing scan-scheduled on push-triggered runs
- keep scheduled weekly scan strict (fail-on-vuln true only on schedule)
- add workflow_dispatch to validate workflow behavior safely

Verification:
- Triggered OSV-Scanner on this branch: https://github.com/Hiroki-org/OpenShelf/actions/runs/24294940651
- Result: scan-scheduled / osv-scan succeeded while vulnerabilities were still reported

This prevents main update pushes from failing due existing known vulnerabilities while preserving scheduled security signal.

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

mainブランチへの `push` でOSVスキャンが既知の脆弱性によって失敗してしまう問題を修正するため、`fail-on-vuln` をイベント種別によって切り替えるよう変更した。`schedule`（週次）のみ `fail-on-vuln: true` とし、`push` や `workflow_dispatch` では非ブロッキングにすることで、PR段階での厳格なチェック（`scan-pr`）を維持しつつ、mainへのマージを妨げない設計になっている。
</details>

<h3>Confidence Score: 5/5</h3>

マージしても安全です。変更は意図通りに機能しており、P0/P1の問題はありません。

変更内容はシンプルで範囲が限定的（CIワークフロー1ファイルのみ）。PR作者が実際にワークフローを実行して動作確認済み。残る指摘はP2（`workflow_dispatch`時の`fail-on-vuln`挙動）のみで、ブロッカーではない。

特に注意が必要なファイルはありません。

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| .github/workflows/osv-scanner.yml | `workflow_dispatch` トリガーと `fail-on-vuln` の条件分岐を追加。スケジュール実行時のみ失敗させ、push 時はソフトスキャンに変更。設計意図は明確で、PR段階では `scan-pr` が引き続き厳格にチェックする。 |

</details>

</details>

<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[GitHub Event] --> B{イベント種別}
    B -->|pull_request / merge_group| C[scan-pr ジョブ]
    B -->|push to main| D[scan-scheduled ジョブ]
    B -->|schedule 週次| E[scan-scheduled ジョブ]
    B -->|workflow_dispatch| F[scan-scheduled ジョブ]

    C --> G[osv-scanner-reusable-pr.yml\nfail-on-vuln: true デフォルト]
    D --> H[osv-scanner-reusable.yml\nfail-on-vuln: false ✅ 非ブロッキング]
    E --> I[osv-scanner-reusable.yml\nfail-on-vuln: true ⚠️ ブロッキング]
    F --> J[osv-scanner-reusable.yml\nfail-on-vuln: false ℹ️ 非ブロッキング]

    style G fill:#d4edda
    style H fill:#fff3cd
    style I fill:#f8d7da
    style J fill:#fff3cd
```

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
This is a comment left during a code review.
Path: .github/workflows/osv-scanner.yml
Line: 25

Comment:
**`workflow_dispatch` 時も `fail-on-vuln: false` になる点**

現在の式では `workflow_dispatch` によるトリガー時も `fail-on-vuln: false` となります。PRの意図（「安全なワークフロー動作確認」）には合っていますが、将来セキュリティエンジニアが手動でブロッキングスキャンを実行したい場合（例: リリース前の確認）には対応できません。`workflow_dispatch` でも strict に実行したい場合は、入力パラメータを追加する方法も検討できます。

```suggestion
      fail-on-vuln: ${{ github.event_name == 'schedule' || github.event_name == 'workflow_dispatch' }}
```

もしくは `workflow_dispatch` 用のブール入力を追加する方法もあります（現状の「常に非ブロッキング」でも問題ない場合はそのままで構いません）。

How can I resolve this? If you propose a fix, please make it concise.
`````

</details>

<sub>Reviews (1): Last reviewed commit: ["fix(ci): avoid failing OSV scan on main ..."](https://github.com/hiroki-org/openshelf/commit/36acd605cc64a3597e86d8c169afd6e496104b69) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=28107467)</sub>

> Greptile also left **1 inline comment** on this PR.

**Context used:**

- Context used - 日本語で！！！ ([source](https://app.greptile.com/review/custom-context?memory=instruction-0))

<!-- /greptile_comment -->