### PR TITLE
fix: resolve workflow issues #420 #421 #431

### DIFF
--- a/.github/scripts/sync-main-to-staging.sh
+++ b/.github/scripts/sync-main-to-staging.sh
@@ -76,6 +76,11 @@ if [ "$DRY_RUN" != "1" ]; then
     exit 0
   else
     echo "Direct merge failed (e.g. conflicts). Falling back to creating a PR."
+    if [ -n "$existing_pr_url" ]; then
+      echo "Existing sync PR remains open: $existing_pr_url"
+      echo "Skipping PR creation because a sync PR already exists."
+      exit 0
+    fi
   fi
 fi
 

--- a/.github/workflows/osv-auto-fix.yml
+++ b/.github/workflows/osv-auto-fix.yml
@@ -41,10 +41,14 @@ jobs:
           fi
 
       - name: Ensure PR token is configured
-        if: ${{ !secrets.OSV_AUTO_FIX_TOKEN && !secrets.SYNC_PR_TOKEN }}
+        env:
+          OSV_AUTO_FIX_TOKEN: ${{ secrets.OSV_AUTO_FIX_TOKEN }}
+          SYNC_PR_TOKEN: ${{ secrets.SYNC_PR_TOKEN }}
         run: |
-          echo "::error::Set OSV_AUTO_FIX_TOKEN or SYNC_PR_TOKEN to create auto-fix PRs with CI-triggering credentials."
-          exit 1
+          if [ -z "${OSV_AUTO_FIX_TOKEN}" ] && [ -z "${SYNC_PR_TOKEN}" ]; then
+            echo "::error::Set OSV_AUTO_FIX_TOKEN or SYNC_PR_TOKEN to create auto-fix PRs with CI-triggering credentials."
+            exit 1
+          fi
 
       - name: Create Pull Request
         uses: peter-evans/create-pull-request@67df0571927e887e4d593f7a4b15a4b86b8d4fac # v6.0.6

--- a/.github/workflows/osv-auto-fix.yml
+++ b/.github/workflows/osv-auto-fix.yml
@@ -33,18 +33,23 @@ jobs:
         run: |
           npm install --ignore-scripts
           npm audit fix
-          npm update brace-expansion
 
           # Fix apps/web if present
           if [ -d "apps/web" ]; then
             npm --prefix apps/web install --ignore-scripts
             npm --prefix apps/web audit fix
-            npm --prefix apps/web update brace-expansion
           fi
+
+      - name: Ensure PR token is configured
+        if: ${{ !secrets.OSV_AUTO_FIX_TOKEN && !secrets.SYNC_PR_TOKEN }}
+        run: |
+          echo "::error::Set OSV_AUTO_FIX_TOKEN or SYNC_PR_TOKEN to create auto-fix PRs with CI-triggering credentials."
+          exit 1
 
       - name: Create Pull Request
         uses: peter-evans/create-pull-request@67df0571927e887e4d593f7a4b15a4b86b8d4fac # v6.0.6
         with:
+          token: ${{ secrets.OSV_AUTO_FIX_TOKEN || secrets.SYNC_PR_TOKEN }}
           commit-message: "chore(security): fix vulnerabilities detected by OSV-Scanner"
           title: "chore(security): auto-fix vulnerabilities"
           body: |


### PR DESCRIPTION
## Summary
- remove `brace-expansion` hard-coded updates from OSV auto-fix workflow and keep generic `npm audit fix` flow
- configure OSV auto-fix PR creation to use PAT/App token (`OSV_AUTO_FIX_TOKEN` fallback `SYNC_PR_TOKEN`) so downstream CI can run on generated PRs
- prevent sync-main-to-staging script from failing when a sync PR already exists and direct merge fails due branch protection/rules

## Details
- `.github/workflows/osv-auto-fix.yml`
  - removed `npm update brace-expansion` in root/apps/web
  - added explicit token guard step
  - passed token to `peter-evans/create-pull-request`
- `.github/scripts/sync-main-to-staging.sh`
  - when direct merge fails and an existing sync PR is already open, exit successfully instead of trying to create a duplicate PR

## References
- ref #420
- ref #421
- ref #431

