### PR TITLE
TSK-514: feat: add FeedButton to collection pages

### DIFF
--- a/apps/web/src/app/__tests__/user-collection-page.test.tsx
+++ b/apps/web/src/app/__tests__/user-collection-page.test.tsx
@@ -1,14 +1,10 @@
 import { cleanup, render, screen, waitFor } from "@testing-library/react";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
-import UserCollectionPage from "../users/[id]/c/[collectionSlug]/page";
+import UserCollectionPageClient from "../users/[id]/c/[collectionSlug]/user-collection-page-client";
 import { apiFetch } from "@/lib/api";
 
 vi.mock("@/lib/api", () => ({
   apiFetch: vi.fn(),
-}));
-
-vi.mock("next/navigation", () => ({
-  useParams: () => ({ id: "user-1", collectionSlug: "favorites" }),
 }));
 
 vi.mock("next/link", () => ({
@@ -67,7 +63,9 @@ describe("UserCollectionPage", () => {
       throw new Error(`Unexpected request: ${String(url)}`);
     });
 
-    render(<UserCollectionPage />);
+    render(
+      <UserCollectionPageClient id="user-1" collectionSlug="favorites" />,
+    );
 
     await waitFor(() => {
       expect(screen.getByText("Favorites")).toBeInTheDocument();
@@ -82,7 +80,9 @@ describe("UserCollectionPage", () => {
       new Response(JSON.stringify({ collections: [] }), { status: 200 }),
     );
 
-    render(<UserCollectionPage />);
+    render(
+      <UserCollectionPageClient id="user-1" collectionSlug="favorites" />,
+    );
 
     expect(await screen.findByText("コレクションが見つかりません")).toBeInTheDocument();
   });

--- a/apps/web/src/app/orgs/[slug]/c/[collectionSlug]/__tests__/org-collection-page-client.test.tsx
+++ b/apps/web/src/app/orgs/[slug]/c/[collectionSlug]/__tests__/org-collection-page-client.test.tsx
@@ -94,6 +94,7 @@ describe("OrgCollectionPageClient", () => {
     await waitFor(() => {
       expect(screen.getByText("Featured")).toBeInTheDocument();
     });
+    expect(screen.getByRole("button", { name: "📡 Feed" })).toBeInTheDocument();
 
     fireEvent.click(screen.getAllByRole("button", { name: "↓" })[0]);
 

--- a/apps/web/src/app/orgs/[slug]/c/[collectionSlug]/org-collection-page-client.tsx
+++ b/apps/web/src/app/orgs/[slug]/c/[collectionSlug]/org-collection-page-client.tsx
@@ -1,5 +1,6 @@
 "use client";
 
+import { FeedButton } from "@/components/feed-button";
 import { useAuth } from "@/components/auth-provider";
 import { apiFetch } from "@/lib/api";
 import Link from "next/link";
@@ -34,6 +35,7 @@ export default function OrgCollectionPageClient({
   collectionSlug,
 }: OrgCollectionPageClientProps) {
   const { user } = useAuth();
+  const feedUrl = `${process.env.NEXT_PUBLIC_API_URL ?? "http://localhost:8787"}/feed/orgs/${slug}/collections/${collectionSlug}/atom.xml`;
   const [collection, setCollection] = useState<Collection | null>(null);
   const [papers, setPapers] = useState<Paper[]>([]);
   const [members, setMembers] = useState<Member[]>([]);
@@ -135,15 +137,20 @@ export default function OrgCollectionPageClient({
         >
           ← 組織ページに戻る
         </Link>
-        <h1 className="text-2xl font-bold mt-2">{collection.name}</h1>
-        {collection.description && (
-          <p className="text-sm text-gray-600 mt-1 dark:text-gray-400">
-            {collection.description}
-          </p>
-        )}
-        <p className="text-xs text-gray-500 mt-2">
-          visibility: {collection.visibility}
-        </p>
+        <div className="mt-2 flex items-start justify-between gap-3">
+          <div>
+            <h1 className="text-2xl font-bold">{collection.name}</h1>
+            {collection.description && (
+              <p className="text-sm text-gray-600 mt-1 dark:text-gray-400">
+                {collection.description}
+              </p>
+            )}
+            <p className="text-xs text-gray-500 mt-2">
+              visibility: {collection.visibility}
+            </p>
+          </div>
+          <FeedButton url={feedUrl} />
+        </div>
       </div>
 
       {papers.length === 0 ? (

--- a/apps/web/src/app/orgs/[slug]/c/[collectionSlug]/org-collection-page-client.tsx
+++ b/apps/web/src/app/orgs/[slug]/c/[collectionSlug]/org-collection-page-client.tsx
@@ -35,7 +35,7 @@ export default function OrgCollectionPageClient({
   collectionSlug,
 }: OrgCollectionPageClientProps) {
   const { user } = useAuth();
-  const feedUrl = `${process.env.NEXT_PUBLIC_API_URL ?? "http://localhost:8787"}/feed/orgs/${slug}/collections/${collectionSlug}/atom.xml`;
+  const feedUrl = `${process.env.NEXT_PUBLIC_API_URL ?? "http://localhost:8787"}/feed/orgs/${safePath(slug)}/collections/${safePath(collectionSlug)}/atom.xml`;
   const [collection, setCollection] = useState<Collection | null>(null);
   const [papers, setPapers] = useState<Paper[]>([]);
   const [members, setMembers] = useState<Member[]>([]);

--- a/apps/web/src/app/orgs/[slug]/c/[collectionSlug]/page.tsx
+++ b/apps/web/src/app/orgs/[slug]/c/[collectionSlug]/page.tsx
@@ -26,9 +26,7 @@ const API_BASE =
   process.env.NEXT_PUBLIC_API_URL ??
   "http://localhost:8787";
 const PUBLIC_API_BASE =
-  process.env.NEXT_PUBLIC_API_URL ??
-  process.env.API_URL ??
-  "http://localhost:8787";
+  process.env.NEXT_PUBLIC_API_URL ?? "http://localhost:8787";
 const SITE_BASE =
   process.env.SITE_URL ??
   process.env.NEXT_PUBLIC_SITE_URL ??
@@ -78,6 +76,15 @@ export async function generateMetadata(props: {
   params: Params | Promise<Params>;
 }): Promise<Metadata> {
   const { slug, collectionSlug } = await Promise.resolve(props.params);
+  let safeSlug: string;
+  let safeCollectionSlug: string;
+  try {
+    safeSlug = safePath(slug);
+    safeCollectionSlug = safePath(collectionSlug);
+  } catch {
+    return { title: "コレクション詳細 | OpenShelf" };
+  }
+
   const data = await fetchCollectionMetadata(slug, collectionSlug);
 
   if (!data) {
@@ -87,7 +94,7 @@ export async function generateMetadata(props: {
       title,
       openGraph: {
         title,
-        url: `${SITE_BASE}/orgs/${slug}/c/${collectionSlug}`,
+        url: `${SITE_BASE}/orgs/${safeSlug}/c/${safeCollectionSlug}`,
         images: [{ url: ogImage, width: 1200, height: 630 }],
       },
       twitter: {
@@ -102,7 +109,7 @@ export async function generateMetadata(props: {
   const description =
     data.collection.description ?? `${data.orgName} のコレクション`;
   const ogImage = buildOgImageUrl(data.collection.name, data.orgName);
-  const feedUrl = `${PUBLIC_API_BASE}/feed/orgs/${slug}/collections/${collectionSlug}/atom.xml`;
+  const feedUrl = `${PUBLIC_API_BASE}/feed/orgs/${safeSlug}/collections/${safeCollectionSlug}/atom.xml`;
 
   return {
     title,
@@ -116,7 +123,7 @@ export async function generateMetadata(props: {
       title,
       description,
       type: "website",
-      url: `${SITE_BASE}/orgs/${slug}/c/${collectionSlug}`,
+      url: `${SITE_BASE}/orgs/${safeSlug}/c/${safeCollectionSlug}`,
       images: [{ url: ogImage, width: 1200, height: 630 }],
     },
     twitter: {

--- a/apps/web/src/app/orgs/[slug]/c/[collectionSlug]/page.tsx
+++ b/apps/web/src/app/orgs/[slug]/c/[collectionSlug]/page.tsx
@@ -25,6 +25,10 @@ const API_BASE =
   process.env.API_URL ??
   process.env.NEXT_PUBLIC_API_URL ??
   "http://localhost:8787";
+const PUBLIC_API_BASE =
+  process.env.NEXT_PUBLIC_API_URL ??
+  process.env.API_URL ??
+  "http://localhost:8787";
 const SITE_BASE =
   process.env.SITE_URL ??
   process.env.NEXT_PUBLIC_SITE_URL ??
@@ -98,10 +102,16 @@ export async function generateMetadata(props: {
   const description =
     data.collection.description ?? `${data.orgName} のコレクション`;
   const ogImage = buildOgImageUrl(data.collection.name, data.orgName);
+  const feedUrl = `${PUBLIC_API_BASE}/feed/orgs/${slug}/collections/${collectionSlug}/atom.xml`;
 
   return {
     title,
     description,
+    alternates: {
+      types: {
+        "application/atom+xml": feedUrl,
+      },
+    },
     openGraph: {
       title,
       description,

--- a/apps/web/src/app/users/[id]/c/[collectionSlug]/__tests__/page-metadata.test.tsx
+++ b/apps/web/src/app/users/[id]/c/[collectionSlug]/__tests__/page-metadata.test.tsx
@@ -1,13 +1,13 @@
 import { cleanup, render, screen } from "@testing-library/react";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
-vi.mock("../org-collection-page-client", () => ({
-  default: ({ slug, collectionSlug }: any) => (
-    <div>{`org-collection:${slug}:${collectionSlug}`}</div>
+vi.mock("../user-collection-page-client", () => ({
+  default: ({ id, collectionSlug }: { id: string; collectionSlug: string }) => (
+    <div>{`user-collection:${id}:${collectionSlug}`}</div>
   ),
 }));
 
-describe("orgs/[slug]/c/[collectionSlug]/page metadata", () => {
+describe("users/[id]/c/[collectionSlug]/page metadata", () => {
   const originalApiUrl = process.env.API_URL;
   const originalPublicApiUrl = process.env.NEXT_PUBLIC_API_URL;
 
@@ -21,20 +21,23 @@ describe("orgs/[slug]/c/[collectionSlug]/page metadata", () => {
     vi.clearAllMocks();
   });
 
-  it("builds org collection metadata", async () => {
+  it("builds user collection metadata and renders the client page", async () => {
     process.env.API_URL = "http://internal-api:8787";
     process.env.NEXT_PUBLIC_API_URL = "https://public-api.example.com";
     vi.resetModules();
-    const { generateMetadata } = await import("../page");
+
+    const { default: UserCollectionPage, generateMetadata } = await import(
+      "../page"
+    );
 
     vi.spyOn(global, "fetch")
       .mockResolvedValueOnce(
         new Response(
           JSON.stringify({
-            org: { slug: "lab", name: "Research Lab" },
+            user: { id: "user-1", name: "Alice", displayName: "Alice A." },
           }),
           { status: 200 },
-        ) as any,
+        ) as Response,
       )
       .mockResolvedValueOnce(
         new Response(
@@ -48,23 +51,30 @@ describe("orgs/[slug]/c/[collectionSlug]/page metadata", () => {
             ],
           }),
           { status: 200 },
-        ) as any,
+        ) as Response,
       );
 
     const metadata = await generateMetadata({
-      params: { slug: "lab", collectionSlug: "featured" },
+      params: { id: "user-1", collectionSlug: "featured" },
     });
+    const view = await UserCollectionPage({
+      params: { id: "user-1", collectionSlug: "featured" },
+    });
+    render(view);
 
-    expect(metadata.title).toBe("Featured | Research Lab | OpenShelf");
+    expect(metadata.title).toBe("Featured | Alice A. | OpenShelf");
     expect(metadata.alternates?.types?.["application/atom+xml"]).toBe(
-      "https://public-api.example.com/feed/orgs/lab/collections/featured/atom.xml",
+      "https://public-api.example.com/feed/users/user-1/collections/featured/atom.xml",
     );
+    expect(
+      screen.getByText("user-collection:user-1:featured"),
+    ).toBeInTheDocument();
   });
 
-  it("renders an invalid identifier message for invalid params", async () => {
-    const { default: OrgCollectionPage } = await import("../page");
-    const view = await OrgCollectionPage({
-      params: { slug: "../bad", collectionSlug: "featured" },
+  it("renders invalid identifier message for invalid params", async () => {
+    const { default: UserCollectionPage } = await import("../page");
+    const view = await UserCollectionPage({
+      params: { id: "../bad", collectionSlug: "featured" },
     });
     render(view);
 

--- a/apps/web/src/app/users/[id]/c/[collectionSlug]/__tests__/page-metadata.test.tsx
+++ b/apps/web/src/app/users/[id]/c/[collectionSlug]/__tests__/page-metadata.test.tsx
@@ -13,8 +13,19 @@ describe("users/[id]/c/[collectionSlug]/page metadata", () => {
 
   afterEach(() => {
     cleanup();
-    process.env.API_URL = originalApiUrl;
-    process.env.NEXT_PUBLIC_API_URL = originalPublicApiUrl;
+    if (originalApiUrl === undefined) {
+      delete process.env.API_URL;
+    } else {
+      process.env.API_URL = originalApiUrl;
+    }
+
+    if (originalPublicApiUrl === undefined) {
+      delete process.env.NEXT_PUBLIC_API_URL;
+    } else {
+      process.env.NEXT_PUBLIC_API_URL = originalPublicApiUrl;
+    }
+
+    vi.restoreAllMocks();
   });
 
   beforeEach(() => {

--- a/apps/web/src/app/users/[id]/c/[collectionSlug]/__tests__/user-collection-page-client.test.tsx
+++ b/apps/web/src/app/users/[id]/c/[collectionSlug]/__tests__/user-collection-page-client.test.tsx
@@ -1,5 +1,5 @@
-import { render, screen, waitFor } from "@testing-library/react";
-import { beforeEach, describe, expect, it, vi } from "vitest";
+import { cleanup, render, screen, waitFor } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import UserCollectionPageClient from "../user-collection-page-client";
 import { apiFetch } from "@/lib/api";
 
@@ -16,6 +16,10 @@ vi.mock("next/link", () => ({
 }));
 
 describe("UserCollectionPageClient", () => {
+  afterEach(() => {
+    cleanup();
+  });
+
   beforeEach(() => {
     vi.clearAllMocks();
   });

--- a/apps/web/src/app/users/[id]/c/[collectionSlug]/__tests__/user-collection-page-client.test.tsx
+++ b/apps/web/src/app/users/[id]/c/[collectionSlug]/__tests__/user-collection-page-client.test.tsx
@@ -1,0 +1,54 @@
+import { render, screen, waitFor } from "@testing-library/react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import UserCollectionPageClient from "../user-collection-page-client";
+import { apiFetch } from "@/lib/api";
+
+vi.mock("@/lib/api", () => ({
+  apiFetch: vi.fn(),
+}));
+
+vi.mock("next/link", () => ({
+  default: ({ href, children, ...props }: any) => (
+    <a href={href} {...props}>
+      {children}
+    </a>
+  ),
+}));
+
+describe("UserCollectionPageClient", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("renders FeedButton on user collection pages", async () => {
+    vi.mocked(apiFetch).mockImplementation(async (url) => {
+      if (url === "/api/users/user-1/collections") {
+        return new Response(
+          JSON.stringify({
+            collections: [
+              {
+                id: "col-1",
+                slug: "featured",
+                name: "Featured",
+                description: "Featured papers",
+                visibility: "public",
+              },
+            ],
+          }),
+          { status: 200 },
+        );
+      }
+      if (url === "/api/collections/col-1/papers") {
+        return new Response(JSON.stringify({ papers: [] }), { status: 200 });
+      }
+      throw new Error(`Unexpected request: ${String(url)}`);
+    });
+
+    render(<UserCollectionPageClient id="user-1" collectionSlug="featured" />);
+
+    await waitFor(() => {
+      expect(screen.getByText("Featured")).toBeInTheDocument();
+    });
+    expect(screen.getByRole("button", { name: "📡 Feed" })).toBeInTheDocument();
+  });
+});

--- a/apps/web/src/app/users/[id]/c/[collectionSlug]/page.tsx
+++ b/apps/web/src/app/users/[id]/c/[collectionSlug]/page.tsx
@@ -27,9 +27,7 @@ const API_BASE =
   process.env.NEXT_PUBLIC_API_URL ??
   "http://localhost:8787";
 const PUBLIC_API_BASE =
-  process.env.NEXT_PUBLIC_API_URL ??
-  process.env.API_URL ??
-  "http://localhost:8787";
+  process.env.NEXT_PUBLIC_API_URL ?? "http://localhost:8787";
 const SITE_BASE =
   process.env.SITE_URL ??
   process.env.NEXT_PUBLIC_SITE_URL ??
@@ -65,9 +63,11 @@ export async function generateMetadata(props: {
   params: Params | Promise<Params>;
 }): Promise<Metadata> {
   const { id, collectionSlug } = await Promise.resolve(props.params);
+  let safeId: string;
+  let safeCollectionSlug: string;
   try {
-    safePath(id);
-    safePath(collectionSlug);
+    safeId = safePath(id);
+    safeCollectionSlug = safePath(collectionSlug);
   } catch {
     return { title: "OpenShelf" };
   }
@@ -80,7 +80,7 @@ export async function generateMetadata(props: {
   const title = `${data.collection.name} | ${data.userName} | OpenShelf`;
   const description =
     data.collection.description ?? `${data.userName} のコレクション`;
-  const feedUrl = `${PUBLIC_API_BASE}/feed/users/${id}/collections/${collectionSlug}/atom.xml`;
+  const feedUrl = `${PUBLIC_API_BASE}/feed/users/${safeId}/collections/${safeCollectionSlug}/atom.xml`;
 
   return {
     title,
@@ -93,7 +93,7 @@ export async function generateMetadata(props: {
     openGraph: {
       title,
       description,
-      url: `${SITE_BASE}/users/${id}/c/${collectionSlug}`,
+      url: `${SITE_BASE}/users/${safeId}/c/${safeCollectionSlug}`,
     },
   };
 }

--- a/apps/web/src/app/users/[id]/c/[collectionSlug]/page.tsx
+++ b/apps/web/src/app/users/[id]/c/[collectionSlug]/page.tsx
@@ -1,124 +1,113 @@
-"use client";
+import type { Metadata } from "next";
+import { safePath } from "@/lib/sanitization";
+import UserCollectionPageClient from "./user-collection-page-client";
 
-import { apiFetch } from "@/lib/api";
-import Link from "next/link";
-import { useParams } from "next/navigation";
-import { useEffect, useState } from "react";
+type Params = { id: string; collectionSlug: string };
+
+type UserResponse = {
+  user: {
+    id: string;
+    name: string;
+    displayName: string | null;
+  };
+};
 
 type Collection = {
-  id: string;
   slug: string;
   name: string;
   description: string | null;
-  visibility: string;
 };
 
-type Paper = {
-  id: string;
-  title: string;
-  abstract: string | null;
-  visibility: string;
-  sortOrder: number;
+type CollectionsResponse = {
+  collections: Collection[];
 };
 
-export default function UserCollectionPage() {
-  const { id, collectionSlug } = useParams<{
-    id: string;
-    collectionSlug: string;
-  }>();
+const API_BASE =
+  process.env.API_URL ??
+  process.env.NEXT_PUBLIC_API_URL ??
+  "http://localhost:8787";
+const PUBLIC_API_BASE =
+  process.env.NEXT_PUBLIC_API_URL ??
+  process.env.API_URL ??
+  "http://localhost:8787";
+const SITE_BASE =
+  process.env.SITE_URL ??
+  process.env.NEXT_PUBLIC_SITE_URL ??
+  "http://localhost:3000";
 
-  const [collection, setCollection] = useState<Collection | null>(null);
-  const [papers, setPapers] = useState<Paper[]>([]);
-  const [error, setError] = useState("");
+async function fetchCollectionMetadata(id: string, collectionSlug: string) {
+  try {
+    const [userRes, collectionsRes] = await Promise.all([
+      fetch(`${API_BASE}/api/users/${safePath(id)}`, { cache: "no-store" }),
+      fetch(`${API_BASE}/api/users/${safePath(id)}/collections`, {
+        cache: "no-store",
+      }),
+    ]);
+    if (!userRes.ok || !collectionsRes.ok) return null;
 
-  useEffect(() => {
-    (async () => {
-      try {
-        const listRes = await apiFetch(
-          `/api/users/${encodeURIComponent(id)}/collections`,
-        );
-        const listData = listRes.ok
-          ? await listRes.json()
-          : { collections: [] };
-        const found =
-          (listData.collections ?? []).find(
-            (c: Collection) => c.slug === collectionSlug,
-          ) ?? null;
-        if (!found) {
-          setError("コレクションが見つかりません");
-          return;
-        }
-        setCollection(found);
+    const userData = (await userRes.json()) as UserResponse;
+    const collectionsData = (await collectionsRes.json()) as CollectionsResponse;
+    const collection = collectionsData.collections.find(
+      (item) => item.slug === collectionSlug,
+    );
+    if (!collection) return null;
 
-        const papersRes = await apiFetch(
-          `/api/collections/${encodeURIComponent(found.id)}/papers`,
-        );
-        if (papersRes.ok) {
-          const papersData = await papersRes.json();
-          setPapers(
-            (papersData.papers ?? [])
-              .slice()
-              .sort((a: Paper, b: Paper) => a.sortOrder - b.sortOrder),
-          );
-        }
-      } catch {
-        setError("取得に失敗しました");
-      }
-    })();
-  }, [id, collectionSlug]);
+    return {
+      userName: userData.user.displayName ?? userData.user.name,
+      collection,
+    };
+  } catch {
+    return null;
+  }
+}
 
-  if (error)
-    return <div className="text-center py-16 text-red-600">{error}</div>;
-  if (!collection)
-    return <div className="text-center py-16">読み込み中...</div>;
+export async function generateMetadata(props: {
+  params: Params | Promise<Params>;
+}): Promise<Metadata> {
+  const { id, collectionSlug } = await Promise.resolve(props.params);
+  try {
+    safePath(id);
+    safePath(collectionSlug);
+  } catch {
+    return { title: "OpenShelf" };
+  }
 
-  return (
-    <div className="max-w-4xl">
-      <div className="mb-6">
-        <Link
-          href={`/users/${id}`}
-          className="text-sm text-blue-600 hover:underline dark:text-blue-400"
-        >
-          ← ユーザーページに戻る
-        </Link>
-        <h1 className="text-2xl font-bold mt-2">{collection.name}</h1>
-        {collection.description && (
-          <p className="text-sm text-gray-600 mt-1 dark:text-gray-400">
-            {collection.description}
-          </p>
-        )}
-        <p className="text-xs text-gray-500 mt-2">
-          visibility: {collection.visibility}
-        </p>
-      </div>
+  const data = await fetchCollectionMetadata(id, collectionSlug);
+  if (!data) {
+    return { title: "コレクション詳細 | OpenShelf" };
+  }
 
-      {papers.length === 0 ? (
-        <p className="text-sm text-gray-500">論文がありません</p>
-      ) : (
-        <ul className="space-y-3">
-          {papers.map((paper) => (
-            <li
-              key={paper.id}
-              className="rounded-md border p-3 dark:border-gray-700"
-            >
-              <Link
-                href={`/papers/${paper.id}`}
-                className="font-medium hover:underline"
-              >
-                {paper.title}
-              </Link>
-              {paper.abstract && (
-                <p className="text-xs text-gray-500 mt-1 line-clamp-2">
-                  {paper.abstract}
-                </p>
-              )}
-              <p className="text-xs text-gray-400 mt-1">
-                visibility: {paper.visibility}
-              </p>
-            </li>
-          ))}
-        </ul>
-      )}
-    </div>
-  );
+  const title = `${data.collection.name} | ${data.userName} | OpenShelf`;
+  const description =
+    data.collection.description ?? `${data.userName} のコレクション`;
+  const feedUrl = `${PUBLIC_API_BASE}/feed/users/${id}/collections/${collectionSlug}/atom.xml`;
+
+  return {
+    title,
+    description,
+    alternates: {
+      types: {
+        "application/atom+xml": feedUrl,
+      },
+    },
+    openGraph: {
+      title,
+      description,
+      url: `${SITE_BASE}/users/${id}/c/${collectionSlug}`,
+    },
+  };
+}
+
+export default async function UserCollectionPage(props: {
+  params: Params | Promise<Params>;
+}) {
+  const { id, collectionSlug } = await Promise.resolve(props.params);
+  try {
+    safePath(id);
+    safePath(collectionSlug);
+  } catch {
+    return <div className="text-center py-16">無効な識別子です</div>;
+  }
+
+  return <UserCollectionPageClient id={id} collectionSlug={collectionSlug} />;
 }

--- a/apps/web/src/app/users/[id]/c/[collectionSlug]/user-collection-page-client.tsx
+++ b/apps/web/src/app/users/[id]/c/[collectionSlug]/user-collection-page-client.tsx
@@ -1,0 +1,144 @@
+"use client";
+
+import { FeedButton } from "@/components/feed-button";
+import { apiFetch } from "@/lib/api";
+import Link from "next/link";
+import { useEffect, useState } from "react";
+import { safePath } from "@/lib/sanitization";
+
+type Collection = {
+  id: string;
+  slug: string;
+  name: string;
+  description: string | null;
+  visibility: string;
+};
+
+type Paper = {
+  id: string;
+  title: string;
+  abstract: string | null;
+  visibility: string;
+  sortOrder: number;
+};
+
+type UserCollectionPageClientProps = {
+  id: string;
+  collectionSlug: string;
+};
+
+export default function UserCollectionPageClient({
+  id,
+  collectionSlug,
+}: UserCollectionPageClientProps) {
+  const feedUrl = `${process.env.NEXT_PUBLIC_API_URL ?? "http://localhost:8787"}/feed/users/${id}/collections/${collectionSlug}/atom.xml`;
+  const [collection, setCollection] = useState<Collection | null>(null);
+  const [papers, setPapers] = useState<Paper[]>([]);
+  const [error, setError] = useState("");
+
+  useEffect(() => {
+    let cancelled = false;
+
+    (async () => {
+      try {
+        const listRes = await apiFetch(
+          `/api/users/${safePath(id)}/collections`,
+        );
+        const listData = listRes.ok
+          ? await listRes.json()
+          : { collections: [] };
+        if (cancelled) return;
+
+        const found =
+          (listData.collections ?? []).find(
+            (c: Collection) => c.slug === collectionSlug,
+          ) ?? null;
+        if (!found) {
+          setError("コレクションが見つかりません");
+          return;
+        }
+        setCollection(found);
+
+        const papersRes = await apiFetch(
+          `/api/collections/${safePath(found.id)}/papers`,
+        );
+        if (!papersRes.ok) return;
+
+        const papersData = await papersRes.json();
+        if (cancelled) return;
+        setPapers(
+          (papersData.papers ?? [])
+            .slice()
+            .sort((a: Paper, b: Paper) => a.sortOrder - b.sortOrder),
+        );
+      } catch {
+        if (cancelled) return;
+        setError("取得に失敗しました");
+      }
+    })();
+
+    return () => {
+      cancelled = true;
+    };
+  }, [id, collectionSlug]);
+
+  if (error)
+    return <div className="text-center py-16 text-red-600">{error}</div>;
+  if (!collection)
+    return <div className="text-center py-16">読み込み中...</div>;
+
+  return (
+    <div className="max-w-4xl">
+      <div className="mb-6">
+        <Link
+          href={`/users/${safePath(id)}`}
+          className="text-sm text-blue-600 hover:underline dark:text-blue-400"
+        >
+          ← ユーザーページに戻る
+        </Link>
+        <div className="mt-2 flex items-start justify-between gap-3">
+          <div>
+            <h1 className="text-2xl font-bold">{collection.name}</h1>
+            {collection.description && (
+              <p className="text-sm text-gray-600 mt-1 dark:text-gray-400">
+                {collection.description}
+              </p>
+            )}
+            <p className="text-xs text-gray-500 mt-2">
+              visibility: {collection.visibility}
+            </p>
+          </div>
+          <FeedButton url={feedUrl} />
+        </div>
+      </div>
+
+      {papers.length === 0 ? (
+        <p className="text-sm text-gray-500">論文がありません</p>
+      ) : (
+        <ul className="space-y-3">
+          {papers.map((paper) => (
+            <li
+              key={paper.id}
+              className="rounded-md border p-3 dark:border-gray-700"
+            >
+              <Link
+                href={`/papers/${paper.id}`}
+                className="font-medium hover:underline"
+              >
+                {paper.title}
+              </Link>
+              {paper.abstract && (
+                <p className="text-xs text-gray-500 mt-1 line-clamp-2">
+                  {paper.abstract}
+                </p>
+              )}
+              <p className="text-xs text-gray-400 mt-1">
+                visibility: {paper.visibility}
+              </p>
+            </li>
+          ))}
+        </ul>
+      )}
+    </div>
+  );
+}

--- a/apps/web/src/app/users/[id]/c/[collectionSlug]/user-collection-page-client.tsx
+++ b/apps/web/src/app/users/[id]/c/[collectionSlug]/user-collection-page-client.tsx
@@ -31,7 +31,7 @@ export default function UserCollectionPageClient({
   id,
   collectionSlug,
 }: UserCollectionPageClientProps) {
-  const feedUrl = `${process.env.NEXT_PUBLIC_API_URL ?? "http://localhost:8787"}/feed/users/${id}/collections/${collectionSlug}/atom.xml`;
+  const feedUrl = `${process.env.NEXT_PUBLIC_API_URL ?? "http://localhost:8787"}/feed/users/${safePath(id)}/collections/${safePath(collectionSlug)}/atom.xml`;
   const [collection, setCollection] = useState<Collection | null>(null);
   const [papers, setPapers] = useState<Paper[]>([]);
   const [error, setError] = useState("");


### PR DESCRIPTION
ref TSK-514

## Summary
- add FeedButton to org and user collection page headers
- add Atom alternates metadata for org/user collection pages
- add/update tests for FeedButton presence and collection metadata alternates

## Validation
- npm run typecheck
- npm run lint
- npm run test
- npm --prefix apps/web run test -- "src/app/orgs/[slug]/c/[collectionSlug]/__tests__/org-collection-page-client.test.tsx" "src/app/orgs/[slug]/c/[collectionSlug]/__tests__/page-metadata.test.tsx" "src/app/users/[id]/c/[collectionSlug]/__tests__/user-collection-page-client.test.tsx" "src/app/users/[id]/c/[collectionSlug]/__tests__/page-metadata.test.tsx" "src/app/__tests__/user-collection-page.test.tsx"

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

ユーザーコレクションページを Server Component + Client Component に分離し（Org ページと同じ構成に統一）、両コレクションページのヘッダーに `FeedButton` と Atom フィードの `<link rel=\"alternate\">` メタデータを追加した PR です。リファクタリングの設計は整合的で、`safePath` によるパス検証・`cancelled` フラグによるレース条件対策など既存の実装パターンが踏襲されています。
</details>

<h3>Confidence Score: 5/5</h3>

マージは安全です。残る指摘はいずれも P2（スタイル・設定上の懸念）です。

P0/P1 の問題は検出されませんでした。`safePath` によるパス検証は既存パターンと一致しており、テストカバレッジも十分です。`afterEach(cleanup)` の欠落と `PUBLIC_API_BASE` のフォールバック挙動は P2 相当であり、マージをブロックするものではありません。

特に注意が必要なファイルはありません。`user-collection-page-client.test.tsx` の `afterEach` 追加を推奨します。

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| apps/web/src/app/users/[id]/c/[collectionSlug]/user-collection-page-client.tsx | 新規ファイル。旧 `page.tsx` のクライアントロジックを分離し、`FeedButton` 追加・`safePath` による検証・`cancelled` フラグによるレース条件対策が実装されている。 |
| apps/web/src/app/users/[id]/c/[collectionSlug]/page.tsx | クライアント専用から Server Component + `generateMetadata` を持つ構成に刷新。Atom フィードの `alternates` を追加。`PUBLIC_API_BASE` が `API_URL` にフォールバックする場合に内部 URL がメタデータに漏れる可能性あり（P2）。 |
| apps/web/src/app/orgs/[slug]/c/[collectionSlug]/org-collection-page-client.tsx | `FeedButton` とフィード URL を追加。`slug`/`collectionSlug` は呼び出し元 `page.tsx` で `safePath` 検証済みのため安全。レイアウトを `flex` で再構成。 |
| apps/web/src/app/orgs/[slug]/c/[collectionSlug]/page.tsx | `PUBLIC_API_BASE` 定数と Atom フィードの `alternates` メタデータを追加。ユーザーページと対称的な実装になっている。 |
| apps/web/src/app/users/[id]/c/[collectionSlug]/__tests__/user-collection-page-client.test.tsx | 新規テスト。`FeedButton` の表示を確認する。`afterEach(cleanup)` が抜けており、他テストファイルと不整合（P2）。 |
| apps/web/src/app/users/[id]/c/[collectionSlug]/__tests__/page-metadata.test.tsx | 新規テスト。`vi.resetModules()` + 動的 `import` で環境変数を差し替えて `generateMetadata` の Atom URL を検証する正しいパターン。 |
| apps/web/src/app/orgs/[slug]/c/[collectionSlug]/__tests__/page-metadata.test.tsx | 環境変数リストアを `afterEach` で行う修正を追加し、Atom alternate URL のアサーションを追加。 |
| apps/web/src/app/__tests__/user-collection-page.test.tsx | テスト対象を `UserCollectionPage` (Server) から `UserCollectionPageClient` に変更。`useParams` モックが不要になり props を直接渡す形に整理。 |
| apps/web/src/app/orgs/[slug]/c/[collectionSlug]/__tests__/org-collection-page-client.test.tsx | `FeedButton` の表示アサーションを追加のみ。既存テストは破壊せず。 |

</details>

</details>

<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant Browser
    participant NextServer as Next.js Server
    participant API as API Server

    Browser->>NextServer: GET /users/[id]/c/[collectionSlug]
    NextServer->>NextServer: safePath(id), safePath(collectionSlug)
    alt 無効な識別子
        NextServer-->>Browser: 無効な識別子です
    else 有効
        par generateMetadata
            NextServer->>API: GET /api/users/:id
            NextServer->>API: GET /api/users/:id/collections
            API-->>NextServer: ユーザー & コレクション情報
            NextServer-->>Browser: alternates: atom.xml URL (PUBLIC_API_BASE)
        and Page render
            NextServer-->>Browser: UserCollectionPageClient id collectionSlug
        end
    end
    Browser->>API: apiFetch /api/users/:id/collections
    Browser->>API: apiFetch /api/collections/:id/papers
    API-->>Browser: コレクション & 論文データ
    Browser->>Browser: FeedButton 表示 (NEXT_PUBLIC_API_URL)
```

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
This is a comment left during a code review.
Path: apps/web/src/app/users/[id]/c/[collectionSlug]/__tests__/user-collection-page-client.test.tsx
Line: 18-22

Comment:
**`afterEach(cleanup)` が抜けています**

`page-metadata.test.tsx` などの他のテストファイルと異なり、`afterEach(() => { cleanup(); })` が定義されていません。テスト間で描画済みコンポーネントが残ると、後続のテストに影響する可能性があります。

```suggestion
describe("UserCollectionPageClient", () => {
  afterEach(() => {
    cleanup();
  });

  beforeEach(() => {
    vi.clearAllMocks();
  });
```

How can I resolve this? If you propose a fix, please make it concise.

---

This is a comment left during a code review.
Path: apps/web/src/app/users/[id]/c/[collectionSlug]/page.tsx
Line: 92-95

Comment:
**`PUBLIC_API_BASE` が内部 URL にフォールバックする可能性**

`PUBLIC_API_BASE` は `NEXT_PUBLIC_API_URL ?? API_URL ?? localhost` の優先度で解決されます。`NEXT_PUBLIC_API_URL` が未設定で `API_URL` のみ設定されている環境（例: `http://internal-api:8787`）では、その内部 URL がメタデータの `<link rel="alternate">` に出力されます。クライアントコンポーネント側の `feedUrl` は `NEXT_PUBLIC_API_URL` のみ参照するため、両者の URL が一致しなくなるリスクがあります。`NEXT_PUBLIC_API_URL` の設定を必須とするか、未設定時に警告ログを出すことを検討してください（`org/page.tsx` にも同じ構造があります）。

How can I resolve this? If you propose a fix, please make it concise.
`````

</details>

<sub>Reviews (1): Last reviewed commit: ["feat(web): add FeedButton to collection ..."](https://github.com/hiroki-org/openshelf/commit/f277bf96c0794061d24f7e035ecf3f9d34ace3f8) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=28184633)</sub>

> Greptile also left **2 inline comments** on this PR.

<!-- /greptile_comment -->