### PR TITLE
fix: address PR 414 review feedback

### DIFF
--- a/apps/api/src/routes/papers.ts
+++ b/apps/api/src/routes/papers.ts
@@ -694,14 +694,16 @@ papersRoute.post("/", authMiddleware, async (c) => {
             })),
         );
     } catch (error) {
+        const cleanupPromises: Promise<void>[] = [];
         for (let i = 0; i < uploadedKeys.length; i += 1000) {
-            try {
-                await c.env.BUCKET.delete(uploadedKeys.slice(i, i + 1000));
-            } /* v8 ignore start */ catch (e) {
-                // Ignore cleanup errors
-                console.error("Cleanup failed intentionally:", e instanceof Error ? e.message : String(e));
-            } /* v8 ignore stop */
+            cleanupPromises.push(
+                c.env.BUCKET.delete(uploadedKeys.slice(i, i + 1000)).catch((e) => {
+                    // Ignore cleanup errors
+                    console.error("Cleanup failed intentionally:", e instanceof Error ? e.message : String(e));
+                }),
+            );
         }
+        await Promise.all(cleanupPromises);
         await db.delete(papers).where(eq(papers.id, paperId));
         throw error;
     }
@@ -1293,9 +1295,11 @@ papersRoute.delete("/:id", authMiddleware, async (c) => {
         .all();
 
     const keys = files.map((f) => f.r2Key);
+    const deletePromises: Promise<void>[] = [];
     for (let i = 0; i < keys.length; i += 1000) {
-        await c.env.BUCKET.delete(keys.slice(i, i + 1000));
+        deletePromises.push(c.env.BUCKET.delete(keys.slice(i, i + 1000)));
     }
+    await Promise.all(deletePromises);
     await db.delete(papers).where(eq(papers.id, paperId));
 
     return c.json({ ok: true });

--- a/apps/e2e/tests/scenarios/auth-flow.spec.ts
+++ b/apps/e2e/tests/scenarios/auth-flow.spec.ts
@@ -42,9 +42,16 @@ test.describe('Auth Flow', () => {
             },
         });
         expect(meRes.status()).toBe(200);
-        await expect(meRes.json()).resolves.toMatchObject({
+        await expect(meRes.json()).resolves.toEqual({
             user: {
                 id: user.sub,
+                githubId: user.githubId,
+                name: user.name,
+                displayName: null,
+                avatarUrl: null,
+                email: null,
+                createdAt: expect.any(String),
+                updatedAt: expect.any(String),
             },
         });
 
@@ -55,7 +62,7 @@ test.describe('Auth Flow', () => {
 
         const unauthRes = await page.request.get('/api/users/me');
         expect(unauthRes.status()).toBe(401);
-        await expect(unauthRes.json()).resolves.toMatchObject({
+        await expect(unauthRes.json()).resolves.toEqual({
             error: 'Unauthorized',
         });
     });

--- a/apps/e2e/tests/scenarios/backend-auth-e2e.spec.ts
+++ b/apps/e2e/tests/scenarios/backend-auth-e2e.spec.ts
@@ -31,7 +31,7 @@ test.describe('Backend Auth E2E', () => {
     });
 
     expect(res.status()).toBe(401);
-    await expect(res.json()).resolves.toMatchObject({
+    await expect(res.json()).resolves.toEqual({
       error: 'Unauthorized (E2E)',
     });
   });
@@ -46,7 +46,7 @@ test.describe('Backend Auth E2E', () => {
     });
 
     expect(res.status()).toBe(400);
-    await expect(res.json()).resolves.toMatchObject({
+    await expect(res.json()).resolves.toEqual({
       error: 'Invalid request body',
     });
   });
@@ -64,11 +64,16 @@ test.describe('Backend Auth E2E', () => {
     });
 
     expect(res.status()).toBe(200);
-    await expect(res.json()).resolves.toMatchObject({
+    await expect(res.json()).resolves.toEqual({
       user: {
         id: payload.sub,
         githubId: payload.githubId,
         name: payload.name,
+        displayName: null,
+        avatarUrl: null,
+        email: null,
+        createdAt: expect.any(String),
+        updatedAt: expect.any(String),
       },
     });
   });
@@ -84,7 +89,7 @@ test.describe('Backend Auth E2E', () => {
       headers: baseHeaders,
     });
     expect(unauthorizedRes.status()).toBe(401);
-    await expect(unauthorizedRes.json()).resolves.toMatchObject({
+    await expect(unauthorizedRes.json()).resolves.toEqual({
       error: 'Unauthorized (E2E)',
     });
   });
@@ -101,7 +106,7 @@ test.describe('Backend Auth E2E', () => {
       headers: testAuthHeaders,
     });
     expect(invalidRes.status()).toBe(400);
-    await expect(invalidRes.json()).resolves.toMatchObject({
+    await expect(invalidRes.json()).resolves.toEqual({
       error: 'userId and orgId are required',
     });
   });
@@ -121,6 +126,6 @@ test.describe('Backend Auth E2E', () => {
       headers: testAuthHeaders,
     });
     expect(validRes.status()).toBe(200);
-    await expect(validRes.json()).resolves.toMatchObject({ ok: true });
+    await expect(validRes.json()).resolves.toEqual({ ok: true });
   });
 });


### PR DESCRIPTION
Resolve the open review feedback on PR #414 by restoring concurrent cleanup/deletion in apps/api/src/routes/papers.ts and updating the Playwright JSON assertions to use toEqual with full payloads.

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

PR #414 のレビュー指摘に対応し、`papers.ts` のアップロードエラー時クリーンアップを並列R2バッチ削除方式に戻すとともに、PlaywrightのAPIアサーションを `toEqual` による完全ペイロード検証に更新しています。

- **P1**: アップロードのcatchブロック（line 707）で `db.delete(papers)` がエラーを投げると `throw error` が実行されず、元のアップロードエラーがDBエラーに上書きされます。また、既にインサート済みの `papers` レコードが孤立してDBに残ります。`.catch()` で吸収してから元のエラーを再スローしてください。
</details>

<h3>Confidence Score: 4/5</h3>

P1バグ（アップロードキャッチブロックでの db.delete エラーハンドリング欠如）が残っているためマージ前に修正が必要。

E2Eテストの修正は適切で問題なし。papers.ts のR2並列削除の復元も意図通り。しかしアップロードエラーのcatchブロックで db.delete が失敗した場合に孤立レコードが残り元エラーが失われるP1バグが存在し、スコアは4。

apps/api/src/routes/papers.ts（特にL707のクリーンアップ処理）

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| apps/api/src/routes/papers.ts | アップロードエラーのキャッチブロックで db.delete(papers) が例外を投げると元のエラーが上書きされ孤立レコードが残るP1バグがある。DELETEエンドポイントの並列R2削除は復元済み。 |
| apps/e2e/tests/scenarios/auth-flow.spec.ts | toEqual による完全ペイロードアサーション（expect.any(String) で動的フィールドを吸収）に更新され、より強固なテストになっている。 |
| apps/e2e/tests/scenarios/backend-auth-e2e.spec.ts | 全テストケースで toEqual 完全ペイロードアサーションが適用されており、PR#414 のレビュー指摘に対応した修正として適切。 |

</details>

</details>

<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[POST /api/papers - アップロード開始] --> B[pMap: R2ファイル並列アップロード]
    B -->|成功| C[db.insert papers]
    B -->|失敗| E[catch block]
    C --> D[db.insert paperAuthors / paperOrgs / paperFiles]
    D -->|成功| F[201 OK]
    D -->|失敗| E
    E --> G[Promise.all: R2クリーンアップ - エラー無視]
    G --> H[db.delete papers ⚠️ エラーハンドリングなし]
    H -->|成功| I[throw 元エラー]
    H -->|失敗⚠️| J[DBエラー伝播 - 孤立レコード残存]

    K[DELETE /api/papers/:id] --> L[権限確認]
    L --> M[R2ファイルキー取得]
    M --> N[Promise.all: R2バッチ削除 並列実行]
    N -->|成功| O[db.delete papers]
    N -->|部分失敗⚠️| P[500 - 一部R2ファイルが消える可能性]
    O --> Q[200 OK]
```

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
This is a comment left during a code review.
Path: apps/api/src/routes/papers.ts
Line: 707-708

Comment:
**クリーンアップの `db.delete` エラーが元のエラーを上書きする**

`db.delete(papers)` が例外を投げると、`throw error`（元のアップロードエラー）は実行されず、DBエラーがそのまま伝播します。その結果、ファイルのない孤立した `papers` レコードがDBに残り（ステップ 3〜5 でパーパーが既にインサートされていた場合）、ユーザーへ返るエラーも元の原因とは無関係のDB例外になります。`.catch()` でエラーを飲み込んだ上で元のエラーを再スローしてください。

```suggestion
        await db.delete(papers).where(eq(papers.id, paperId)).catch((dbErr) => {
            console.error("Failed to clean up paper record during rollback:", dbErr instanceof Error ? dbErr.message : String(dbErr));
        });
        throw error;
```

How can I resolve this? If you propose a fix, please make it concise.

---

This is a comment left during a code review.
Path: apps/api/src/routes/papers.ts
Line: 1298-1303

Comment:
**R2 バッチ削除が失敗した際にファイルが部分的に消える可能性**

`Promise.all(deletePromises)` がリジェクトすると `db.delete(papers)` はスキップされ、ペーパーレコードはDBに残ります（ユーザーに 500 が返る）。ただし Promise.all は既にスタート済みの他バッチをキャンセルしないため、複数バッチがある場合に一部の R2 ファイルだけが削除されてしまいます。R2 エラーをキャッチして DB 削除まで進めるか、DBから先に削除することを検討してください。

How can I resolve this? If you propose a fix, please make it concise.
`````

</details>

<sub>Reviews (1): Last reviewed commit: ["fix: address PR 414 review feedback"](https://github.com/hiroki-org/openshelf/commit/121365b37cd67600cc6a9d4e9df077462b8e116d) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=28159400)</sub>

> Greptile also left **2 inline comments** on this PR.

**Context used:**

- Context used - 日本語で！！！ ([source](https://app.greptile.com/review/custom-context?memory=instruction-0))

<!-- /greptile_comment -->