### PR TITLE
test(e2e): strengthen backend auth and real session coverage

### DIFF
--- a/apps/e2e/helpers/auth.ts
+++ b/apps/e2e/helpers/auth.ts
@@ -1,42 +1,67 @@
-import { Page } from '@playwright/test';
+import { APIRequestContext, Page } from '@playwright/test';
 import { randomUUID } from 'crypto';
 
 const apiURL = process.env.E2E_API_URL || 'http://localhost:8787';
+const testAuthSecret = process.env.TEST_AUTH_SECRET || 'test-secret';
+const testOrigin = process.env.E2E_BASE_URL || 'http://localhost:3000';
 
-export async function loginAsTestUser(page: Page, user?: { sub?: string; githubId?: string; name?: string }) {
-    const payload = {
-        sub: user?.sub || randomUUID(),
-        githubId: user?.githubId || randomUUID(),
-        name: user?.name || 'Test User',
-    };
+type TestUserInput = {
+  sub?: string;
+  githubId?: string;
+  name?: string;
+};
 
-    const res = await page.request.post(`${apiURL}/api/test-auth/test-token`, {
-        data: payload,
-        headers: {
-            'x-test-auth-secret': process.env.TEST_AUTH_SECRET || 'test-secret',
-            'origin': process.env.E2E_BASE_URL || 'http://localhost:3000',
-            'referer': process.env.E2E_BASE_URL || 'http://localhost:3000',
-        }
-    });
+export async function issueTestToken(
+  request: APIRequestContext,
+  user?: TestUserInput,
+): Promise<{ token: string; payload: Required<TestUserInput> }> {
+  const payload: Required<TestUserInput> = {
+    sub: user?.sub || randomUUID(),
+    githubId: user?.githubId || randomUUID(),
+    name: user?.name || 'Test User',
+  };
 
-    if (!res.ok()) {
-        throw new Error(`Failed to get test token: ${await res.text()}`);
-    }
+  const res = await request.post(`${apiURL}/api/test-auth/test-token`, {
+    data: payload,
+    headers: {
+      'x-test-auth-secret': testAuthSecret,
+      origin: testOrigin,
+      referer: testOrigin,
+    },
+  });
 
-    const data = await res.json();
-    if (!data || typeof data !== 'object' || typeof (data as { token?: unknown }).token !== 'string') {
-        throw new Error(`Invalid token response from /api/test-auth/test-token: ${JSON.stringify(data)}`);
-    }
-    const token = (data as { token: string }).token;
-    if (token.length === 0) {
-        throw new Error('Invalid token response from /api/test-auth/test-token: empty token');
-    }
+  if (!res.ok()) {
+    throw new Error(`Failed to get test token: ${await res.text()}`);
+  }
 
-    await page.goto('/');
-    await page.evaluate((jwt) => {
-        localStorage.setItem('auth_token', jwt);
-    }, token);
-    await page.reload();
+  const data = await res.json();
+  if (
+    !data ||
+    typeof data !== 'object' ||
+    typeof (data as { token?: unknown }).token !== 'string'
+  ) {
+    throw new Error(
+      `Invalid token response from /api/test-auth/test-token: ${JSON.stringify(data)}`,
+    );
+  }
+  const token = (data as { token: string }).token;
+  if (token.length === 0) {
+    throw new Error(
+      'Invalid token response from /api/test-auth/test-token: empty token',
+    );
+  }
 
-    return payload;
+  return { token, payload };
+}
+
+export async function loginAsTestUser(page: Page, user?: TestUserInput) {
+  const { token, payload } = await issueTestToken(page.request, user);
+
+  await page.goto('/');
+  await page.evaluate((jwt) => {
+    localStorage.setItem('auth_token', jwt);
+  }, token);
+  await page.reload();
+
+  return payload;
 }

--- a/apps/e2e/helpers/auth.ts
+++ b/apps/e2e/helpers/auth.ts
@@ -1,9 +1,9 @@
 import { APIRequestContext, Page } from '@playwright/test';
 import { randomUUID } from 'crypto';
 
-const apiURL = process.env.E2E_API_URL || 'http://localhost:8787';
-const testAuthSecret = process.env.TEST_AUTH_SECRET || 'test-secret';
-const testOrigin = process.env.E2E_BASE_URL || 'http://localhost:3000';
+export const apiURL = process.env.E2E_API_URL || 'http://localhost:8787';
+export const testAuthSecret = process.env.TEST_AUTH_SECRET || 'test-secret';
+export const testOrigin = process.env.E2E_BASE_URL || 'http://localhost:3000';
 
 type TestUserInput = {
   sub?: string;

--- a/apps/e2e/tests/scenarios/auth-flow.spec.ts
+++ b/apps/e2e/tests/scenarios/auth-flow.spec.ts
@@ -30,4 +30,33 @@ test.describe('Auth Flow', () => {
         await page.waitForURL(url => url.pathname !== '/upload');
         expect(page.url()).not.toContain('/upload');
     });
+
+    test('認証トークンで API にアクセスでき、ログアウト後は未認証になること', async ({ page }) => {
+        const user = await loginAsTestUser(page);
+        const token = await page.evaluate(() => localStorage.getItem('auth_token'));
+        expect(token).toBeTruthy();
+
+        const meRes = await page.request.get('/api/users/me', {
+            headers: {
+                Authorization: `Bearer ${token}`,
+            },
+        });
+        expect(meRes.status()).toBe(200);
+        await expect(meRes.json()).resolves.toMatchObject({
+            user: {
+                id: user.sub,
+            },
+        });
+
+        await page.getByRole('button', { name: 'ログアウト' }).click();
+        await expect.poll(async () => {
+            return page.evaluate(() => localStorage.getItem('auth_token'));
+        }).toBeNull();
+
+        const unauthRes = await page.request.get('/api/users/me');
+        expect(unauthRes.status()).toBe(401);
+        await expect(unauthRes.json()).resolves.toMatchObject({
+            error: 'Unauthorized',
+        });
+    });
 });

