### PR TITLE
ci: attempt direct merge before creating sync or promote PRs

### DIFF
--- a/.github/scripts/create-staging-to-main-pr.sh
+++ b/.github/scripts/create-staging-to-main-pr.sh
@@ -168,7 +168,11 @@ done < <(
     awk '!seen[$0]++'
 )
 
-included_pr_lines="$(build_included_pr_lines "${pr_numbers[@]}")"
+if [ "${#pr_numbers[@]}" -gt 0 ]; then
+  included_pr_lines="$(build_included_pr_lines "${pr_numbers[@]}")"
+else
+  included_pr_lines="$(build_included_pr_lines)"
+fi
 body="$(build_body "$included_pr_lines")"
 
 declare -a label_values=()
@@ -187,12 +191,15 @@ while IFS= read -r value; do
   reviewer_values+=("$value")
 done < <(csv_to_lines "$PROMOTION_PR_REVIEWERS")
 
-if [ "$DRY_RUN" != "1" ]; then
+if [ "$DRY_RUN" = "1" ]; then
+  echo "DRY_RUN=1, skipping direct merge attempt."
+  echo "Would attempt direct merge: $HEAD_BRANCH -> $BASE_BRANCH"
+else
   echo "Attempting direct merge: $HEAD_BRANCH -> $BASE_BRANCH"
   if gh api --method POST "repos/$GH_REPO/merges" \
     -f base="$BASE_BRANCH" \
     -f head="$HEAD_BRANCH" \
-    -f commit_message="$PROMOTION_PR_TITLE" > /dev/null 2>&1; then
+    -f commit_message="$PROMOTION_PR_TITLE" > /dev/null; then
     echo "Successfully merged $HEAD_BRANCH into $BASE_BRANCH directly."
     if [ -n "$existing_pr_number" ]; then
       echo "Closing existing promotion PR: $existing_pr_url"

--- a/.github/scripts/create-staging-to-main-pr.sh
+++ b/.github/scripts/create-staging-to-main-pr.sh
@@ -168,11 +168,7 @@ done < <(
     awk '!seen[$0]++'
 )
 
-if [ "${#pr_numbers[@]}" -gt 0 ]; then
-  included_pr_lines="$(build_included_pr_lines "${pr_numbers[@]}")"
-else
-  included_pr_lines="$(build_included_pr_lines)"
-fi
+included_pr_lines="$(build_included_pr_lines "${pr_numbers[@]}")"
 body="$(build_body "$included_pr_lines")"
 
 declare -a label_values=()
@@ -191,10 +187,7 @@ while IFS= read -r value; do
   reviewer_values+=("$value")
 done < <(csv_to_lines "$PROMOTION_PR_REVIEWERS")
 
-if [ "$DRY_RUN" = "1" ]; then
-  echo "DRY_RUN=1, skipping direct merge attempt."
-  echo "Would attempt direct merge: $HEAD_BRANCH -> $BASE_BRANCH"
-else
+if [ "$DRY_RUN" != "1" ]; then
   echo "Attempting direct merge: $HEAD_BRANCH -> $BASE_BRANCH"
   if gh api --method POST "repos/$GH_REPO/merges" \
     -f base="$BASE_BRANCH" \
@@ -212,6 +205,8 @@ else
 fi
 
 if [ "$DRY_RUN" = "1" ]; then
+  echo "DRY_RUN=1, attempting simulated direct merge:"
+  echo "  gh api --method POST repos/$GH_REPO/merges -f base=$BASE_BRANCH -f head=$HEAD_BRANCH"
   if [ -n "$existing_pr_number" ] && [ "$UPDATE_EXISTING_PR" = "1" ]; then
     echo "DRY_RUN=1, skipping PR update."
     echo "Would update PR #$existing_pr_number: $existing_pr_url"

--- a/.github/scripts/create-staging-to-main-pr.sh
+++ b/.github/scripts/create-staging-to-main-pr.sh
@@ -187,6 +187,23 @@ while IFS= read -r value; do
   reviewer_values+=("$value")
 done < <(csv_to_lines "$PROMOTION_PR_REVIEWERS")
 
