### PR TITLE
TSK-496: feat: improve PDF viewer UX

### DIFF
--- a/apps/web/src/app/globals.css
+++ b/apps/web/src/app/globals.css
@@ -51,3 +51,12 @@ body {
   color: var(--foreground);
   font-family: Arial, Helvetica, sans-serif;
 }
+
+.react-pdf__Page {
+  position: relative;
+}
+
+.react-pdf__Page__textContent {
+  inset: 0;
+  user-select: text;
+}

--- a/apps/web/src/components/__tests__/pdf-viewer.test.tsx
+++ b/apps/web/src/components/__tests__/pdf-viewer.test.tsx
@@ -1,6 +1,13 @@
 import type { ReactNode } from "react";
-import { render } from "@testing-library/react";
-import { beforeEach, describe, expect, it, vi } from "vitest";
+import {
+  act,
+  cleanup,
+  fireEvent,
+  render,
+  screen,
+  waitFor,
+} from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { PdfViewer } from "../pdf-viewer";
 
 type DocumentOptions = {
@@ -13,13 +20,23 @@ type MockDocumentProps = {
   children?: ReactNode;
   file?: string;
   options?: DocumentOptions;
+  onLoadSuccess?: (info: unknown) => void;
 };
 
 const mockDocument = vi.fn((props: MockDocumentProps) => (
   <div data-testid="mock-document">{props.children}</div>
 ));
 
-const mockPage = vi.fn(() => <div data-testid="mock-page" />);
+type MockPageProps = {
+  pageNumber: number;
+  width?: number;
+  renderTextLayer?: boolean;
+  renderAnnotationLayer?: boolean;
+};
+
+const mockPage = vi.fn((props: MockPageProps) => (
+  <div data-testid={`mock-page-${props.pageNumber}`} />
+));
 
 vi.mock("react-pdf", () => {
   const workerOptions = { workerSrc: "" };
@@ -30,11 +47,26 @@ vi.mock("react-pdf", () => {
       GlobalWorkerOptions: workerOptions,
     },
     Document: (props: MockDocumentProps) => mockDocument(props),
-    Page: () => mockPage(),
+    Page: (props: MockPageProps) => mockPage(props),
   };
 });
 
+function createMockPdfDocument(pageTexts: string[]) {
+  return {
+    numPages: pageTexts.length,
+    getPage: vi.fn(async (pageNumber: number) => ({
+      getTextContent: vi.fn(async () => ({
+        items: [{ str: pageTexts[pageNumber - 1] ?? "" }],
+      })),
+    })),
+  };
+}
+
 describe("PdfViewer", () => {
+  afterEach(() => {
+    cleanup();
+  });
+
   beforeEach(() => {
     vi.clearAllMocks();
 
@@ -42,18 +74,57 @@ describe("PdfViewer", () => {
       observe() {}
       disconnect() {}
     }
+    class MockIntersectionObserver {
+      observe() {}
+      unobserve() {}
+      disconnect() {}
+      takeRecords() {
+        return [];
+      }
+    }
 
     Object.defineProperty(window, "ResizeObserver", {
       configurable: true,
       writable: true,
       value: MockResizeObserver,
     });
+    Object.defineProperty(window, "IntersectionObserver", {
+      configurable: true,
+      writable: true,
+      value: MockIntersectionObserver,
+    });
+    Object.defineProperty(globalThis, "IntersectionObserver", {
+      configurable: true,
+      writable: true,
+      value: MockIntersectionObserver,
+    });
+
+    Object.defineProperty(window, "matchMedia", {
+      configurable: true,
+      writable: true,
+      value: vi.fn().mockImplementation((query: string) => ({
+        matches: false,
+        media: query,
+        onchange: null,
+        addEventListener: vi.fn(),
+        removeEventListener: vi.fn(),
+        addListener: vi.fn(),
+        removeListener: vi.fn(),
+        dispatchEvent: vi.fn(),
+      })),
+    });
+
+    Object.defineProperty(Element.prototype, "scrollIntoView", {
+      configurable: true,
+      writable: true,
+      value: vi.fn(),
+    });
   });
 
-  it("passes multilingual font options to react-pdf Document", () => {
+  it("passes multilingual font options and text layer flags to react-pdf", () => {
     render(<PdfViewer fileUrl="https://example.com/paper.pdf" />);
 
-    expect(mockDocument).toHaveBeenCalledTimes(1);
+    expect(mockDocument).toHaveBeenCalled();
     const [props] = mockDocument.mock.calls[0] as [MockDocumentProps];
 
     expect(props.file).toBe("https://example.com/paper.pdf");
@@ -62,5 +133,103 @@ describe("PdfViewer", () => {
       cMapUrl: expect.stringContaining("/cmaps/"),
       standardFontDataUrl: expect.stringContaining("/standard_fonts/"),
     });
+
+    const [pageProps] = mockPage.mock.calls[0] as [MockPageProps];
+    expect(pageProps.pageNumber).toBe(1);
+    expect(pageProps.renderTextLayer).toBe(true);
+    expect(pageProps.renderAnnotationLayer).toBe(true);
+  });
+
+  it("defaults to continuous mode on mobile and virtualizes distant pages", async () => {
+    vi.mocked(window.matchMedia).mockImplementation(
+      (query: string) =>
+        ({
+          matches: query.includes("max-width"),
+          media: query,
+          onchange: null,
+          addEventListener: vi.fn(),
+          removeEventListener: vi.fn(),
+          addListener: vi.fn(),
+          removeListener: vi.fn(),
+          dispatchEvent: vi.fn(),
+        }) as MediaQueryList,
+    );
+
+    render(<PdfViewer fileUrl="https://example.com/mobile.pdf" />);
+    await waitFor(() => {
+      expect(
+        screen.getByRole("button", { name: "ページ送り" }),
+      ).toBeInTheDocument();
+    });
+
+    const [documentProps] = mockDocument.mock.calls.at(-1) as [MockDocumentProps];
+    mockPage.mockClear();
+    await act(async () => {
+      documentProps.onLoadSuccess?.(
+        createMockPdfDocument(["p1", "p2", "p3", "p4"]),
+      );
+    });
+
+    await waitFor(() => {
+      const renderedPages = mockPage.mock.calls.map(
+        ([props]) => props.pageNumber,
+      );
+      expect(renderedPages).toEqual(expect.arrayContaining([1, 2, 3]));
+      expect(renderedPages).not.toContain(4);
+    });
+  });
+
+  it("supports custom search navigation across pages", async () => {
+    render(<PdfViewer fileUrl="https://example.com/search.pdf" />);
+    const [documentProps] = mockDocument.mock.calls.at(-1) as [MockDocumentProps];
+
+    await act(async () => {
+      documentProps.onLoadSuccess?.(
+        createMockPdfDocument(["alpha", "beta target", "gamma target"]),
+      );
+    });
+
+    fireEvent.change(screen.getByRole("searchbox", { name: "PDF内検索" }), {
+      target: { value: "target" },
+    });
+
+    await waitFor(() => {
+      expect(screen.getByText("1 / 2")).toBeInTheDocument();
+    });
+
+    fireEvent.click(screen.getByRole("button", { name: "次の一致" }));
+
+    await waitFor(() => {
+      expect(screen.getByText("2 / 2")).toBeInTheDocument();
+      const renderedPages = mockPage.mock.calls.map(
+        ([props]) => props.pageNumber,
+      );
+      expect(renderedPages).toContain(3);
+    });
+  });
+
+  it("syncs pinch zoom with zoom controls on touch devices", async () => {
+    render(<PdfViewer fileUrl="https://example.com/pinch.pdf" />);
+    const surface = screen.getByTestId("pdf-viewer-surface");
+    const zoomSelect = screen.getByLabelText("PDF zoom") as HTMLSelectElement;
+
+    fireEvent.touchStart(surface, {
+      touches: [
+        { clientX: 0, clientY: 0 },
+        { clientX: 100, clientY: 0 },
+      ],
+    });
+    fireEvent.touchMove(surface, {
+      touches: [
+        { clientX: 0, clientY: 0 },
+        { clientX: 180, clientY: 0 },
+      ],
+    });
+    fireEvent.touchEnd(surface, { touches: [] });
+
+    expect(zoomSelect.value).toBe("1.75");
+
+    fireEvent.click(screen.getByRole("button", { name: "+" }));
+    expect(zoomSelect.value).toBe("2");
   });
 });

--- a/apps/web/src/components/__tests__/pdf-viewer.test.tsx
+++ b/apps/web/src/components/__tests__/pdf-viewer.test.tsx
@@ -34,9 +34,65 @@ type MockPageProps = {
   renderAnnotationLayer?: boolean;
 };
 
+type MockObserverEntry = {
+  target: Element;
+  isIntersecting?: boolean;
+  intersectionRatio?: number;
+};
+
+type MockIntersectionCallback = (
+  entries: IntersectionObserverEntry[],
+  observer: IntersectionObserver,
+) => void;
+
 const mockPage = vi.fn((props: MockPageProps) => (
   <div data-testid={`mock-page-${props.pageNumber}`} />
 ));
+
+class MockIntersectionObserver {
+  static instances: MockIntersectionObserver[] = [];
+
+  readonly observed = new Set<Element>();
+  private readonly callback: MockIntersectionCallback;
+
+  constructor(callback: MockIntersectionCallback) {
+    this.callback = callback;
+    MockIntersectionObserver.instances.push(this);
+  }
+
+  observe(target: Element) {
+    this.observed.add(target);
+  }
+
+  unobserve(target: Element) {
+    this.observed.delete(target);
+  }
+
+  disconnect() {
+    this.observed.clear();
+  }
+
+  takeRecords() {
+    return [];
+  }
+
+  triggerIntersect(entries: MockObserverEntry[]) {
+    const normalizedEntries = entries.map(
+      ({ target, isIntersecting = true, intersectionRatio = 1 }) =>
+        ({
+          target,
+          isIntersecting,
+          intersectionRatio,
+          time: 0,
+          rootBounds: null,
+          boundingClientRect: {} as DOMRectReadOnly,
+          intersectionRect: {} as DOMRectReadOnly,
+        }) as IntersectionObserverEntry,
+    );
+
+    this.callback(normalizedEntries, this as unknown as IntersectionObserver);
+  }
+}
 
 vi.mock("react-pdf", () => {
   const workerOptions = { workerSrc: "" };
@@ -69,18 +125,11 @@ describe("PdfViewer", () => {
 
   beforeEach(() => {
     vi.clearAllMocks();
+    MockIntersectionObserver.instances = [];
 
     class MockResizeObserver {
       observe() {}
       disconnect() {}
-    }
-    class MockIntersectionObserver {
-      observe() {}
-      unobserve() {}
-      disconnect() {}
-      takeRecords() {
-        return [];
-      }
     }
 
     Object.defineProperty(window, "ResizeObserver", {
@@ -162,7 +211,9 @@ describe("PdfViewer", () => {
       ).toBeInTheDocument();
     });
 
-    const [documentProps] = mockDocument.mock.calls.at(-1) as [MockDocumentProps];
+    const [documentProps] = mockDocument.mock.calls[mockDocument.mock.calls.length - 1] as [
+      MockDocumentProps,
+    ];
     mockPage.mockClear();
     await act(async () => {
       documentProps.onLoadSuccess?.(
@@ -177,11 +228,46 @@ describe("PdfViewer", () => {
       expect(renderedPages).toEqual(expect.arrayContaining([1, 2, 3]));
       expect(renderedPages).not.toContain(4);
     });
+
+    const currentObserver =
+      MockIntersectionObserver.instances[
+        MockIntersectionObserver.instances.length - 1
+      ];
+    const page3Node = document.querySelector('[data-page-number="3"]');
+    expect(currentObserver).toBeDefined();
+    expect(page3Node).toBeTruthy();
+
+    act(() => {
+      currentObserver?.triggerIntersect([
+        { target: page3Node as Element, intersectionRatio: 1 },
+      ]);
+    });
+
+    await waitFor(() => {
+      expect(screen.getByText("3 / 4")).toBeInTheDocument();
+    });
+
+    await waitFor(() => {
+      const renderedPages = mockPage.mock.calls.map(
+        ([props]) => props.pageNumber,
+      );
+      expect(renderedPages).toContain(4);
+    });
+
+    const refreshedObserver =
+      MockIntersectionObserver.instances[
+        MockIntersectionObserver.instances.length - 1
+      ];
+    const page4Node = document.querySelector('[data-page-number="4"]');
+    expect(page4Node).toBeTruthy();
+    expect(refreshedObserver?.observed.has(page4Node as Element)).toBe(true);
   });
 
   it("supports custom search navigation across pages", async () => {
     render(<PdfViewer fileUrl="https://example.com/search.pdf" />);
-    const [documentProps] = mockDocument.mock.calls.at(-1) as [MockDocumentProps];
+    const [documentProps] = mockDocument.mock.calls[mockDocument.mock.calls.length - 1] as [
+      MockDocumentProps,
+    ];
 
     await act(async () => {
       documentProps.onLoadSuccess?.(

--- a/apps/web/src/components/pdf-viewer.tsx
+++ b/apps/web/src/components/pdf-viewer.tsx
@@ -1,6 +1,13 @@
 "use client";
 
-import { useCallback, useEffect, useMemo, useRef, useState } from "react";
+import {
+  useCallback,
+  useEffect,
+  useMemo,
+  useRef,
+  useState,
+  type TouchEvent,
+} from "react";
 import { Document, Page, pdfjs } from "react-pdf";
 
 type PdfViewerProps = {
@@ -8,7 +15,49 @@ type PdfViewerProps = {
   onDownloadFallback?: () => void;
 };
 
-const ZOOM_PRESETS = [0.5, 0.75, 1, 1.25, 1.5] as const;
+type ViewMode = "paged" | "continuous";
+
+type PdfTextContent = {
+  items: unknown[];
+};
+
+type PdfPageProxy = {
+  getTextContent: () => Promise<PdfTextContent>;
+};
+
+type PdfDocumentProxy = {
+  numPages: number;
+  getPage: (pageNumber: number) => Promise<PdfPageProxy>;
+};
+
+const ZOOM_PRESETS = [0.5, 0.67, 0.75, 0.9, 1, 1.1, 1.25, 1.5, 1.75, 2] as const;
+const MIN_ZOOM = ZOOM_PRESETS[0];
+const MAX_ZOOM = ZOOM_PRESETS[ZOOM_PRESETS.length - 1];
+const CONTINUOUS_BUFFER = 2;
+const PAGE_ASPECT_RATIO = 1.414;
+
+function clampZoom(value: number): number {
+  return Math.min(MAX_ZOOM, Math.max(MIN_ZOOM, value));
+}
+
+function snapZoom(value: number): (typeof ZOOM_PRESETS)[number] {
+  const clamped = clampZoom(value);
+  const nearest = ZOOM_PRESETS.reduce((previous, current) =>
+    Math.abs(current - clamped) < Math.abs(previous - clamped)
+      ? current
+      : previous,
+  );
+  return nearest;
+}
+
+function touchDistance(
+  a: { clientX: number; clientY: number },
+  b: { clientX: number; clientY: number },
+): number {
+  const dx = a.clientX - b.clientX;
+  const dy = a.clientY - b.clientY;
+  return Math.sqrt(dx * dx + dy * dy);
+}
 
 pdfjs.GlobalWorkerOptions.workerSrc = `https://unpkg.com/pdfjs-dist@${pdfjs.version}/build/pdf.worker.min.mjs`;
 
@@ -20,11 +69,31 @@ const options = {
 
 export function PdfViewer({ fileUrl, onDownloadFallback }: PdfViewerProps) {
   const containerRef = useRef<HTMLDivElement | null>(null);
+  const pageNodesRef = useRef<Map<number, HTMLDivElement>>(new Map());
+  const pinchStateRef = useRef<{ startDistance: number; startZoom: number } | null>(null);
+  const pdfDocumentRef = useRef<PdfDocumentProxy | null>(null);
+
   const [containerWidth, setContainerWidth] = useState(0);
   const [numPages, setNumPages] = useState(0);
   const [pageNumber, setPageNumber] = useState(1);
   const [zoom, setZoom] = useState<(typeof ZOOM_PRESETS)[number]>(1);
+  const [viewMode, setViewMode] = useState<ViewMode>("paged");
+  const [visiblePage, setVisiblePage] = useState(1);
   const [loadingError, setLoadingError] = useState(false);
+  const [searchQuery, setSearchQuery] = useState("");
+  const [searchMatches, setSearchMatches] = useState<number[]>([]);
+  const [activeMatchIndex, setActiveMatchIndex] = useState(-1);
+  const [isPinching, setIsPinching] = useState(false);
+
+  useEffect(() => {
+    if (typeof window === "undefined" || typeof window.matchMedia !== "function") {
+      return;
+    }
+
+    if (window.matchMedia("(max-width: 768px), (pointer: coarse)").matches) {
+      setViewMode("continuous");
+    }
+  }, []);
 
   useEffect(() => {
     const node = containerRef.current;
@@ -43,17 +112,73 @@ export function PdfViewer({ fileUrl, onDownloadFallback }: PdfViewerProps) {
     if (containerWidth <= 0) return undefined;
     return Math.max(280, Math.floor(containerWidth * zoom));
   }, [containerWidth, zoom]);
+  const placeholderHeight = Math.max(
+    360,
+    Math.floor((pageWidth ?? containerWidth ?? 420) * PAGE_ASPECT_RATIO),
+  );
 
-  const canPrev = pageNumber > 1;
-  const canNext = numPages > 0 && pageNumber < numPages;
+  const activePage = viewMode === "continuous" ? visiblePage : pageNumber;
+  const canPrev = activePage > 1;
+  const canNext = numPages > 0 && activePage < numPages;
+  const pages = useMemo(
+    () => Array.from({ length: numPages }, (_, index) => index + 1),
+    [numPages],
+  );
+  const renderRange = useMemo(() => {
+    if (viewMode !== "continuous" || numPages === 0) {
+      return { start: 1, end: numPages };
+    }
+    return {
+      start: Math.max(1, visiblePage - CONTINUOUS_BUFFER),
+      end: Math.min(numPages, visiblePage + CONTINUOUS_BUFFER),
+    };
+  }, [numPages, viewMode, visiblePage]);
 
-  const onDocumentLoadSuccess = useCallback((info: { numPages: number }) => {
-    setNumPages(info.numPages);
+  const setPageNode = useCallback(
+    (page: number) => (node: HTMLDivElement | null) => {
+      if (node) {
+        pageNodesRef.current.set(page, node);
+      } else {
+        pageNodesRef.current.delete(page);
+      }
+    },
+    [],
+  );
+
+  const scrollToPage = useCallback((targetPage: number, behavior: ScrollBehavior = "smooth") => {
+    const node = pageNodesRef.current.get(targetPage);
+    if (!node) return;
+    node.scrollIntoView({ behavior, block: "start" });
+  }, []);
+
+  const goToPage = useCallback(
+    (targetPage: number) => {
+      if (numPages <= 0) return;
+      const boundedPage = Math.min(numPages, Math.max(1, targetPage));
+      setPageNumber(boundedPage);
+      if (viewMode === "continuous") {
+        setVisiblePage(boundedPage);
+        requestAnimationFrame(() => {
+          scrollToPage(boundedPage);
+        });
+      }
+    },
+    [numPages, scrollToPage, viewMode],
+  );
+
+  const onDocumentLoadSuccess = useCallback((info: unknown) => {
+    const document = info as PdfDocumentProxy;
+    pdfDocumentRef.current = document;
+    setNumPages(document.numPages);
     setPageNumber(1);
+    setVisiblePage(1);
+    setSearchMatches([]);
+    setActiveMatchIndex(-1);
     setLoadingError(false);
   }, []);
 
   const onDocumentLoadError = useCallback(() => {
+    pdfDocumentRef.current = null;
     setLoadingError(true);
   }, []);
 
@@ -69,6 +194,149 @@ export function PdfViewer({ fileUrl, onDownloadFallback }: PdfViewerProps) {
     await document.exitFullscreen();
   }, []);
 
+  useEffect(() => {
+    if (viewMode !== "continuous") return;
+    requestAnimationFrame(() => {
+      scrollToPage(pageNumber, "auto");
+    });
+  }, [viewMode, pageNumber, scrollToPage]);
+
+  useEffect(() => {
+    if (viewMode !== "continuous" || numPages === 0) return;
+    const root = containerRef.current;
+    if (!root) return;
+
+    const observer = new IntersectionObserver(
+      (entries) => {
+        const visibleEntries = entries
+          .filter((entry) => entry.isIntersecting)
+          .sort((a, b) => b.intersectionRatio - a.intersectionRatio);
+        const primaryEntry = visibleEntries[0];
+        if (!primaryEntry) return;
+        const page = Number(
+          (primaryEntry.target as HTMLElement).dataset.pageNumber ?? "",
+        );
+        if (!Number.isFinite(page)) return;
+        setVisiblePage(page);
+        setPageNumber(page);
+      },
+      {
+        root,
+        threshold: [0.2, 0.4, 0.6, 0.8],
+      },
+    );
+
+    pageNodesRef.current.forEach((node) => observer.observe(node));
+    return () => observer.disconnect();
+  }, [numPages, viewMode, pageWidth]);
+
+  useEffect(() => {
+    const query = searchQuery.trim().toLowerCase();
+    const doc = pdfDocumentRef.current;
+    if (!doc || !query) {
+      setSearchMatches([]);
+      setActiveMatchIndex(-1);
+      return;
+    }
+
+    let cancelled = false;
+
+    void (async () => {
+      const matches: number[] = [];
+      for (let page = 1; page <= doc.numPages; page += 1) {
+        try {
+          const pdfPage = await doc.getPage(page);
+          const textContent = await pdfPage.getTextContent();
+          const pageText = textContent.items
+            .map((item) => {
+              if (
+                item &&
+                typeof item === "object" &&
+                "str" in item &&
+                typeof (item as { str?: unknown }).str === "string"
+              ) {
+                return ((item as { str: string }).str).toLowerCase();
+              }
+              return "";
+            })
+            .join(" ");
+          if (pageText.includes(query)) {
+            matches.push(page);
+          }
+        } catch {
+          // Ignore extraction failures and continue searching other pages.
+        }
+      }
+      if (cancelled) return;
+      setSearchMatches(matches);
+      if (matches.length === 0) {
+        setActiveMatchIndex(-1);
+        return;
+      }
+      setActiveMatchIndex(0);
+      goToPage(matches[0]);
+    })();
+
+    return () => {
+      cancelled = true;
+    };
+  }, [goToPage, searchQuery]);
+
+  const activeMatchPage =
+    activeMatchIndex >= 0 ? searchMatches[activeMatchIndex] : undefined;
+  const moveMatchCursor = useCallback(
+    (direction: -1 | 1) => {
+      if (searchMatches.length === 0) return;
+      const current = activeMatchIndex >= 0 ? activeMatchIndex : 0;
+      const next =
+        (current + direction + searchMatches.length) % searchMatches.length;
+      setActiveMatchIndex(next);
+      goToPage(searchMatches[next]);
+    },
+    [activeMatchIndex, goToPage, searchMatches],
+  );
+
+  const handleTouchStart = useCallback(
+    (event: TouchEvent<HTMLDivElement>) => {
+      if (event.touches.length !== 2) return;
+      const first = event.touches[0];
+      const second = event.touches[1];
+      pinchStateRef.current = {
+        startDistance: touchDistance(first, second),
+        startZoom: zoom,
+      };
+      setIsPinching(true);
+    },
+    [zoom],
+  );
+
+  const handleTouchMove = useCallback((event: TouchEvent<HTMLDivElement>) => {
+    const state = pinchStateRef.current;
+    if (!state || event.touches.length !== 2) return;
+    event.preventDefault();
+    const first = event.touches[0];
+    const second = event.touches[1];
+    const nextDistance = touchDistance(first, second);
+    if (nextDistance <= 0 || state.startDistance <= 0) return;
+    const nextZoom = state.startZoom * (nextDistance / state.startDistance);
+    setZoom(snapZoom(nextZoom));
+  }, []);
+
+  const handleTouchEnd = useCallback((event: TouchEvent<HTMLDivElement>) => {
+    if (event.touches.length >= 2) return;
+    pinchStateRef.current = null;
+    setIsPinching(false);
+  }, []);
+
+  const renderPage = (targetPage: number) => (
+    <Page
+      pageNumber={targetPage}
+      width={pageWidth}
+      renderTextLayer
+      renderAnnotationLayer
+    />
+  );
+
   return (
     <div
       data-testid="pdf-viewer"
@@ -76,36 +344,36 @@ export function PdfViewer({ fileUrl, onDownloadFallback }: PdfViewerProps) {
     >
       <div className="mb-3 flex flex-wrap items-center justify-between gap-2">
         <div className="flex items-center gap-2">
-          <button
-            type="button"
-            onClick={() => setPageNumber((p) => Math.max(1, p - 1))}
-            disabled={!canPrev}
-            className="rounded border border-gray-300 px-2 py-1 text-xs disabled:cursor-not-allowed disabled:opacity-50 dark:border-gray-600"
-          >
-            前へ
-          </button>
-          <span className="text-xs text-gray-600 dark:text-gray-300">
-            {pageNumber} / {numPages || "-"}
-          </span>
-          <button
-            type="button"
-            onClick={() => setPageNumber((p) => Math.min(numPages, p + 1))}
-            disabled={!canNext}
-            className="rounded border border-gray-300 px-2 py-1 text-xs disabled:cursor-not-allowed disabled:opacity-50 dark:border-gray-600"
-          >
+            <button
+              type="button"
+              onClick={() => goToPage(activePage - 1)}
+              disabled={!canPrev}
+              className="rounded border border-gray-300 px-2 py-1 text-xs disabled:cursor-not-allowed disabled:opacity-50 dark:border-gray-600"
+            >
+              前へ
+            </button>
+            <span className="text-xs text-gray-600 dark:text-gray-300">
+              {activePage} / {numPages || "-"}
+            </span>
+            <button
+              type="button"
+              onClick={() => goToPage(activePage + 1)}
+              disabled={!canNext}
+              className="rounded border border-gray-300 px-2 py-1 text-xs disabled:cursor-not-allowed disabled:opacity-50 dark:border-gray-600"
+            >
             次へ
           </button>
         </div>
 
         <div className="flex items-center gap-2">
-          <button
-            type="button"
-            onClick={() => {
-              const idx = ZOOM_PRESETS.indexOf(zoom);
-              if (idx > 0) setZoom(ZOOM_PRESETS[idx - 1]);
-            }}
-            disabled={zoom === ZOOM_PRESETS[0]}
-            className="rounded border border-gray-300 px-2 py-1 text-xs disabled:cursor-not-allowed disabled:opacity-50 dark:border-gray-600"
+            <button
+              type="button"
+              onClick={() => {
+                const currentIndex = ZOOM_PRESETS.indexOf(snapZoom(zoom));
+                if (currentIndex > 0) setZoom(ZOOM_PRESETS[currentIndex - 1]);
+              }}
+              disabled={zoom === ZOOM_PRESETS[0]}
+              className="rounded border border-gray-300 px-2 py-1 text-xs disabled:cursor-not-allowed disabled:opacity-50 dark:border-gray-600"
           >
             -
           </button>
@@ -125,32 +393,84 @@ export function PdfViewer({ fileUrl, onDownloadFallback }: PdfViewerProps) {
             ))}
           </select>
 
-          <button
-            type="button"
-            onClick={() => {
-              const idx = ZOOM_PRESETS.indexOf(zoom);
-              if (idx < ZOOM_PRESETS.length - 1) setZoom(ZOOM_PRESETS[idx + 1]);
-            }}
-            disabled={zoom === ZOOM_PRESETS[ZOOM_PRESETS.length - 1]}
-            className="rounded border border-gray-300 px-2 py-1 text-xs disabled:cursor-not-allowed disabled:opacity-50 dark:border-gray-600"
+            <button
+              type="button"
+              onClick={() => {
+                const currentIndex = ZOOM_PRESETS.indexOf(snapZoom(zoom));
+                if (currentIndex < ZOOM_PRESETS.length - 1) {
+                  setZoom(ZOOM_PRESETS[currentIndex + 1]);
+                }
+              }}
+              disabled={zoom === ZOOM_PRESETS[ZOOM_PRESETS.length - 1]}
+              className="rounded border border-gray-300 px-2 py-1 text-xs disabled:cursor-not-allowed disabled:opacity-50 dark:border-gray-600"
           >
             +
           </button>
 
+            <button
+              type="button"
+              onClick={toggleFullScreen}
+              className="rounded bg-gray-800 px-2 py-1 text-xs text-white hover:bg-gray-700 dark:bg-gray-200 dark:text-gray-900"
+            >
+              全画面
+            </button>
+
+            <button
+              type="button"
+              onClick={() =>
+                setViewMode((mode) =>
+                  mode === "paged" ? "continuous" : "paged",
+                )
+              }
+              className="rounded border border-gray-300 px-2 py-1 text-xs dark:border-gray-600"
+            >
+              {viewMode === "paged" ? "連続スクロール" : "ページ送り"}
+            </button>
+          </div>
+        </div>
+
+        <div className="mb-3 flex flex-wrap items-center gap-2">
+          <input
+            aria-label="PDF内検索"
+            type="search"
+            value={searchQuery}
+            onChange={(event) => setSearchQuery(event.target.value)}
+            placeholder="検索語を入力"
+            className="min-w-[180px] flex-1 rounded border border-gray-300 px-2 py-1 text-xs dark:border-gray-600 dark:bg-gray-900"
+          />
           <button
             type="button"
-            onClick={toggleFullScreen}
-            className="rounded bg-gray-800 px-2 py-1 text-xs text-white hover:bg-gray-700 dark:bg-gray-200 dark:text-gray-900"
+            disabled={searchMatches.length === 0}
+            onClick={() => moveMatchCursor(-1)}
+            className="rounded border border-gray-300 px-2 py-1 text-xs disabled:cursor-not-allowed disabled:opacity-50 dark:border-gray-600"
           >
-            全画面
+            前の一致
           </button>
+          <button
+            type="button"
+            disabled={searchMatches.length === 0}
+            onClick={() => moveMatchCursor(1)}
+            className="rounded border border-gray-300 px-2 py-1 text-xs disabled:cursor-not-allowed disabled:opacity-50 dark:border-gray-600"
+          >
+            次の一致
+          </button>
+          <span className="text-xs text-gray-500 dark:text-gray-300">
+            {searchQuery.trim().length === 0
+              ? ""
+              : searchMatches.length === 0
+                ? "一致なし"
+                : `${activeMatchIndex + 1} / ${searchMatches.length}`}
+          </span>
         </div>
-      </div>
 
       <div
         ref={containerRef}
         data-testid="pdf-viewer-surface"
-        className="flex min-h-[420px] items-center justify-center overflow-auto rounded bg-gray-50 p-2 dark:bg-gray-950"
+        className={`min-h-[420px] overflow-auto rounded bg-gray-50 p-2 dark:bg-gray-950 ${isPinching ? "touch-none" : "touch-pan-y"}`}
+        onTouchStart={handleTouchStart}
+        onTouchMove={handleTouchMove}
+        onTouchEnd={handleTouchEnd}
+        onTouchCancel={handleTouchEnd}
       >
         <Document
           key={fileUrl}
@@ -185,7 +505,50 @@ export function PdfViewer({ fileUrl, onDownloadFallback }: PdfViewerProps) {
             </div>
           }
         >
-          {!loadingError && <Page pageNumber={pageNumber} width={pageWidth} />}
+          {!loadingError &&
+            (viewMode === "continuous" ? (
+              <div className="flex flex-col items-center gap-4 py-1">
+                {pages.map((targetPage) => {
+                  const isVisibleByBuffer =
+                    targetPage >= renderRange.start && targetPage <= renderRange.end;
+                  const isSearchMatch = searchMatches.includes(targetPage);
+                  const isActiveSearchMatch = activeMatchPage === targetPage;
+                  const shouldRender = isVisibleByBuffer || isActiveSearchMatch;
+
+                  return (
+                    <div
+                      key={targetPage}
+                      ref={setPageNode(targetPage)}
+                      data-page-number={targetPage}
+                      className={`w-full rounded ${
+                        isActiveSearchMatch
+                          ? "ring-2 ring-blue-500"
+                          : isSearchMatch
+                            ? "ring-1 ring-blue-300"
+                            : ""
+                      }`}
+                    >
+                      {shouldRender ? (
+                        renderPage(targetPage)
+                      ) : (
+                        <div
+                          aria-hidden="true"
+                          className="mx-auto rounded border border-dashed border-gray-300 bg-gray-100/60 dark:border-gray-700 dark:bg-gray-900/40"
+                          style={{
+                            width: pageWidth ?? "100%",
+                            height: placeholderHeight,
+                          }}
+                        />
+                      )}
+                    </div>
+                  );
+                })}
+              </div>
+            ) : (
+              <div className="flex items-center justify-center">
+                {renderPage(pageNumber)}
+              </div>
+            ))}
         </Document>
       </div>
     </div>

--- a/apps/web/src/components/pdf-viewer.tsx
+++ b/apps/web/src/components/pdf-viewer.tsx
@@ -113,6 +113,22 @@ export function PdfViewer({ fileUrl, onDownloadFallback }: PdfViewerProps) {
     return () => observer.disconnect();
   }, []);
 
+  useEffect(() => {
+    const node = containerRef.current;
+    if (!node) return;
+
+    const handleNativeTouchMove = (event: Event) => {
+      const touchEvent = event as globalThis.TouchEvent;
+      if (!pinchStateRef.current || touchEvent.touches.length !== 2) return;
+      touchEvent.preventDefault();
+    };
+
+    node.addEventListener("touchmove", handleNativeTouchMove, { passive: false });
+    return () => {
+      node.removeEventListener("touchmove", handleNativeTouchMove);
+    };
+  }, []);
+
   const pageWidth = useMemo(() => {
     if (containerWidth <= 0) return undefined;
     return Math.max(280, Math.floor(containerWidth * zoom));
@@ -125,6 +141,10 @@ export function PdfViewer({ fileUrl, onDownloadFallback }: PdfViewerProps) {
   const activePage = viewMode === "continuous" ? visiblePage : pageNumber;
   const canPrev = activePage > 1;
   const canNext = numPages > 0 && activePage < numPages;
+  const searchMatchSet = useMemo(
+    () => new Set(searchMatches),
+    [searchMatches],
+  );
   const pages = useMemo(
     () => Array.from({ length: numPages }, (_, index) => index + 1),
     [numPages],
@@ -170,10 +190,10 @@ export function PdfViewer({ fileUrl, onDownloadFallback }: PdfViewerProps) {
   );
 
   const onDocumentLoadSuccess = useCallback((info: unknown) => {
-    const document = info as PdfDocumentProxy;
-    pdfDocumentRef.current = document;
+    const pdfDocument = info as PdfDocumentProxy;
+    pdfDocumentRef.current = pdfDocument;
     searchTextCacheRef.current.clear();
-    setNumPages(document.numPages);
+    setNumPages(pdfDocument.numPages);
     setPageNumber(1);
     setVisiblePage(1);
     setSearchMatches([]);
@@ -482,7 +502,11 @@ export function PdfViewer({ fileUrl, onDownloadFallback }: PdfViewerProps) {
           >
             次の一致
           </button>
-          <span className="text-xs text-gray-500 dark:text-gray-300">
+          <span
+            aria-live="polite"
+            aria-atomic="true"
+            className="text-xs text-gray-500 dark:text-gray-300"
+          >
             {searchQuery.trim().length === 0
               ? ""
               : searchMatches.length === 0
@@ -539,7 +563,7 @@ export function PdfViewer({ fileUrl, onDownloadFallback }: PdfViewerProps) {
                 {pages.map((targetPage) => {
                   const isVisibleByBuffer =
                     targetPage >= renderRange.start && targetPage <= renderRange.end;
-                  const isSearchMatch = searchMatches.includes(targetPage);
+                  const isSearchMatch = searchMatchSet.has(targetPage);
                   const isActiveSearchMatch = activeMatchPage === targetPage;
                   const shouldRender = isVisibleByBuffer || isActiveSearchMatch;
 

--- a/apps/web/src/components/pdf-viewer.tsx
+++ b/apps/web/src/components/pdf-viewer.tsx
@@ -35,6 +35,7 @@ const MIN_ZOOM = ZOOM_PRESETS[0];
 const MAX_ZOOM = ZOOM_PRESETS[ZOOM_PRESETS.length - 1];
 const CONTINUOUS_BUFFER = 2;
 const PAGE_ASPECT_RATIO = 1.414;
+const SEARCH_DEBOUNCE_MS = 350;
 
 function clampZoom(value: number): number {
   return Math.min(MAX_ZOOM, Math.max(MIN_ZOOM, value));
@@ -72,15 +73,19 @@ export function PdfViewer({ fileUrl, onDownloadFallback }: PdfViewerProps) {
   const pageNodesRef = useRef<Map<number, HTMLDivElement>>(new Map());
   const pinchStateRef = useRef<{ startDistance: number; startZoom: number } | null>(null);
   const pdfDocumentRef = useRef<PdfDocumentProxy | null>(null);
+  const searchTextCacheRef = useRef<Map<number, string>>(new Map());
+  const isProgrammaticNavRef = useRef(false);
+  const prevViewModeRef = useRef<ViewMode>("paged");
 
   const [containerWidth, setContainerWidth] = useState(0);
   const [numPages, setNumPages] = useState(0);
   const [pageNumber, setPageNumber] = useState(1);
-  const [zoom, setZoom] = useState<(typeof ZOOM_PRESETS)[number]>(1);
+  const [zoom, setZoom] = useState(1);
   const [viewMode, setViewMode] = useState<ViewMode>("paged");
   const [visiblePage, setVisiblePage] = useState(1);
   const [loadingError, setLoadingError] = useState(false);
   const [searchQuery, setSearchQuery] = useState("");
+  const [debouncedSearchQuery, setDebouncedSearchQuery] = useState("");
   const [searchMatches, setSearchMatches] = useState<number[]>([]);
   const [activeMatchIndex, setActiveMatchIndex] = useState(-1);
   const [isPinching, setIsPinching] = useState(false);
@@ -157,18 +162,17 @@ export function PdfViewer({ fileUrl, onDownloadFallback }: PdfViewerProps) {
       const boundedPage = Math.min(numPages, Math.max(1, targetPage));
       setPageNumber(boundedPage);
       if (viewMode === "continuous") {
+        isProgrammaticNavRef.current = true;
         setVisiblePage(boundedPage);
-        requestAnimationFrame(() => {
-          scrollToPage(boundedPage);
-        });
       }
     },
-    [numPages, scrollToPage, viewMode],
+    [numPages, viewMode],
   );
 
   const onDocumentLoadSuccess = useCallback((info: unknown) => {
     const document = info as PdfDocumentProxy;
     pdfDocumentRef.current = document;
+    searchTextCacheRef.current.clear();
     setNumPages(document.numPages);
     setPageNumber(1);
     setVisiblePage(1);
@@ -179,6 +183,7 @@ export function PdfViewer({ fileUrl, onDownloadFallback }: PdfViewerProps) {
 
   const onDocumentLoadError = useCallback(() => {
     pdfDocumentRef.current = null;
+    searchTextCacheRef.current.clear();
     setLoadingError(true);
   }, []);
 
@@ -195,10 +200,20 @@ export function PdfViewer({ fileUrl, onDownloadFallback }: PdfViewerProps) {
   }, []);
 
   useEffect(() => {
-    if (viewMode !== "continuous") return;
-    requestAnimationFrame(() => {
-      scrollToPage(pageNumber, "auto");
-    });
+    const enteringContinuous =
+      viewMode === "continuous" && prevViewModeRef.current !== "continuous";
+    const shouldScroll =
+      viewMode === "continuous" &&
+      (enteringContinuous || isProgrammaticNavRef.current);
+
+    if (shouldScroll) {
+      requestAnimationFrame(() => {
+        scrollToPage(pageNumber, "auto");
+      });
+    }
+
+    isProgrammaticNavRef.current = false;
+    prevViewModeRef.current = viewMode;
   }, [viewMode, pageNumber, scrollToPage]);
 
   useEffect(() => {
@@ -228,10 +243,20 @@ export function PdfViewer({ fileUrl, onDownloadFallback }: PdfViewerProps) {
 
     pageNodesRef.current.forEach((node) => observer.observe(node));
     return () => observer.disconnect();
-  }, [numPages, viewMode, pageWidth]);
+  }, [numPages, viewMode, pageWidth, renderRange.start, renderRange.end]);
 
   useEffect(() => {
-    const query = searchQuery.trim().toLowerCase();
+    const timer = window.setTimeout(() => {
+      setDebouncedSearchQuery(searchQuery.trim());
+    }, SEARCH_DEBOUNCE_MS);
+
+    return () => {
+      window.clearTimeout(timer);
+    };
+  }, [searchQuery]);
+
+  useEffect(() => {
+    const query = debouncedSearchQuery.toLowerCase();
     const doc = pdfDocumentRef.current;
     if (!doc || !query) {
       setSearchMatches([]);
@@ -245,21 +270,25 @@ export function PdfViewer({ fileUrl, onDownloadFallback }: PdfViewerProps) {
       const matches: number[] = [];
       for (let page = 1; page <= doc.numPages; page += 1) {
         try {
-          const pdfPage = await doc.getPage(page);
-          const textContent = await pdfPage.getTextContent();
-          const pageText = textContent.items
-            .map((item) => {
-              if (
-                item &&
-                typeof item === "object" &&
-                "str" in item &&
-                typeof (item as { str?: unknown }).str === "string"
-              ) {
-                return ((item as { str: string }).str).toLowerCase();
-              }
-              return "";
-            })
-            .join(" ");
+          let pageText = searchTextCacheRef.current.get(page);
+          if (pageText === undefined) {
+            const pdfPage = await doc.getPage(page);
+            const textContent = await pdfPage.getTextContent();
+            pageText = textContent.items
+              .map((item) => {
+                if (
+                  item &&
+                  typeof item === "object" &&
+                  "str" in item &&
+                  typeof (item as { str?: unknown }).str === "string"
+                ) {
+                  return ((item as { str: string }).str).toLowerCase();
+                }
+                return "";
+              })
+              .join(" ");
+            searchTextCacheRef.current.set(page, pageText);
+          }
           if (pageText.includes(query)) {
             matches.push(page);
           }
@@ -274,13 +303,12 @@ export function PdfViewer({ fileUrl, onDownloadFallback }: PdfViewerProps) {
         return;
       }
       setActiveMatchIndex(0);
-      goToPage(matches[0]);
     })();
 
     return () => {
       cancelled = true;
     };
-  }, [goToPage, searchQuery]);
+  }, [debouncedSearchQuery, numPages]);
 
   const activeMatchPage =
     activeMatchIndex >= 0 ? searchMatches[activeMatchIndex] : undefined;
@@ -319,12 +347,14 @@ export function PdfViewer({ fileUrl, onDownloadFallback }: PdfViewerProps) {
     const nextDistance = touchDistance(first, second);
     if (nextDistance <= 0 || state.startDistance <= 0) return;
     const nextZoom = state.startZoom * (nextDistance / state.startDistance);
-    setZoom(snapZoom(nextZoom));
+    setZoom(clampZoom(nextZoom));
   }, []);
 
   const handleTouchEnd = useCallback((event: TouchEvent<HTMLDivElement>) => {
     if (event.touches.length >= 2) return;
+    if (!pinchStateRef.current) return;
     pinchStateRef.current = null;
+    setZoom((current) => snapZoom(current));
     setIsPinching(false);
   }, []);
 
@@ -372,7 +402,7 @@ export function PdfViewer({ fileUrl, onDownloadFallback }: PdfViewerProps) {
                 const currentIndex = ZOOM_PRESETS.indexOf(snapZoom(zoom));
                 if (currentIndex > 0) setZoom(ZOOM_PRESETS[currentIndex - 1]);
               }}
-              disabled={zoom === ZOOM_PRESETS[0]}
+              disabled={zoom <= MIN_ZOOM}
               className="rounded border border-gray-300 px-2 py-1 text-xs disabled:cursor-not-allowed disabled:opacity-50 dark:border-gray-600"
           >
             -
@@ -380,10 +410,8 @@ export function PdfViewer({ fileUrl, onDownloadFallback }: PdfViewerProps) {
 
           <select
             aria-label="PDF zoom"
-            value={zoom}
-            onChange={(e) =>
-              setZoom(Number(e.target.value) as (typeof ZOOM_PRESETS)[number])
-            }
+            value={snapZoom(zoom)}
+            onChange={(e) => setZoom(Number(e.target.value))}
             className="rounded border border-gray-300 px-2 py-1 text-xs dark:border-gray-600 dark:bg-gray-900"
           >
             {ZOOM_PRESETS.map((preset) => (
@@ -401,7 +429,7 @@ export function PdfViewer({ fileUrl, onDownloadFallback }: PdfViewerProps) {
                   setZoom(ZOOM_PRESETS[currentIndex + 1]);
                 }
               }}
-              disabled={zoom === ZOOM_PRESETS[ZOOM_PRESETS.length - 1]}
+              disabled={zoom >= MAX_ZOOM}
               className="rounded border border-gray-300 px-2 py-1 text-xs disabled:cursor-not-allowed disabled:opacity-50 dark:border-gray-600"
           >
             +


### PR DESCRIPTION
ref TSK-496

## Summary
- extend PdfViewer with continuous-scroll mode and mode toggle
- enable text layer rendering and add in-view search UI with page navigation
- add mobile pinch-zoom support and virtualization buffer around visible pages
- track visible page with IntersectionObserver in continuous mode
- expand PdfViewer tests for mode, search, virtualization, and pinch behavior

## Validation
- npm run typecheck
- npm run lint
- npm run test
- npm --prefix apps/web run test -- "src/components/__tests__/pdf-viewer.test.tsx" "src/app/papers/[id]/__tests__/paper-detail-client.test.tsx"

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

PdfViewer コンポーネントに連続スクロールモード・ページ内テキスト検索・モバイルピンチズーム・IntersectionObserver による可視ページ追跡・仮想化バッファを追加した大規模なUX改善PRです。

- **P1**: 検索エフェクトの依存配列に `goToPage` が含まれているため、ビューモードを切り替えると `goToPage` の参照が変わりエフェクトが再実行され、`activeMatchIndex` が強制的に 0 にリセットされます（`pdf-viewer.tsx` 233〜283行目）。マージ前に修正が必要です。
</details>

<h3>Confidence Score: 4/5</h3>

P1 バグ（モード切替による検索位置リセット）が残っているため、修正後のマージを推奨します。

P1 が 1 件（viewMode 変更時に goToPage が再生成されて検索エフェクトが再実行→activeMatchIndex が 0 にリセット）あり、ユーザーの操作フローを直接破壊します。その他は P2（パフォーマンス・可読性・アクセシビリティ）であり即時の機能破壊はありません。P1 の修正は局所的（deps 配列と useRef の小変更）で、修正後はマージ可能です。

apps/web/src/components/pdf-viewer.tsx の検索 useEffect（233〜283行目）を重点的に確認してください。

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| apps/web/src/components/pdf-viewer.tsx | 連続スクロールモード・テキスト検索・ピンチズームを追加。viewMode 変更時に goToPage 依存で検索位置がリセットされる P1 バグあり。searchMatches.includes の O(n²) スキャン、デバウンス欠如、document 変数シャドウなど複数の P2 課題も含む。 |
| apps/web/src/components/__tests__/pdf-viewer.test.tsx | IntersectionObserver・matchMedia・scrollIntoView のモックを追加し、モバイル連続モード・検索ナビゲーション・ピンチズームの新テストを追加。全体的に適切なカバレッジ。 |
| apps/web/src/app/globals.css | react-pdf のテキストレイヤー表示に必要な CSS を追加。問題なし。 |

</details>

</details>

<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[ユーザー操作] --> B{操作種別}
    B --> |検索クエリ入力| C[searchQuery 変更]
    B --> |モード切替ボタン| D[viewMode 変更]
    B --> |前へ/次へ| E[goToPage 呼び出し]
    B --> |ピンチズーム| F[touchStart/Move/End]

    C --> G[検索 useEffect 実行\n全ページ getTextContent]
    D --> H[goToPage 再生成\nviewMode 依存]
    H --> G
    G --> |matches 確定| I[setActiveMatchIndex 0\ngoToPage matches0]

    D --> J[スクロール useEffect\nscrollToPage pageNumber auto]
    D --> K[IntersectionObserver 再構築\nnumPages/viewMode/pageWidth 依存]

    E --> L{viewMode}
    L --> |paged| M[setPageNumber]
    L --> |continuous| N[setPageNumber\nsetVisiblePage\nscrollToPage]

    F --> O[snapZoom 計算\nsetZoom]

    K --> P[pageNodesRef 全ノード observe]
    P --> Q[スクロールで visiblePage 更新\nsetVisiblePage / setPageNumber]
    Q --> R[renderRange 再計算\nバッファ±2ページをレンダー]

    style H fill:#f99,stroke:#c00
    style G fill:#f99,stroke:#c00
    style I fill:#f99,stroke:#c00
```

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
This is a comment left during a code review.
Path: apps/web/src/components/pdf-viewer.tsx
Line: 233-283

Comment:
**表示モード切替でサーチ位置がリセットされる**

`goToPage` が `searchQuery` と並んで検索エフェクトの依存配列に含まれているため、`viewMode` が変わると `goToPage` の参照も変わり、エフェクトが再実行されます。その結果、`setActiveMatchIndex(0)` と `goToPage(matches[0])` が呼ばれて、ユーザーが "2/3" 番目のマッチを表示中でも強制的に最初のマッチに戻ってしまいます。

テキスト抽出とナビゲーションを分離し、`goToPage` への参照を `useRef` で保持するか、`matches[0]` への遷移を別の `useEffect` に切り出すことで修正できます。

```tsx
const goToPageRef = useRef(goToPage);
useEffect(() => { goToPageRef.current = goToPage; }, [goToPage]);

// 検索エフェクト (deps から goToPage を除外)
useEffect(() => {
  const query = searchQuery.trim().toLowerCase();
  const doc = pdfDocumentRef.current;
  if (!doc || !query) { setSearchMatches([]); setActiveMatchIndex(-1); return; }
  let cancelled = false;
  void (async () => {
    // ... text extraction ...
    if (cancelled) return;
    setSearchMatches(matches);
    setActiveMatchIndex(matches.length > 0 ? 0 : -1);
    if (matches.length > 0) goToPageRef.current(matches[0]);
  })();
  return () => { cancelled = true; };
}, [searchQuery]); // goToPage を依存から外す
```

How can I resolve this? If you propose a fix, please make it concise.

---

This is a comment left during a code review.
Path: apps/web/src/components/pdf-viewer.tsx
Line: 508-545

Comment:
**O(n²) の線形探索をSetに変換する**

`searchMatches.includes(targetPage)` は `pages.map()` の内側で呼ばれるため、全ページ数 × マッチ数の線形スキャンが毎レンダーで発生します。100ページで50件マッチすると5,000回の比較が走ります。`useMemo` で `Set` を作ると O(1) ルックアップになります。

```tsx
const searchMatchSet = useMemo(
  () => new Set(searchMatches),
  [searchMatches],
);
// 使用箇所
const isSearchMatch = searchMatchSet.has(targetPage);
```

How can I resolve this? If you propose a fix, please make it concise.

---

This is a comment left during a code review.
Path: apps/web/src/components/pdf-viewer.tsx
Line: 169-178

Comment:
**`document` 変数がグローバルの `document` を隠蔽している**

`const document = info as PdfDocumentProxy` はグローバルの `document` オブジェクトを同スコープ内でシャドウします。現状この関数内でグローバル `document` は使っていないため動作に問題はありませんが、将来のメンテナンス時に `document.fullscreenElement` などを追加した場合に予期しない挙動を引き起こす可能性があります。

```suggestion
  const onDocumentLoadSuccess = useCallback((info: unknown) => {
    const pdfDoc = info as PdfDocumentProxy;
    pdfDocumentRef.current = pdfDoc;
    setNumPages(pdfDoc.numPages);
    setPageNumber(1);
    setVisiblePage(1);
    setSearchMatches([]);
    setActiveMatchIndex(-1);
    setLoadingError(false);
  }, []);
```

How can I resolve this? If you propose a fix, please make it concise.

---

This is a comment left during a code review.
Path: apps/web/src/components/pdf-viewer.tsx
Line: 233-240

Comment:
**検索クエリにデバウンスがない**

キー入力のたびに全ページのテキスト抽出(`getPage` → `getTextContent`)が非同期で走ります。`cancelled` フラグで正確性は保たれますが、大容量PDFでは不要なCPU消費が発生します。200ms程度のデバウンスを `searchQuery` に適用することで改善できます。

How can I resolve this? If you propose a fix, please make it concise.

---

This is a comment left during a code review.
Path: apps/web/src/components/pdf-viewer.tsx
Line: 457-463

Comment:
**スクリーンリーダー向けの `aria-live` がない**

検索結果カウント（`"1 / 2"`）が変わっても `aria-live` 属性がないため、スクリーンリーダーは変化を読み上げません。

```suggestion
          <span aria-live="polite" aria-atomic="true" className="text-xs text-gray-500 dark:text-gray-300">
            {searchQuery.trim().length === 0
              ? ""
              : searchMatches.length === 0
                ? "一致なし"
                : `${activeMatchIndex + 1} / ${searchMatches.length}`}
          </span>
```

How can I resolve this? If you propose a fix, please make it concise.

---

This is a comment left during a code review.
Path: apps/web/src/components/pdf-viewer.tsx
Line: 313-323

Comment:
**ピンチ中スクロール抑制の信頼性に懸念あり**

`handleTouchMove` で `event.preventDefault()` を呼んでいますが、React 17+ では `onTouchMove` ハンドラが passive リスナーとして登録される場合があり、その場合 `preventDefault()` は無視されます（ブラウザコンソールに警告が出ます）。また `isPinching` による `touch-none` クラス切り替えは次のレンダー後に反映されるため、ジェスチャー開始直後の数回の `touchmove` イベントには間に合わないことがあります。確実にスクロールを抑制するには、`containerRef` に対して `{ passive: false }` で `addEventListener` を直接使用してください。

How can I resolve this? If you propose a fix, please make it concise.
`````

</details>

<sub>Reviews (1): Last reviewed commit: ["feat(web): improve PDF viewer UX"](https://github.com/hiroki-org/openshelf/commit/a2e3e5ef727fdc5f24bb0e8c81ea8cb701b6adbe) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=28185331)</sub>

> Greptile also left **6 inline comments** on this PR.

<!-- /greptile_comment -->