### PR TITLE
Staging

### DIFF
--- a/.github/workflows/osv-scanner.yml
+++ b/.github/workflows/osv-scanner.yml
@@ -7,6 +7,7 @@ on:
     branches: [main]
   schedule:
     - cron: '15 13 * * 1'
+  workflow_dispatch:
   push:
     branches: [main]
 
@@ -17,8 +18,11 @@ permissions:
 
 jobs:
   scan-scheduled:
-    if: ${{ github.event_name == 'push' || github.event_name == 'schedule' }}
+    if: ${{ github.event_name == 'push' || github.event_name == 'schedule' || github.event_name == 'workflow_dispatch' }}
     uses: "google/osv-scanner-action/.github/workflows/osv-scanner-reusable.yml@v2.3.5"
+    with:
+      # Keep scheduled scans blocking on known vulns, but do not fail main push runs.
+      fail-on-vuln: ${{ github.event_name == 'schedule' }}
   scan-pr:
     if: ${{ github.event_name == 'pull_request' || github.event_name == 'merge_group' }}
     uses: "google/osv-scanner-action/.github/workflows/osv-scanner-reusable-pr.yml@v2.3.5"

--- a/apps/api/src/routes/__tests__/collections.test.ts
+++ b/apps/api/src/routes/__tests__/collections.test.ts
@@ -1,922 +1,855 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import {
-  createTestApp,
-  createMockDb as createSharedMockDb,
-  createTestEnv,
-  createTestJWT,
-  makeQuery,
-  queueSelectResponses as queueSharedSelectResponses,
+    createTestApp,
+    createMockDb as createSharedMockDb,
+    createTestEnv,
+    createTestJWT,
+    makeQuery,
+    queueSelectResponses as queueSharedSelectResponses,
 } from "../../test/helpers";
 
 let mockDb: any;
 
 vi.mock("drizzle-orm/d1", () => ({
-  drizzle: vi.fn(() => mockDb),
+    drizzle: vi.fn(() => mockDb),
 }));
 
 function createMockDb() {
-  return createSharedMockDb();
+    return createSharedMockDb();
 }
 
 function queueSelectResponses(
-  responses: Array<{ getResult?: unknown; allResult?: unknown[] }>,
+    responses: Array<{ getResult?: unknown; allResult?: unknown[] }>,
 ) {
-  queueSharedSelectResponses(mockDb, responses);
+    queueSharedSelectResponses(mockDb, responses);
 }
 
 describe("collections routes", () => {
-  beforeEach(() => {
-    vi.restoreAllMocks();
-    vi.resetModules();
-    mockDb = createMockDb();
-  });
+    beforeEach(() => {
+        vi.restoreAllMocks();
+        vi.resetModules();
+        mockDb = createMockDb();
+    });
 
-  it("POST /api/collections requires auth", async () => {
-    const app = await createTestApp();
-    const env = createTestEnv();
+    it("POST /api/collections requires auth", async () => {
+        const app = await createTestApp();
+        const env = createTestEnv();
 
-    const res = await app.request(
-      "http://localhost/api/collections",
-      {
-        method: "POST",
-        headers: {
-          "Content-Type": "application/json",
-          Origin: "http://localhost:3000",
-        },
-        body: JSON.stringify({
-          owner_type: "user",
-          name: "My Collection",
-          slug: "my-collection",
-        }),
-      },
-      env as any,
-    );
+        const res = await app.request(
+            "http://localhost/api/collections",
+            {
+                method: "POST",
+                headers: {
+                    "Content-Type": "application/json",
+                    Origin: "http://localhost:3000",
+                },
+                body: JSON.stringify({ owner_type: "user", name: "My Collection", slug: "my-collection" }),
+            },
+            env as any,
+        );
 
-    expect(res.status).toBe(401);
-  });
+        expect(res.status).toBe(401);
+    });
 
-  it("POST /api/collections returns 400 for invalid JSON body", async () => {
-    const token = await createTestJWT({ sub: "user-1" });
-    const app = await createTestApp();
-    const env = createTestEnv();
 
-    const res = await app.request(
-      "http://localhost/api/collections",
-      {
-        method: "POST",
-        headers: {
-          Authorization: `Bearer ${token}`,
-          "Content-Type": "application/json",
-        },
-        body: "invalid json {",
-      },
-      env as any,
-    );
+    it("POST /api/collections returns 400 for invalid JSON body", async () => {
+        const token = await createTestJWT({ sub: "user-1" });
+        const app = await createTestApp();
+        const env = createTestEnv();
 
-    expect(res.status).toBe(400);
-    expect(((await res.json()) as any).error).toBe("Invalid JSON body");
-  });
-  it("GET /api/collections/:id returns 404 when not found", async () => {
-    mockDb.select = vi.fn(() => makeQuery({ getResult: null }));
+        const res = await app.request(
+            "http://localhost/api/collections",
+            {
+                method: "POST",
+                headers: {
+                    Authorization: `Bearer ${token}`,
+                    "Content-Type": "application/json",
+                },
+                body: "invalid json {",
+            },
+            env as any,
+        );
 
-    const app = await createTestApp();
-    const env = createTestEnv();
+        expect(res.status).toBe(400);
+        expect(((await res.json()) as any).error).toBe("Invalid JSON body");
+    });
+    it("GET /api/collections/:id returns 404 when not found", async () => {
+        mockDb.select = vi.fn(() => makeQuery({ getResult: null }));
 
-    const res = await app.request(
-      "http://localhost/api/collections/not-found",
-      {},
-      env as any,
-    );
+        const app = await createTestApp();
+        const env = createTestEnv();
 
-    expect(res.status).toBe(404);
-  });
+        const res = await app.request("http://localhost/api/collections/not-found", {}, env as any);
 
-  it("GET /api/users/:id/collections returns list", async () => {
-    mockDb.select = vi.fn(() =>
-      makeQuery({
-        allResult: [
-          {
+        expect(res.status).toBe(404);
+    });
+
+    it("GET /api/users/:id/collections returns list", async () => {
+        mockDb.select = vi.fn(() =>
+            makeQuery({
+                allResult: [
+                    {
+                        id: "col-1",
+                        ownerType: "user",
+                        ownerId: "user-1",
+                        slug: "favorites",
+                        name: "Favorites",
+                        description: null,
+                        visibility: "public",
+                    },
+                ],
+            }),
+        );
+
+        const app = await createTestApp();
+        const env = createTestEnv();
+
+        const res = await app.request("http://localhost/api/users/user-1/collections", {}, env as any);
+
+        expect(res.status).toBe(200);
+        const body = (await res.json()) as any;
+        expect(body.collections).toHaveLength(1);
+        expect(body.collections[0].slug).toBe("favorites");
+    });
+
+    it("POST /api/collections creates a user collection", async () => {
+        const token = await createTestJWT({ sub: "user-1" });
+        const createdCollection = {
             id: "col-1",
             ownerType: "user",
             ownerId: "user-1",
             slug: "favorites",
             name: "Favorites",
+            description: "Picked papers",
+            visibility: "private",
+        };
+        queueSelectResponses([{ getResult: createdCollection }]);
+
+        const insertValues = vi.fn(async () => undefined);
+        mockDb.insert = vi.fn(() => ({ values: insertValues }));
+
+        const app = await createTestApp();
+        const env = createTestEnv();
+
+        const res = await app.request(
+            "http://localhost/api/collections",
+            {
+                method: "POST",
+                headers: {
+                    Authorization: `Bearer ${token}`,
+                    "Content-Type": "application/json",
+                },
+                body: JSON.stringify({
+                    owner_type: "user",
+                    name: "Favorites",
+                    slug: "favorites",
+                    description: " Picked papers ",
+                }),
+            },
+            env as any,
+        );
+
+        expect(res.status).toBe(201);
+        expect(insertValues).toHaveBeenCalledWith(
+            expect.objectContaining({
+                ownerType: "user",
+                ownerId: "user-1",
+                slug: "favorites",
+                name: "Favorites",
+                description: "Picked papers",
+                visibility: "private",
+            }),
+        );
+    });
+
+    it("POST /api/collections returns 403 when requester cannot manage org collections", async () => {
+        const token = await createTestJWT({ sub: "user-1" });
+        queueSelectResponses([
+            { getResult: { id: "org-1", slug: "lab" } },
+            { getResult: { orgId: "org-1", userId: "user-1", role: "member" } },
+        ]);
+
+        const app = await createTestApp();
+        const env = createTestEnv();
+
+        const res = await app.request(
+            "http://localhost/api/collections",
+            {
+                method: "POST",
+                headers: {
+                    Authorization: `Bearer ${token}`,
+                    "Content-Type": "application/json",
+                },
+                body: JSON.stringify({
+                    owner_type: "org",
+                    org_slug: "lab",
+                    name: "Lab picks",
+                    slug: "lab-picks",
+                    visibility: "org_only",
+                }),
+            },
+            env as any,
+        );
+
+        expect(res.status).toBe(403);
+        expect((await res.json()) as any).toEqual({
+            error: "Forbidden: admin access required",
+        });
+    });
+
+    it("GET /api/collections/:id hides private collections from anonymous users", async () => {
+        queueSelectResponses([
+            {
+                getResult: {
+                    id: "col-1",
+                    ownerType: "user",
+                    ownerId: "user-1",
+                    visibility: "private",
+                },
+            },
+        ]);
+
+        const app = await createTestApp();
+        const env = createTestEnv();
+
+        const res = await app.request("http://localhost/api/collections/col-1", {}, env as any);
+
+        expect(res.status).toBe(404);
+    });
+
+    it("GET /api/collections/:id returns a private collection to its owner", async () => {
+        const token = await createTestJWT({ sub: "user-1" });
+        queueSelectResponses([
+            {
+                getResult: {
+                    id: "col-1",
+                    ownerType: "user",
+                    ownerId: "user-1",
+                    visibility: "private",
+                },
+            },
+        ]);
+
+        const app = await createTestApp();
+        const env = createTestEnv();
+
+        const res = await app.request(
+            "http://localhost/api/collections/col-1",
+            {
+                headers: { Authorization: `Bearer ${token}` },
+            },
+            env as any,
+        );
+
+        expect(res.status).toBe(200);
+        expect(((await res.json()) as any).collection.id).toBe("col-1");
+    });
+
+    it("PATCH /api/collections/:id updates collection details for the owner", async () => {
+        const token = await createTestJWT({ sub: "user-1" });
+        const existingCollection = {
+            id: "col-1",
+            ownerType: "user",
+            ownerId: "user-1",
+            name: "Old",
+            slug: "old",
             description: null,
-            visibility: "public",
-          },
-        ],
-      }),
-    );
-
-    const app = await createTestApp();
-    const env = createTestEnv();
-
-    const res = await app.request(
-      "http://localhost/api/users/user-1/collections",
-      {},
-      env as any,
-    );
-
-    expect(res.status).toBe(200);
-    const body = (await res.json()) as any;
-    expect(body.collections).toHaveLength(1);
-    expect(body.collections[0].slug).toBe("favorites");
-  });
-
-  it("POST /api/collections creates a user collection", async () => {
-    const token = await createTestJWT({ sub: "user-1" });
-    const createdCollection = {
-      id: "col-1",
-      ownerType: "user",
-      ownerId: "user-1",
-      slug: "favorites",
-      name: "Favorites",
-      description: "Picked papers",
-      visibility: "private",
-    };
-    queueSelectResponses([{ getResult: createdCollection }]);
-
-    const insertValues = vi.fn(async () => undefined);
-    mockDb.insert = vi.fn(() => ({ values: insertValues }));
-
-    const app = await createTestApp();
-    const env = createTestEnv();
-
-    const res = await app.request(
-      "http://localhost/api/collections",
-      {
-        method: "POST",
-        headers: {
-          Authorization: `Bearer ${token}`,
-          "Content-Type": "application/json",
-        },
-        body: JSON.stringify({
-          owner_type: "user",
-          name: "Favorites",
-          slug: "favorites",
-          description: " Picked papers ",
-        }),
-      },
-      env as any,
-    );
-
-    expect(res.status).toBe(201);
-    expect(insertValues).toHaveBeenCalledWith(
-      expect.objectContaining({
-        ownerType: "user",
-        ownerId: "user-1",
-        slug: "favorites",
-        name: "Favorites",
-        description: "Picked papers",
-        visibility: "private",
-      }),
-    );
-  });
-
-  it("POST /api/collections returns 403 when requester cannot manage org collections", async () => {
-    const token = await createTestJWT({ sub: "user-1" });
-    queueSelectResponses([
-      { getResult: { id: "org-1", slug: "lab" } },
-      { getResult: { orgId: "org-1", userId: "user-1", role: "member" } },
-    ]);
-
-    const app = await createTestApp();
-    const env = createTestEnv();
-
-    const res = await app.request(
-      "http://localhost/api/collections",
-      {
-        method: "POST",
-        headers: {
-          Authorization: `Bearer ${token}`,
-          "Content-Type": "application/json",
-        },
-        body: JSON.stringify({
-          owner_type: "org",
-          org_slug: "lab",
-          name: "Lab picks",
-          slug: "lab-picks",
-          visibility: "org_only",
-        }),
-      },
-      env as any,
-    );
-
-    expect(res.status).toBe(403);
-    expect((await res.json()) as any).toEqual({
-      error: "Forbidden: admin access required",
-    });
-  });
-
-  it("GET /api/collections/:id hides private collections from anonymous users", async () => {
-    queueSelectResponses([
-      {
-        getResult: {
-          id: "col-1",
-          ownerType: "user",
-          ownerId: "user-1",
-          visibility: "private",
-        },
-      },
-    ]);
-
-    const app = await createTestApp();
-    const env = createTestEnv();
-
-    const res = await app.request(
-      "http://localhost/api/collections/col-1",
-      {},
-      env as any,
-    );
-
-    expect(res.status).toBe(404);
-  });
-
-  it("GET /api/collections/:id returns a private collection to its owner", async () => {
-    const token = await createTestJWT({ sub: "user-1" });
-    queueSelectResponses([
-      {
-        getResult: {
-          id: "col-1",
-          ownerType: "user",
-          ownerId: "user-1",
-          visibility: "private",
-        },
-      },
-    ]);
-
-    const app = await createTestApp();
-    const env = createTestEnv();
-
-    const res = await app.request(
-      "http://localhost/api/collections/col-1",
-      {
-        headers: { Authorization: `Bearer ${token}` },
-      },
-      env as any,
-    );
-
-    expect(res.status).toBe(200);
-    expect(((await res.json()) as any).collection.id).toBe("col-1");
-  });
-
-  it("PATCH /api/collections/:id updates collection details for the owner", async () => {
-    const token = await createTestJWT({ sub: "user-1" });
-    const existingCollection = {
-      id: "col-1",
-      ownerType: "user",
-      ownerId: "user-1",
-      name: "Old",
-      slug: "old",
-      description: null,
-      visibility: "private",
-    };
-    const updatedCollection = {
-      ...existingCollection,
-      name: "Renamed",
-      slug: "renamed",
-      visibility: "public",
-    };
-    queueSelectResponses([
-      { getResult: existingCollection },
-      { getResult: updatedCollection },
-    ]);
-
-    const setValues = vi.fn(() => ({ where: vi.fn(async () => undefined) }));
-    mockDb.update = vi.fn(() => ({ set: setValues }));
-
-    const app = await createTestApp();
-    const env = createTestEnv();
-
-    const res = await app.request(
-      "http://localhost/api/collections/col-1",
-      {
-        method: "PATCH",
-        headers: {
-          Authorization: `Bearer ${token}`,
-          "Content-Type": "application/json",
-        },
-        body: JSON.stringify({
-          name: " Renamed ",
-          slug: "RENAMED",
-          visibility: "public",
-        }),
-      },
-      env as any,
-    );
-
-    expect(res.status).toBe(200);
-    expect(setValues).toHaveBeenCalledWith(
-      expect.objectContaining({
-        name: "Renamed",
-        slug: "renamed",
-        visibility: "public",
-      }),
-    );
-    expect(((await res.json()) as any).collection.slug).toBe("renamed");
-  });
-
-  it("PATCH /api/collections/:id rejects requests without updatable fields", async () => {
-    const token = await createTestJWT({ sub: "user-1" });
-    queueSelectResponses([
-      {
-        getResult: {
-          id: "col-1",
-          ownerType: "user",
-          ownerId: "user-1",
-          visibility: "private",
-        },
-      },
-    ]);
-
-    const app = await createTestApp();
-    const env = createTestEnv();
-
-    const res = await app.request(
-      "http://localhost/api/collections/col-1",
-      {
-        method: "PATCH",
-        headers: {
-          Authorization: `Bearer ${token}`,
-          "Content-Type": "application/json",
-        },
-        body: JSON.stringify({}),
-      },
-      env as any,
-    );
-
-    expect(res.status).toBe(400);
-    expect(((await res.json()) as any).error).toBe("No fields to update");
-  });
-
-  it("PATCH /api/collections/:id returns 409 when slug is already in use", async () => {
-    const token = await createTestJWT({ sub: "user-1" });
-    queueSelectResponses([
-      {
-        getResult: {
-          id: "col-1",
-          ownerType: "user",
-          ownerId: "user-1",
-          visibility: "private",
-        },
-      },
-    ]);
-
-    const setValues = vi.fn(() => ({
-      where: vi.fn(async () => {
-        throw new Error("UNIQUE constraint failed: collections.slug");
-      }),
-    }));
-    // @ts-ignore
-    mockDb.update = vi.fn(() => ({ set: setValues }));
-
-    const app = await createTestApp();
-    const env = createTestEnv();
-
-    const res = await app.request(
-      "http://localhost/api/collections/col-1",
-      {
-        method: "PATCH",
-        headers: {
-          Authorization: `Bearer ${token}`,
-          "Content-Type": "application/json",
-        },
-        body: JSON.stringify({ slug: "existing-slug" }),
-      },
-      env as any,
-    );
-
-    expect(res.status).toBe(409);
-    expect(((await res.json()) as any).error).toBe("slug already in use");
-  });
-
-  it("DELETE /api/collections/:id deletes a collection for the owner", async () => {
-    const token = await createTestJWT({ sub: "user-1" });
-    queueSelectResponses([
-      {
-        getResult: {
-          id: "col-1",
-          ownerType: "user",
-          ownerId: "user-1",
-          visibility: "private",
-        },
-      },
-    ]);
-
-    const deleteWhere = vi.fn(async () => ({ meta: { changes: 1 } }));
-    mockDb.delete = vi.fn(() => ({ where: deleteWhere }));
-
-    const app = await createTestApp();
-    const env = createTestEnv();
-
-    const res = await app.request(
-      "http://localhost/api/collections/col-1",
-      {
-        method: "DELETE",
-        headers: { Authorization: `Bearer ${token}` },
-      },
-      env as any,
-    );
-
-    expect(res.status).toBe(200);
-    await expect(res.json()).resolves.toEqual({ ok: true });
-    expect(deleteWhere).toHaveBeenCalled();
-  });
-
-  it("GET /api/orgs/:slug/collections returns admin-visible collections", async () => {
-    const token = await createTestJWT({ sub: "user-1" });
-    queueSelectResponses([
-      { getResult: { id: "org-1", slug: "lab" } },
-      {
-        allResult: [
-          {
-            id: "c1",
-            visibility: "public",
-            ownerType: "org",
-            ownerId: "org-1",
-          },
-          {
-            id: "c2",
-            visibility: "org_only",
-            ownerType: "org",
-            ownerId: "org-1",
-          },
-          {
-            id: "c3",
             visibility: "private",
-            ownerType: "org",
-            ownerId: "org-1",
-          },
-        ],
-      },
-      { getResult: { orgId: "org-1", userId: "user-1", role: "admin" } },
-    ]);
-
-    const app = await createTestApp();
-    const env = createTestEnv();
-
-    const res = await app.request(
-      "http://localhost/api/orgs/lab/collections",
-      {
-        headers: { Authorization: `Bearer ${token}` },
-      },
-      env as any,
-    );
-
-    expect(res.status).toBe(200);
-    expect(((await res.json()) as any).collections).toHaveLength(3);
-  });
-
-  it("GET /api/orgs/:slug/collections hides private org collections from non-admin members", async () => {
-    const token = await createTestJWT({ sub: "user-1" });
-    queueSelectResponses([
-      { getResult: { id: "org-1", slug: "lab" } },
-      {
-        allResult: [
-          {
-            id: "c1",
+        };
+        const updatedCollection = {
+            ...existingCollection,
+            name: "Renamed",
+            slug: "renamed",
             visibility: "public",
-            ownerType: "org",
-            ownerId: "org-1",
-          },
-          {
-            id: "c2",
-            visibility: "org_only",
-            ownerType: "org",
-            ownerId: "org-1",
-          },
-          {
-            id: "c3",
-            visibility: "private",
-            ownerType: "org",
-            ownerId: "org-1",
-          },
-        ],
-      },
-      { getResult: { orgId: "org-1", userId: "user-1", role: "member" } },
-    ]);
+        };
+        queueSelectResponses([
+            { getResult: existingCollection },
+            { getResult: updatedCollection },
+        ]);
 
-    const app = await createTestApp();
-    const env = createTestEnv();
+        const setValues = vi.fn(() => ({ where: vi.fn(async () => undefined) }));
+        mockDb.update = vi.fn(() => ({ set: setValues }));
 
-    const res = await app.request(
-      "http://localhost/api/orgs/lab/collections",
-      {
-        headers: { Authorization: `Bearer ${token}` },
-      },
-      env as any,
-    );
+        const app = await createTestApp();
+        const env = createTestEnv();
 
-    expect(res.status).toBe(200);
-    expect(
-      ((await res.json()) as any).collections.map((row: any) => row.id),
-    ).toEqual(["c1", "c2"]);
-  });
+        const res = await app.request(
+            "http://localhost/api/collections/col-1",
+            {
+                method: "PATCH",
+                headers: {
+                    Authorization: `Bearer ${token}`,
+                    "Content-Type": "application/json",
+                },
+                body: JSON.stringify({
+                    name: " Renamed ",
+                    slug: "RENAMED",
+                    visibility: "public",
+                }),
+            },
+            env as any,
+        );
 
-  it("POST /api/collections/:id/papers rejects invalid JSON", async () => {
-    const token = await createTestJWT({ sub: "user-1" });
-    queueSelectResponses([
-      {
-        getResult: {
-          id: "col-1",
-          ownerType: "user",
-          ownerId: "user-1",
-          visibility: "private",
-        },
-      },
-    ]);
-
-    const app = await createTestApp();
-    const env = createTestEnv();
-
-    const res = await app.request(
-      "http://localhost/api/collections/col-1/papers",
-      {
-        method: "POST",
-        headers: {
-          Authorization: `Bearer ${token}`,
-          "Content-Type": "application/json",
-        },
-        body: "invalid-json",
-      },
-      env as any,
-    );
-
-    expect(res.status).toBe(400);
-    await expect(res.json()).resolves.toEqual({ error: "Invalid JSON body" });
-  });
-
-  it("POST /api/collections/:id/papers adds a visible paper with the next sort order", async () => {
-    const token = await createTestJWT({ sub: "user-1" });
-    const collection = {
-      id: "col-1",
-      ownerType: "user",
-      ownerId: "user-1",
-      visibility: "private",
-    };
-    queueSelectResponses([
-      { getResult: collection },
-      { getResult: { id: "paper-1", visibility: "private" } },
-      { getResult: { paperId: "paper-1" } },
-      { getResult: { maxOrder: 2 } },
-    ]);
-
-    const insertValues = vi.fn(async () => undefined);
-    mockDb.insert = vi.fn(() => ({ values: insertValues }));
-
-    const app = await createTestApp();
-    const env = createTestEnv();
-
-    const res = await app.request(
-      "http://localhost/api/collections/col-1/papers",
-      {
-        method: "POST",
-        headers: {
-          Authorization: `Bearer ${token}`,
-          "Content-Type": "application/json",
-        },
-        body: JSON.stringify({ paper_id: "paper-1" }),
-      },
-      env as any,
-    );
-
-    expect(res.status).toBe(201);
-    expect(insertValues).toHaveBeenCalledWith({
-      collectionId: "col-1",
-      paperId: "paper-1",
-      sortOrder: 3,
+        expect(res.status).toBe(200);
+        expect(setValues).toHaveBeenCalledWith(
+            expect.objectContaining({
+                name: "Renamed",
+                slug: "renamed",
+                visibility: "public",
+            }),
+        );
+        expect(((await res.json()) as any).collection.slug).toBe("renamed");
     });
-  });
 
-  it("POST /api/collections/:id/papers adds a paper the manager can view via org membership", async () => {
-    const token = await createTestJWT({ sub: "user-1" });
-    const collection = {
-      id: "col-1",
-      ownerType: "user",
-      ownerId: "user-1",
-      visibility: "private",
-    };
-    queueSelectResponses([
-      { getResult: collection }, // Collection query
-      { getResult: { id: "paper-1", visibility: "org_only" } }, // Paper query
-      { getResult: null }, // isPaperAuthor returns false
-      { getResult: { id: "user-1" } }, // isMemberOfPaperOrg returns true
-      { getResult: { maxOrder: 2 } }, // maxOrder query
-    ]);
+    it("PATCH /api/collections/:id rejects requests without updatable fields", async () => {
+        const token = await createTestJWT({ sub: "user-1" });
+        queueSelectResponses([
+            {
+                getResult: {
+                    id: "col-1",
+                    ownerType: "user",
+                    ownerId: "user-1",
+                    visibility: "private",
+                },
+            },
+        ]);
 
-    const insertValues = vi.fn(async () => undefined);
-    mockDb.insert = vi.fn(() => ({ values: insertValues }));
+        const app = await createTestApp();
+        const env = createTestEnv();
 
-    const app = await createTestApp();
-    const env = createTestEnv();
+        const res = await app.request(
+            "http://localhost/api/collections/col-1",
+            {
+                method: "PATCH",
+                headers: {
+                    Authorization: `Bearer ${token}`,
+                    "Content-Type": "application/json",
+                },
+                body: JSON.stringify({}),
+            },
+            env as any,
+        );
 
-    const res = await app.request(
-      "http://localhost/api/collections/col-1/papers",
-      {
-        method: "POST",
-        headers: {
-          Authorization: `Bearer ${token}`,
-          "Content-Type": "application/json",
-        },
-        body: JSON.stringify({ paper_id: "paper-1" }),
-      },
-      env as any,
-    );
-
-    expect(res.status).toBe(201);
-    expect(insertValues).toHaveBeenCalledWith({
-      collectionId: "col-1",
-      paperId: "paper-1",
-      sortOrder: 3,
+        expect(res.status).toBe(400);
+        expect(((await res.json()) as any).error).toBe("No fields to update");
     });
-  });
 
-  it("POST /api/collections/:id/papers adds a public paper without specific membership", async () => {
-    const token = await createTestJWT({ sub: "user-1" });
-    const collection = {
-      id: "col-1",
-      ownerType: "user",
-      ownerId: "user-1",
-      visibility: "private",
-    };
-    queueSelectResponses([
-      { getResult: collection }, // Collection query
-      { getResult: { id: "paper-1", visibility: "public" } }, // Paper query
-      { getResult: { maxOrder: 2 } }, // maxOrder query
-    ]);
+    it("PATCH /api/collections/:id returns 409 when slug is already in use", async () => {
+        const token = await createTestJWT({ sub: "user-1" });
+        queueSelectResponses([
+            {
+                getResult: {
+                    id: "col-1",
+                    ownerType: "user",
+                    ownerId: "user-1",
+                    visibility: "private",
+                },
+            },
+        ]);
 
-    const insertValues = vi.fn(async () => undefined);
-    mockDb.insert = vi.fn(() => ({ values: insertValues }));
+        const setValues = vi.fn(() => ({
+            where: vi.fn(async () => {
+                throw new Error("UNIQUE constraint failed: collections.slug");
+            }),
+        }));
+        mockDb.update = vi.fn(() => ({ set: setValues }));
 
-    const app = await createTestApp();
-    const env = createTestEnv();
+        const app = await createTestApp();
+        const env = createTestEnv();
 
-    const res = await app.request(
-      "http://localhost/api/collections/col-1/papers",
-      {
-        method: "POST",
-        headers: {
-          Authorization: `Bearer ${token}`,
-          "Content-Type": "application/json",
-        },
-        body: JSON.stringify({ paper_id: "paper-1" }),
-      },
-      env as any,
-    );
+        const res = await app.request(
+            "http://localhost/api/collections/col-1",
+            {
+                method: "PATCH",
+                headers: {
+                    Authorization: "Bearer " + token,
+                    "Content-Type": "application/json",
+                },
+                body: JSON.stringify({ slug: "existing-slug" }),
+            },
+            env as any,
+        );
 
-    expect(res.status).toBe(201);
-    expect(insertValues).toHaveBeenCalledWith({
-      collectionId: "col-1",
-      paperId: "paper-1",
-      sortOrder: 3,
+        expect(res.status).toBe(409);
+        await expect(res.json()).resolves.toEqual({ error: "slug already in use" });
     });
-  });
 
-  it("POST /api/collections/:id/papers rejects papers the manager cannot view", async () => {
-    const token = await createTestJWT({ sub: "user-1" });
-    queueSelectResponses([
-      {
-        getResult: {
-          id: "col-1",
-          ownerType: "user",
-          ownerId: "user-1",
-          visibility: "private",
-        },
-      },
-      { getResult: { id: "paper-1", visibility: "private" } },
-      { getResult: null },
-    ]);
+    it("DELETE /api/collections/:id deletes a collection for the owner", async () => {
+        const token = await createTestJWT({ sub: "user-1" });
+        queueSelectResponses([
+            {
+                getResult: {
+                    id: "col-1",
+                    ownerType: "user",
+                    ownerId: "user-1",
+                    visibility: "private",
+                },
+            },
+        ]);
 
-    const app = await createTestApp();
-    const env = createTestEnv();
+        const deleteWhere = vi.fn(async () => ({ meta: { changes: 1 } }));
+        mockDb.delete = vi.fn(() => ({ where: deleteWhere }));
 
-    const res = await app.request(
-      "http://localhost/api/collections/col-1/papers",
-      {
-        method: "POST",
-        headers: {
-          Authorization: `Bearer ${token}`,
-          "Content-Type": "application/json",
-        },
-        body: JSON.stringify({ paper_id: "paper-1" }),
-      },
-      env as any,
-    );
+        const app = await createTestApp();
+        const env = createTestEnv();
 
-    expect(res.status).toBe(404);
-    expect(((await res.json()) as any).error).toBe("Paper not found");
-  });
+        const res = await app.request(
+            "http://localhost/api/collections/col-1",
+            {
+                method: "DELETE",
+                headers: { Authorization: `Bearer ${token}` },
+            },
+            env as any,
+        );
 
-  it("PATCH /api/collections/:id/papers rejects duplicate paper IDs", async () => {
-    const token = await createTestJWT({ sub: "user-1" });
-    queueSelectResponses([
-      {
-        getResult: {
-          id: "col-1",
-          ownerType: "user",
-          ownerId: "user-1",
-          visibility: "private",
-        },
-      },
-      {
-        allResult: [{ paperId: "paper-1" }, { paperId: "paper-2" }],
-      },
-    ]);
+        expect(res.status).toBe(200);
+        await expect(res.json()).resolves.toEqual({ ok: true });
+        expect(deleteWhere).toHaveBeenCalled();
+    });
 
-    const app = await createTestApp();
-    const env = createTestEnv();
+    it("GET /api/orgs/:slug/collections returns admin-visible collections", async () => {
+        const token = await createTestJWT({ sub: "user-1" });
+        queueSelectResponses([
+            { getResult: { id: "org-1", slug: "lab" } },
+            {
+                allResult: [
+                    { id: "c1", visibility: "public", ownerType: "org", ownerId: "org-1" },
+                    { id: "c2", visibility: "org_only", ownerType: "org", ownerId: "org-1" },
+                    { id: "c3", visibility: "private", ownerType: "org", ownerId: "org-1" },
+                ],
+            },
+            { getResult: { orgId: "org-1", userId: "user-1", role: "admin" } },
+        ]);
 
-    const res = await app.request(
-      "http://localhost/api/collections/col-1/papers",
-      {
-        method: "PATCH",
-        headers: {
-          Authorization: `Bearer ${token}`,
-          "Content-Type": "application/json",
-        },
-        body: JSON.stringify({ paper_ids: ["paper-1", "paper-1"] }),
-      },
-      env as any,
-    );
+        const app = await createTestApp();
+        const env = createTestEnv();
 
-    expect(res.status).toBe(400);
-    expect(((await res.json()) as any).error).toBe(
-      "paper_ids must not contain duplicates",
-    );
-  });
+        const res = await app.request(
+            "http://localhost/api/orgs/lab/collections",
+            {
+                headers: { Authorization: `Bearer ${token}` },
+            },
+            env as any,
+        );
 
-  it("PATCH /api/collections/:id/papers requires every existing paper to be included", async () => {
-    const token = await createTestJWT({ sub: "user-1" });
-    queueSelectResponses([
-      {
-        getResult: {
-          id: "col-1",
-          ownerType: "user",
-          ownerId: "user-1",
-          visibility: "private",
-        },
-      },
-      {
-        allResult: [{ paperId: "paper-1" }, { paperId: "paper-2" }],
-      },
-    ]);
+        expect(res.status).toBe(200);
+        expect(((await res.json()) as any).collections).toHaveLength(3);
+    });
 
-    const app = await createTestApp();
-    const env = createTestEnv();
+    it("GET /api/orgs/:slug/collections hides private org collections from non-admin members", async () => {
+        const token = await createTestJWT({ sub: "user-1" });
+        queueSelectResponses([
+            { getResult: { id: "org-1", slug: "lab" } },
+            {
+                allResult: [
+                    { id: "c1", visibility: "public", ownerType: "org", ownerId: "org-1" },
+                    { id: "c2", visibility: "org_only", ownerType: "org", ownerId: "org-1" },
+                    { id: "c3", visibility: "private", ownerType: "org", ownerId: "org-1" },
+                ],
+            },
+            { getResult: { orgId: "org-1", userId: "user-1", role: "member" } },
+        ]);
 
-    const res = await app.request(
-      "http://localhost/api/collections/col-1/papers",
-      {
-        method: "PATCH",
-        headers: {
-          Authorization: `Bearer ${token}`,
-          "Content-Type": "application/json",
-        },
-        body: JSON.stringify({ paper_ids: ["paper-1"] }),
-      },
-      env as any,
-    );
+        const app = await createTestApp();
+        const env = createTestEnv();
 
-    expect(res.status).toBe(400);
-    expect(((await res.json()) as any).error).toBe(
-      "paper_ids must include all papers in collection",
-    );
-  });
+        const res = await app.request(
+            "http://localhost/api/orgs/lab/collections",
+            {
+                headers: { Authorization: `Bearer ${token}` },
+            },
+            env as any,
+        );
 
-  it("DELETE /api/collections/:id/papers/:paperId returns 404 when the paper is not in the collection", async () => {
-    const token = await createTestJWT({ sub: "user-1" });
-    queueSelectResponses([
-      {
-        getResult: {
-          id: "col-1",
-          ownerType: "user",
-          ownerId: "user-1",
-          visibility: "private",
-        },
-      },
-    ]);
+        expect(res.status).toBe(200);
+        expect(((await res.json()) as any).collections.map((row: any) => row.id)).toEqual([
+            "c1",
+            "c2",
+        ]);
+    });
 
-    mockDb.delete = vi.fn(() => ({
-      where: vi.fn(async () => ({ meta: { changes: 0 } })),
-    }));
+    it("POST /api/collections/:id/papers rejects invalid JSON", async () => {
+        const token = await createTestJWT({ sub: "user-1" });
+        queueSelectResponses([
+            {
+                getResult: {
+                    id: "col-1",
+                    ownerType: "user",
+                    ownerId: "user-1",
+                    visibility: "private",
+                },
+            },
+        ]);
 
-    const app = await createTestApp();
-    const env = createTestEnv();
+        const app = await createTestApp();
+        const env = createTestEnv();
 
-    const res = await app.request(
-      "http://localhost/api/collections/col-1/papers/paper-1",
-      {
-        method: "DELETE",
-        headers: { Authorization: `Bearer ${token}` },
-      },
-      env as any,
-    );
+        const res = await app.request(
+            "http://localhost/api/collections/col-1/papers",
+            {
+                method: "POST",
+                headers: {
+                    Authorization: `Bearer ${token}`,
+                    "Content-Type": "application/json",
+                },
+                body: "invalid-json",
+            },
+            env as any,
+        );
 
-    expect(res.status).toBe(404);
-    expect(((await res.json()) as any).error).toBe("Paper not in collection");
-  });
+        expect(res.status).toBe(400);
+        await expect(res.json()).resolves.toEqual({ error: "Invalid JSON body" });
+    });
 
-  it("GET /api/collections/:id/papers filters restricted papers by authorship and org access", async () => {
-    const token = await createTestJWT({ sub: "user-1" });
-    queueSelectResponses([
-      {
-        getResult: {
-          id: "col-1",
-          ownerType: "org",
-          ownerId: "org-1",
-          visibility: "public",
-        },
-      },
-      {
-        allResult: [
-          {
-            id: "paper-public",
-            title: "Public",
-            visibility: "public",
-            sortOrder: 0,
-          },
-          {
-            id: "paper-authored",
-            title: "Mine",
+    it("POST /api/collections/:id/papers adds a visible paper with the next sort order", async () => {
+        const token = await createTestJWT({ sub: "user-1" });
+        const collection = {
+            id: "col-1",
+            ownerType: "user",
+            ownerId: "user-1",
             visibility: "private",
-            sortOrder: 1,
-          },
-          {
-            id: "paper-org",
-            title: "Org only",
-            visibility: "org_only",
-            sortOrder: 2,
-          },
-          {
-            id: "paper-hidden",
-            title: "Hidden",
-            visibility: "private",
+        };
+        queueSelectResponses([
+            { getResult: collection },
+            { getResult: { id: "paper-1", visibility: "private" } },
+            { getResult: { paperId: "paper-1" } },
+            { getResult: { maxOrder: 2 } },
+        ]);
+
+        const insertValues = vi.fn(async () => undefined);
+        mockDb.insert = vi.fn(() => ({ values: insertValues }));
+
+        const app = await createTestApp();
+        const env = createTestEnv();
+
+        const res = await app.request(
+            "http://localhost/api/collections/col-1/papers",
+            {
+                method: "POST",
+                headers: {
+                    Authorization: `Bearer ${token}`,
+                    "Content-Type": "application/json",
+                },
+                body: JSON.stringify({ paper_id: "paper-1" }),
+            },
+            env as any,
+        );
+
+        expect(res.status).toBe(201);
+        expect(insertValues).toHaveBeenCalledWith({
+            collectionId: "col-1",
+            paperId: "paper-1",
             sortOrder: 3,
-          },
-        ],
-      },
-      { allResult: [{ paperId: "paper-authored" }] },
-      { allResult: [{ paperId: "paper-org" }] },
-    ]);
+        });
+    });
 
-    const app = await createTestApp();
-    const env = createTestEnv();
 
-    const res = await app.request(
-      "http://localhost/api/collections/col-1/papers",
-      {
-        headers: { Authorization: `Bearer ${token}` },
-      },
-      env as any,
-    );
 
-    expect(res.status).toBe(200);
-    expect(
-      ((await res.json()) as any).papers.map((paper: any) => paper.id),
-    ).toEqual(["paper-public", "paper-authored", "paper-org"]);
-  });
+    it("POST /api/collections/:id/papers adds a paper the manager can view via org membership", async () => {
+        const token = await createTestJWT({ sub: "user-1" });
+        const collection = {
+            id: "col-1",
+            ownerType: "user",
+            ownerId: "user-1",
+            visibility: "private",
+        };
+        queueSelectResponses([
+            { getResult: collection }, // Collection query
+            { getResult: { id: "paper-1", visibility: "org_only" } }, // Paper query
+            { getResult: null }, // isPaperAuthor returns false
+            { getResult: { id: "user-1" } }, // isMemberOfPaperOrg returns true
+            { getResult: { maxOrder: 2 } }, // maxOrder query
+        ]);
 
-  it("POST /api/collections/:id/papers returns 409 when paper is already in collection", async () => {
-    const token = await createTestJWT({ sub: "user-1" });
-    const collection = {
-      id: "col-1",
-      ownerType: "user",
-      ownerId: "user-1",
-      visibility: "private",
-    };
-    queueSelectResponses([
-      { getResult: collection }, // Collection query
-      { getResult: { id: "paper-1", visibility: "public" } }, // Paper query
-      { getResult: { maxOrder: 2 } }, // maxOrder query
-    ]);
+        const insertValues = vi.fn(async () => undefined);
+        mockDb.insert = vi.fn(() => ({ values: insertValues }));
 
-    mockDb.insert = vi.fn(() => ({
-      values: vi
-        .fn()
-        .mockRejectedValue(
-          new Error(
-            "UNIQUE constraint failed: collection_papers.collection_id, collection_papers.paper_id",
-          ),
-        ),
-    }));
+        const app = await createTestApp();
+        const env = createTestEnv();
 
-    const app = await createTestApp();
-    const env = createTestEnv();
+        const res = await app.request(
+            "http://localhost/api/collections/col-1/papers",
+            {
+                method: "POST",
+                headers: {
+                    Authorization: `Bearer ${token}`,
+                    "Content-Type": "application/json",
+                },
+                body: JSON.stringify({ paper_id: "paper-1" }),
+            },
+            env as any,
+        );
 
-    const res = await app.request(
-      "http://localhost/api/collections/col-1/papers",
-      {
-        method: "POST",
-        headers: {
-          Authorization: `Bearer ${token}`,
-          "Content-Type": "application/json",
-        },
-        body: JSON.stringify({ paper_id: "paper-1" }),
-      },
-      env as any,
-    );
+        expect(res.status).toBe(201);
+        expect(insertValues).toHaveBeenCalledWith({
+            collectionId: "col-1",
+            paperId: "paper-1",
+            sortOrder: 3,
+        });
+    });
 
-    expect(res.status).toBe(409);
-    expect(((await res.json()) as any).error).toBe("Paper already added");
-  });
+    it("POST /api/collections/:id/papers adds a public paper without specific membership", async () => {
+        const token = await createTestJWT({ sub: "user-1" });
+        const collection = {
+            id: "col-1",
+            ownerType: "user",
+            ownerId: "user-1",
+            visibility: "private",
+        };
+        queueSelectResponses([
+            { getResult: collection }, // Collection query
+            { getResult: { id: "paper-1", visibility: "public" } }, // Paper query
+            { getResult: { maxOrder: 2 } }, // maxOrder query
+        ]);
+
+        const insertValues = vi.fn(async () => undefined);
+        mockDb.insert = vi.fn(() => ({ values: insertValues }));
+
+        const app = await createTestApp();
+        const env = createTestEnv();
+
+        const res = await app.request(
+            "http://localhost/api/collections/col-1/papers",
+            {
+                method: "POST",
+                headers: {
+                    Authorization: `Bearer ${token}`,
+                    "Content-Type": "application/json",
+                },
+                body: JSON.stringify({ paper_id: "paper-1" }),
+            },
+            env as any,
+        );
+
+        expect(res.status).toBe(201);
+        expect(insertValues).toHaveBeenCalledWith({
+            collectionId: "col-1",
+            paperId: "paper-1",
+            sortOrder: 3,
+        });
+    });
+
+    it("POST /api/collections/:id/papers rejects papers the manager cannot view", async () => {
+        const token = await createTestJWT({ sub: "user-1" });
+        queueSelectResponses([
+            {
+                getResult: {
+                    id: "col-1",
+                    ownerType: "user",
+                    ownerId: "user-1",
+                    visibility: "private",
+                },
+            },
+            { getResult: { id: "paper-1", visibility: "private" } },
+            { getResult: null },
+        ]);
+
+        const app = await createTestApp();
+        const env = createTestEnv();
+
+        const res = await app.request(
+            "http://localhost/api/collections/col-1/papers",
+            {
+                method: "POST",
+                headers: {
+                    Authorization: `Bearer ${token}`,
+                    "Content-Type": "application/json",
+                },
+                body: JSON.stringify({ paper_id: "paper-1" }),
+            },
+            env as any,
+        );
+
+        expect(res.status).toBe(404);
+        expect(((await res.json()) as any).error).toBe("Paper not found");
+    });
+
+    it("PATCH /api/collections/:id/papers rejects duplicate paper IDs", async () => {
+        const token = await createTestJWT({ sub: "user-1" });
+        queueSelectResponses([
+            {
+                getResult: {
+                    id: "col-1",
+                    ownerType: "user",
+                    ownerId: "user-1",
+                    visibility: "private",
+                },
+            },
+            {
+                allResult: [{ paperId: "paper-1" }, { paperId: "paper-2" }],
+            },
+        ]);
+
+        const app = await createTestApp();
+        const env = createTestEnv();
+
+        const res = await app.request(
+            "http://localhost/api/collections/col-1/papers",
+            {
+                method: "PATCH",
+                headers: {
+                    Authorization: `Bearer ${token}`,
+                    "Content-Type": "application/json",
+                },
+                body: JSON.stringify({ paper_ids: ["paper-1", "paper-1"] }),
+            },
+            env as any,
+        );
+
+        expect(res.status).toBe(400);
+        expect(((await res.json()) as any).error).toBe(
+            "paper_ids must not contain duplicates",
+        );
+    });
+
+    it("PATCH /api/collections/:id/papers requires every existing paper to be included", async () => {
+        const token = await createTestJWT({ sub: "user-1" });
+        queueSelectResponses([
+            {
+                getResult: {
+                    id: "col-1",
+                    ownerType: "user",
+                    ownerId: "user-1",
+                    visibility: "private",
+                },
+            },
+            {
+                allResult: [{ paperId: "paper-1" }, { paperId: "paper-2" }],
+            },
+        ]);
+
+        const app = await createTestApp();
+        const env = createTestEnv();
+
+        const res = await app.request(
+            "http://localhost/api/collections/col-1/papers",
+            {
+                method: "PATCH",
+                headers: {
+                    Authorization: `Bearer ${token}`,
+                    "Content-Type": "application/json",
+                },
+                body: JSON.stringify({ paper_ids: ["paper-1"] }),
+            },
+            env as any,
+        );
+
+        expect(res.status).toBe(400);
+        expect(((await res.json()) as any).error).toBe(
+            "paper_ids must include all papers in collection",
+        );
+    });
+
+    it("DELETE /api/collections/:id/papers/:paperId returns 404 when the paper is not in the collection", async () => {
+        const token = await createTestJWT({ sub: "user-1" });
+        queueSelectResponses([
+            {
+                getResult: {
+                    id: "col-1",
+                    ownerType: "user",
+                    ownerId: "user-1",
+                    visibility: "private",
+                },
+            },
+        ]);
+
+        mockDb.delete = vi.fn(() => ({
+            where: vi.fn(async () => ({ meta: { changes: 0 } })),
+        }));
+
+        const app = await createTestApp();
+        const env = createTestEnv();
+
+        const res = await app.request(
+            "http://localhost/api/collections/col-1/papers/paper-1",
+            {
+                method: "DELETE",
+                headers: { Authorization: `Bearer ${token}` },
+            },
+            env as any,
+        );
+
+        expect(res.status).toBe(404);
+        expect(((await res.json()) as any).error).toBe("Paper not in collection");
+    });
+
+    it("GET /api/collections/:id/papers filters restricted papers by authorship and org access", async () => {
+        const token = await createTestJWT({ sub: "user-1" });
+        queueSelectResponses([
+            {
+                getResult: {
+                    id: "col-1",
+                    ownerType: "org",
+                    ownerId: "org-1",
+                    visibility: "public",
+                },
+            },
+            {
+                allResult: [
+                    { id: "paper-public", title: "Public", visibility: "public", sortOrder: 0 },
+                    { id: "paper-authored", title: "Mine", visibility: "private", sortOrder: 1 },
+                    { id: "paper-org", title: "Org only", visibility: "org_only", sortOrder: 2 },
+                    { id: "paper-hidden", title: "Hidden", visibility: "private", sortOrder: 3 },
+                ],
+            },
+            { allResult: [{ paperId: "paper-authored" }] },
+            { allResult: [{ paperId: "paper-org" }] },
+        ]);
+
+        const app = await createTestApp();
+        const env = createTestEnv();
+
+        const res = await app.request(
+            "http://localhost/api/collections/col-1/papers",
+            {
+                headers: { Authorization: `Bearer ${token}` },
+            },
+            env as any,
+        );
+
+        expect(res.status).toBe(200);
+        expect(((await res.json()) as any).papers.map((paper: any) => paper.id)).toEqual([
+            "paper-public",
+            "paper-authored",
+            "paper-org",
+        ]);
+    });
+
+    it("POST /api/collections/:id/papers returns 409 when paper is already in collection", async () => {
+        const token = await createTestJWT({ sub: "user-1" });
+        const collection = {
+            id: "col-1",
+            ownerType: "user",
+            ownerId: "user-1",
+            visibility: "private",
+        };
+        queueSelectResponses([
+            { getResult: collection }, // Collection query
+            { getResult: { id: "paper-1", visibility: "public" } }, // Paper query
+            { getResult: { maxOrder: 2 } }, // maxOrder query
+        ]);
+
+        mockDb.insert = vi.fn(() => ({
+            values: vi.fn().mockRejectedValue(new Error("UNIQUE constraint failed: collection_papers.collection_id, collection_papers.paper_id")),
+        }));
+
+        const app = await createTestApp();
+        const env = createTestEnv();
+
+        const res = await app.request(
+            "http://localhost/api/collections/col-1/papers",
+            {
+                method: "POST",
+                headers: {
+                    Authorization: `Bearer ${token}`,
+                    "Content-Type": "application/json",
+                },
+                body: JSON.stringify({ paper_id: "paper-1" }),
+            },
+            env as any,
+        );
+
+        expect(res.status).toBe(409);
+        expect(((await res.json()) as any).error).toBe("Paper already added");
+    });
 });

--- a/apps/api/src/routes/__tests__/collections.test.ts
+++ b/apps/api/src/routes/__tests__/collections.test.ts
@@ -1,815 +1,922 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import {
-    createTestApp,
-    createMockDb as createSharedMockDb,
-    createTestEnv,
-    createTestJWT,
-    makeQuery,
-    queueSelectResponses as queueSharedSelectResponses,
+  createTestApp,
+  createMockDb as createSharedMockDb,
+  createTestEnv,
+  createTestJWT,
+  makeQuery,
+  queueSelectResponses as queueSharedSelectResponses,
 } from "../../test/helpers";
 
 let mockDb: any;
 
 vi.mock("drizzle-orm/d1", () => ({
-    drizzle: vi.fn(() => mockDb),
+  drizzle: vi.fn(() => mockDb),
 }));
 
 function createMockDb() {
-    return createSharedMockDb();
+  return createSharedMockDb();
 }
 
 function queueSelectResponses(
-    responses: Array<{ getResult?: unknown; allResult?: unknown[] }>,
+  responses: Array<{ getResult?: unknown; allResult?: unknown[] }>,
 ) {
-    queueSharedSelectResponses(mockDb, responses);
+  queueSharedSelectResponses(mockDb, responses);
 }
 
 describe("collections routes", () => {
-    beforeEach(() => {
-        vi.restoreAllMocks();
-        vi.resetModules();
-        mockDb = createMockDb();
-    });
+  beforeEach(() => {
+    vi.restoreAllMocks();
+    vi.resetModules();
+    mockDb = createMockDb();
+  });
 
-    it("POST /api/collections requires auth", async () => {
-        const app = await createTestApp();
-        const env = createTestEnv();
+  it("POST /api/collections requires auth", async () => {
+    const app = await createTestApp();
+    const env = createTestEnv();
 
-        const res = await app.request(
-            "http://localhost/api/collections",
-            {
-                method: "POST",
-                headers: {
-                    "Content-Type": "application/json",
-                    Origin: "http://localhost:3000",
-                },
-                body: JSON.stringify({ owner_type: "user", name: "My Collection", slug: "my-collection" }),
-            },
-            env as any,
-        );
+    const res = await app.request(
+      "http://localhost/api/collections",
+      {
+        method: "POST",
+        headers: {
+          "Content-Type": "application/json",
+          Origin: "http://localhost:3000",
+        },
+        body: JSON.stringify({
+          owner_type: "user",
+          name: "My Collection",
+          slug: "my-collection",
+        }),
+      },
+      env as any,
+    );
 
-        expect(res.status).toBe(401);
-    });
+    expect(res.status).toBe(401);
+  });
 
+  it("POST /api/collections returns 400 for invalid JSON body", async () => {
+    const token = await createTestJWT({ sub: "user-1" });
+    const app = await createTestApp();
+    const env = createTestEnv();
 
-    it("POST /api/collections returns 400 for invalid JSON body", async () => {
-        const token = await createTestJWT({ sub: "user-1" });
-        const app = await createTestApp();
-        const env = createTestEnv();
+    const res = await app.request(
+      "http://localhost/api/collections",
+      {
+        method: "POST",
+        headers: {
+          Authorization: `Bearer ${token}`,
+          "Content-Type": "application/json",
+        },
+        body: "invalid json {",
+      },
+      env as any,
+    );
 
-        const res = await app.request(
-            "http://localhost/api/collections",
-            {
-                method: "POST",
-                headers: {
-                    Authorization: `Bearer ${token}`,
-                    "Content-Type": "application/json",
-                },
-                body: "invalid json {",
-            },
-            env as any,
-        );
+    expect(res.status).toBe(400);
+    expect(((await res.json()) as any).error).toBe("Invalid JSON body");
+  });
+  it("GET /api/collections/:id returns 404 when not found", async () => {
+    mockDb.select = vi.fn(() => makeQuery({ getResult: null }));
 
-        expect(res.status).toBe(400);
-        expect(((await res.json()) as any).error).toBe("Invalid JSON body");
-    });
-    it("GET /api/collections/:id returns 404 when not found", async () => {
-        mockDb.select = vi.fn(() => makeQuery({ getResult: null }));
+    const app = await createTestApp();
+    const env = createTestEnv();
 
-        const app = await createTestApp();
-        const env = createTestEnv();
+    const res = await app.request(
+      "http://localhost/api/collections/not-found",
+      {},
+      env as any,
+    );
 
-        const res = await app.request("http://localhost/api/collections/not-found", {}, env as any);
+    expect(res.status).toBe(404);
+  });
 
-        expect(res.status).toBe(404);
-    });
-
-    it("GET /api/users/:id/collections returns list", async () => {
-        mockDb.select = vi.fn(() =>
-            makeQuery({
-                allResult: [
-                    {
-                        id: "col-1",
-                        ownerType: "user",
-                        ownerId: "user-1",
-                        slug: "favorites",
-                        name: "Favorites",
-                        description: null,
-                        visibility: "public",
-                    },
-                ],
-            }),
-        );
-
-        const app = await createTestApp();
-        const env = createTestEnv();
-
-        const res = await app.request("http://localhost/api/users/user-1/collections", {}, env as any);
-
-        expect(res.status).toBe(200);
-        const body = (await res.json()) as any;
-        expect(body.collections).toHaveLength(1);
-        expect(body.collections[0].slug).toBe("favorites");
-    });
-
-    it("POST /api/collections creates a user collection", async () => {
-        const token = await createTestJWT({ sub: "user-1" });
-        const createdCollection = {
+  it("GET /api/users/:id/collections returns list", async () => {
+    mockDb.select = vi.fn(() =>
+      makeQuery({
+        allResult: [
+          {
             id: "col-1",
             ownerType: "user",
             ownerId: "user-1",
             slug: "favorites",
             name: "Favorites",
-            description: "Picked papers",
-            visibility: "private",
-        };
-        queueSelectResponses([{ getResult: createdCollection }]);
-
-        const insertValues = vi.fn(async () => undefined);
-        mockDb.insert = vi.fn(() => ({ values: insertValues }));
-
-        const app = await createTestApp();
-        const env = createTestEnv();
-
-        const res = await app.request(
-            "http://localhost/api/collections",
-            {
-                method: "POST",
-                headers: {
-                    Authorization: `Bearer ${token}`,
-                    "Content-Type": "application/json",
-                },
-                body: JSON.stringify({
-                    owner_type: "user",
-                    name: "Favorites",
-                    slug: "favorites",
-                    description: " Picked papers ",
-                }),
-            },
-            env as any,
-        );
-
-        expect(res.status).toBe(201);
-        expect(insertValues).toHaveBeenCalledWith(
-            expect.objectContaining({
-                ownerType: "user",
-                ownerId: "user-1",
-                slug: "favorites",
-                name: "Favorites",
-                description: "Picked papers",
-                visibility: "private",
-            }),
-        );
-    });
-
-    it("POST /api/collections returns 403 when requester cannot manage org collections", async () => {
-        const token = await createTestJWT({ sub: "user-1" });
-        queueSelectResponses([
-            { getResult: { id: "org-1", slug: "lab" } },
-            { getResult: { orgId: "org-1", userId: "user-1", role: "member" } },
-        ]);
-
-        const app = await createTestApp();
-        const env = createTestEnv();
-
-        const res = await app.request(
-            "http://localhost/api/collections",
-            {
-                method: "POST",
-                headers: {
-                    Authorization: `Bearer ${token}`,
-                    "Content-Type": "application/json",
-                },
-                body: JSON.stringify({
-                    owner_type: "org",
-                    org_slug: "lab",
-                    name: "Lab picks",
-                    slug: "lab-picks",
-                    visibility: "org_only",
-                }),
-            },
-            env as any,
-        );
-
-        expect(res.status).toBe(403);
-        expect((await res.json()) as any).toEqual({
-            error: "Forbidden: admin access required",
-        });
-    });
-
-    it("GET /api/collections/:id hides private collections from anonymous users", async () => {
-        queueSelectResponses([
-            {
-                getResult: {
-                    id: "col-1",
-                    ownerType: "user",
-                    ownerId: "user-1",
-                    visibility: "private",
-                },
-            },
-        ]);
-
-        const app = await createTestApp();
-        const env = createTestEnv();
-
-        const res = await app.request("http://localhost/api/collections/col-1", {}, env as any);
-
-        expect(res.status).toBe(404);
-    });
-
-    it("GET /api/collections/:id returns a private collection to its owner", async () => {
-        const token = await createTestJWT({ sub: "user-1" });
-        queueSelectResponses([
-            {
-                getResult: {
-                    id: "col-1",
-                    ownerType: "user",
-                    ownerId: "user-1",
-                    visibility: "private",
-                },
-            },
-        ]);
-
-        const app = await createTestApp();
-        const env = createTestEnv();
-
-        const res = await app.request(
-            "http://localhost/api/collections/col-1",
-            {
-                headers: { Authorization: `Bearer ${token}` },
-            },
-            env as any,
-        );
-
-        expect(res.status).toBe(200);
-        expect(((await res.json()) as any).collection.id).toBe("col-1");
-    });
-
-    it("PATCH /api/collections/:id updates collection details for the owner", async () => {
-        const token = await createTestJWT({ sub: "user-1" });
-        const existingCollection = {
-            id: "col-1",
-            ownerType: "user",
-            ownerId: "user-1",
-            name: "Old",
-            slug: "old",
             description: null,
-            visibility: "private",
-        };
-        const updatedCollection = {
-            ...existingCollection,
-            name: "Renamed",
-            slug: "renamed",
             visibility: "public",
-        };
-        queueSelectResponses([
-            { getResult: existingCollection },
-            { getResult: updatedCollection },
-        ]);
+          },
+        ],
+      }),
+    );
 
-        const setValues = vi.fn(() => ({ where: vi.fn(async () => undefined) }));
-        mockDb.update = vi.fn(() => ({ set: setValues }));
+    const app = await createTestApp();
+    const env = createTestEnv();
 
-        const app = await createTestApp();
-        const env = createTestEnv();
+    const res = await app.request(
+      "http://localhost/api/users/user-1/collections",
+      {},
+      env as any,
+    );
 
-        const res = await app.request(
-            "http://localhost/api/collections/col-1",
-            {
-                method: "PATCH",
-                headers: {
-                    Authorization: `Bearer ${token}`,
-                    "Content-Type": "application/json",
-                },
-                body: JSON.stringify({
-                    name: " Renamed ",
-                    slug: "RENAMED",
-                    visibility: "public",
-                }),
-            },
-            env as any,
-        );
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as any;
+    expect(body.collections).toHaveLength(1);
+    expect(body.collections[0].slug).toBe("favorites");
+  });
 
-        expect(res.status).toBe(200);
-        expect(setValues).toHaveBeenCalledWith(
-            expect.objectContaining({
-                name: "Renamed",
-                slug: "renamed",
-                visibility: "public",
-            }),
-        );
-        expect(((await res.json()) as any).collection.slug).toBe("renamed");
+  it("POST /api/collections creates a user collection", async () => {
+    const token = await createTestJWT({ sub: "user-1" });
+    const createdCollection = {
+      id: "col-1",
+      ownerType: "user",
+      ownerId: "user-1",
+      slug: "favorites",
+      name: "Favorites",
+      description: "Picked papers",
+      visibility: "private",
+    };
+    queueSelectResponses([{ getResult: createdCollection }]);
+
+    const insertValues = vi.fn(async () => undefined);
+    mockDb.insert = vi.fn(() => ({ values: insertValues }));
+
+    const app = await createTestApp();
+    const env = createTestEnv();
+
+    const res = await app.request(
+      "http://localhost/api/collections",
+      {
+        method: "POST",
+        headers: {
+          Authorization: `Bearer ${token}`,
+          "Content-Type": "application/json",
+        },
+        body: JSON.stringify({
+          owner_type: "user",
+          name: "Favorites",
+          slug: "favorites",
+          description: " Picked papers ",
+        }),
+      },
+      env as any,
+    );
+
+    expect(res.status).toBe(201);
+    expect(insertValues).toHaveBeenCalledWith(
+      expect.objectContaining({
+        ownerType: "user",
+        ownerId: "user-1",
+        slug: "favorites",
+        name: "Favorites",
+        description: "Picked papers",
+        visibility: "private",
+      }),
+    );
+  });
+
+  it("POST /api/collections returns 403 when requester cannot manage org collections", async () => {
+    const token = await createTestJWT({ sub: "user-1" });
+    queueSelectResponses([
+      { getResult: { id: "org-1", slug: "lab" } },
+      { getResult: { orgId: "org-1", userId: "user-1", role: "member" } },
+    ]);
+
+    const app = await createTestApp();
+    const env = createTestEnv();
+
+    const res = await app.request(
+      "http://localhost/api/collections",
+      {
+        method: "POST",
+        headers: {
+          Authorization: `Bearer ${token}`,
+          "Content-Type": "application/json",
+        },
+        body: JSON.stringify({
+          owner_type: "org",
+          org_slug: "lab",
+          name: "Lab picks",
+          slug: "lab-picks",
+          visibility: "org_only",
+        }),
+      },
+      env as any,
+    );
+
+    expect(res.status).toBe(403);
+    expect((await res.json()) as any).toEqual({
+      error: "Forbidden: admin access required",
     });
+  });
 
-    it("PATCH /api/collections/:id rejects requests without updatable fields", async () => {
-        const token = await createTestJWT({ sub: "user-1" });
-        queueSelectResponses([
-            {
-                getResult: {
-                    id: "col-1",
-                    ownerType: "user",
-                    ownerId: "user-1",
-                    visibility: "private",
-                },
-            },
-        ]);
+  it("GET /api/collections/:id hides private collections from anonymous users", async () => {
+    queueSelectResponses([
+      {
+        getResult: {
+          id: "col-1",
+          ownerType: "user",
+          ownerId: "user-1",
+          visibility: "private",
+        },
+      },
+    ]);
 
-        const app = await createTestApp();
-        const env = createTestEnv();
+    const app = await createTestApp();
+    const env = createTestEnv();
 
-        const res = await app.request(
-            "http://localhost/api/collections/col-1",
-            {
-                method: "PATCH",
-                headers: {
-                    Authorization: `Bearer ${token}`,
-                    "Content-Type": "application/json",
-                },
-                body: JSON.stringify({}),
-            },
-            env as any,
-        );
+    const res = await app.request(
+      "http://localhost/api/collections/col-1",
+      {},
+      env as any,
+    );
 
-        expect(res.status).toBe(400);
-        expect(((await res.json()) as any).error).toBe("No fields to update");
-    });
+    expect(res.status).toBe(404);
+  });
 
-    it("DELETE /api/collections/:id deletes a collection for the owner", async () => {
-        const token = await createTestJWT({ sub: "user-1" });
-        queueSelectResponses([
-            {
-                getResult: {
-                    id: "col-1",
-                    ownerType: "user",
-                    ownerId: "user-1",
-                    visibility: "private",
-                },
-            },
-        ]);
+  it("GET /api/collections/:id returns a private collection to its owner", async () => {
+    const token = await createTestJWT({ sub: "user-1" });
+    queueSelectResponses([
+      {
+        getResult: {
+          id: "col-1",
+          ownerType: "user",
+          ownerId: "user-1",
+          visibility: "private",
+        },
+      },
+    ]);
 
-        const deleteWhere = vi.fn(async () => ({ meta: { changes: 1 } }));
-        mockDb.delete = vi.fn(() => ({ where: deleteWhere }));
+    const app = await createTestApp();
+    const env = createTestEnv();
 
-        const app = await createTestApp();
-        const env = createTestEnv();
+    const res = await app.request(
+      "http://localhost/api/collections/col-1",
+      {
+        headers: { Authorization: `Bearer ${token}` },
+      },
+      env as any,
+    );
 
-        const res = await app.request(
-            "http://localhost/api/collections/col-1",
-            {
-                method: "DELETE",
-                headers: { Authorization: `Bearer ${token}` },
-            },
-            env as any,
-        );
+    expect(res.status).toBe(200);
+    expect(((await res.json()) as any).collection.id).toBe("col-1");
+  });
 
-        expect(res.status).toBe(200);
-        await expect(res.json()).resolves.toEqual({ ok: true });
-        expect(deleteWhere).toHaveBeenCalled();
-    });
+  it("PATCH /api/collections/:id updates collection details for the owner", async () => {
+    const token = await createTestJWT({ sub: "user-1" });
+    const existingCollection = {
+      id: "col-1",
+      ownerType: "user",
+      ownerId: "user-1",
+      name: "Old",
+      slug: "old",
+      description: null,
+      visibility: "private",
+    };
+    const updatedCollection = {
+      ...existingCollection,
+      name: "Renamed",
+      slug: "renamed",
+      visibility: "public",
+    };
+    queueSelectResponses([
+      { getResult: existingCollection },
+      { getResult: updatedCollection },
+    ]);
 
-    it("GET /api/orgs/:slug/collections returns admin-visible collections", async () => {
-        const token = await createTestJWT({ sub: "user-1" });
-        queueSelectResponses([
-            { getResult: { id: "org-1", slug: "lab" } },
-            {
-                allResult: [
-                    { id: "c1", visibility: "public", ownerType: "org", ownerId: "org-1" },
-                    { id: "c2", visibility: "org_only", ownerType: "org", ownerId: "org-1" },
-                    { id: "c3", visibility: "private", ownerType: "org", ownerId: "org-1" },
-                ],
-            },
-            { getResult: { orgId: "org-1", userId: "user-1", role: "admin" } },
-        ]);
+    const setValues = vi.fn(() => ({ where: vi.fn(async () => undefined) }));
+    mockDb.update = vi.fn(() => ({ set: setValues }));
 
-        const app = await createTestApp();
-        const env = createTestEnv();
+    const app = await createTestApp();
+    const env = createTestEnv();
 
-        const res = await app.request(
-            "http://localhost/api/orgs/lab/collections",
-            {
-                headers: { Authorization: `Bearer ${token}` },
-            },
-            env as any,
-        );
+    const res = await app.request(
+      "http://localhost/api/collections/col-1",
+      {
+        method: "PATCH",
+        headers: {
+          Authorization: `Bearer ${token}`,
+          "Content-Type": "application/json",
+        },
+        body: JSON.stringify({
+          name: " Renamed ",
+          slug: "RENAMED",
+          visibility: "public",
+        }),
+      },
+      env as any,
+    );
 
-        expect(res.status).toBe(200);
-        expect(((await res.json()) as any).collections).toHaveLength(3);
-    });
+    expect(res.status).toBe(200);
+    expect(setValues).toHaveBeenCalledWith(
+      expect.objectContaining({
+        name: "Renamed",
+        slug: "renamed",
+        visibility: "public",
+      }),
+    );
+    expect(((await res.json()) as any).collection.slug).toBe("renamed");
+  });
 
-    it("GET /api/orgs/:slug/collections hides private org collections from non-admin members", async () => {
-        const token = await createTestJWT({ sub: "user-1" });
-        queueSelectResponses([
-            { getResult: { id: "org-1", slug: "lab" } },
-            {
-                allResult: [
-                    { id: "c1", visibility: "public", ownerType: "org", ownerId: "org-1" },
-                    { id: "c2", visibility: "org_only", ownerType: "org", ownerId: "org-1" },
-                    { id: "c3", visibility: "private", ownerType: "org", ownerId: "org-1" },
-                ],
-            },
-            { getResult: { orgId: "org-1", userId: "user-1", role: "member" } },
-        ]);
+  it("PATCH /api/collections/:id rejects requests without updatable fields", async () => {
+    const token = await createTestJWT({ sub: "user-1" });
+    queueSelectResponses([
+      {
+        getResult: {
+          id: "col-1",
+          ownerType: "user",
+          ownerId: "user-1",
+          visibility: "private",
+        },
+      },
+    ]);
 
-        const app = await createTestApp();
-        const env = createTestEnv();
+    const app = await createTestApp();
+    const env = createTestEnv();
 
-        const res = await app.request(
-            "http://localhost/api/orgs/lab/collections",
-            {
-                headers: { Authorization: `Bearer ${token}` },
-            },
-            env as any,
-        );
+    const res = await app.request(
+      "http://localhost/api/collections/col-1",
+      {
+        method: "PATCH",
+        headers: {
+          Authorization: `Bearer ${token}`,
+          "Content-Type": "application/json",
+        },
+        body: JSON.stringify({}),
+      },
+      env as any,
+    );
 
-        expect(res.status).toBe(200);
-        expect(((await res.json()) as any).collections.map((row: any) => row.id)).toEqual([
-            "c1",
-            "c2",
-        ]);
-    });
+    expect(res.status).toBe(400);
+    expect(((await res.json()) as any).error).toBe("No fields to update");
+  });
 
-    it("POST /api/collections/:id/papers rejects invalid JSON", async () => {
-        const token = await createTestJWT({ sub: "user-1" });
-        queueSelectResponses([
-            {
-                getResult: {
-                    id: "col-1",
-                    ownerType: "user",
-                    ownerId: "user-1",
-                    visibility: "private",
-                },
-            },
-        ]);
+  it("PATCH /api/collections/:id returns 409 when slug is already in use", async () => {
+    const token = await createTestJWT({ sub: "user-1" });
+    queueSelectResponses([
+      {
+        getResult: {
+          id: "col-1",
+          ownerType: "user",
+          ownerId: "user-1",
+          visibility: "private",
+        },
+      },
+    ]);
 
-        const app = await createTestApp();
-        const env = createTestEnv();
+    const setValues = vi.fn(() => ({
+      where: vi.fn(async () => {
+        throw new Error("UNIQUE constraint failed: collections.slug");
+      }),
+    }));
+    // @ts-ignore
+    mockDb.update = vi.fn(() => ({ set: setValues }));
 
-        const res = await app.request(
-            "http://localhost/api/collections/col-1/papers",
-            {
-                method: "POST",
-                headers: {
-                    Authorization: `Bearer ${token}`,
-                    "Content-Type": "application/json",
-                },
-                body: "invalid-json",
-            },
-            env as any,
-        );
+    const app = await createTestApp();
+    const env = createTestEnv();
 
-        expect(res.status).toBe(400);
-        await expect(res.json()).resolves.toEqual({ error: "Invalid JSON body" });
-    });
+    const res = await app.request(
+      "http://localhost/api/collections/col-1",
+      {
+        method: "PATCH",
+        headers: {
+          Authorization: `Bearer ${token}`,
+          "Content-Type": "application/json",
+        },
+        body: JSON.stringify({ slug: "existing-slug" }),
+      },
+      env as any,
+    );
 
-    it("POST /api/collections/:id/papers adds a visible paper with the next sort order", async () => {
-        const token = await createTestJWT({ sub: "user-1" });
-        const collection = {
-            id: "col-1",
-            ownerType: "user",
-            ownerId: "user-1",
+    expect(res.status).toBe(409);
+    expect(((await res.json()) as any).error).toBe("slug already in use");
+  });
+
+  it("DELETE /api/collections/:id deletes a collection for the owner", async () => {
+    const token = await createTestJWT({ sub: "user-1" });
+    queueSelectResponses([
+      {
+        getResult: {
+          id: "col-1",
+          ownerType: "user",
+          ownerId: "user-1",
+          visibility: "private",
+        },
+      },
+    ]);
+
+    const deleteWhere = vi.fn(async () => ({ meta: { changes: 1 } }));
+    mockDb.delete = vi.fn(() => ({ where: deleteWhere }));
+
+    const app = await createTestApp();
+    const env = createTestEnv();
+
+    const res = await app.request(
+      "http://localhost/api/collections/col-1",
+      {
+        method: "DELETE",
+        headers: { Authorization: `Bearer ${token}` },
+      },
+      env as any,
+    );
+
+    expect(res.status).toBe(200);
+    await expect(res.json()).resolves.toEqual({ ok: true });
+    expect(deleteWhere).toHaveBeenCalled();
+  });
+
+  it("GET /api/orgs/:slug/collections returns admin-visible collections", async () => {
+    const token = await createTestJWT({ sub: "user-1" });
+    queueSelectResponses([
+      { getResult: { id: "org-1", slug: "lab" } },
+      {
+        allResult: [
+          {
+            id: "c1",
+            visibility: "public",
+            ownerType: "org",
+            ownerId: "org-1",
+          },
+          {
+            id: "c2",
+            visibility: "org_only",
+            ownerType: "org",
+            ownerId: "org-1",
+          },
+          {
+            id: "c3",
             visibility: "private",
-        };
-        queueSelectResponses([
-            { getResult: collection },
-            { getResult: { id: "paper-1", visibility: "private" } },
-            { getResult: { paperId: "paper-1" } },
-            { getResult: { maxOrder: 2 } },
-        ]);
+            ownerType: "org",
+            ownerId: "org-1",
+          },
+        ],
+      },
+      { getResult: { orgId: "org-1", userId: "user-1", role: "admin" } },
+    ]);
 
-        const insertValues = vi.fn(async () => undefined);
-        mockDb.insert = vi.fn(() => ({ values: insertValues }));
+    const app = await createTestApp();
+    const env = createTestEnv();
 
-        const app = await createTestApp();
-        const env = createTestEnv();
+    const res = await app.request(
+      "http://localhost/api/orgs/lab/collections",
+      {
+        headers: { Authorization: `Bearer ${token}` },
+      },
+      env as any,
+    );
 
-        const res = await app.request(
-            "http://localhost/api/collections/col-1/papers",
-            {
-                method: "POST",
-                headers: {
-                    Authorization: `Bearer ${token}`,
-                    "Content-Type": "application/json",
-                },
-                body: JSON.stringify({ paper_id: "paper-1" }),
-            },
-            env as any,
-        );
+    expect(res.status).toBe(200);
+    expect(((await res.json()) as any).collections).toHaveLength(3);
+  });
 
-        expect(res.status).toBe(201);
-        expect(insertValues).toHaveBeenCalledWith({
-            collectionId: "col-1",
-            paperId: "paper-1",
+  it("GET /api/orgs/:slug/collections hides private org collections from non-admin members", async () => {
+    const token = await createTestJWT({ sub: "user-1" });
+    queueSelectResponses([
+      { getResult: { id: "org-1", slug: "lab" } },
+      {
+        allResult: [
+          {
+            id: "c1",
+            visibility: "public",
+            ownerType: "org",
+            ownerId: "org-1",
+          },
+          {
+            id: "c2",
+            visibility: "org_only",
+            ownerType: "org",
+            ownerId: "org-1",
+          },
+          {
+            id: "c3",
+            visibility: "private",
+            ownerType: "org",
+            ownerId: "org-1",
+          },
+        ],
+      },
+      { getResult: { orgId: "org-1", userId: "user-1", role: "member" } },
+    ]);
+
+    const app = await createTestApp();
+    const env = createTestEnv();
+
+    const res = await app.request(
+      "http://localhost/api/orgs/lab/collections",
+      {
+        headers: { Authorization: `Bearer ${token}` },
+      },
+      env as any,
+    );
+
+    expect(res.status).toBe(200);
+    expect(
+      ((await res.json()) as any).collections.map((row: any) => row.id),
+    ).toEqual(["c1", "c2"]);
+  });
+
+  it("POST /api/collections/:id/papers rejects invalid JSON", async () => {
+    const token = await createTestJWT({ sub: "user-1" });
+    queueSelectResponses([
+      {
+        getResult: {
+          id: "col-1",
+          ownerType: "user",
+          ownerId: "user-1",
+          visibility: "private",
+        },
+      },
+    ]);
+
+    const app = await createTestApp();
+    const env = createTestEnv();
+
+    const res = await app.request(
+      "http://localhost/api/collections/col-1/papers",
+      {
+        method: "POST",
+        headers: {
+          Authorization: `Bearer ${token}`,
+          "Content-Type": "application/json",
+        },
+        body: "invalid-json",
+      },
+      env as any,
+    );
+
+    expect(res.status).toBe(400);
+    await expect(res.json()).resolves.toEqual({ error: "Invalid JSON body" });
+  });
+
+  it("POST /api/collections/:id/papers adds a visible paper with the next sort order", async () => {
+    const token = await createTestJWT({ sub: "user-1" });
+    const collection = {
+      id: "col-1",
+      ownerType: "user",
+      ownerId: "user-1",
+      visibility: "private",
+    };
+    queueSelectResponses([
+      { getResult: collection },
+      { getResult: { id: "paper-1", visibility: "private" } },
+      { getResult: { paperId: "paper-1" } },
+      { getResult: { maxOrder: 2 } },
+    ]);
+
+    const insertValues = vi.fn(async () => undefined);
+    mockDb.insert = vi.fn(() => ({ values: insertValues }));
+
+    const app = await createTestApp();
+    const env = createTestEnv();
+
+    const res = await app.request(
+      "http://localhost/api/collections/col-1/papers",
+      {
+        method: "POST",
+        headers: {
+          Authorization: `Bearer ${token}`,
+          "Content-Type": "application/json",
+        },
+        body: JSON.stringify({ paper_id: "paper-1" }),
+      },
+      env as any,
+    );
+
+    expect(res.status).toBe(201);
+    expect(insertValues).toHaveBeenCalledWith({
+      collectionId: "col-1",
+      paperId: "paper-1",
+      sortOrder: 3,
+    });
+  });
+
+  it("POST /api/collections/:id/papers adds a paper the manager can view via org membership", async () => {
+    const token = await createTestJWT({ sub: "user-1" });
+    const collection = {
+      id: "col-1",
+      ownerType: "user",
+      ownerId: "user-1",
+      visibility: "private",
+    };
+    queueSelectResponses([
+      { getResult: collection }, // Collection query
+      { getResult: { id: "paper-1", visibility: "org_only" } }, // Paper query
+      { getResult: null }, // isPaperAuthor returns false
+      { getResult: { id: "user-1" } }, // isMemberOfPaperOrg returns true
+      { getResult: { maxOrder: 2 } }, // maxOrder query
+    ]);
+
+    const insertValues = vi.fn(async () => undefined);
+    mockDb.insert = vi.fn(() => ({ values: insertValues }));
+
+    const app = await createTestApp();
+    const env = createTestEnv();
+
+    const res = await app.request(
+      "http://localhost/api/collections/col-1/papers",
+      {
+        method: "POST",
+        headers: {
+          Authorization: `Bearer ${token}`,
+          "Content-Type": "application/json",
+        },
+        body: JSON.stringify({ paper_id: "paper-1" }),
+      },
+      env as any,
+    );
+
+    expect(res.status).toBe(201);
+    expect(insertValues).toHaveBeenCalledWith({
+      collectionId: "col-1",
+      paperId: "paper-1",
+      sortOrder: 3,
+    });
+  });
+
+  it("POST /api/collections/:id/papers adds a public paper without specific membership", async () => {
+    const token = await createTestJWT({ sub: "user-1" });
+    const collection = {
+      id: "col-1",
+      ownerType: "user",
+      ownerId: "user-1",
+      visibility: "private",
+    };
+    queueSelectResponses([
+      { getResult: collection }, // Collection query
+      { getResult: { id: "paper-1", visibility: "public" } }, // Paper query
+      { getResult: { maxOrder: 2 } }, // maxOrder query
+    ]);
+
+    const insertValues = vi.fn(async () => undefined);
+    mockDb.insert = vi.fn(() => ({ values: insertValues }));
+
+    const app = await createTestApp();
+    const env = createTestEnv();
+
+    const res = await app.request(
+      "http://localhost/api/collections/col-1/papers",
+      {
+        method: "POST",
+        headers: {
+          Authorization: `Bearer ${token}`,
+          "Content-Type": "application/json",
+        },
+        body: JSON.stringify({ paper_id: "paper-1" }),
+      },
+      env as any,
+    );
+
+    expect(res.status).toBe(201);
+    expect(insertValues).toHaveBeenCalledWith({
+      collectionId: "col-1",
+      paperId: "paper-1",
+      sortOrder: 3,
+    });
+  });
+
+  it("POST /api/collections/:id/papers rejects papers the manager cannot view", async () => {
+    const token = await createTestJWT({ sub: "user-1" });
+    queueSelectResponses([
+      {
+        getResult: {
+          id: "col-1",
+          ownerType: "user",
+          ownerId: "user-1",
+          visibility: "private",
+        },
+      },
+      { getResult: { id: "paper-1", visibility: "private" } },
+      { getResult: null },
+    ]);
+
+    const app = await createTestApp();
+    const env = createTestEnv();
+
+    const res = await app.request(
+      "http://localhost/api/collections/col-1/papers",
+      {
+        method: "POST",
+        headers: {
+          Authorization: `Bearer ${token}`,
+          "Content-Type": "application/json",
+        },
+        body: JSON.stringify({ paper_id: "paper-1" }),
+      },
+      env as any,
+    );
+
+    expect(res.status).toBe(404);
+    expect(((await res.json()) as any).error).toBe("Paper not found");
+  });
+
+  it("PATCH /api/collections/:id/papers rejects duplicate paper IDs", async () => {
+    const token = await createTestJWT({ sub: "user-1" });
+    queueSelectResponses([
+      {
+        getResult: {
+          id: "col-1",
+          ownerType: "user",
+          ownerId: "user-1",
+          visibility: "private",
+        },
+      },
+      {
+        allResult: [{ paperId: "paper-1" }, { paperId: "paper-2" }],
+      },
+    ]);
+
+    const app = await createTestApp();
+    const env = createTestEnv();
+
+    const res = await app.request(
+      "http://localhost/api/collections/col-1/papers",
+      {
+        method: "PATCH",
+        headers: {
+          Authorization: `Bearer ${token}`,
+          "Content-Type": "application/json",
+        },
+        body: JSON.stringify({ paper_ids: ["paper-1", "paper-1"] }),
+      },
+      env as any,
+    );
+
+    expect(res.status).toBe(400);
+    expect(((await res.json()) as any).error).toBe(
+      "paper_ids must not contain duplicates",
+    );
+  });
+
+  it("PATCH /api/collections/:id/papers requires every existing paper to be included", async () => {
+    const token = await createTestJWT({ sub: "user-1" });
+    queueSelectResponses([
+      {
+        getResult: {
+          id: "col-1",
+          ownerType: "user",
+          ownerId: "user-1",
+          visibility: "private",
+        },
+      },
+      {
+        allResult: [{ paperId: "paper-1" }, { paperId: "paper-2" }],
+      },
+    ]);
+
+    const app = await createTestApp();
+    const env = createTestEnv();
+
+    const res = await app.request(
+      "http://localhost/api/collections/col-1/papers",
+      {
+        method: "PATCH",
+        headers: {
+          Authorization: `Bearer ${token}`,
+          "Content-Type": "application/json",
+        },
+        body: JSON.stringify({ paper_ids: ["paper-1"] }),
+      },
+      env as any,
+    );
+
+    expect(res.status).toBe(400);
+    expect(((await res.json()) as any).error).toBe(
+      "paper_ids must include all papers in collection",
+    );
+  });
+
+  it("DELETE /api/collections/:id/papers/:paperId returns 404 when the paper is not in the collection", async () => {
+    const token = await createTestJWT({ sub: "user-1" });
+    queueSelectResponses([
+      {
+        getResult: {
+          id: "col-1",
+          ownerType: "user",
+          ownerId: "user-1",
+          visibility: "private",
+        },
+      },
+    ]);
+
+    mockDb.delete = vi.fn(() => ({
+      where: vi.fn(async () => ({ meta: { changes: 0 } })),
+    }));
+
+    const app = await createTestApp();
+    const env = createTestEnv();
+
+    const res = await app.request(
+      "http://localhost/api/collections/col-1/papers/paper-1",
+      {
+        method: "DELETE",
+        headers: { Authorization: `Bearer ${token}` },
+      },
+      env as any,
+    );
+
+    expect(res.status).toBe(404);
+    expect(((await res.json()) as any).error).toBe("Paper not in collection");
+  });
+
+  it("GET /api/collections/:id/papers filters restricted papers by authorship and org access", async () => {
+    const token = await createTestJWT({ sub: "user-1" });
+    queueSelectResponses([
+      {
+        getResult: {
+          id: "col-1",
+          ownerType: "org",
+          ownerId: "org-1",
+          visibility: "public",
+        },
+      },
+      {
+        allResult: [
+          {
+            id: "paper-public",
+            title: "Public",
+            visibility: "public",
+            sortOrder: 0,
+          },
+          {
+            id: "paper-authored",
+            title: "Mine",
+            visibility: "private",
+            sortOrder: 1,
+          },
+          {
+            id: "paper-org",
+            title: "Org only",
+            visibility: "org_only",
+            sortOrder: 2,
+          },
+          {
+            id: "paper-hidden",
+            title: "Hidden",
+            visibility: "private",
             sortOrder: 3,
-        });
-    });
+          },
+        ],
+      },
+      { allResult: [{ paperId: "paper-authored" }] },
+      { allResult: [{ paperId: "paper-org" }] },
+    ]);
 
+    const app = await createTestApp();
+    const env = createTestEnv();
 
+    const res = await app.request(
+      "http://localhost/api/collections/col-1/papers",
+      {
+        headers: { Authorization: `Bearer ${token}` },
+      },
+      env as any,
+    );
 
-    it("POST /api/collections/:id/papers adds a paper the manager can view via org membership", async () => {
-        const token = await createTestJWT({ sub: "user-1" });
-        const collection = {
-            id: "col-1",
-            ownerType: "user",
-            ownerId: "user-1",
-            visibility: "private",
-        };
-        queueSelectResponses([
-            { getResult: collection }, // Collection query
-            { getResult: { id: "paper-1", visibility: "org_only" } }, // Paper query
-            { getResult: null }, // isPaperAuthor returns false
-            { getResult: { id: "user-1" } }, // isMemberOfPaperOrg returns true
-            { getResult: { maxOrder: 2 } }, // maxOrder query
-        ]);
+    expect(res.status).toBe(200);
+    expect(
+      ((await res.json()) as any).papers.map((paper: any) => paper.id),
+    ).toEqual(["paper-public", "paper-authored", "paper-org"]);
+  });
 
-        const insertValues = vi.fn(async () => undefined);
-        mockDb.insert = vi.fn(() => ({ values: insertValues }));
+  it("POST /api/collections/:id/papers returns 409 when paper is already in collection", async () => {
+    const token = await createTestJWT({ sub: "user-1" });
+    const collection = {
+      id: "col-1",
+      ownerType: "user",
+      ownerId: "user-1",
+      visibility: "private",
+    };
+    queueSelectResponses([
+      { getResult: collection }, // Collection query
+      { getResult: { id: "paper-1", visibility: "public" } }, // Paper query
+      { getResult: { maxOrder: 2 } }, // maxOrder query
+    ]);
 
-        const app = await createTestApp();
-        const env = createTestEnv();
+    mockDb.insert = vi.fn(() => ({
+      values: vi
+        .fn()
+        .mockRejectedValue(
+          new Error(
+            "UNIQUE constraint failed: collection_papers.collection_id, collection_papers.paper_id",
+          ),
+        ),
+    }));
 
-        const res = await app.request(
-            "http://localhost/api/collections/col-1/papers",
-            {
-                method: "POST",
-                headers: {
-                    Authorization: `Bearer ${token}`,
-                    "Content-Type": "application/json",
-                },
-                body: JSON.stringify({ paper_id: "paper-1" }),
-            },
-            env as any,
-        );
+    const app = await createTestApp();
+    const env = createTestEnv();
 
-        expect(res.status).toBe(201);
-        expect(insertValues).toHaveBeenCalledWith({
-            collectionId: "col-1",
-            paperId: "paper-1",
-            sortOrder: 3,
-        });
-    });
+    const res = await app.request(
+      "http://localhost/api/collections/col-1/papers",
+      {
+        method: "POST",
+        headers: {
+          Authorization: `Bearer ${token}`,
+          "Content-Type": "application/json",
+        },
+        body: JSON.stringify({ paper_id: "paper-1" }),
+      },
+      env as any,
+    );
 
-    it("POST /api/collections/:id/papers adds a public paper without specific membership", async () => {
-        const token = await createTestJWT({ sub: "user-1" });
-        const collection = {
-            id: "col-1",
-            ownerType: "user",
-            ownerId: "user-1",
-            visibility: "private",
-        };
-        queueSelectResponses([
-            { getResult: collection }, // Collection query
-            { getResult: { id: "paper-1", visibility: "public" } }, // Paper query
-            { getResult: { maxOrder: 2 } }, // maxOrder query
-        ]);
-
-        const insertValues = vi.fn(async () => undefined);
-        mockDb.insert = vi.fn(() => ({ values: insertValues }));
-
-        const app = await createTestApp();
-        const env = createTestEnv();
-
-        const res = await app.request(
-            "http://localhost/api/collections/col-1/papers",
-            {
-                method: "POST",
-                headers: {
-                    Authorization: `Bearer ${token}`,
-                    "Content-Type": "application/json",
-                },
-                body: JSON.stringify({ paper_id: "paper-1" }),
-            },
-            env as any,
-        );
-
-        expect(res.status).toBe(201);
-        expect(insertValues).toHaveBeenCalledWith({
-            collectionId: "col-1",
-            paperId: "paper-1",
-            sortOrder: 3,
-        });
-    });
-
-    it("POST /api/collections/:id/papers rejects papers the manager cannot view", async () => {
-        const token = await createTestJWT({ sub: "user-1" });
-        queueSelectResponses([
-            {
-                getResult: {
-                    id: "col-1",
-                    ownerType: "user",
-                    ownerId: "user-1",
-                    visibility: "private",
-                },
-            },
-            { getResult: { id: "paper-1", visibility: "private" } },
-            { getResult: null },
-        ]);
-
-        const app = await createTestApp();
-        const env = createTestEnv();
-
-        const res = await app.request(
-            "http://localhost/api/collections/col-1/papers",
-            {
-                method: "POST",
-                headers: {
-                    Authorization: `Bearer ${token}`,
-                    "Content-Type": "application/json",
-                },
-                body: JSON.stringify({ paper_id: "paper-1" }),
-            },
-            env as any,
-        );
-
-        expect(res.status).toBe(404);
-        expect(((await res.json()) as any).error).toBe("Paper not found");
-    });
-
-    it("PATCH /api/collections/:id/papers rejects duplicate paper IDs", async () => {
-        const token = await createTestJWT({ sub: "user-1" });
-        queueSelectResponses([
-            {
-                getResult: {
-                    id: "col-1",
-                    ownerType: "user",
-                    ownerId: "user-1",
-                    visibility: "private",
-                },
-            },
-            {
-                allResult: [{ paperId: "paper-1" }, { paperId: "paper-2" }],
-            },
-        ]);
-
-        const app = await createTestApp();
-        const env = createTestEnv();
-
-        const res = await app.request(
-            "http://localhost/api/collections/col-1/papers",
-            {
-                method: "PATCH",
-                headers: {
-                    Authorization: `Bearer ${token}`,
-                    "Content-Type": "application/json",
-                },
-                body: JSON.stringify({ paper_ids: ["paper-1", "paper-1"] }),
-            },
-            env as any,
-        );
-
-        expect(res.status).toBe(400);
-        expect(((await res.json()) as any).error).toBe(
-            "paper_ids must not contain duplicates",
-        );
-    });
-
-    it("PATCH /api/collections/:id/papers requires every existing paper to be included", async () => {
-        const token = await createTestJWT({ sub: "user-1" });
-        queueSelectResponses([
-            {
-                getResult: {
-                    id: "col-1",
-                    ownerType: "user",
-                    ownerId: "user-1",
-                    visibility: "private",
-                },
-            },
-            {
-                allResult: [{ paperId: "paper-1" }, { paperId: "paper-2" }],
-            },
-        ]);
-
-        const app = await createTestApp();
-        const env = createTestEnv();
-
-        const res = await app.request(
-            "http://localhost/api/collections/col-1/papers",
-            {
-                method: "PATCH",
-                headers: {
-                    Authorization: `Bearer ${token}`,
-                    "Content-Type": "application/json",
-                },
-                body: JSON.stringify({ paper_ids: ["paper-1"] }),
-            },
-            env as any,
-        );
-
-        expect(res.status).toBe(400);
-        expect(((await res.json()) as any).error).toBe(
-            "paper_ids must include all papers in collection",
-        );
-    });
-
-    it("DELETE /api/collections/:id/papers/:paperId returns 404 when the paper is not in the collection", async () => {
-        const token = await createTestJWT({ sub: "user-1" });
-        queueSelectResponses([
-            {
-                getResult: {
-                    id: "col-1",
-                    ownerType: "user",
-                    ownerId: "user-1",
-                    visibility: "private",
-                },
-            },
-        ]);
-
-        mockDb.delete = vi.fn(() => ({
-            where: vi.fn(async () => ({ meta: { changes: 0 } })),
-        }));
-
-        const app = await createTestApp();
-        const env = createTestEnv();
-
-        const res = await app.request(
-            "http://localhost/api/collections/col-1/papers/paper-1",
-            {
-                method: "DELETE",
-                headers: { Authorization: `Bearer ${token}` },
-            },
-            env as any,
-        );
-
-        expect(res.status).toBe(404);
-        expect(((await res.json()) as any).error).toBe("Paper not in collection");
-    });
-
-    it("GET /api/collections/:id/papers filters restricted papers by authorship and org access", async () => {
-        const token = await createTestJWT({ sub: "user-1" });
-        queueSelectResponses([
-            {
-                getResult: {
-                    id: "col-1",
-                    ownerType: "org",
-                    ownerId: "org-1",
-                    visibility: "public",
-                },
-            },
-            {
-                allResult: [
-                    { id: "paper-public", title: "Public", visibility: "public", sortOrder: 0 },
-                    { id: "paper-authored", title: "Mine", visibility: "private", sortOrder: 1 },
-                    { id: "paper-org", title: "Org only", visibility: "org_only", sortOrder: 2 },
-                    { id: "paper-hidden", title: "Hidden", visibility: "private", sortOrder: 3 },
-                ],
-            },
-            { allResult: [{ paperId: "paper-authored" }] },
-            { allResult: [{ paperId: "paper-org" }] },
-        ]);
-
-        const app = await createTestApp();
-        const env = createTestEnv();
-
-        const res = await app.request(
-            "http://localhost/api/collections/col-1/papers",
-            {
-                headers: { Authorization: `Bearer ${token}` },
-            },
-            env as any,
-        );
-
-        expect(res.status).toBe(200);
-        expect(((await res.json()) as any).papers.map((paper: any) => paper.id)).toEqual([
-            "paper-public",
-            "paper-authored",
-            "paper-org",
-        ]);
-    });
-
-    it("POST /api/collections/:id/papers returns 409 when paper is already in collection", async () => {
-        const token = await createTestJWT({ sub: "user-1" });
-        const collection = {
-            id: "col-1",
-            ownerType: "user",
-            ownerId: "user-1",
-            visibility: "private",
-        };
-        queueSelectResponses([
-            { getResult: collection }, // Collection query
-            { getResult: { id: "paper-1", visibility: "public" } }, // Paper query
-            { getResult: { maxOrder: 2 } }, // maxOrder query
-        ]);
-
-        mockDb.insert = vi.fn(() => ({
-            values: vi.fn().mockRejectedValue(new Error("UNIQUE constraint failed: collection_papers.collection_id, collection_papers.paper_id")),
-        }));
-
-        const app = await createTestApp();
-        const env = createTestEnv();
-
-        const res = await app.request(
-            "http://localhost/api/collections/col-1/papers",
-            {
-                method: "POST",
-                headers: {
-                    Authorization: `Bearer ${token}`,
-                    "Content-Type": "application/json",
-                },
-                body: JSON.stringify({ paper_id: "paper-1" }),
-            },
-            env as any,
-        );
-
-        expect(res.status).toBe(409);
-        expect(((await res.json()) as any).error).toBe("Paper already added");
-    });
+    expect(res.status).toBe(409);
+    expect(((await res.json()) as any).error).toBe("Paper already added");
+  });
 });

--- a/apps/api/src/routes/auth.ts
+++ b/apps/api/src/routes/auth.ts
@@ -3,7 +3,7 @@ import { deleteCookie, getCookie, setCookie } from "hono/cookie";
 import { sign } from "hono/jwt";
 import { drizzle } from "drizzle-orm/d1";
 import { eq } from "drizzle-orm";
-import { users, orgs, orgMembers, enableForeignKeys, touchUpdatedAt } from "../db/schema";
+import { users, enableForeignKeys, touchUpdatedAt } from "../db/schema";
 import type { Env, Variables } from "../types";
 import { authMiddleware } from "../middleware/auth";
 import { parseOriginList, resolveAllowedOrigin } from "../utils/origin";

--- a/apps/api/src/routes/collections.ts
+++ b/apps/api/src/routes/collections.ts
@@ -559,16 +559,16 @@ collectionsRoute.get("/collections/:id/papers", async (c) => {
             .filter(r => r.visibility === "org_only" && !authoredSet.has(r.id))
             .map(r => r.id);
 
-        let orgAccessSet = new Set<string>();
-        if (orgOnlyIds.length > 0) {
-            const orgAccessRows = await db
-                .select({ paperId: paperOrgs.paperId })
-                .from(orgMembers)
-                .innerJoin(paperOrgs, eq(orgMembers.orgId, paperOrgs.orgId))
-                .where(and(inArray(paperOrgs.paperId, orgOnlyIds), eq(orgMembers.userId, currentUserId)))
-                .all();
-            orgAccessSet = new Set(orgAccessRows.map(r => r.paperId));
-        }
+        const orgAccessSet = orgOnlyIds.length > 0
+            ? new Set(
+                (await db
+                    .select({ paperId: paperOrgs.paperId })
+                    .from(orgMembers)
+                    .innerJoin(paperOrgs, eq(orgMembers.orgId, paperOrgs.orgId))
+                    .where(and(inArray(paperOrgs.paperId, orgOnlyIds), eq(orgMembers.userId, currentUserId)))
+                    .all()).map(r => r.paperId),
+            )
+            : new Set<string>();
 
         visiblePapers = rows.filter(r => {
             if (r.visibility === "public") return true;

--- a/apps/api/src/routes/collections.ts
+++ b/apps/api/src/routes/collections.ts
@@ -558,7 +558,8 @@ collectionsRoute.get("/collections/:id/papers", async (c) => {
         const orgOnlyIds = restrictedRows
             .filter(r => r.visibility === "org_only" && !authoredSet.has(r.id))
             .map(r => r.id);
-        const orgAccessSet = new Set<string>();
+
+        let orgAccessSet = new Set<string>();
         if (orgOnlyIds.length > 0) {
             const orgAccessRows = await db
                 .select({ paperId: paperOrgs.paperId })
@@ -566,7 +567,7 @@ collectionsRoute.get("/collections/:id/papers", async (c) => {
                 .innerJoin(paperOrgs, eq(orgMembers.orgId, paperOrgs.orgId))
                 .where(and(inArray(paperOrgs.paperId, orgOnlyIds), eq(orgMembers.userId, currentUserId)))
                 .all();
-            for (const r of orgAccessRows) orgAccessSet.add(r.paperId);
+            orgAccessSet = new Set(orgAccessRows.map(r => r.paperId));
         }
 
         visiblePapers = rows.filter(r => {

--- a/apps/api/src/utils/__tests__/file.test.ts
+++ b/apps/api/src/utils/__tests__/file.test.ts
@@ -195,17 +195,15 @@ describe("validateMagicNumbers", () => {
   });
 
   it("returns false when DataView throws a RangeError for a corrupt file", async () => {
+    const zipHeader = new Uint8Array([0x50, 0x4b, 0x03, 0x04, 0, 0, 0, 0]);
     const corruptFile = {
       size: 100000,
       type: "application/vnd.openxmlformats-officedocument.presentationml.presentation",
       slice(start?: number, end?: number) {
-        if (start === 0 && end === 8) {
+        if (start === 0 && end === zipHeader.byteLength) {
           // Pass the magic number check for ZIP
           return {
-            arrayBuffer: () =>
-              Promise.resolve(
-                new Uint8Array([0x50, 0x4b, 0x03, 0x04, 0, 0, 0, 0]).buffer,
-              ),
+            arrayBuffer: () => Promise.resolve(zipHeader.buffer),
           };
         }
         // Throw a RangeError when hasZipEntry calls slice(start).arrayBuffer()

--- a/apps/api/src/utils/__tests__/file.test.ts
+++ b/apps/api/src/utils/__tests__/file.test.ts
@@ -189,8 +189,40 @@ describe("validateMagicNumbers", () => {
       new Uint8Array([0x89, 0x50, 0x4e, 0x47]),
     );
 
+    await expect(validateMagicNumbers(truncatedPng, "image/png")).resolves.toBe(
+      false,
+    );
+  });
+
+  it("returns false when DataView throws a RangeError for a corrupt file", async () => {
+    const corruptFile = {
+      size: 100000,
+      type: "application/vnd.openxmlformats-officedocument.presentationml.presentation",
+      slice(start?: number, end?: number) {
+        if (start === 0 && end === 8) {
+          // Pass the magic number check for ZIP
+          return {
+            arrayBuffer: () =>
+              Promise.resolve(
+                new Uint8Array([0x50, 0x4b, 0x03, 0x04, 0, 0, 0, 0]).buffer,
+              ),
+          };
+        }
+        // Throw a RangeError when hasZipEntry calls slice(start).arrayBuffer()
+        return {
+          arrayBuffer: () =>
+            Promise.reject(
+              new RangeError("Offset is outside the bounds of the DataView"),
+            ),
+        };
+      },
+    } as any as File;
+
     await expect(
-      validateMagicNumbers(truncatedPng, "image/png"),
+      validateMagicNumbers(
+        corruptFile,
+        "application/vnd.openxmlformats-officedocument.presentationml.presentation",
+      ),
     ).resolves.toBe(false);
   });
 });

--- a/apps/api/src/utils/__tests__/origin.test.ts
+++ b/apps/api/src/utils/__tests__/origin.test.ts
@@ -2,6 +2,10 @@ import { describe, expect, it } from "vitest";
 import { isAllowedOrigin, normalizeOrigin } from "../origin";
 
 describe("origin utils", () => {
+    it("returns null for malformed URI components", () => {
+        expect(normalizeOrigin("not-a-url-%E0%A4%A")).toBeNull();
+    });
+
     it("normalizes exact origins before comparison", () => {
         const origin = normalizeOrigin("https://app.example.com")!;
         const frontendOrigin = normalizeOrigin("https://frontend.example.com")!;

--- a/apps/api/src/utils/__tests__/origin.test.ts
+++ b/apps/api/src/utils/__tests__/origin.test.ts
@@ -6,6 +6,10 @@ describe("origin utils", () => {
         expect(normalizeOrigin("not-a-url-%E0%A4%A")).toBeNull();
     });
 
+    it("decodes encoded origins when direct URL parsing fails", () => {
+        expect(normalizeOrigin("https%3A%2F%2Fapp.example.com")).toBe("https://app.example.com");
+    });
+
     it("normalizes exact origins before comparison", () => {
         const origin = normalizeOrigin("https://app.example.com")!;
         const frontendOrigin = normalizeOrigin("https://frontend.example.com")!;

--- a/apps/api/src/utils/file.ts
+++ b/apps/api/src/utils/file.ts
@@ -214,54 +214,11 @@ export async function validateMagicNumbers(
     const bytes = new Uint8Array(buffer);
 
     let detectedType: string | null = null;
-    if (
-      bytes.length >= 5 &&
-      bytes[0] === 0x25 &&
-      bytes[1] === 0x50 &&
-      bytes[2] === 0x44 &&
-      bytes[3] === 0x46 &&
-      bytes[4] === 0x2d
-    ) {
-      detectedType = "application/pdf";
-    } else if (
-      bytes.length >= 8 &&
-      bytes[0] === 0x89 &&
-      bytes[1] === 0x50 &&
-      bytes[2] === 0x4e &&
-      bytes[3] === 0x47 &&
-      bytes[4] === 0x0d &&
-      bytes[5] === 0x0a &&
-      bytes[6] === 0x1a &&
-      bytes[7] === 0x0a
-    ) {
-      detectedType = "image/png";
-    } else if (
-      bytes.length >= 3 &&
-      bytes[0] === 0xff &&
-      bytes[1] === 0xd8 &&
-      bytes[2] === 0xff
-    ) {
-      detectedType = "image/jpeg";
-    } else if (
-      bytes.length >= 8 &&
-      bytes[0] === 0xd0 &&
-      bytes[1] === 0xcf &&
-      bytes[2] === 0x11 &&
-      bytes[3] === 0xe0 &&
-      bytes[4] === 0xa1 &&
-      bytes[5] === 0xb1 &&
-      bytes[6] === 0x1a &&
-      bytes[7] === 0xe1
-    ) {
-      detectedType = "application/x-ole-storage";
-    } else if (
-      bytes.length >= 4 &&
-      bytes[0] === 0x50 &&
-      bytes[1] === 0x4b &&
-      bytes[2] === 0x03 &&
-      bytes[3] === 0x04
-    ) {
-      detectedType = "application/zip";
+    for (const [signature, mimeType] of MAGIC_NUMBER_MAP) {
+      if (matchesMagicPrefix(bytes, signature)) {
+        detectedType = mimeType;
+        break;
+      }
     }
 
     if (!detectedType) return false;
@@ -282,7 +239,10 @@ export async function validateMagicNumbers(
     }
 
     return true;
-  } catch {
-    return false;
+  } catch (error) {
+    if (error instanceof RangeError || error instanceof TypeError) {
+      return false;
+    }
+    throw error;
   }
 }

--- a/apps/api/src/utils/file.ts
+++ b/apps/api/src/utils/file.ts
@@ -8,21 +8,20 @@ const MIME_COMPATIBILITY: Record<string, readonly string[]> = {
   ],
 };
 
-const MAGIC_NUMBER_MAP: ReadonlyArray<
-  readonly [Readonly<Uint8Array>, string]
-> = [
-  [Uint8Array.from([0x25, 0x50, 0x44, 0x46, 0x2d]), "application/pdf"],
+const MAGIC_NUMBER_MAP: ReadonlyArray<readonly [Readonly<Uint8Array>, string]> =
   [
-    Uint8Array.from([0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a]),
-    "image/png",
-  ],
-  [Uint8Array.from([0xff, 0xd8, 0xff]), "image/jpeg"],
-  [
-    Uint8Array.from([0xd0, 0xcf, 0x11, 0xe0, 0xa1, 0xb1, 0x1a, 0xe1]),
-    "application/x-ole-storage",
-  ],
-  [Uint8Array.from([0x50, 0x4b, 0x03, 0x04]), "application/zip"],
-];
+    [Uint8Array.from([0x25, 0x50, 0x44, 0x46, 0x2d]), "application/pdf"],
+    [
+      Uint8Array.from([0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a]),
+      "image/png",
+    ],
+    [Uint8Array.from([0xff, 0xd8, 0xff]), "image/jpeg"],
+    [
+      Uint8Array.from([0xd0, 0xcf, 0x11, 0xe0, 0xa1, 0xb1, 0x1a, 0xe1]),
+      "application/x-ole-storage",
+    ],
+    [Uint8Array.from([0x50, 0x4b, 0x03, 0x04]), "application/zip"],
+  ];
 const MAX_MAGIC_SIZE = Math.max(
   ...MAGIC_NUMBER_MAP.map(([signature]) => signature.length),
 );
@@ -210,38 +209,80 @@ export async function validateMagicNumbers(
   file: File,
   declaredMime: string,
 ): Promise<boolean> {
-  const buffer = await file.slice(0, MAX_MAGIC_SIZE).arrayBuffer();
-  const bytes = new Uint8Array(buffer);
+  try {
+    const buffer = await file.slice(0, MAX_MAGIC_SIZE).arrayBuffer();
+    const bytes = new Uint8Array(buffer);
 
-  let detectedType: string | null = null;
-  if (bytes.length >= 5 && bytes[0] === 0x25 && bytes[1] === 0x50 && bytes[2] === 0x44 && bytes[3] === 0x46 && bytes[4] === 0x2d) {
-    detectedType = "application/pdf";
-  } else if (bytes.length >= 8 && bytes[0] === 0x89 && bytes[1] === 0x50 && bytes[2] === 0x4e && bytes[3] === 0x47 && bytes[4] === 0x0d && bytes[5] === 0x0a && bytes[6] === 0x1a && bytes[7] === 0x0a) {
-    detectedType = "image/png";
-  } else if (bytes.length >= 3 && bytes[0] === 0xff && bytes[1] === 0xd8 && bytes[2] === 0xff) {
-    detectedType = "image/jpeg";
-  } else if (bytes.length >= 8 && bytes[0] === 0xd0 && bytes[1] === 0xcf && bytes[2] === 0x11 && bytes[3] === 0xe0 && bytes[4] === 0xa1 && bytes[5] === 0xb1 && bytes[6] === 0x1a && bytes[7] === 0xe1) {
-    detectedType = "application/x-ole-storage";
-  } else if (bytes.length >= 4 && bytes[0] === 0x50 && bytes[1] === 0x4b && bytes[2] === 0x03 && bytes[3] === 0x04) {
-    detectedType = "application/zip";
+    let detectedType: string | null = null;
+    if (
+      bytes.length >= 5 &&
+      bytes[0] === 0x25 &&
+      bytes[1] === 0x50 &&
+      bytes[2] === 0x44 &&
+      bytes[3] === 0x46 &&
+      bytes[4] === 0x2d
+    ) {
+      detectedType = "application/pdf";
+    } else if (
+      bytes.length >= 8 &&
+      bytes[0] === 0x89 &&
+      bytes[1] === 0x50 &&
+      bytes[2] === 0x4e &&
+      bytes[3] === 0x47 &&
+      bytes[4] === 0x0d &&
+      bytes[5] === 0x0a &&
+      bytes[6] === 0x1a &&
+      bytes[7] === 0x0a
+    ) {
+      detectedType = "image/png";
+    } else if (
+      bytes.length >= 3 &&
+      bytes[0] === 0xff &&
+      bytes[1] === 0xd8 &&
+      bytes[2] === 0xff
+    ) {
+      detectedType = "image/jpeg";
+    } else if (
+      bytes.length >= 8 &&
+      bytes[0] === 0xd0 &&
+      bytes[1] === 0xcf &&
+      bytes[2] === 0x11 &&
+      bytes[3] === 0xe0 &&
+      bytes[4] === 0xa1 &&
+      bytes[5] === 0xb1 &&
+      bytes[6] === 0x1a &&
+      bytes[7] === 0xe1
+    ) {
+      detectedType = "application/x-ole-storage";
+    } else if (
+      bytes.length >= 4 &&
+      bytes[0] === 0x50 &&
+      bytes[1] === 0x4b &&
+      bytes[2] === 0x03 &&
+      bytes[3] === 0x04
+    ) {
+      detectedType = "application/zip";
+    }
+
+    if (!detectedType) return false;
+
+    const isValidBasic = (MIME_COMPATIBILITY[declaredMime] ?? []).includes(
+      detectedType,
+    );
+    if (!isValidBasic) return false;
+
+    // Deeper inspection of PPT/PPTX files
+    if (
+      declaredMime ===
+      "application/vnd.openxmlformats-officedocument.presentationml.presentation"
+    ) {
+      return await hasZipEntry(file, "ppt/presentation.xml");
+    } else if (declaredMime === "application/vnd.ms-powerpoint") {
+      return await hasOleStream(file, "PowerPoint Document");
+    }
+
+    return true;
+  } catch {
+    return false;
   }
-
-  if (!detectedType) return false;
-
-  const isValidBasic = (MIME_COMPATIBILITY[declaredMime] ?? []).includes(
-    detectedType,
-  );
-  if (!isValidBasic) return false;
-
-  // Deeper inspection of PPT/PPTX files
-  if (
-    declaredMime ===
-    "application/vnd.openxmlformats-officedocument.presentationml.presentation"
-  ) {
-    return hasZipEntry(file, "ppt/presentation.xml");
-  } else if (declaredMime === "application/vnd.ms-powerpoint") {
-    return hasOleStream(file, "PowerPoint Document");
-  }
-
-  return true;
 }

--- a/apps/api/vitest.config.ts
+++ b/apps/api/vitest.config.ts
@@ -1,6 +1,6 @@
-import { defineConfig, type UserConfig } from "vitest/config";
+import { defineConfig } from "vitest/config";
 
-export default defineConfig(async (): Promise<UserConfig> => {
+export default defineConfig(async () => {
     const { default: codspeedPlugin } = await import("@codspeed/vitest-plugin");
     return {
     plugins: [codspeedPlugin()],
@@ -20,5 +20,5 @@ export default defineConfig(async (): Promise<UserConfig> => {
             exclude: ["src/types.ts", "**/coverage/**"],
         }
     }
-    };
+    } as any;
 });

--- a/apps/api/vitest.config.ts
+++ b/apps/api/vitest.config.ts
@@ -1,24 +1,24 @@
-import { defineConfig } from "vitest/config";
+import { defineConfig, type UserConfig } from "vitest/config";
 
-export default defineConfig(async () => {
+export default defineConfig(async (): Promise<UserConfig> => {
     const { default: codspeedPlugin } = await import("@codspeed/vitest-plugin");
     return {
-    plugins: [codspeedPlugin()],
-    test: {
-        environment: "node",
-        include: ["src/**/__tests__/**/*.test.ts"],
-        reporters: ["default", "junit"],
-        outputFile: {
-            lcov: "./coverage/lcov.info",
-            junit: "./test-report.junit.xml",
+        plugins: [codspeedPlugin()],
+        test: {
+            environment: "node",
+            include: ["src/**/__tests__/**/*.test.ts"],
+            reporters: ["default", "junit"],
+            outputFile: {
+                lcov: "./coverage/lcov.info",
+                junit: "./test-report.junit.xml",
+            },
+            coverage: {
+                provider: "v8",
+                reporter: ["text", "lcov"],
+                reportsDirectory: "./coverage",
+                include: ["src/**/*.ts"],
+                exclude: ["src/types.ts", "**/coverage/**"],
+            },
         },
-        coverage: {
-            provider: "v8",
-            reporter: ["text", "lcov"],
-            reportsDirectory: "./coverage",
-            include: ["src/**/*.ts"],
-            exclude: ["src/types.ts", "**/coverage/**"],
-        }
-    }
-    } as any;
+    };
 });

--- a/apps/web/package-lock.json
+++ b/apps/web/package-lock.json
@@ -4278,9 +4278,9 @@
       }
     },
     "node_modules/axios": {
-      "version": "1.14.0",
-      "resolved": "https://registry.npmjs.org/axios/-/axios-1.14.0.tgz",
-      "integrity": "sha512-3Y8yrqLSwjuzpXuZ0oIYZ/XGgLwUIBU3uLvbcpb0pidD9ctpShJd43KSlEEkVQg6DS0G9NKyzOvBfUtDKEyHvQ==",
+      "version": "1.15.0",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-1.15.0.tgz",
+      "integrity": "sha512-wWyJDlAatxk30ZJer+GeCWS209sA42X+N5jU2jy6oHTp7ufw8uzUTVFBX9+wTfAlhiJXGS0Bq7X6efruWjuK9Q==",
       "dev": true,
       "license": "MIT",
       "dependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -696,7 +696,7 @@
       "dependencies": {
         "@vercel/analytics": "^2.0.1",
         "@vercel/speed-insights": "^2.0.0",
-        "next": "^16.2.3",
+        "next": "16.2.3",
         "react": "19.2.3",
         "react-dom": "19.2.3",
         "react-markdown": "^10.1.0",
@@ -4761,9 +4761,9 @@
       }
     },
     "node_modules/axios": {
-      "version": "1.14.0",
-      "resolved": "https://registry.npmjs.org/axios/-/axios-1.14.0.tgz",
-      "integrity": "sha512-3Y8yrqLSwjuzpXuZ0oIYZ/XGgLwUIBU3uLvbcpb0pidD9ctpShJd43KSlEEkVQg6DS0G9NKyzOvBfUtDKEyHvQ==",
+      "version": "1.15.0",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-1.15.0.tgz",
+      "integrity": "sha512-wWyJDlAatxk30ZJer+GeCWS209sA42X+N5jU2jy6oHTp7ufw8uzUTVFBX9+wTfAlhiJXGS0Bq7X6efruWjuK9Q==",
       "dev": true,
       "license": "MIT",
       "dependencies": {


### PR DESCRIPTION
<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

このPRはファイル検証の堅牢性向上（`validateMagicNumbers`へのtry-catchとawait追加）、`collections/:id/papers`における`orgAccessSet`の関数型スタイルへのリファクタリング、`auth.ts`の不要インポート削除、そしてこれらの変更に対応したテストの追加を行っています。

`file.ts`の変更で特筆すべきは、`hasZipEntry`と`hasOleStream`の呼び出しに`await`が追加された点です。以前は`return hasZipEntry(...)`のように`await`なしで返していたため、これらの関数内で発生した`RangeError`や`TypeError`がtry-catchに捕捉されず、呼び出し元にそのまま伝播していました。今回のtry-catch導入と`await`追加により、破損ファイルへの対応が適切になっています。
</details>

<h3>Confidence Score: 5/5</h3>

このPRはマージ可能です。バグ修正・リファクタリング・テスト追加のみで、破壊的変更はありません。

P0/P1の問題は見当たりません。TypeErrorの捕捉範囲に関するP2コメントを1件残しましたが、マージブロックとなるものではありません。awaitの追加により破損ファイルの例外が正しくtry-catchに捕捉されるようになった点はバグ修正として重要ですが、既に適切に実装されています。

特に注意が必要なファイルはありません。

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| apps/api/src/utils/file.ts | validateMagicNumbers にtry-catchを追加し、hasZipEntry/hasOleStreamにawaitを付与。破損ファイルによるRangeError/TypeErrorを適切にキャッチしてfalseを返すよう修正。 |
| apps/api/src/routes/collections.ts | orgAccessSet構築を命令型から三項演算子+mapの関数型スタイルにリファクタリング。動作は等価。 |
| apps/api/src/routes/auth.ts | 未使用のorgs/orgMembersインポートを削除。クリーンアップのみ。 |
| apps/api/src/utils/__tests__/file.test.ts | 破損ZIPファイルでRangeErrorが発生するケースのテストを追加。既存テストをリフォーマット。 |
| apps/api/src/routes/__tests__/collections.test.ts | PATCH /collections/:idでslugが重複した場合に409を返すテストを追加。 |
| apps/api/vitest.config.ts | インデントの修正のみ。動作変更なし。 |

</details>

</details>

<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[validateMagicNumbers 呼び出し] --> B[file.slice で先頭バイト取得]
    B --> C{try-catch ブロック}
    C --> D[MAGIC_NUMBER_MAP をループで照合]
    D --> E{マジックナンバー一致?}
    E -- No --> F[return false]
    E -- Yes --> G[MIME_COMPATIBILITY で型確認]
    G --> H{MIME 一致?}
    H -- No --> F
    H -- Yes --> I{PPTX?}
    I -- Yes --> J[await hasZipEntry]
    I --> K{PPT?}
    K -- Yes --> L[await hasOleStream]
    K -- No --> M[return true]
    J --> N[return boolean]
    L --> N
    C -- RangeError / TypeError --> O[return false]
    C -- その他のエラー --> P[throw error]
```

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
This is a comment left during a code review.
Path: apps/api/src/utils/file.ts
Line: 244-247

Comment:
**TypeErrorの捕捉範囲が広め**

`TypeError`はJavaScript全般の型エラー（例: `undefined`や`null`に対するプロパティアクセス）でも発生します。実装バグ由来の`TypeError`もここで`false`に変換されるため、予期しない問題が隠蔽される可能性があります。意図が「ファイルAPIが返すエラーのみ捕捉」であれば、`RangeError`のみに絞る選択肢もあります。

```suggestion
    } catch (error) {
      if (error instanceof RangeError) {
        return false;
      }
      throw error;
    }
```

How can I resolve this? If you propose a fix, please make it concise.
`````

</details>

<sub>Reviews (1): Last reviewed commit: ["Merge pull request #401 from Hiroki-org/..."](https://github.com/hiroki-org/openshelf/commit/80116bec6ab7e13eb42f5ed4980dca3b834fec78) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=28108157)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->