+if [ "$DRY_RUN" != "1" ]; then
+  echo "Attempting direct merge: $HEAD_BRANCH -> $BASE_BRANCH"
+  if gh api --method POST "repos/$GH_REPO/merges" \
+    -f base="$BASE_BRANCH" \
+    -f head="$HEAD_BRANCH" \
+    -f commit_message="$PROMOTION_PR_TITLE" > /dev/null 2>&1; then
+    echo "Successfully merged $HEAD_BRANCH into $BASE_BRANCH directly."
+    if [ -n "$existing_pr_number" ]; then
+      echo "Closing existing promotion PR: $existing_pr_url"
+      gh pr close "$existing_pr_number" --repo "$GH_REPO" || true
+    fi
+    exit 0
+  else
+    echo "Direct merge failed (e.g. conflicts). Falling back to updating/creating a PR."
+  fi
+fi
+
 if [ "$DRY_RUN" = "1" ]; then
   if [ -n "$existing_pr_number" ] && [ "$UPDATE_EXISTING_PR" = "1" ]; then
     echo "DRY_RUN=1, skipping PR update."

--- a/.github/scripts/sync-main-to-staging.sh
+++ b/.github/scripts/sync-main-to-staging.sh
@@ -37,19 +37,20 @@ parse_csv_values() {
   done
 }
 
-existing_pr_url=$(
+existing_pr_row="$(
   gh pr list \
     --repo "$GH_REPO" \
     --state open \
     --base "$BASE_BRANCH" \
     --head "$HEAD_BRANCH" \
-    --json url \
-    --jq '.[0].url // ""'
-)
+    --json number,url \
+    --jq 'if length > 0 then .[0] | [(.number | tostring), .url] | @tsv else "" end'
+)"
 
