### PR TITLE
build: patch lockfile vulnerabilities on staging

### DIFF
--- a/.github/scripts/create-staging-to-main-pr.sh
+++ b/.github/scripts/create-staging-to-main-pr.sh
@@ -163,7 +163,7 @@ while IFS= read -r pr_number; do
 done < <(
   git log --pretty=format:'%s' "$base_ref..$head_ref" |
     while IFS= read -r subject; do
-      printf '%s\n' "$subject" | grep -oE '#[0-9]+' | sed 's/#//' || true
+      printf '%s\n' "$subject" | sed -nE 's/^Merge pull request #([0-9]+).*$/\1/p'
     done |
     awk '!seen[$0]++'
 )

--- a/apps/api/src/routes/auth.ts
+++ b/apps/api/src/routes/auth.ts
@@ -3,7 +3,7 @@ import { deleteCookie, getCookie, setCookie } from "hono/cookie";
 import { sign } from "hono/jwt";
 import { drizzle } from "drizzle-orm/d1";
 import { eq } from "drizzle-orm";
-import { users, orgs, orgMembers, enableForeignKeys, touchUpdatedAt } from "../db/schema";
+import { users, enableForeignKeys, touchUpdatedAt } from "../db/schema";
 import type { Env, Variables } from "../types";
 import { authMiddleware } from "../middleware/auth";
 import { parseOriginList, resolveAllowedOrigin } from "../utils/origin";

--- a/apps/api/src/routes/feed.ts
+++ b/apps/api/src/routes/feed.ts
@@ -386,6 +386,7 @@ async function buildUserFeedResponse(c: FeedContext, id: string): Promise<Respon
 
     const user = await db.select().from(users).where(eq(users.id, id)).get();
     if (!user) return c.json({ error: "User not found" }, 404);
+    const authorName = (user.displayName ?? user.name ?? "").trim() || "OpenShelf";
 
     const papersRows = await db
         .select(PAPER_FEED_SELECT)
