### PR TITLE
fix(api): bound R2 delete batch concurrency

### DIFF
--- a/apps/api/src/routes/__tests__/papers.test.ts
+++ b/apps/api/src/routes/__tests__/papers.test.ts
@@ -1289,6 +1289,64 @@ describe("papers routes", () => {
         expect(res.status).toBe(200);
     });
 
+    it("DELETE /api/papers/:id bounds concurrent R2 batch deletes", async () => {
+        const token = await createTestJWT({ sub: "user-1", githubId: "123", name: "Uploader" });
+        const files = Array.from({ length: 2001 }, (_, index) => ({
+            r2Key: `papers/paper-1/file-${index}.pdf`,
+        }));
+        mockDb.select = vi
+            .fn()
+            .mockImplementationOnce(() => makeQuery({ getResult: { paperId: "paper-1", userId: "user-1", role: "uploader" } }))
+            .mockImplementationOnce(() => makeQuery({ allResult: files }));
+
+        const app = await createTestApp();
+        const env = createTestEnv();
+        const pendingDeletes: Array<() => void> = [];
+        let activeDeletes = 0;
+        let maxActiveDeletes = 0;
+        const bucketDeleteSpy = vi.spyOn(env.BUCKET, "delete").mockImplementation(
+            async () =>
+                new Promise<void>((resolve) => {
+                    activeDeletes += 1;
+                    maxActiveDeletes = Math.max(maxActiveDeletes, activeDeletes);
+                    pendingDeletes.push(() => {
+                        activeDeletes -= 1;
+                        resolve();
+                    });
+                }),
+        );
+
+        const responsePromise = app.request(
+            "http://localhost/api/papers/paper-1",
+            {
+                method: "DELETE",
+                headers: {
+                    Authorization: `Bearer ${token}`,
+                    Origin: "http://localhost:3000",
+                },
+            },
+            env as any,
+        );
+
+        await vi.waitFor(() => {
+            expect(bucketDeleteSpy).toHaveBeenCalledTimes(2);
+        });
+        expect(maxActiveDeletes).toBe(2);
+
+        pendingDeletes.shift()?.();
+        await vi.waitFor(() => {
+            expect(bucketDeleteSpy).toHaveBeenCalledTimes(3);
+        });
+        expect(maxActiveDeletes).toBe(2);
+
+        pendingDeletes.shift()?.();
+        pendingDeletes.shift()?.();
+
+        const res = await responsePromise;
+        expect(res.status).toBe(200);
+        bucketDeleteSpy.mockRestore();
+    });
+
     it("GET /api/papers/:id returns 404 when paper does not exist", async () => {
         mockDb.select = vi.fn(() => makeQuery({ getResult: null }));
 

--- a/apps/api/src/routes/papers.ts
+++ b/apps/api/src/routes/papers.ts
@@ -28,6 +28,8 @@ const papersRoute = new Hono<{ Bindings: Env; Variables: Variables }>();
 
 const MAX_FILE_SIZE = 50 * 1024 * 1024; // 50 MB
 const MAX_CONCURRENT_UPLOADS = 3;
+const R2_DELETE_BATCH_SIZE = 1000;
+const MAX_CONCURRENT_R2_DELETES = 2;
 const ALLOWED_MIME_TYPES = [
     "application/pdf",
     "application/vnd.ms-powerpoint",
@@ -60,6 +62,13 @@ const BOT_USER_AGENT_KEYWORDS = [
 ];
 
 type TrackEvent = typeof TRACKABLE_EVENTS[number];
+type DeleteBatchErrorInfo = {
+    chunkStart: number;
+    chunkEndExclusive: number;
+    chunkSize: number;
+    chunkSample: string[];
+    error: string;
+};
 
 function formatDateKey(date: Date): string {
     return date.toISOString().slice(0, 10);
@@ -107,6 +116,41 @@ function normalizeReferrer(value: unknown): string | null {
     const trimmed = value.trim();
     if (!trimmed) return null;
     return trimmed.slice(0, MAX_REFERRER_LENGTH);
+}
+
+async function deleteKeysInBatches(
+    bucket: Env["BUCKET"],
+    keys: string[],
+    onChunkError?: (info: DeleteBatchErrorInfo) => void,
+): Promise<void> {
+    const chunkStarts = Array.from(
+        { length: Math.ceil(keys.length / R2_DELETE_BATCH_SIZE) },
+        (_, index) => index * R2_DELETE_BATCH_SIZE,
+    );
+
+    await pMap(
+        chunkStarts,
+        async (chunkStart) => {
+            const chunk = keys.slice(chunkStart, chunkStart + R2_DELETE_BATCH_SIZE);
+            try {
+                await bucket.delete(chunk);
+            } catch (error) {
+                const info = {
+                    chunkStart,
+                    chunkEndExclusive: chunkStart + chunk.length,
+                    chunkSize: chunk.length,
+                    chunkSample: chunk.slice(0, 3),
+                    error: error instanceof Error ? error.message : String(error),
+                };
+                if (onChunkError) {
+                    onChunkError(info);
+                    return;
+                }
+                throw error;
+            }
+        },
+        { concurrency: MAX_CONCURRENT_R2_DELETES },
+    );
 }
 
 /**
@@ -694,23 +738,10 @@ papersRoute.post("/", authMiddleware, async (c) => {
             })),
         );
     } catch (error) {
-        const cleanupPromises: Promise<void>[] = [];
-        for (let i = 0; i < uploadedKeys.length; i += 1000) {
-            const chunk = uploadedKeys.slice(i, i + 1000);
-            cleanupPromises.push(
-                c.env.BUCKET.delete(chunk).catch((e) => {
-                    // Ignore cleanup errors
-                    console.error("Cleanup error (non-fatal, rollback continues)", {
-                        chunkStart: i,
-                        chunkEndExclusive: i + chunk.length,
-                        chunkSize: chunk.length,
-                        chunkSample: chunk.slice(0, 3),
-                        error: e instanceof Error ? e.message : String(e),
-                    });
-                }),
-            );
-        }
-        await Promise.all(cleanupPromises);
+        await deleteKeysInBatches(c.env.BUCKET, uploadedKeys, (info) => {
+            // Ignore cleanup errors during rollback after a later failure.
+            console.error("Cleanup error (non-fatal, rollback continues)", info);
+        });
         await db.delete(papers).where(eq(papers.id, paperId));
         throw error;
     }
@@ -1302,11 +1333,7 @@ papersRoute.delete("/:id", authMiddleware, async (c) => {
         .all();
 
     const keys = files.map((f) => f.r2Key);
-    const deletePromises: Promise<void>[] = [];
-    for (let i = 0; i < keys.length; i += 1000) {
-        deletePromises.push(c.env.BUCKET.delete(keys.slice(i, i + 1000)));
-    }
-    await Promise.all(deletePromises);
+    await deleteKeysInBatches(c.env.BUCKET, keys);
     await db.delete(papers).where(eq(papers.id, paperId));
 
     return c.json({ ok: true });


### PR DESCRIPTION
## Summary
- reuse a bounded helper for R2 delete batches instead of unbounded Promise.all
- apply the helper to rollback cleanup and normal paper deletion
- add a regression test that verifies only two R2 delete batches run concurrently

## Testing
- ../../node_modules/.bin/vitest run --config vitest.config.ts src/routes/__tests__/papers.test.ts

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

このPRは、R2バッチ削除の同時実行数を`pMap`（`concurrency: 2`）で制限する`deleteKeysInBatches`ヘルパーを導入し、ロールバックと通常の論文削除の両方に適用しています。変更はシンプルかつ正確で、コンカレンシー検証テストも適切に機能しています。
</details>

<h3>Confidence Score: 5/5</h3>

マージ安全。P0/P1の問題は見当たらず、変更は意図通りに動作しています。

実装は正確で、`pMap`の`concurrency: 2`により同時実行数が適切に制限されています。ロールバックパスでは`onChunkError`コールバックがエラーを飲み込んで全チャンクを試行し、通常削除パスでは`throw error`で正しくエラーを伝播します。コンカレンシーテストはペンディングPromiseキュー方式で動作を厳密に検証しており、残留するP2指摘もありません。

特に注意が必要なファイルはありません。

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| apps/api/src/routes/papers.ts | `deleteKeysInBatches`を追加し、`pMap(concurrency:2)`でR2バッチ削除を制限。ロールバックと通常削除の両パスで正しく利用されている。 |
| apps/api/src/routes/__tests__/papers.test.ts | 同時実行上限のリグレッションテストを追加（2001ファイル・3バッチ構成）。ペンディングPromiseキューを使って最大同時実行数=2を正確に検証している。 |

</details>

</details>

<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A["deleteKeysInBatches(bucket, keys, onChunkError?)"] --> B["chunkStarts = 配列を1000件ずつ分割"]
    B --> C["pMap(chunkStarts, mapper, {concurrency: 2})"]
    C --> D["bucket.delete(chunk) を最大2並列で実行"]
    D --> E{エラー?}
    E -- "なし" --> F["次のチャンクへ"]
    E -- "あり & onChunkError提供" --> G["onChunkError(info) を呼び出してreturn\n（ロールバックパス：全チャンク継続）"]
    E -- "あり & onChunkError未提供" --> H["throw error\n（通常削除パス：新規チャンク停止）"]
    G --> F
    F --> I["全チャンク完了"]
    I --> J["呼び出し元へ解決"]
```

<sub>Reviews (1): Last reviewed commit: ["fix(api): bound R2 delete batch concurre..."](https://github.com/hiroki-org/openshelf/commit/f9ea1f30b2c0faada33363dbde708654d4f45952) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=28161399)</sub>

<!-- /greptile_comment -->