-if [ -n "$existing_pr_url" ]; then
-  echo "Sync PR already open: $existing_pr_url"
-  exit 0
+existing_pr_number=""
+existing_pr_url=""
+if [ -n "$existing_pr_row" ]; then
+  IFS=$'\t' read -r existing_pr_number existing_pr_url <<< "$existing_pr_row"
 fi
 
 ahead_by=$(
@@ -62,17 +63,29 @@ if [ "${ahead_by:-0}" -eq 0 ]; then
   exit 0
 fi
 
-if [ "$DRY_RUN" != "1" ]; then
+if [ "$DRY_RUN" = "1" ]; then
+  echo "DRY_RUN=1, skipping direct merge attempt."
+  echo "Would attempt direct merge: $HEAD_BRANCH -> $BASE_BRANCH"
+else
   echo "Attempting direct merge: $HEAD_BRANCH -> $BASE_BRANCH"
   if gh api --method POST "repos/$GH_REPO/merges" \
     -f base="$BASE_BRANCH" \
     -f head="$HEAD_BRANCH" \
-    -f commit_message="chore: sync $HEAD_BRANCH into $BASE_BRANCH" > /dev/null 2>&1; then
+    -f commit_message="chore: sync $HEAD_BRANCH into $BASE_BRANCH" > /dev/null; then
     echo "Successfully merged $HEAD_BRANCH into $BASE_BRANCH directly."
+    if [ -n "$existing_pr_number" ]; then
+      echo "Closing existing sync PR: $existing_pr_url"
+      gh pr close "$existing_pr_number" --repo "$GH_REPO" || true
+    fi
     exit 0
   else
     echo "Direct merge failed (e.g. conflicts). Falling back to creating a PR."
   fi
+fi
+
+if [ -n "$existing_pr_url" ]; then
+  echo "Sync PR already open: $existing_pr_url"
+  exit 0
 fi
 
 title="chore: sync $HEAD_BRANCH into $BASE_BRANCH"

--- a/.github/scripts/sync-main-to-staging.sh
+++ b/.github/scripts/sync-main-to-staging.sh
@@ -62,6 +62,19 @@ if [ "${ahead_by:-0}" -eq 0 ]; then
   exit 0
 fi
 
+if [ "$DRY_RUN" != "1" ]; then
+  echo "Attempting direct merge: $HEAD_BRANCH -> $BASE_BRANCH"
+  if gh api --method POST "repos/$GH_REPO/merges" \
+    -f base="$BASE_BRANCH" \
+    -f head="$HEAD_BRANCH" \
+    -f commit_message="chore: sync $HEAD_BRANCH into $BASE_BRANCH" > /dev/null 2>&1; then
+    echo "Successfully merged $HEAD_BRANCH into $BASE_BRANCH directly."
+    exit 0
+  else
+    echo "Direct merge failed (e.g. conflicts). Falling back to creating a PR."
+  fi
+fi
+
 title="chore: sync $HEAD_BRANCH into $BASE_BRANCH"
 body=$(
   cat <<EOF

--- a/.github/scripts/sync-main-to-staging.sh
+++ b/.github/scripts/sync-main-to-staging.sh
@@ -37,20 +37,19 @@ parse_csv_values() {
   done
 }
 
-existing_pr_row="$(
+existing_pr_url=$(
   gh pr list \
     --repo "$GH_REPO" \
     --state open \
     --base "$BASE_BRANCH" \
     --head "$HEAD_BRANCH" \
-    --json number,url \
-    --jq 'if length > 0 then .[0] | [(.number | tostring), .url] | @tsv else "" end'
-)"
+    --json url \
+    --jq '.[0].url // ""'
+)
 
-existing_pr_number=""
-existing_pr_url=""
-if [ -n "$existing_pr_row" ]; then
-  IFS=$'\t' read -r existing_pr_number existing_pr_url <<< "$existing_pr_row"
+if [ -n "$existing_pr_url" ]; then
+  echo "Sync PR already open: $existing_pr_url"
+  echo "Will attempt direct merge first, and close the PR if successful."
 fi
 
 ahead_by=$(
@@ -63,29 +62,21 @@ if [ "${ahead_by:-0}" -eq 0 ]; then
   exit 0
 fi
 
-if [ "$DRY_RUN" = "1" ]; then
-  echo "DRY_RUN=1, skipping direct merge attempt."
-  echo "Would attempt direct merge: $HEAD_BRANCH -> $BASE_BRANCH"
-else
+if [ "$DRY_RUN" != "1" ]; then
   echo "Attempting direct merge: $HEAD_BRANCH -> $BASE_BRANCH"
   if gh api --method POST "repos/$GH_REPO/merges" \
     -f base="$BASE_BRANCH" \
     -f head="$HEAD_BRANCH" \
     -f commit_message="chore: sync $HEAD_BRANCH into $BASE_BRANCH" > /dev/null; then
     echo "Successfully merged $HEAD_BRANCH into $BASE_BRANCH directly."
-    if [ -n "$existing_pr_number" ]; then
+    if [ -n "$existing_pr_url" ]; then
       echo "Closing existing sync PR: $existing_pr_url"
-      gh pr close "$existing_pr_number" --repo "$GH_REPO" || true
+      gh pr close "$existing_pr_url" --repo "$GH_REPO" || true
     fi
     exit 0
   else
     echo "Direct merge failed (e.g. conflicts). Falling back to creating a PR."
   fi
-fi
-
-if [ -n "$existing_pr_url" ]; then
-  echo "Sync PR already open: $existing_pr_url"
-  exit 0
 fi
 
 title="chore: sync $HEAD_BRANCH into $BASE_BRANCH"
@@ -113,6 +104,8 @@ parse_csv_values "$SYNC_PR_ASSIGNEES" assignee_values
 parse_csv_values "$SYNC_PR_REVIEWERS" reviewer_values
 
 if [ "$DRY_RUN" = "1" ]; then
+  echo "DRY_RUN=1, attempting simulated direct merge:"
+  echo "  gh api --method POST repos/$GH_REPO/merges -f base=$BASE_BRANCH -f head=$HEAD_BRANCH"
   echo "DRY_RUN=1, skipping PR creation."
   echo "Would create PR: $HEAD_BRANCH -> $BASE_BRANCH"
   echo "Title: $title"

--- a/.github/workflows/promote-staging-to-main.yml
+++ b/.github/workflows/promote-staging-to-main.yml
@@ -10,19 +10,19 @@ concurrency:
   cancel-in-progress: true
 
 permissions:
-  contents: read
+  contents: write
   issues: write
   pull-requests: write
 
 jobs:
   open-promote-pr:
-    name: Open Staging -> Main PR
+    name: Promote Staging -> Main
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
         with:
           fetch-depth: 0
-      - name: Create or update staging -> main PR
+      - name: Attempt direct merge or create promote PR
         env:
           GH_TOKEN: ${{ github.token }}
           GH_REPO: ${{ github.repository }}

--- a/.github/workflows/sync-main-to-staging.yml
+++ b/.github/workflows/sync-main-to-staging.yml
@@ -10,17 +10,17 @@ concurrency:
   cancel-in-progress: true
 
 permissions:
-  contents: read
+  contents: write
   issues: write
   pull-requests: write
 
 jobs:
   open-sync-pr:
-    name: Open Main -> Staging Sync PR
+    name: Sync Main -> Staging
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
-      - name: Create or reuse main -> staging sync PR
+      - name: Attempt direct merge or create sync PR
         env:
           GH_TOKEN: ${{ github.token }}
           GH_REPO: ${{ github.repository }}


### PR DESCRIPTION
Update the auto-sync (main -> staging) and auto-promote (staging -> main)
workflows to attempt a direct branch merge via the GitHub API before
falling back to creating or updating a Pull Request.

This eliminates the noise and manual effort of automatically created
PRs when there are no merge conflicts between the branches.

---
*PR created automatically by Jules for task [781743930148950186](https://jules.google.com/task/781743930148950186) started by @is0692vs*

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

このPRは `sync-main-to-staging` および `promote-staging-to-main` ワークフローにGitHub APIを使った直接マージ試行を追加し、コンフリクトがない場合にPRを作成せずマージを完了させることでノイズを削減します。

- `sync-main-to-staging.sh` は既存のオープンPRが見つかった時点で早期 `exit 0` するため、新しい直接マージロジック（line 65–76）に到達できません。コンフリクトにより一度sync PRが作成された後、コンフリクトが解消されても以降の実行は常に `\"Sync PR already open\"` で終了し、直接マージもPRのクローズも行われません。`create-staging-to-main-pr.sh` は既存PRを考慮したうえで直接マージを試みクローズしており、両スクリプトで挙動が一貫していません。
</details>


<h3>Confidence Score: 4/5</h3>

P1バグを修正すれば安全にマージ可能

sync-main-to-staging.sh の早期exitにより既存オープンPRが存在する場合に直接マージが試みられないP1ロジックバグがある。promote側は正しく実装されており、ワークフロー定義の変更は適切。

.github/scripts/sync-main-to-staging.sh の既存PR早期exitロジック（line 40–53）を要確認

<details><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| .github/scripts/sync-main-to-staging.sh | 既存オープンPRが存在する際の早期exitにより、新しい直接マージロジックが到達不能になるP1バグがある |
| .github/scripts/create-staging-to-main-pr.sh | 既存PRがある場合でも直接マージを試みて正しくクローズする実装。DRY_RUN時にマージシミュレーション出力がない点が改善余地 |
| .github/workflows/promote-staging-to-main.yml | ステップ名を更新し contents: write 権限を追加。変更は正確 |
| .github/workflows/sync-main-to-staging.yml | ステップ名を更新し contents: write 権限を追加。マージAPIへのwrite権限付与は適切 |

</details>


</details>


<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[push to main/staging] --> B{既存のオープンPRあり?}

    subgraph sync["sync-main-to-staging.sh (現状の問題)"]
        B -- はい --> C["🚫 exit 0\n直接マージは試みない"]
        B -- いいえ --> D{ahead_by == 0?}
        D -- はい --> E[exit 0: 同期不要]
        D -- いいえ --> F{DRY_RUN?}
        F -- いいえ --> G[GitHub API: 直接マージ試行]
        G -- 成功 --> H[exit 0: マージ完了]
        G -- 失敗 --> I[PR作成にフォールバック]
        F -- はい --> J[DRY_RUN出力 → exit 0]
    end

    subgraph promote["create-staging-to-main-pr.sh (正しい実装)"]
        B2[既存PR情報を記録・早期exitしない] --> D2{ahead_by == 0?}
        D2 -- はい --> E2[exit 0: 昇格不要]
        D2 -- いいえ --> F2{DRY_RUN?}
        F2 -- いいえ --> G2[GitHub API: 直接マージ試行]
        G2 -- 成功 --> H2{既存PRあり?}
        H2 -- はい --> I2[既存PRをクローズ → exit 0]
        H2 -- いいえ --> J2[exit 0: マージ完了]
        G2 -- 失敗 --> K2[PR作成/更新にフォールバック]
    end
```

<!-- greptile_failed_comments -->
<details open><summary><h3>Comments Outside Diff (1)</h3></summary>

1. `.github/scripts/sync-main-to-staging.sh`, line 40-53 ([link](https://github.com/hiroki-org/openshelf/blob/84ad7f0087188c0a67792feb515b1b6ea9e5822e/.github/scripts/sync-main-to-staging.sh#L40-L53)) 

   <a href="#"><img alt="P1" src="https://greptile-static-assets.s3.amazonaws.com/badges/p1.svg?v=7" align="top"></a> **既存PR が存在する場合にダイレクトマージが試みられない問題**

   既存のオープン PR が見つかった場合、スクリプトは line 52 で即座に `exit 0` します。これにより、その後に追加された直接マージロジック（line 65–76）に到達できません。

   過去のコンフリクトによって sync PR が作成済みの状態でコンフリクトが解消されても、次回以降の main への push では常に `"Sync PR already open"` で終了し、直接マージを試みたり古い PR をクローズしたりすることが一切なくなります。一方、`create-staging-to-main-pr.sh` は既存 PR の情報を記録するだけで早期終了せず、直接マージを試み、成功すれば既存 PR をクローズしています（line 197–200）。この PR の目的（不要な PR を削減する）と矛盾する動作です。

   <details><summary>Prompt To Fix With AI</summary>

   `````markdown
   This is a comment left during a code review.
   Path: .github/scripts/sync-main-to-staging.sh
   Line: 40-53

   Comment:
   **既存PR が存在する場合にダイレクトマージが試みられない問題**

   既存のオープン PR が見つかった場合、スクリプトは line 52 で即座に `exit 0` します。これにより、その後に追加された直接マージロジック（line 65–76）に到達できません。

   過去のコンフリクトによって sync PR が作成済みの状態でコンフリクトが解消されても、次回以降の main への push では常に `"Sync PR already open"` で終了し、直接マージを試みたり古い PR をクローズしたりすることが一切なくなります。一方、`create-staging-to-main-pr.sh` は既存 PR の情報を記録するだけで早期終了せず、直接マージを試み、成功すれば既存 PR をクローズしています（line 197–200）。この PR の目的（不要な PR を削減する）と矛盾する動作です。

   How can I resolve this? If you propose a fix, please make it concise.
   `````
   </details>

</details>

<!-- /greptile_failed_comments -->

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
This is a comment left during a code review.
Path: .github/scripts/sync-main-to-staging.sh
Line: 40-53

Comment:
**既存PR が存在する場合にダイレクトマージが試みられない問題**

既存のオープン PR が見つかった場合、スクリプトは line 52 で即座に `exit 0` します。これにより、その後に追加された直接マージロジック（line 65–76）に到達できません。

過去のコンフリクトによって sync PR が作成済みの状態でコンフリクトが解消されても、次回以降の main への push では常に `"Sync PR already open"` で終了し、直接マージを試みたり古い PR をクローズしたりすることが一切なくなります。一方、`create-staging-to-main-pr.sh` は既存 PR の情報を記録するだけで早期終了せず、直接マージを試み、成功すれば既存 PR をクローズしています（line 197–200）。この PR の目的（不要な PR を削減する）と矛盾する動作です。

How can I resolve this? If you propose a fix, please make it concise.

---

This is a comment left during a code review.
Path: .github/scripts/create-staging-to-main-pr.sh
Line: 192-205

Comment:
**DRY_RUN 時にダイレクトマージのシミュレーションが行われない**

`DRY_RUN=1` の場合、直接マージブロック（line 190–205）はスキップされます。ドライラン実行時には「直接マージを試みる」という動作のシミュレーションが出力に含まれないため、新しい直接マージパスをテストしにくくなっています。`sync-main-to-staging.sh` も同様の問題を抱えています（line 65–76）。

How can I resolve this? If you propose a fix, please make it concise.

---

This is a comment left during a code review.
Path: .github/scripts/sync-main-to-staging.sh
Line: 67-70

Comment:
**APIエラーが完全に抑制されデバッグが困難**

`> /dev/null 2>&1` によりマージAPIのレスポンスが全て破棄されます。コンフリクト（HTTP 409）以外のエラー（例: 権限不足の HTTP 403 や不正リクエストの HTTP 422）も同様に無言で失敗し PR 作成フォールバックに移行するため、実際の失敗原因が追跡できません。`create-staging-to-main-pr.sh` の line 193–195 も同じ問題を抱えています。stderr のみ保持することで権限系エラーのデバッグが容易になります。

How can I resolve this? If you propose a fix, please make it concise.
`````

</details>

<sub>Reviews (1): Last reviewed commit: ["ci: attempt direct merge before creating..."](https://github.com/hiroki-org/openshelf/commit/84ad7f0087188c0a67792feb515b1b6ea9e5822e) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=28164830)</sub>

> Greptile also left **2 inline comments** on this PR.

<!-- /greptile_comment -->