(As requested, this PR does not include #278.)

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

このPRは、OSVオートフィックスワークフローのトークン設定を強化し、sync-main-to-stagingスクリプトが重複PRを作成しないよう改善するものです。`brace-expansion` のハードコードされた更新を削除して汎用的な `npm audit fix` フローに戻し、`peter-evans/create-pull-request` に PAT/Appトークンを渡すことでCI実行を可能にしています。全体的なロジックは意図通りに動作しており、明確な不具合はありません。
</details>


<h3>Confidence Score: 5/5</h3>

このPRはマージ安全です。残存する指摘はすべてP2（スタイル改善）であり、動作に影響するバグはありません。

直接マージ失敗時の重複PR防止ロジックとトークンガードの実装は共に正しく、論理フローに問題はありません。指摘は暗黙的な型強制とDRY_RUNの出力精度に関するスタイル提案のみです。

特に注意が必要なファイルはありません。osv-auto-fix.yml の `if:` 条件は動作上問題ありませんが、明示的な記法への変更を検討してください。

<details><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| .github/workflows/osv-auto-fix.yml | トークンガードステップとPR作成時のPATトークン渡しを追加。`if:` 条件でのシークレット評価に微妙な問題あり（詳細はコメント参照）。 |
| .github/scripts/sync-main-to-staging.sh | 直接マージ失敗時に既存のsync PRが存在する場合、重複PR作成をスキップして exit 0 するロジックを追加。フローは正しく実装されている。 |

</details>


</details>


<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A([sync-main-to-staging.sh 開始]) --> B{既存のsync PRが\nオープンか?}
    B -- はい --> C[existing_pr_url を記録]
    B -- いいえ --> D{ahead_by == 0?}
    C --> D
    D -- はい --> E([exit 0: 同期不要])
    D -- いいえ --> F{DRY_RUN != 1?}
    F -- いいえ --> G[DRY_RUN: 結果を出力して exit 0]
    F -- はい --> H[直接マージを試みる\ngh api POST /merges]
    H -- 成功 --> I{existing_pr_urlあり?}
    I -- はい --> J[既存PRをクローズ]
    I -- いいえ --> K([exit 0: 直接マージ成功])
    J --> K
    H -- 失敗 --> L{existing_pr_urlあり?}
    L -- はい --> M([exit 0: 重複PR作成をスキップ ★ NEW])
    L -- いいえ --> N[新しいsync PRを作成\ngh pr create]
    N --> O([exit: PR作成完了])
```

<!-- greptile_failed_comments -->
<details open><summary><h3>Comments Outside Diff (1)</h3></summary>

1. `.github/scripts/sync-main-to-staging.sh`, line 111-121 ([link](https://github.com/hiroki-org/openshelf/blob/d27e30135bd910b2a21755f3708492af47efcb7d/.github/scripts/sync-main-to-staging.sh#L111-L121)) 

   <a href="#"><img alt="P2" src="https://greptile-static-assets.s3.amazonaws.com/badges/p2.svg?v=7" align="top"></a> **DRY_RUN が既存PR存在時の新ロジックを反映していない**

   `DRY_RUN=1` のとき、スクリプトはライン65の `if [ "$DRY_RUN" != "1" ]` ブロックをスキップするため、「既存PRがあれば作成をスキップする」新しいロジックがドライラン出力に反映されません。`existing_pr_url` が設定されている場合でも「Would create PR」と出力されてしまい、ドライランで動作検証する際に誤解を招く可能性があります。

   <details><summary>Prompt To Fix With AI</summary>

   `````markdown
   This is a comment left during a code review.
   Path: .github/scripts/sync-main-to-staging.sh
   Line: 111-121

   Comment:
   **DRY_RUN が既存PR存在時の新ロジックを反映していない**

   `DRY_RUN=1` のとき、スクリプトはライン65の `if [ "$DRY_RUN" != "1" ]` ブロックをスキップするため、「既存PRがあれば作成をスキップする」新しいロジックがドライラン出力に反映されません。`existing_pr_url` が設定されている場合でも「Would create PR」と出力されてしまい、ドライランで動作検証する際に誤解を招く可能性があります。

   How can I resolve this? If you propose a fix, please make it concise.
   `````
   </details>

</details>

<!-- /greptile_failed_comments -->

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
This is a comment left during a code review.
Path: .github/workflows/osv-auto-fix.yml
Line: 44

Comment:
**シークレット評価の暗黙的な型強制**

`!secrets.OSV_AUTO_FIX_TOKEN` は GitHub Actions 式内で空文字列 `''` を `false` として評価しているため、現状の動作は正しいです。ただし、暗黙的な型強制に依存しているため、`== ''` を使った明示的な比較のほうが意図が伝わりやすくなります。

```suggestion
        if: ${{ secrets.OSV_AUTO_FIX_TOKEN == '' && secrets.SYNC_PR_TOKEN == '' }}
```

How can I resolve this? If you propose a fix, please make it concise.

---

This is a comment left during a code review.
Path: .github/scripts/sync-main-to-staging.sh
Line: 111-121

Comment:
**DRY_RUN が既存PR存在時の新ロジックを反映していない**

`DRY_RUN=1` のとき、スクリプトはライン65の `if [ "$DRY_RUN" != "1" ]` ブロックをスキップするため、「既存PRがあれば作成をスキップする」新しいロジックがドライラン出力に反映されません。`existing_pr_url` が設定されている場合でも「Would create PR」と出力されてしまい、ドライランで動作検証する際に誤解を招く可能性があります。

How can I resolve this? If you propose a fix, please make it concise.
`````

</details>

<sub>Reviews (1): Last reviewed commit: ["fix: harden OSV auto-fix and sync workfl..."](https://github.com/hiroki-org/openshelf/commit/d27e30135bd910b2a21755f3708492af47efcb7d) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=28188178)</sub>

> Greptile also left **1 inline comment** on this PR.

**Context used:**

- Context used - 日本語で！！！ ([source](https://app.greptile.com/review/custom-context?memory=instruction-0))

<!-- /greptile_comment -->