@@ -399,12 +400,12 @@ async function buildUserFeedResponse(c: FeedContext, id: string): Promise<Respon
     return await buildFeedResponse(
         c,
         {
-            title: `${user.displayName ?? user.name} - OpenShelf`,
+            title: `${authorName} - OpenShelf`,
             link: `${normalizeBaseUrl(c.env.FRONTEND_URL)}/users/${encodeURIComponent(id)}`,
             selfLink: c.req.url,
             id: `urn:openshelf:user:${id}`,
             updatedFallback: user.updatedAt,
-            authorName: user.displayName ?? user.name,
+            authorName,
         },
         // SQLで絞り込み済みだが、フィルタの整合性確認と重複排除を兼ねて再利用する
         filterPaperRowsByTag(papersRows, tagFilter),
@@ -476,6 +477,7 @@ async function buildUserCollectionFeedResponse(
 
     const user = await db.select().from(users).where(eq(users.id, id)).get();
     if (!user) return c.json({ error: "User not found" }, 404);
+    const authorName = (user.displayName ?? user.name ?? "").trim() || "OpenShelf";
 
     const collection = await db
         .select()
@@ -505,12 +507,12 @@ async function buildUserCollectionFeedResponse(
     return await buildFeedResponse(
         c,
         {
-            title: `${collection.name} - ${user.displayName ?? user.name} - OpenShelf`,
+            title: `${collection.name} - ${authorName} - OpenShelf`,
             link: `${normalizeBaseUrl(c.env.FRONTEND_URL)}/users/${encodeURIComponent(id)}/c/${encodeURIComponent(collectionSlug)}`,
             selfLink: c.req.url,
             id: `urn:openshelf:collection:${collection.id}`,
             updatedFallback: collection.updatedAt,
-            authorName: user.displayName ?? user.name,
+            authorName,
         },
         dedupePaperRows(papersRows),
     );

--- a/apps/api/src/utils/file.ts
+++ b/apps/api/src/utils/file.ts
@@ -227,41 +227,53 @@ export async function validateMagicNumbers(
   file: File,
   declaredMime: string,
 ): Promise<boolean> {
-  const buffer = await file.slice(0, MAX_MAGIC_SIZE).arrayBuffer();
-  const bytes = new Uint8Array(buffer);
+  try {
+    const buffer = await file.slice(0, MAX_MAGIC_SIZE).arrayBuffer();
+    const bytes = new Uint8Array(buffer);
 
-  let detectedType: string | null = null;
-  for (const [signature, mimeType] of MAGIC_NUMBER_MAP) {
-    if (bytes.length < signature.length) continue;
-    let match = true;
-    for (let i = 0; i < signature.length; i++) {
-      if (bytes[i] !== signature[i]) {
-        match = false;
+    let detectedType: string | null = null;
+    for (const [signature, mimeType] of MAGIC_NUMBER_MAP) {
+      if (bytes.length < signature.length) continue;
+      let match = true;
+      for (let i = 0; i < signature.length; i++) {
+        if (bytes[i] !== signature[i]) {
+          match = false;
+          break;
+        }
+      }
+      if (match) {
+        detectedType = mimeType;
         break;
       }
     }
-    if (match) {
-      detectedType = mimeType;
-      break;
+
+    if (!detectedType) return false;
+
+    const isValidBasic = (MIME_COMPATIBILITY[declaredMime] ?? []).includes(
+      detectedType,
+    );
+    if (!isValidBasic) return false;
+
+    // Deeper inspection of PPT/PPTX files
+    if (
+      declaredMime ===
+      "application/vnd.openxmlformats-officedocument.presentationml.presentation"
+    ) {
+      return await hasZipEntry(file, "ppt/presentation.xml");
     }
+    if (declaredMime === "application/vnd.ms-powerpoint") {
+      return await hasOleStream(file, "PowerPoint Document");
+    }
+
+    return true;
+  } catch (error) {
+    if (
+      error instanceof RangeError ||
+      error instanceof TypeError ||
+      (error instanceof DOMException && error.name === "InvalidStateError")
+    ) {
+      return false;
+    }
+    throw error;
   }
-
-  if (!detectedType) return false;
-
-  const isValidBasic = (MIME_COMPATIBILITY[declaredMime] ?? []).includes(
-    detectedType,
-  );
-  if (!isValidBasic) return false;
-
-  // Deeper inspection of PPT/PPTX files
-  if (
-    declaredMime ===
-    "application/vnd.openxmlformats-officedocument.presentationml.presentation"
-  ) {
-    return hasZipEntry(file, "ppt/presentation.xml");
-  } else if (declaredMime === "application/vnd.ms-powerpoint") {
-    return hasOleStream(file, "PowerPoint Document");
-  }
-
-  return true;
 }

--- a/apps/api/vitest.config.ts
+++ b/apps/api/vitest.config.ts
@@ -9,7 +9,6 @@ export default defineConfig(async (): Promise<UserConfig> => {
         include: ["src/**/__tests__/**/*.test.ts"],
         reporters: ["default", "junit"],
         outputFile: {
-            lcov: "./coverage/lcov.info",
             junit: "./test-report.junit.xml",
         },
         coverage: {

--- a/apps/web/package-lock.json
+++ b/apps/web/package-lock.json
@@ -35,20 +35,6 @@
         "tailwindcss": "^4",
         "typescript": "^5",
         "vitest": "^3.2.4"
-      },
-      "optionalDependencies": {
-        "@next/swc-linux-arm64-gnu": "^16.2.3",
-        "@next/swc-linux-arm64-musl": "^16.2.3",
-        "@next/swc-linux-x64-gnu": "^16.2.3",
-        "@next/swc-linux-x64-musl": "^16.2.3",
-        "@tailwindcss/oxide-linux-arm64-gnu": "^4.2.1",
-        "@tailwindcss/oxide-linux-arm64-musl": "^4.2.1",
-        "@tailwindcss/oxide-linux-x64-gnu": "^4.2.1",
-        "@tailwindcss/oxide-linux-x64-musl": "^4.2.1",
-        "lightningcss-linux-arm64-gnu": "^1.31.1",
-        "lightningcss-linux-arm64-musl": "^1.31.1",
-        "lightningcss-linux-x64-gnu": "^1.31.1",
-        "lightningcss-linux-x64-musl": "^1.31.1"
       }
     },
     "node_modules/@acemir/cssom": {
@@ -2789,6 +2775,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2805,6 +2792,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2821,6 +2809,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2837,6 +2826,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -7288,6 +7278,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -7308,6 +7299,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -7328,6 +7320,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -7348,6 +7341,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "MPL-2.0",
       "optional": true,
       "os": [

--- a/apps/web/package-lock.json
+++ b/apps/web/package-lock.json
@@ -11,7 +11,7 @@
       "dependencies": {
         "@vercel/analytics": "^2.0.1",
         "@vercel/speed-insights": "^2.0.0",
-        "next": "16.2.1",
+        "next": "16.2.3",
         "react": "19.2.3",
         "react-dom": "19.2.3",
         "react-markdown": "^10.1.0",
@@ -30,17 +30,17 @@
         "@types/react-dom": "^19",
         "babel-plugin-react-compiler": "1.0.0",
         "eslint": "^9",
-        "eslint-config-next": "16.2.1",
+        "eslint-config-next": "16.2.3",
         "jsdom": "^27.0.1",
         "tailwindcss": "^4",
         "typescript": "^5",
         "vitest": "^3.2.4"
       },
       "optionalDependencies": {
-        "@next/swc-linux-arm64-gnu": "^16.2.1",
-        "@next/swc-linux-arm64-musl": "^16.2.1",
-        "@next/swc-linux-x64-gnu": "^16.2.1",
-        "@next/swc-linux-x64-musl": "^16.2.1",
+        "@next/swc-linux-arm64-gnu": "^16.2.3",
+        "@next/swc-linux-arm64-musl": "^16.2.3",
+        "@next/swc-linux-x64-gnu": "^16.2.3",
+        "@next/swc-linux-x64-musl": "^16.2.3",
         "@tailwindcss/oxide-linux-arm64-gnu": "^4.2.1",
         "@tailwindcss/oxide-linux-arm64-musl": "^4.2.1",
         "@tailwindcss/oxide-linux-x64-gnu": "^4.2.1",
@@ -2100,15 +2100,15 @@
       }
     },
     "node_modules/@next/env": {
-      "version": "16.2.1",
-      "resolved": "https://registry.npmjs.org/@next/env/-/env-16.2.1.tgz",
-      "integrity": "sha512-n8P/HCkIWW+gVal2Z8XqXJ6aB3J0tuM29OcHpCsobWlChH/SITBs1DFBk/HajgrwDkqqBXPbuUuzgDvUekREPg==",
+      "version": "16.2.3",
+      "resolved": "https://registry.npmjs.org/@next/env/-/env-16.2.3.tgz",
+      "integrity": "sha512-ZWXyj4uNu4GCWQw9cjRxWlbD+33mcDszIo9iQxFnBX3Wmgq9ulaSJcl6VhuWx5pCWqqD+9W6Wfz7N0lM5lYPMA==",
       "license": "MIT"
     },
     "node_modules/@next/eslint-plugin-next": {
-      "version": "16.2.1",
-      "resolved": "https://registry.npmjs.org/@next/eslint-plugin-next/-/eslint-plugin-next-16.2.1.tgz",
-      "integrity": "sha512-r0epZGo24eT4g08jJlg2OEryBphXqO8aL18oajoTKLzHJ6jVr6P6FI58DLMug04MwD3j8Fj0YK0slyzneKVyzA==",
+      "version": "16.2.3",
+      "resolved": "https://registry.npmjs.org/@next/eslint-plugin-next/-/eslint-plugin-next-16.2.3.tgz",
+      "integrity": "sha512-nE/b9mht28XJxjTwKs/yk7w4XTaU3t40UHVAky6cjiijdP/SEy3hGsnQMPxmXPTpC7W4/97okm6fngKnvCqVaA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -2116,9 +2116,9 @@
       }
     },
     "node_modules/@next/swc-darwin-arm64": {
-      "version": "16.2.1",
-      "resolved": "https://registry.npmjs.org/@next/swc-darwin-arm64/-/swc-darwin-arm64-16.2.1.tgz",
-      "integrity": "sha512-BwZ8w8YTaSEr2HIuXLMLxIdElNMPvY9fLqb20LX9A9OMGtJilhHLbCL3ggyd0TwjmMcTxi0XXt+ur1vWUoxj2Q==",
+      "version": "16.2.3",
+      "resolved": "https://registry.npmjs.org/@next/swc-darwin-arm64/-/swc-darwin-arm64-16.2.3.tgz",
+      "integrity": "sha512-u37KDKTKQ+OQLvY+z7SNXixwo4Q2/IAJFDzU1fYe66IbCE51aDSAzkNDkWmLN0yjTUh4BKBd+hb69jYn6qqqSg==",
       "cpu": [
         "arm64"
       ],
@@ -2132,9 +2132,9 @@
       }
     },
     "node_modules/@next/swc-darwin-x64": {
-      "version": "16.2.1",
-      "resolved": "https://registry.npmjs.org/@next/swc-darwin-x64/-/swc-darwin-x64-16.2.1.tgz",
-      "integrity": "sha512-/vrcE6iQSJq3uL3VGVHiXeaKbn8Es10DGTGRJnRZlkNQQk3kaNtAJg8Y6xuAlrx/6INKVjkfi5rY0iEXorZ6uA==",
+      "version": "16.2.3",
+      "resolved": "https://registry.npmjs.org/@next/swc-darwin-x64/-/swc-darwin-x64-16.2.3.tgz",
+      "integrity": "sha512-gHjL/qy6Q6CG3176FWbAKyKh9IfntKZTB3RY/YOJdDFpHGsUDXVH38U4mMNpHVGXmeYW4wj22dMp1lTfmu/bTQ==",
       "cpu": [
         "x64"
       ],
@@ -2148,9 +2148,9 @@
       }
     },
     "node_modules/@next/swc-linux-arm64-gnu": {
-      "version": "16.2.1",
-      "resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-gnu/-/swc-linux-arm64-gnu-16.2.1.tgz",
-      "integrity": "sha512-uLn+0BK+C31LTVbQ/QU+UaVrV0rRSJQ8RfniQAHPghDdgE+SlroYqcmFnO5iNjNfVWCyKZHYrs3Nl0mUzWxbBw==",
+      "version": "16.2.3",
+      "resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-gnu/-/swc-linux-arm64-gnu-16.2.3.tgz",
+      "integrity": "sha512-U6vtblPtU/P14Y/b/n9ZY0GOxbbIhTFuaFR7F4/uMBidCi2nSdaOFhA0Go81L61Zd6527+yvuX44T4ksnf8T+Q==",
       "cpu": [
         "arm64"
       ],
@@ -2164,9 +2164,9 @@
       }
     },
     "node_modules/@next/swc-linux-arm64-musl": {
-      "version": "16.2.1",
-      "resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-musl/-/swc-linux-arm64-musl-16.2.1.tgz",
-      "integrity": "sha512-ssKq6iMRnHdnycGp9hCuGnXJZ0YPr4/wNwrfE5DbmvEcgl9+yv97/Kq3TPVDfYome1SW5geciLB9aiEqKXQjlQ==",
+      "version": "16.2.3",
+      "resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-musl/-/swc-linux-arm64-musl-16.2.3.tgz",
+      "integrity": "sha512-/YV0LgjHUmfhQpn9bVoGc4x4nan64pkhWR5wyEV8yCOfwwrH630KpvRg86olQHTwHIn1z59uh6JwKvHq1h4QEw==",
       "cpu": [
         "arm64"
       ],
@@ -2180,9 +2180,9 @@
       }
     },
     "node_modules/@next/swc-linux-x64-gnu": {
-      "version": "16.2.1",
-      "resolved": "https://registry.npmjs.org/@next/swc-linux-x64-gnu/-/swc-linux-x64-gnu-16.2.1.tgz",
-      "integrity": "sha512-HQm7SrHRELJ30T1TSmT706IWovFFSRGxfgUkyWJZF/RKBMdbdRWJuFrcpDdE5vy9UXjFOx6L3mRdqH04Mmx0hg==",
+      "version": "16.2.3",
+      "resolved": "https://registry.npmjs.org/@next/swc-linux-x64-gnu/-/swc-linux-x64-gnu-16.2.3.tgz",
+      "integrity": "sha512-/HiWEcp+WMZ7VajuiMEFGZ6cg0+aYZPqCJD3YJEfpVWQsKYSjXQG06vJP6F1rdA03COD9Fef4aODs3YxKx+RDQ==",
       "cpu": [
         "x64"
       ],
@@ -2196,9 +2196,9 @@
       }
     },
     "node_modules/@next/swc-linux-x64-musl": {
-      "version": "16.2.1",
-      "resolved": "https://registry.npmjs.org/@next/swc-linux-x64-musl/-/swc-linux-x64-musl-16.2.1.tgz",
-      "integrity": "sha512-aV2iUaC/5HGEpbBkE+4B8aHIudoOy5DYekAKOMSHoIYQ66y/wIVeaRx8MS2ZMdxe/HIXlMho4ubdZs/J8441Tg==",
+      "version": "16.2.3",
+      "resolved": "https://registry.npmjs.org/@next/swc-linux-x64-musl/-/swc-linux-x64-musl-16.2.3.tgz",
+      "integrity": "sha512-Kt44hGJfZSefebhk/7nIdivoDr3Ugp5+oNz9VvF3GUtfxutucUIHfIO0ZYO8QlOPDQloUVQn4NVC/9JvHRk9hw==",
       "cpu": [
         "x64"
       ],
@@ -2212,9 +2212,9 @@
       }
     },
     "node_modules/@next/swc-win32-arm64-msvc": {
-      "version": "16.2.1",
-      "resolved": "https://registry.npmjs.org/@next/swc-win32-arm64-msvc/-/swc-win32-arm64-msvc-16.2.1.tgz",
-      "integrity": "sha512-IXdNgiDHaSk0ZUJ+xp0OQTdTgnpx1RCfRTalhn3cjOP+IddTMINwA7DXZrwTmGDO8SUr5q2hdP/du4DcrB1GxA==",
+      "version": "16.2.3",
+      "resolved": "https://registry.npmjs.org/@next/swc-win32-arm64-msvc/-/swc-win32-arm64-msvc-16.2.3.tgz",
+      "integrity": "sha512-O2NZ9ie3Tq6xj5Z5CSwBT3+aWAMW2PIZ4egUi9MaWLkwaehgtB7YZjPm+UpcNpKOme0IQuqDcor7BsW6QBiQBw==",
       "cpu": [
         "arm64"
       ],
@@ -2228,9 +2228,9 @@
       }
     },
     "node_modules/@next/swc-win32-x64-msvc": {
-      "version": "16.2.1",
-      "resolved": "https://registry.npmjs.org/@next/swc-win32-x64-msvc/-/swc-win32-x64-msvc-16.2.1.tgz",
-      "integrity": "sha512-qvU+3a39Hay+ieIztkGSbF7+mccbbg1Tk25hc4JDylf8IHjYmY/Zm64Qq1602yPyQqvie+vf5T/uPwNxDNIoeg==",
+      "version": "16.2.3",
+      "resolved": "https://registry.npmjs.org/@next/swc-win32-x64-msvc/-/swc-win32-x64-msvc-16.2.3.tgz",
+      "integrity": "sha512-Ibm29/GgB/ab5n7XKqlStkm54qqZE8v2FnijUPBgrd67FWrac45o/RsNlaOWjme/B5UqeWt/8KM4aWBwA1D2Kw==",
       "cpu": [
         "x64"
       ],
@@ -4278,9 +4278,9 @@
       }
     },
     "node_modules/axios": {
-      "version": "1.14.0",
-      "resolved": "https://registry.npmjs.org/axios/-/axios-1.14.0.tgz",
-      "integrity": "sha512-3Y8yrqLSwjuzpXuZ0oIYZ/XGgLwUIBU3uLvbcpb0pidD9ctpShJd43KSlEEkVQg6DS0G9NKyzOvBfUtDKEyHvQ==",
+      "version": "1.15.0",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-1.15.0.tgz",
+      "integrity": "sha512-wWyJDlAatxk30ZJer+GeCWS209sA42X+N5jU2jy6oHTp7ufw8uzUTVFBX9+wTfAlhiJXGS0Bq7X6efruWjuK9Q==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -5334,13 +5334,13 @@
       }
     },
     "node_modules/eslint-config-next": {
-      "version": "16.2.1",
-      "resolved": "https://registry.npmjs.org/eslint-config-next/-/eslint-config-next-16.2.1.tgz",
-      "integrity": "sha512-qhabwjQZ1Mk53XzXvmogf8KQ0tG0CQXF0CZ56+2/lVhmObgmaqj7x5A1DSrWdZd3kwI7GTPGUjFne+krRxYmFg==",
+      "version": "16.2.3",
+      "resolved": "https://registry.npmjs.org/eslint-config-next/-/eslint-config-next-16.2.3.tgz",
+      "integrity": "sha512-Dnkrylzjof/Az7iNoIQJqD18zTxQZcngir19KJaiRsMnnjpQSVoa6aEg/1Q4hQC+cW90uTlgQYadwL1CYNwFWA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@next/eslint-plugin-next": "16.2.1",
+        "@next/eslint-plugin-next": "16.2.3",
         "eslint-import-resolver-node": "^0.3.6",
         "eslint-import-resolver-typescript": "^3.5.2",
         "eslint-plugin-import": "^2.32.0",
@@ -8536,12 +8536,12 @@
       "license": "MIT"
     },
     "node_modules/next": {
-      "version": "16.2.1",
-      "resolved": "https://registry.npmjs.org/next/-/next-16.2.1.tgz",
-      "integrity": "sha512-VaChzNL7o9rbfdt60HUj8tev4m6d7iC1igAy157526+cJlXOQu5LzsBXNT+xaJnTP/k+utSX5vMv7m0G+zKH+Q==",
+      "version": "16.2.3",
+      "resolved": "https://registry.npmjs.org/next/-/next-16.2.3.tgz",
+      "integrity": "sha512-9V3zV4oZFza3PVev5/poB9g0dEafVcgNyQ8eTRop8GvxZjV2G15FC5ARuG1eFD42QgeYkzJBJzHghNP8Ad9xtA==",
       "license": "MIT",
       "dependencies": {
-        "@next/env": "16.2.1",
+        "@next/env": "16.2.3",
         "@swc/helpers": "0.5.15",
         "baseline-browser-mapping": "^2.9.19",
         "caniuse-lite": "^1.0.30001579",
@@ -8555,14 +8555,14 @@
         "node": ">=20.9.0"
       },
       "optionalDependencies": {
-        "@next/swc-darwin-arm64": "16.2.1",
-        "@next/swc-darwin-x64": "16.2.1",
-        "@next/swc-linux-arm64-gnu": "16.2.1",
-        "@next/swc-linux-arm64-musl": "16.2.1",
-        "@next/swc-linux-x64-gnu": "16.2.1",
-        "@next/swc-linux-x64-musl": "16.2.1",
-        "@next/swc-win32-arm64-msvc": "16.2.1",
-        "@next/swc-win32-x64-msvc": "16.2.1",
+        "@next/swc-darwin-arm64": "16.2.3",
+        "@next/swc-darwin-x64": "16.2.3",
+        "@next/swc-linux-arm64-gnu": "16.2.3",
+        "@next/swc-linux-arm64-musl": "16.2.3",
+        "@next/swc-linux-x64-gnu": "16.2.3",
+        "@next/swc-linux-x64-musl": "16.2.3",
+        "@next/swc-win32-arm64-msvc": "16.2.3",
+        "@next/swc-win32-x64-msvc": "16.2.3",
         "sharp": "^0.34.5"
       },
       "peerDependencies": {

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -15,7 +15,7 @@
   "dependencies": {
     "@vercel/analytics": "^2.0.1",
     "@vercel/speed-insights": "^2.0.0",
-    "next": "16.2.1",
+    "next": "16.2.3",
     "react": "19.2.3",
     "react-dom": "19.2.3",
     "react-markdown": "^10.1.0",
@@ -34,17 +34,17 @@
     "@types/react-dom": "^19",
     "babel-plugin-react-compiler": "1.0.0",
     "eslint": "^9",
-    "eslint-config-next": "16.2.1",
+    "eslint-config-next": "16.2.3",
     "jsdom": "^27.0.1",
     "tailwindcss": "^4",
     "typescript": "^5",
     "vitest": "^3.2.4"
   },
   "optionalDependencies": {
-    "@next/swc-linux-arm64-gnu": "^16.2.1",
-    "@next/swc-linux-arm64-musl": "^16.2.1",
-    "@next/swc-linux-x64-gnu": "^16.2.1",
-    "@next/swc-linux-x64-musl": "^16.2.1",
+    "@next/swc-linux-arm64-gnu": "^16.2.3",
+    "@next/swc-linux-arm64-musl": "^16.2.3",
+    "@next/swc-linux-x64-gnu": "^16.2.3",
+    "@next/swc-linux-x64-musl": "^16.2.3",
     "@tailwindcss/oxide-linux-arm64-gnu": "^4.2.1",
     "@tailwindcss/oxide-linux-arm64-musl": "^4.2.1",
     "@tailwindcss/oxide-linux-x64-gnu": "^4.2.1",
@@ -55,6 +55,7 @@
     "lightningcss-linux-x64-musl": "^1.31.1"
   },
   "overrides": {
+    "axios": "^1.15.0",
     "flatted": "^3.4.2",
     "micromatch": {
       "picomatch": "^2.3.2"

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -40,27 +40,5 @@
     "typescript": "^5",
     "vitest": "^3.2.4"
   },
-  "optionalDependencies": {
-    "@next/swc-linux-arm64-gnu": "^16.2.3",
-    "@next/swc-linux-arm64-musl": "^16.2.3",
-    "@next/swc-linux-x64-gnu": "^16.2.3",
-    "@next/swc-linux-x64-musl": "^16.2.3",
-    "@tailwindcss/oxide-linux-arm64-gnu": "^4.2.1",
-    "@tailwindcss/oxide-linux-arm64-musl": "^4.2.1",
-    "@tailwindcss/oxide-linux-x64-gnu": "^4.2.1",
-    "@tailwindcss/oxide-linux-x64-musl": "^4.2.1",
-    "lightningcss-linux-arm64-gnu": "^1.31.1",
-    "lightningcss-linux-arm64-musl": "^1.31.1",
-    "lightningcss-linux-x64-gnu": "^1.31.1",
-    "lightningcss-linux-x64-musl": "^1.31.1"
-  },
-  "overrides": {
-    "axios": "^1.15.0",
-    "flatted": "^3.4.2",
-    "micromatch": {
-      "picomatch": "^2.3.2"
-    },
-    "picomatch@^4.0.0": "^4.0.4"
-  },
   "license": "MIT"
 }

--- a/apps/web/src/components/feed-button.tsx
+++ b/apps/web/src/components/feed-button.tsx
@@ -23,7 +23,7 @@ export function FeedButton({
     if (!open) return;
 
     const focusableSelector =
-      'button:not([tabindex="-1"]), [href]:not([tabindex="-1"]), input:not([tabindex="-1"]), textarea:not([tabindex="-1"]), select:not([tabindex="-1"]), [tabindex]:not([tabindex="-1"])';
+      'button:not([tabindex="-1"]), [href]:not([tabindex="-1"]), input:not([tabindex="-1"]), textarea:not([tabindex="-1"]), select:not([tabindex="-1"]), [contenteditable]:not([contenteditable="false"]):not([tabindex="-1"]), [tabindex]:not([tabindex="-1"])';
     const getFocusableElements = () =>
       Array.from(
         dialogRef.current?.querySelectorAll<HTMLElement>(focusableSelector) ??
@@ -78,7 +78,7 @@ export function FeedButton({
         return;
       }
 
-      if (activeElement === last) {
+      if (activeElement === last || activeElement === dialogRef.current) {
         event.preventDefault();
         first.focus();
       }

--- a/package-lock.json
+++ b/package-lock.json
@@ -696,7 +696,7 @@
       "dependencies": {
         "@vercel/analytics": "^2.0.1",
         "@vercel/speed-insights": "^2.0.0",
-        "next": "16.2.1",
+        "next": "16.2.3",
         "react": "19.2.3",
         "react-dom": "19.2.3",
         "react-markdown": "^10.1.0",
@@ -715,17 +715,17 @@
         "@types/react-dom": "^19",
         "babel-plugin-react-compiler": "1.0.0",
         "eslint": "^9",
-        "eslint-config-next": "16.2.1",
+        "eslint-config-next": "16.2.3",
         "jsdom": "^27.0.1",
         "tailwindcss": "^4",
         "typescript": "^5",
         "vitest": "^3.2.4"
       },
       "optionalDependencies": {
-        "@next/swc-linux-arm64-gnu": "^16.2.1",
-        "@next/swc-linux-arm64-musl": "^16.2.1",
-        "@next/swc-linux-x64-gnu": "^16.2.1",
-        "@next/swc-linux-x64-musl": "^16.2.1",
+        "@next/swc-linux-arm64-gnu": "^16.2.3",
+        "@next/swc-linux-arm64-musl": "^16.2.3",
+        "@next/swc-linux-x64-gnu": "^16.2.3",
+        "@next/swc-linux-x64-musl": "^16.2.3",
         "@tailwindcss/oxide-linux-arm64-gnu": "^4.2.1",
         "@tailwindcss/oxide-linux-arm64-musl": "^4.2.1",
         "@tailwindcss/oxide-linux-x64-gnu": "^4.2.1",
@@ -2861,15 +2861,15 @@
       }
     },
     "node_modules/@next/env": {
-      "version": "16.2.1",
-      "resolved": "https://registry.npmjs.org/@next/env/-/env-16.2.1.tgz",
-      "integrity": "sha512-n8P/HCkIWW+gVal2Z8XqXJ6aB3J0tuM29OcHpCsobWlChH/SITBs1DFBk/HajgrwDkqqBXPbuUuzgDvUekREPg==",
+      "version": "16.2.3",
+      "resolved": "https://registry.npmjs.org/@next/env/-/env-16.2.3.tgz",
+      "integrity": "sha512-ZWXyj4uNu4GCWQw9cjRxWlbD+33mcDszIo9iQxFnBX3Wmgq9ulaSJcl6VhuWx5pCWqqD+9W6Wfz7N0lM5lYPMA==",
       "license": "MIT"
     },
     "node_modules/@next/eslint-plugin-next": {
-      "version": "16.2.1",
-      "resolved": "https://registry.npmjs.org/@next/eslint-plugin-next/-/eslint-plugin-next-16.2.1.tgz",
-      "integrity": "sha512-r0epZGo24eT4g08jJlg2OEryBphXqO8aL18oajoTKLzHJ6jVr6P6FI58DLMug04MwD3j8Fj0YK0slyzneKVyzA==",
+      "version": "16.2.3",
+      "resolved": "https://registry.npmjs.org/@next/eslint-plugin-next/-/eslint-plugin-next-16.2.3.tgz",
+      "integrity": "sha512-nE/b9mht28XJxjTwKs/yk7w4XTaU3t40UHVAky6cjiijdP/SEy3hGsnQMPxmXPTpC7W4/97okm6fngKnvCqVaA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -2877,9 +2877,9 @@
       }
     },
     "node_modules/@next/swc-darwin-arm64": {
-      "version": "16.2.1",
-      "resolved": "https://registry.npmjs.org/@next/swc-darwin-arm64/-/swc-darwin-arm64-16.2.1.tgz",
-      "integrity": "sha512-BwZ8w8YTaSEr2HIuXLMLxIdElNMPvY9fLqb20LX9A9OMGtJilhHLbCL3ggyd0TwjmMcTxi0XXt+ur1vWUoxj2Q==",
+      "version": "16.2.3",
+      "resolved": "https://registry.npmjs.org/@next/swc-darwin-arm64/-/swc-darwin-arm64-16.2.3.tgz",
+      "integrity": "sha512-u37KDKTKQ+OQLvY+z7SNXixwo4Q2/IAJFDzU1fYe66IbCE51aDSAzkNDkWmLN0yjTUh4BKBd+hb69jYn6qqqSg==",
       "cpu": [
         "arm64"
       ],
@@ -2893,9 +2893,9 @@
       }
     },
     "node_modules/@next/swc-darwin-x64": {
-      "version": "16.2.1",
-      "resolved": "https://registry.npmjs.org/@next/swc-darwin-x64/-/swc-darwin-x64-16.2.1.tgz",
-      "integrity": "sha512-/vrcE6iQSJq3uL3VGVHiXeaKbn8Es10DGTGRJnRZlkNQQk3kaNtAJg8Y6xuAlrx/6INKVjkfi5rY0iEXorZ6uA==",
+      "version": "16.2.3",
+      "resolved": "https://registry.npmjs.org/@next/swc-darwin-x64/-/swc-darwin-x64-16.2.3.tgz",
+      "integrity": "sha512-gHjL/qy6Q6CG3176FWbAKyKh9IfntKZTB3RY/YOJdDFpHGsUDXVH38U4mMNpHVGXmeYW4wj22dMp1lTfmu/bTQ==",
       "cpu": [
         "x64"
       ],
@@ -2909,9 +2909,9 @@
       }
     },
     "node_modules/@next/swc-linux-arm64-gnu": {
-      "version": "16.2.1",
-      "resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-gnu/-/swc-linux-arm64-gnu-16.2.1.tgz",
-      "integrity": "sha512-uLn+0BK+C31LTVbQ/QU+UaVrV0rRSJQ8RfniQAHPghDdgE+SlroYqcmFnO5iNjNfVWCyKZHYrs3Nl0mUzWxbBw==",
+      "version": "16.2.3",
+      "resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-gnu/-/swc-linux-arm64-gnu-16.2.3.tgz",
+      "integrity": "sha512-U6vtblPtU/P14Y/b/n9ZY0GOxbbIhTFuaFR7F4/uMBidCi2nSdaOFhA0Go81L61Zd6527+yvuX44T4ksnf8T+Q==",
       "cpu": [
         "arm64"
       ],
@@ -2925,9 +2925,9 @@
       }
     },
     "node_modules/@next/swc-linux-arm64-musl": {
-      "version": "16.2.1",
-      "resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-musl/-/swc-linux-arm64-musl-16.2.1.tgz",
-      "integrity": "sha512-ssKq6iMRnHdnycGp9hCuGnXJZ0YPr4/wNwrfE5DbmvEcgl9+yv97/Kq3TPVDfYome1SW5geciLB9aiEqKXQjlQ==",
+      "version": "16.2.3",
+      "resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-musl/-/swc-linux-arm64-musl-16.2.3.tgz",
+      "integrity": "sha512-/YV0LgjHUmfhQpn9bVoGc4x4nan64pkhWR5wyEV8yCOfwwrH630KpvRg86olQHTwHIn1z59uh6JwKvHq1h4QEw==",
       "cpu": [
         "arm64"
       ],
@@ -2941,9 +2941,9 @@
       }
     },
     "node_modules/@next/swc-linux-x64-gnu": {
-      "version": "16.2.1",
-      "resolved": "https://registry.npmjs.org/@next/swc-linux-x64-gnu/-/swc-linux-x64-gnu-16.2.1.tgz",
-      "integrity": "sha512-HQm7SrHRELJ30T1TSmT706IWovFFSRGxfgUkyWJZF/RKBMdbdRWJuFrcpDdE5vy9UXjFOx6L3mRdqH04Mmx0hg==",
+      "version": "16.2.3",
+      "resolved": "https://registry.npmjs.org/@next/swc-linux-x64-gnu/-/swc-linux-x64-gnu-16.2.3.tgz",
+      "integrity": "sha512-/HiWEcp+WMZ7VajuiMEFGZ6cg0+aYZPqCJD3YJEfpVWQsKYSjXQG06vJP6F1rdA03COD9Fef4aODs3YxKx+RDQ==",
       "cpu": [
         "x64"
       ],
@@ -2957,9 +2957,9 @@
       }
     },
     "node_modules/@next/swc-linux-x64-musl": {
-      "version": "16.2.1",
-      "resolved": "https://registry.npmjs.org/@next/swc-linux-x64-musl/-/swc-linux-x64-musl-16.2.1.tgz",
-      "integrity": "sha512-aV2iUaC/5HGEpbBkE+4B8aHIudoOy5DYekAKOMSHoIYQ66y/wIVeaRx8MS2ZMdxe/HIXlMho4ubdZs/J8441Tg==",
+      "version": "16.2.3",
+      "resolved": "https://registry.npmjs.org/@next/swc-linux-x64-musl/-/swc-linux-x64-musl-16.2.3.tgz",
+      "integrity": "sha512-Kt44hGJfZSefebhk/7nIdivoDr3Ugp5+oNz9VvF3GUtfxutucUIHfIO0ZYO8QlOPDQloUVQn4NVC/9JvHRk9hw==",
       "cpu": [
         "x64"
       ],
@@ -2973,9 +2973,9 @@
       }
     },
     "node_modules/@next/swc-win32-arm64-msvc": {
-      "version": "16.2.1",
-      "resolved": "https://registry.npmjs.org/@next/swc-win32-arm64-msvc/-/swc-win32-arm64-msvc-16.2.1.tgz",
-      "integrity": "sha512-IXdNgiDHaSk0ZUJ+xp0OQTdTgnpx1RCfRTalhn3cjOP+IddTMINwA7DXZrwTmGDO8SUr5q2hdP/du4DcrB1GxA==",
+      "version": "16.2.3",
+      "resolved": "https://registry.npmjs.org/@next/swc-win32-arm64-msvc/-/swc-win32-arm64-msvc-16.2.3.tgz",
+      "integrity": "sha512-O2NZ9ie3Tq6xj5Z5CSwBT3+aWAMW2PIZ4egUi9MaWLkwaehgtB7YZjPm+UpcNpKOme0IQuqDcor7BsW6QBiQBw==",
       "cpu": [
         "arm64"
       ],
@@ -2989,9 +2989,9 @@
       }
     },
     "node_modules/@next/swc-win32-x64-msvc": {
-      "version": "16.2.1",
-      "resolved": "https://registry.npmjs.org/@next/swc-win32-x64-msvc/-/swc-win32-x64-msvc-16.2.1.tgz",
-      "integrity": "sha512-qvU+3a39Hay+ieIztkGSbF7+mccbbg1Tk25hc4JDylf8IHjYmY/Zm64Qq1602yPyQqvie+vf5T/uPwNxDNIoeg==",
+      "version": "16.2.3",
+      "resolved": "https://registry.npmjs.org/@next/swc-win32-x64-msvc/-/swc-win32-x64-msvc-16.2.3.tgz",
+      "integrity": "sha512-Ibm29/GgB/ab5n7XKqlStkm54qqZE8v2FnijUPBgrd67FWrac45o/RsNlaOWjme/B5UqeWt/8KM4aWBwA1D2Kw==",
       "cpu": [
         "x64"
       ],
@@ -4761,9 +4761,9 @@
       }
     },
     "node_modules/axios": {
-      "version": "1.14.0",
-      "resolved": "https://registry.npmjs.org/axios/-/axios-1.14.0.tgz",
-      "integrity": "sha512-3Y8yrqLSwjuzpXuZ0oIYZ/XGgLwUIBU3uLvbcpb0pidD9ctpShJd43KSlEEkVQg6DS0G9NKyzOvBfUtDKEyHvQ==",
+      "version": "1.15.0",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-1.15.0.tgz",
+      "integrity": "sha512-wWyJDlAatxk30ZJer+GeCWS209sA42X+N5jU2jy6oHTp7ufw8uzUTVFBX9+wTfAlhiJXGS0Bq7X6efruWjuK9Q==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -6476,13 +6476,13 @@
       }
     },
     "node_modules/eslint-config-next": {
-      "version": "16.2.1",
-      "resolved": "https://registry.npmjs.org/eslint-config-next/-/eslint-config-next-16.2.1.tgz",
-      "integrity": "sha512-qhabwjQZ1Mk53XzXvmogf8KQ0tG0CQXF0CZ56+2/lVhmObgmaqj7x5A1DSrWdZd3kwI7GTPGUjFne+krRxYmFg==",
+      "version": "16.2.3",
+      "resolved": "https://registry.npmjs.org/eslint-config-next/-/eslint-config-next-16.2.3.tgz",
+      "integrity": "sha512-Dnkrylzjof/Az7iNoIQJqD18zTxQZcngir19KJaiRsMnnjpQSVoa6aEg/1Q4hQC+cW90uTlgQYadwL1CYNwFWA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@next/eslint-plugin-next": "16.2.1",
+        "@next/eslint-plugin-next": "16.2.3",
         "eslint-import-resolver-node": "^0.3.6",
         "eslint-import-resolver-typescript": "^3.5.2",
         "eslint-plugin-import": "^2.32.0",
@@ -9912,12 +9912,12 @@
       "license": "MIT"
     },
     "node_modules/next": {
-      "version": "16.2.1",
-      "resolved": "https://registry.npmjs.org/next/-/next-16.2.1.tgz",
-      "integrity": "sha512-VaChzNL7o9rbfdt60HUj8tev4m6d7iC1igAy157526+cJlXOQu5LzsBXNT+xaJnTP/k+utSX5vMv7m0G+zKH+Q==",
+      "version": "16.2.3",
+      "resolved": "https://registry.npmjs.org/next/-/next-16.2.3.tgz",
+      "integrity": "sha512-9V3zV4oZFza3PVev5/poB9g0dEafVcgNyQ8eTRop8GvxZjV2G15FC5ARuG1eFD42QgeYkzJBJzHghNP8Ad9xtA==",
       "license": "MIT",
       "dependencies": {
-        "@next/env": "16.2.1",
+        "@next/env": "16.2.3",
         "@swc/helpers": "0.5.15",
         "baseline-browser-mapping": "^2.9.19",
         "caniuse-lite": "^1.0.30001579",
@@ -9931,14 +9931,14 @@
         "node": ">=20.9.0"
       },
       "optionalDependencies": {
-        "@next/swc-darwin-arm64": "16.2.1",
-        "@next/swc-darwin-x64": "16.2.1",
-        "@next/swc-linux-arm64-gnu": "16.2.1",
-        "@next/swc-linux-arm64-musl": "16.2.1",
-        "@next/swc-linux-x64-gnu": "16.2.1",
-        "@next/swc-linux-x64-musl": "16.2.1",
-        "@next/swc-win32-arm64-msvc": "16.2.1",
-        "@next/swc-win32-x64-msvc": "16.2.1",
+        "@next/swc-darwin-arm64": "16.2.3",
+        "@next/swc-darwin-x64": "16.2.3",
+        "@next/swc-linux-arm64-gnu": "16.2.3",
+        "@next/swc-linux-arm64-musl": "16.2.3",
+        "@next/swc-linux-x64-gnu": "16.2.3",
+        "@next/swc-linux-x64-musl": "16.2.3",
+        "@next/swc-win32-arm64-msvc": "16.2.3",
+        "@next/swc-win32-x64-msvc": "16.2.3",
         "sharp": "^0.34.5"
       },
       "peerDependencies": {
@@ -10830,6 +10830,7 @@
       "version": "2.3.2",
       "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
       "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
+      "dev": true,
       "hasInstallScript": true,
       "license": "MIT",
       "optional": true,

--- a/package-lock.json
+++ b/package-lock.json
@@ -720,20 +720,6 @@
         "tailwindcss": "^4",
         "typescript": "^5",
         "vitest": "^3.2.4"
-      },
-      "optionalDependencies": {
-        "@next/swc-linux-arm64-gnu": "^16.2.3",
-        "@next/swc-linux-arm64-musl": "^16.2.3",
-        "@next/swc-linux-x64-gnu": "^16.2.3",
-        "@next/swc-linux-x64-musl": "^16.2.3",
-        "@tailwindcss/oxide-linux-arm64-gnu": "^4.2.1",
-        "@tailwindcss/oxide-linux-arm64-musl": "^4.2.1",
-        "@tailwindcss/oxide-linux-x64-gnu": "^4.2.1",
-        "@tailwindcss/oxide-linux-x64-musl": "^4.2.1",
-        "lightningcss-linux-arm64-gnu": "^1.31.1",
-        "lightningcss-linux-arm64-musl": "^1.31.1",
-        "lightningcss-linux-x64-gnu": "^1.31.1",
-        "lightningcss-linux-x64-musl": "^1.31.1"
       }
     },
     "apps/web/node_modules/@alloc/quick-lru": {
@@ -3514,6 +3500,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3530,6 +3517,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3546,6 +3534,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3562,6 +3551,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -8649,6 +8639,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -8669,6 +8660,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -8689,6 +8681,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -8709,6 +8702,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "MPL-2.0",
       "optional": true,
       "os": [

--- a/package.json
+++ b/package.json
@@ -26,6 +26,7 @@
     "vitest": "^3.2.4"
   },
   "overrides": {
+    "axios": "^1.15.0",
     "@esbuild-kit/core-utils": {
       "esbuild": "^0.25.12"
     },


### PR DESCRIPTION
Summary:\n- bump web Next.js toolchain from 16.2.1 to 16.2.3\n- force axios 1.15.0 via overrides in root/web manifests\n- refresh root and apps/web lockfiles to clear OSV findings\n\nValidation:\n- npm run test --workspace apps/web\n- npm run typecheck --workspace apps/web

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

Next.js を 16.2.1 → 16.2.3 にアップグレードし、`overrides` を使って axios を 1.14.0 → 1.15.0 に強制更新することで、OSV で報告された既知の脆弱性を修正するセキュリティパッチ PR です。ルートおよび `apps/web` の両ロックファイルが更新されており、変更は最小限かつ適切な範囲にとどまっています。
</details>

<h3>Confidence Score: 5/5</h3>

セキュリティパッチのみで破壊的変更はなく、マージ可能です。

変更は Next.js のパッチバージョンアップと axios の overrides 追加のみ。ロックファイルの解決バージョンも意図通り更新されており、P0/P1 の問題は見当たりません。

特に注意が必要なファイルはありません。

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| package.json | ルートの overrides に `"axios": "^1.15.0"` を追加。変更は最小限で問題なし。 |
| apps/web/package.json | next / eslint-config-next / @next/swc-* を 16.2.1 → 16.2.3 に更新し、overrides に axios を追加。 |
| package-lock.json | Next.js 関連パッケージと axios の解決バージョンが適切に更新。fsevents が `"dev": true` に修正される副次的変更あり。 |
| apps/web/package-lock.json | web ワークスペースのロックファイルも同様に Next.js と axios が正しく更新されている。 |

</details>

</details>

<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[脆弱性検知 by OSV] --> B{対象パッケージ}
    B --> C[Next.js 16.2.1]
    B --> D[axios 1.14.0]
    C --> E[Next.js 16.2.3 へアップグレード\napps/web/package.json]
    D --> F[overrides で axios ^1.15.0 を強制\npackage.json + apps/web/package.json]
    E --> G[ロックファイル更新\npackage-lock.json]
    E --> H[ロックファイル更新\napps/web/package-lock.json]
    F --> G
    F --> H
    G --> I[脆弱性解消]
    H --> I
```

<sub>Reviews (1): Last reviewed commit: ["build(web): patch vulnerable lockfile de..."](https://github.com/hiroki-org/openshelf/commit/a36e45e41382ec2bedcd6698cc8751b2e64d63d6) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=28131084)</sub>

<!-- /greptile_comment -->