--- a/apps/e2e/tests/scenarios/backend-auth-e2e.spec.ts
+++ b/apps/e2e/tests/scenarios/backend-auth-e2e.spec.ts
@@ -1,10 +1,11 @@
 import { test, expect } from '@playwright/test';
 import { randomUUID } from 'crypto';
-import { issueTestToken } from '../../helpers/auth';
-
-const apiURL = process.env.E2E_API_URL || 'http://localhost:8787';
-const testAuthSecret = process.env.TEST_AUTH_SECRET || 'test-secret';
-const testOrigin = process.env.E2E_BASE_URL || 'http://localhost:3000';
+import {
+  issueTestToken,
+  apiURL,
+  testAuthSecret,
+  testOrigin,
+} from '../../helpers/auth';
 
 test.describe('Backend Auth E2E', () => {
   test('test-token endpoint rejects requests without shared secret', async ({
@@ -69,9 +70,26 @@ test.describe('Backend Auth E2E', () => {
     });
   });
 
-  test('test-org endpoint validates payload then creates membership', async ({
+  test('test-org endpoint rejects requests without shared secret', async ({
     request,
   }) => {
+    const unauthorizedRes = await request.post(`${apiURL}/api/test-auth/test-org`, {
+      data: {
+        userId: randomUUID(),
+        orgId: randomUUID(),
+      },
+      headers: {
+        origin: testOrigin,
+        referer: testOrigin,
+      },
+    });
+    expect(unauthorizedRes.status()).toBe(401);
+    await expect(unauthorizedRes.json()).resolves.toMatchObject({
+      error: 'Unauthorized (E2E)',
+    });
+  });
+
+  test('test-org endpoint validates payload', async ({ request }) => {
     const { payload } = await issueTestToken(request, {
       name: `org-member-${randomUUID().slice(0, 8)}`,
     });
@@ -89,6 +107,14 @@ test.describe('Backend Auth E2E', () => {
     expect(invalidRes.status()).toBe(400);
     await expect(invalidRes.json()).resolves.toMatchObject({
       error: 'userId and orgId are required',
+    });
+  });
+
+  test('test-org endpoint creates membership with valid payload', async ({
+    request,
+  }) => {
+    const { payload } = await issueTestToken(request, {
+      name: `org-member-${randomUUID().slice(0, 8)}`,
     });
 
     const validRes = await request.post(`${apiURL}/api/test-auth/test-org`, {

--- a/apps/e2e/tests/scenarios/backend-auth-e2e.spec.ts
+++ b/apps/e2e/tests/scenarios/backend-auth-e2e.spec.ts
@@ -7,6 +7,16 @@ import {
   testOrigin,
 } from '../../helpers/auth';
 
+const baseHeaders = {
+  origin: testOrigin,
+  referer: testOrigin,
+};
+
+const testAuthHeaders = {
+  ...baseHeaders,
+  'x-test-auth-secret': testAuthSecret,
+};
+
 test.describe('Backend Auth E2E', () => {
   test('test-token endpoint rejects requests without shared secret', async ({
     request,
@@ -17,10 +27,7 @@ test.describe('Backend Auth E2E', () => {
         githubId: randomUUID(),
         name: 'No Secret User',
       },
-      headers: {
-        origin: testOrigin,
-        referer: testOrigin,
-      },
+      headers: baseHeaders,
     });
 
     expect(res.status()).toBe(401);
@@ -35,11 +42,7 @@ test.describe('Backend Auth E2E', () => {
         sub: randomUUID(),
         githubId: randomUUID(),
       },
-      headers: {
-        'x-test-auth-secret': testAuthSecret,
-        origin: testOrigin,
-        referer: testOrigin,
-      },
+      headers: testAuthHeaders,
     });
 
     expect(res.status()).toBe(400);
@@ -78,10 +81,7 @@ test.describe('Backend Auth E2E', () => {
         userId: randomUUID(),
         orgId: randomUUID(),
       },
-      headers: {
-        origin: testOrigin,
-        referer: testOrigin,
-      },
+      headers: baseHeaders,
     });
     expect(unauthorizedRes.status()).toBe(401);
     await expect(unauthorizedRes.json()).resolves.toMatchObject({
@@ -98,11 +98,7 @@ test.describe('Backend Auth E2E', () => {
       data: {
         userId: payload.sub,
       },
-      headers: {
-        'x-test-auth-secret': testAuthSecret,
-        origin: testOrigin,
-        referer: testOrigin,
-      },
+      headers: testAuthHeaders,
     });
     expect(invalidRes.status()).toBe(400);
     await expect(invalidRes.json()).resolves.toMatchObject({
@@ -122,11 +118,7 @@ test.describe('Backend Auth E2E', () => {
         userId: payload.sub,
         orgId: randomUUID(),
       },
-      headers: {
-        'x-test-auth-secret': testAuthSecret,
-        origin: testOrigin,
-        referer: testOrigin,
-      },
+      headers: testAuthHeaders,
     });
     expect(validRes.status()).toBe(200);
     await expect(validRes.json()).resolves.toMatchObject({ ok: true });

--- a/apps/e2e/tests/scenarios/backend-auth-e2e.spec.ts
+++ b/apps/e2e/tests/scenarios/backend-auth-e2e.spec.ts
@@ -1,0 +1,108 @@
+import { test, expect } from '@playwright/test';
+import { randomUUID } from 'crypto';
+import { issueTestToken } from '../../helpers/auth';
+
+const apiURL = process.env.E2E_API_URL || 'http://localhost:8787';
+const testAuthSecret = process.env.TEST_AUTH_SECRET || 'test-secret';
+const testOrigin = process.env.E2E_BASE_URL || 'http://localhost:3000';
+
+test.describe('Backend Auth E2E', () => {
+  test('test-token endpoint rejects requests without shared secret', async ({
+    request,
+  }) => {
+    const res = await request.post(`${apiURL}/api/test-auth/test-token`, {
+      data: {
+        sub: randomUUID(),
+        githubId: randomUUID(),
+        name: 'No Secret User',
+      },
+      headers: {
+        origin: testOrigin,
+        referer: testOrigin,
+      },
+    });
+
+    expect(res.status()).toBe(401);
+    await expect(res.json()).resolves.toMatchObject({
+      error: 'Unauthorized (E2E)',
+    });
+  });
+
+  test('test-token endpoint validates request body', async ({ request }) => {
+    const res = await request.post(`${apiURL}/api/test-auth/test-token`, {
+      data: {
+        sub: randomUUID(),
+        githubId: randomUUID(),
+      },
+      headers: {
+        'x-test-auth-secret': testAuthSecret,
+        origin: testOrigin,
+        referer: testOrigin,
+      },
+    });
+
+    expect(res.status()).toBe(400);
+    await expect(res.json()).resolves.toMatchObject({
+      error: 'Invalid request body',
+    });
+  });
+
+  test('issued test token authenticates /api/users/me', async ({ request }) => {
+    const uniqueSuffix = randomUUID().slice(0, 8);
+    const { token, payload } = await issueTestToken(request, {
+      name: `backend-e2e-${uniqueSuffix}`,
+    });
+
+    const res = await request.get(`${apiURL}/api/users/me`, {
+      headers: {
+        Authorization: `Bearer ${token}`,
+      },
+    });
+
+    expect(res.status()).toBe(200);
+    await expect(res.json()).resolves.toMatchObject({
+      user: {
+        id: payload.sub,
+        githubId: payload.githubId,
+        name: payload.name,
+      },
+    });
+  });
+
+  test('test-org endpoint validates payload then creates membership', async ({
+    request,
+  }) => {
+    const { payload } = await issueTestToken(request, {
+      name: `org-member-${randomUUID().slice(0, 8)}`,
+    });
+
+    const invalidRes = await request.post(`${apiURL}/api/test-auth/test-org`, {
+      data: {
+        userId: payload.sub,
+      },
+      headers: {
+        'x-test-auth-secret': testAuthSecret,
+        origin: testOrigin,
+        referer: testOrigin,
+      },
+    });
+    expect(invalidRes.status()).toBe(400);
+    await expect(invalidRes.json()).resolves.toMatchObject({
+      error: 'userId and orgId are required',
+    });
+
+    const validRes = await request.post(`${apiURL}/api/test-auth/test-org`, {
+      data: {
+        userId: payload.sub,
+        orgId: randomUUID(),
+      },
+      headers: {
+        'x-test-auth-secret': testAuthSecret,
+        origin: testOrigin,
+        referer: testOrigin,
+      },
+    });
+    expect(validRes.status()).toBe(200);
+    await expect(validRes.json()).resolves.toMatchObject({ ok: true });
+  });
+});


### PR DESCRIPTION
Summary:\n- add backend auth E2E scenarios for test-token, test-org, and users/me\n- extract reusable issueTestToken helper for API-side E2E flows\n- extend auth-flow browser E2E to assert API auth before logout and 401 after logout\n\nValidation:\ncd apps/e2e && npm run test -- tests/scenarios/backend-auth-e2e.spec.ts tests/scenarios/auth-flow.spec.ts

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

バックエンド認証のE2Eカバレッジを強化するPRです。`issueTestToken` ヘルパーの切り出し、`test-token`/`test-org` エンドポイントの直接テスト、ブラウザテストへのAPIアクセス検証の追加が含まれます。

`next.config.ts` の `/api/:path*` リライトルールにより `auth-flow.spec.ts` 内の相対パス (`/api/users/me`) は問題なくバックエンドに転送されます。残る指摘はいずれも P2（定数の重複・テストの分割）です。
</details>

<h3>Confidence Score: 5/5</h3>

マージ可能。残る指摘はすべてP2（スタイル・テスト構造の改善）で、機能的な問題はありません。

すべての指摘がP2（定数の重複・テストケース分割）であり、実際の動作に影響しません。Next.jsのリライト設定の確認により、相対パスの懸念も払拭されました。

backend-auth-e2e.spec.ts（定数重複・テスト構造）

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| apps/e2e/helpers/auth.ts | issueTestToken を新たに切り出し、loginAsTestUser がそれを委譲する形に整理。API専用テスト向けの再利用性が向上。ロジックの変更はなく問題なし。 |
| apps/e2e/tests/scenarios/auth-flow.spec.ts | APIアクセス検証とログアウト後の401確認テストを追加。page.request の相対パスは Next.js の /api/* リライトルール経由でバックエンドに到達するため正常に動作する。 |
| apps/e2e/tests/scenarios/backend-auth-e2e.spec.ts | バックエンド認証の新規E2Eスペック。定数の重複定義と test-org のテストが検証・作成を1ケースに混在させている点に改善余地あり。 |

</details>

</details>

<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant PW as Playwright Test
    participant Helper as helpers/auth.ts
    participant Next as Next.js (3000)
    participant API as Backend API (8787)

    Note over PW,API: issueTestToken flow
    PW->>Helper: issueTestToken(request, user)
    Helper->>API: POST /api/test-auth/test-token (x-test-auth-secret)
    API-->>Helper: { token, payload }
    Helper-->>PW: { token, payload }

    Note over PW,API: auth-flow.spec.ts — API auth check
    PW->>Next: GET /api/users/me (Bearer token)
    Next->>API: rewrite → GET /api/users/me (Bearer token)
    API-->>Next: 200 { user }
    Next-->>PW: 200 { user }

    Note over PW,API: backend-auth-e2e.spec.ts — direct API call
    PW->>API: GET /api/users/me (Bearer token) [direct to port 8787]
    API-->>PW: 200 { user }

    Note over PW,API: 401 after logout
    PW->>Next: GET /api/users/me (no token)
    Next->>API: rewrite → GET /api/users/me (no token)
    API-->>Next: 401 { error: Unauthorized }
    Next-->>PW: 401
```

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
This is a comment left during a code review.
Path: apps/e2e/tests/scenarios/backend-auth-e2e.spec.ts
Line: 5-7

Comment:
**定数の重複定義**

`apiURL`・`testAuthSecret`・`testOrigin` の3つの定数は `helpers/auth.ts` でもまったく同じデフォルト値で定義されています。どちらか一方を変更し忘れると、テストがフレーキーに失敗する原因になります。これらは `helpers/auth.ts` からエクスポートするか、共通の設定ファイルにまとめて import することを検討してください。

How can I resolve this? If you propose a fix, please make it concise.

---

This is a comment left during a code review.
Path: apps/e2e/tests/scenarios/backend-auth-e2e.spec.ts
Line: 72-107

Comment:
**1テストに複数のシナリオが混在**

このテストは「不正なリクエストを弾く（400）」と「正常なメンバーシップ作成（200）」の2つのシナリオを1ケースに詰め込んでいます。最初の `expect(invalidRes.status()).toBe(400)` が失敗するとメンバーシップ作成の検証が走らず、失敗原因の特定が難しくなります。それぞれ独立したテストに分割することを推奨します。

また、`test-token` エンドポイントには「シークレットなし → 401」のテストがありますが、`test-org` に同等のテストがありません。認証ガードの網羅性のため追加を検討してください。

How can I resolve this? If you propose a fix, please make it concise.
`````

</details>

<sub>Reviews (1): Last reviewed commit: ["test(e2e): strengthen backend auth and s..."](https://github.com/hiroki-org/openshelf/commit/84d8ec20f4e52d51265f9633fd672bb79866b22a) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=28129558)</sub>

> Greptile also left **2 inline comments** on this PR.

<!-- /greptile_comment -->