### PR TITLE
fix(api): add cleanup chunk context for paper rollback

### DIFF
--- a/apps/api/src/routes/__tests__/papers.test.ts
+++ b/apps/api/src/routes/__tests__/papers.test.ts
@@ -422,6 +422,7 @@ describe("papers routes", () => {
 
         // Spy on BUCKET.delete
         const bucketDeleteSpy = vi.spyOn(env.BUCKET, "delete").mockRejectedValue(new Error("Cleanup failed"));
+        const consoleErrorSpy = vi.spyOn(console, "error").mockImplementation(() => {});
 
         const form = new FormData();
         form.set("metadata", JSON.stringify({ title: "Test Paper", visibility: "private" }));
@@ -449,10 +450,21 @@ describe("papers routes", () => {
         expect(deletedKeys).toEqual(
             expect.arrayContaining([expect.stringContaining("papers/")]),
         );
+        expect(consoleErrorSpy).toHaveBeenCalledWith(
+            "Cleanup failed intentionally",
+            expect.objectContaining({
+                chunkStart: 0,
+                chunkEndExclusive: 1,
+                chunkSize: 1,
+                chunkSample: expect.arrayContaining([expect.stringContaining("papers/")]),
+                error: "Cleanup failed",
+            }),
+        );
 
         // db.delete should be called for papers
         expect(mockDb.delete).toHaveBeenCalledTimes(1);
         expect(mockDeleteWhere).toHaveBeenCalledTimes(1);
+        consoleErrorSpy.mockRestore();
     });
 
     it("POST /api/papers rejects upload when content does not match declared MIME", async () => {

--- a/apps/api/src/routes/__tests__/papers.test.ts
+++ b/apps/api/src/routes/__tests__/papers.test.ts
@@ -451,7 +451,7 @@ describe("papers routes", () => {
             expect.arrayContaining([expect.stringContaining("papers/")]),
         );
         expect(consoleErrorSpy).toHaveBeenCalledWith(
-            "Cleanup failed intentionally",
+            "Cleanup error (non-fatal, rollback continues)",
             expect.objectContaining({
                 chunkStart: 0,
                 chunkEndExclusive: 1,
@@ -465,6 +465,7 @@ describe("papers routes", () => {
         expect(mockDb.delete).toHaveBeenCalledTimes(1);
         expect(mockDeleteWhere).toHaveBeenCalledTimes(1);
         consoleErrorSpy.mockRestore();
+        bucketDeleteSpy.mockRestore();
     });
 
     it("POST /api/papers rejects upload when content does not match declared MIME", async () => {

--- a/apps/api/src/routes/papers.ts
+++ b/apps/api/src/routes/papers.ts
@@ -696,10 +696,17 @@ papersRoute.post("/", authMiddleware, async (c) => {
     } catch (error) {
         const cleanupPromises: Promise<void>[] = [];
         for (let i = 0; i < uploadedKeys.length; i += 1000) {
+            const chunk = uploadedKeys.slice(i, i + 1000);
             cleanupPromises.push(
-                c.env.BUCKET.delete(uploadedKeys.slice(i, i + 1000)).catch((e) => {
+                c.env.BUCKET.delete(chunk).catch((e) => {
                     // Ignore cleanup errors
-                    console.error("Cleanup failed intentionally:", e instanceof Error ? e.message : String(e));
+                    console.error("Cleanup failed intentionally", {
+                        chunkStart: i,
+                        chunkEndExclusive: i + chunk.length,
+                        chunkSize: chunk.length,
+                        chunkSample: chunk.slice(0, 3),
+                        error: e instanceof Error ? e.message : String(e),
+                    });
                 }),
             );
         }

--- a/apps/api/src/routes/papers.ts
+++ b/apps/api/src/routes/papers.ts
@@ -700,7 +700,7 @@ papersRoute.post("/", authMiddleware, async (c) => {
             cleanupPromises.push(
                 c.env.BUCKET.delete(chunk).catch((e) => {
                     // Ignore cleanup errors
-                    console.error("Cleanup failed intentionally", {
+                    console.error("Cleanup error (non-fatal, rollback continues)", {
                         chunkStart: i,
                         chunkEndExclusive: i + chunk.length,
                         chunkSize: chunk.length,


### PR DESCRIPTION
## Summary
- include chunk metadata in paper upload cleanup failure logs
- add a regression test for the cleanup log payload

## Testing
- ../../node_modules/.bin/vitest run --config vitest.config.ts src/routes/__tests__/papers.test.ts

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

R2 オブジェクトのロールバック中にバケット削除が失敗した際の `console.error` ログにチャンクのメタデータ（`chunkStart`/`chunkEndExclusive`/`chunkSize`/`chunkSample`/`error`）を追加し、デバッグ時の可観測性を向上させています。対応するリグレッションテストも追加されています。
</details>

<h3>Confidence Score: 5/5</h3>

マージ安全。変更はログ出力とテストのみで、本番ロジックへの影響はありません。

残る指摘はすべて P2（ログメッセージの表現とスパイ後始末のスタイル統一）であり、正確性・信頼性・セキュリティへの影響はありません。

特に注意が必要なファイルはありません。

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| apps/api/src/routes/papers.ts | クリーンアップ失敗時のログに chunkStart/chunkEndExclusive/chunkSize/chunkSample/error の各フィールドを追加。ロジックは正確で、クロージャ変数の捕捉も適切。 |
| apps/api/src/routes/__tests__/papers.test.ts | クリーンアップ失敗時のログペイロードを検証するリグレッションテストを追加。チャンク構造・エラーメッセージの検証ともに正確。 |

</details>

</details>

<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[POST /api/papers] --> B[BUCKET.put per file]
    B -->|success| C[add to uploadedKeys]
    B -->|failure| D[add to errors list]
    C --> E[DB insert: papers / paperAuthors / paperFiles]
    E -->|success| F[201 Response]
    E -->|failure| G[catch block]
    D --> G
    G --> H[split uploadedKeys into chunks of 1000]
    H --> I[BUCKET.delete chunk]
    I -->|success| J[Promise.all resolved]
    I -->|failure| K[console.error with chunkStart, chunkEndExclusive, chunkSize, chunkSample, error]
    K --> J
    J --> L[DB delete papers record]
    L --> M[re-throw original error to 500]
```

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
This is a comment left during a code review.
Path: apps/api/src/routes/papers.ts
Line: 703

Comment:
**ログメッセージの意図が伝わりにくい**

`"Cleanup failed intentionally"` という表現は「意図的に失敗させた」と読めてしまい、実際の意図（クリーンアップ失敗を意図的に無視して処理を継続する）と乖離があります。`"Cleanup error (non-fatal, rollback continues)"` のような表現の方が、このエラーが致命的でなく処理が続行されることを明示できます。

```suggestion
                    console.error("Cleanup error (non-fatal, rollback continues)", {
```

How can I resolve this? If you propose a fix, please make it concise.

---

This is a comment left during a code review.
Path: apps/api/src/routes/__tests__/papers.test.ts
Line: 467

Comment:
**`bucketDeleteSpy` の restore 漏れ**

`consoleErrorSpy.mockRestore()` は呼ばれていますが、`bucketDeleteSpy.mockRestore()` が抜けています。`env.BUCKET` はテストごとに新しく生成されるため実害はありませんが、スパイ後始末のスタイルを揃えておくと一貫性が保たれます。

```suggestion
        consoleErrorSpy.mockRestore();
        bucketDeleteSpy.mockRestore();
```

How can I resolve this? If you propose a fix, please make it concise.
`````

</details>

<sub>Reviews (1): Last reviewed commit: ["fix(api): add cleanup chunk context for ..."](https://github.com/hiroki-org/openshelf/commit/f291d4c33a5c99a4b457c53c1761b3a2ff059b96) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=28160276)</sub>

> Greptile also left **2 inline comments** on this PR.

<!-- /greptile_comment -->