### PR TITLE
fix: correct env restoration in metadata page tests

### DIFF
--- a/apps/web/src/app/orgs/[slug]/__tests__/page-metadata.test.tsx
+++ b/apps/web/src/app/orgs/[slug]/__tests__/page-metadata.test.tsx
@@ -10,17 +10,11 @@ describe("orgs/[slug]/page metadata", () => {
   const originalPublicApiUrl = process.env.NEXT_PUBLIC_API_URL;
   afterEach(() => {
     cleanup();
-    if (originalApiUrl === undefined) {
-      delete process.env.API_URL;
-    } else {
-      process.env.API_URL = originalApiUrl;
-    }
+    if (originalApiUrl === undefined) delete process.env.API_URL;
+    else process.env.API_URL = originalApiUrl;
 
-    if (originalPublicApiUrl === undefined) {
-      delete process.env.NEXT_PUBLIC_API_URL;
-    } else {
-      process.env.NEXT_PUBLIC_API_URL = originalPublicApiUrl;
-    }
+    if (originalPublicApiUrl === undefined) delete process.env.NEXT_PUBLIC_API_URL;
+    else process.env.NEXT_PUBLIC_API_URL = originalPublicApiUrl;
 
     vi.restoreAllMocks();
   });

--- a/apps/web/src/app/orgs/[slug]/__tests__/page-metadata.test.tsx
+++ b/apps/web/src/app/orgs/[slug]/__tests__/page-metadata.test.tsx
@@ -10,8 +10,19 @@ describe("orgs/[slug]/page metadata", () => {
   const originalPublicApiUrl = process.env.NEXT_PUBLIC_API_URL;
   afterEach(() => {
     cleanup();
-    process.env.API_URL = originalApiUrl;
-    process.env.NEXT_PUBLIC_API_URL = originalPublicApiUrl;
+    if (originalApiUrl === undefined) {
+      delete process.env.API_URL;
+    } else {
+      process.env.API_URL = originalApiUrl;
+    }
+
+    if (originalPublicApiUrl === undefined) {
+      delete process.env.NEXT_PUBLIC_API_URL;
+    } else {
+      process.env.NEXT_PUBLIC_API_URL = originalPublicApiUrl;
+    }
+
+    vi.restoreAllMocks();
   });
 
   beforeEach(() => {

--- a/apps/web/src/app/orgs/[slug]/c/[collectionSlug]/__tests__/page-metadata.test.tsx
+++ b/apps/web/src/app/orgs/[slug]/c/[collectionSlug]/__tests__/page-metadata.test.tsx
@@ -13,8 +13,19 @@ describe("orgs/[slug]/c/[collectionSlug]/page metadata", () => {
 
   afterEach(() => {
     cleanup();
-    process.env.API_URL = originalApiUrl;
-    process.env.NEXT_PUBLIC_API_URL = originalPublicApiUrl;
+    if (originalApiUrl === undefined) {
+      delete process.env.API_URL;
+    } else {
+      process.env.API_URL = originalApiUrl;
+    }
+
+    if (originalPublicApiUrl === undefined) {
+      delete process.env.NEXT_PUBLIC_API_URL;
+    } else {
+      process.env.NEXT_PUBLIC_API_URL = originalPublicApiUrl;
+    }
+
+    vi.restoreAllMocks();
   });
 
   beforeEach(() => {

--- a/apps/web/src/app/orgs/[slug]/c/[collectionSlug]/__tests__/page-metadata.test.tsx
+++ b/apps/web/src/app/orgs/[slug]/c/[collectionSlug]/__tests__/page-metadata.test.tsx
@@ -13,17 +13,11 @@ describe("orgs/[slug]/c/[collectionSlug]/page metadata", () => {
 
   afterEach(() => {
     cleanup();
-    if (originalApiUrl === undefined) {
-      delete process.env.API_URL;
-    } else {
-      process.env.API_URL = originalApiUrl;
-    }
+    if (originalApiUrl === undefined) delete process.env.API_URL;
+    else process.env.API_URL = originalApiUrl;
 
-    if (originalPublicApiUrl === undefined) {
-      delete process.env.NEXT_PUBLIC_API_URL;
-    } else {
-      process.env.NEXT_PUBLIC_API_URL = originalPublicApiUrl;
-    }
+    if (originalPublicApiUrl === undefined) delete process.env.NEXT_PUBLIC_API_URL;
+    else process.env.NEXT_PUBLIC_API_URL = originalPublicApiUrl;
 
     vi.restoreAllMocks();
   });

--- a/apps/web/src/app/users/[id]/__tests__/page-metadata.test.tsx
+++ b/apps/web/src/app/users/[id]/__tests__/page-metadata.test.tsx
@@ -11,8 +11,19 @@ describe("users/[id]/page metadata", () => {
 
   afterEach(() => {
     cleanup();
-    process.env.API_URL = originalApiUrl;
-    process.env.NEXT_PUBLIC_API_URL = originalPublicApiUrl;
+    if (originalApiUrl === undefined) {
+      delete process.env.API_URL;
+    } else {
+      process.env.API_URL = originalApiUrl;
+    }
+
+    if (originalPublicApiUrl === undefined) {
+      delete process.env.NEXT_PUBLIC_API_URL;
+    } else {
+      process.env.NEXT_PUBLIC_API_URL = originalPublicApiUrl;
+    }
+
+    vi.restoreAllMocks();
   });
 
   beforeEach(() => {

--- a/apps/web/src/app/users/[id]/__tests__/page-metadata.test.tsx
+++ b/apps/web/src/app/users/[id]/__tests__/page-metadata.test.tsx
@@ -11,17 +11,11 @@ describe("users/[id]/page metadata", () => {
 
   afterEach(() => {
     cleanup();
-    if (originalApiUrl === undefined) {
-      delete process.env.API_URL;
-    } else {
-      process.env.API_URL = originalApiUrl;
-    }
+    if (originalApiUrl === undefined) delete process.env.API_URL;
+    else process.env.API_URL = originalApiUrl;
 
-    if (originalPublicApiUrl === undefined) {
-      delete process.env.NEXT_PUBLIC_API_URL;
-    } else {
-      process.env.NEXT_PUBLIC_API_URL = originalPublicApiUrl;
-    }
+    if (originalPublicApiUrl === undefined) delete process.env.NEXT_PUBLIC_API_URL;
+    else process.env.NEXT_PUBLIC_API_URL = originalPublicApiUrl;
 
     vi.restoreAllMocks();
   });


### PR DESCRIPTION
## Summary\n- fix env var restoration logic in metadata page tests to avoid assigning the string `"undefined"`\n- restore `process.env.API_URL` / `NEXT_PUBLIC_API_URL` with delete-when-undefined semantics\n- add `vi.restoreAllMocks()` in afterEach to prevent cross-test leakage\n\n## Scope\n- apps/web/src/app/orgs/[slug]/__tests__/page-metadata.test.tsx\n- apps/web/src/app/orgs/[slug]/c/[collectionSlug]/__tests__/page-metadata.test.tsx\n- apps/web/src/app/users/[id]/__tests__/page-metadata.test.tsx\n\nref #434

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

env 変数の復元ロジックを `process.env.X = undefined`（文字列 `"undefined"` が代入される問題）から delete-when-undefined パターンに修正し、`vi.restoreAllMocks()` を `afterEach` に追加してスパイのクロステスト汚染を防止する変更です。修正は3ファイルに一貫して適用されており、ロジックも正確です。
</details>


<h3>Confidence Score: 5/5</h3>

マージ安全。残りの指摘は P2 のスタイル提案のみ。

コアの修正（delete-when-undefined パターンと vi.restoreAllMocks() の追加）は正確で、3ファイルに一貫して適用されている。残る指摘は beforeEach の clearAllMocks が冗長というスタイル上の提案のみで、バグはない。

特に注意が必要なファイルはありません。

<details><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| apps/web/src/app/orgs/[slug]/__tests__/page-metadata.test.tsx | env 変数の復元ロジックを delete-when-undefined パターンに修正し、vi.restoreAllMocks() を afterEach に追加。正しく修正されている。 |
| apps/web/src/app/orgs/[slug]/c/[collectionSlug]/__tests__/page-metadata.test.tsx | 同様の修正が適用済み。2つのテストが含まれており、テスト間の env 変数汚染も適切に防止されている。 |
| apps/web/src/app/users/[id]/__tests__/page-metadata.test.tsx | 同様の修正が適用済み。単一テストで delete-when-undefined パターンと vi.restoreAllMocks() が正しく機能している。 |

</details>


</details>


<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant VT as Vitest Runner
    participant BE as beforeEach
    participant T as Test Body
    participant AE as afterEach

    VT->>BE: vi.clearAllMocks()
    BE-->>VT: done
    VT->>T: process.env.API_URL = "http://..."
    T->>T: vi.resetModules()
    T->>T: await import("../page")
    T->>T: vi.spyOn(global, "fetch")
    T->>T: assertions
    VT->>AE: cleanup()
    AE->>AE: delete process.env.API_URL (if was undefined)
    Note over AE: Fix: delete instead of assigning "undefined"
    AE->>AE: vi.restoreAllMocks()
    AE-->>VT: done
```

<!-- greptile_failed_comments -->
<details open><summary><h3>Comments Outside Diff (1)</h3></summary>

1. `apps/web/src/app/orgs/[slug]/__tests__/page-metadata.test.tsx`, line 28-30 ([link](https://github.com/hiroki-org/openshelf/blob/0deb66ade64ed1468dc2334244c0b97e512755e9/apps/web/src/app/orgs/[slug]/__tests__/page-metadata.test.tsx#L28-L30)) 

   <a href="#"><img alt="P2" src="https://greptile-static-assets.s3.amazonaws.com/badges/p2.svg?v=7" align="top"></a> **beforeEach の vi.clearAllMocks() は冗長**

   `afterEach` で `vi.restoreAllMocks()` を呼ぶと、モックのクリア・リセット・元の実装への復元がすべて行われます（`clearAllMocks` の効果を包含）。そのため `beforeEach` の `vi.clearAllMocks()` は実質的に何もしません。同じパターンが他の2ファイルにも存在します。

   

   <details><summary>Prompt To Fix With AI</summary>

   `````markdown
   This is a comment left during a code review.
   Path: apps/web/src/app/orgs/[slug]/__tests__/page-metadata.test.tsx
   Line: 28-30

   Comment:
   **beforeEach の vi.clearAllMocks() は冗長**

   `afterEach` で `vi.restoreAllMocks()` を呼ぶと、モックのクリア・リセット・元の実装への復元がすべて行われます（`clearAllMocks` の効果を包含）。そのため `beforeEach` の `vi.clearAllMocks()` は実質的に何もしません。同じパターンが他の2ファイルにも存在します。

   

   How can I resolve this? If you propose a fix, please make it concise.
   `````
   </details>

</details>

<!-- /greptile_failed_comments -->

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
This is a comment left during a code review.
Path: apps/web/src/app/orgs/[slug]/__tests__/page-metadata.test.tsx
Line: 28-30

Comment:
**beforeEach の vi.clearAllMocks() は冗長**

`afterEach` で `vi.restoreAllMocks()` を呼ぶと、モックのクリア・リセット・元の実装への復元がすべて行われます（`clearAllMocks` の効果を包含）。そのため `beforeEach` の `vi.clearAllMocks()` は実質的に何もしません。同じパターンが他の2ファイルにも存在します。

```suggestion
  beforeEach(() => {
    // vi.restoreAllMocks() が afterEach で呼ばれるため不要
  });
```

How can I resolve this? If you propose a fix, please make it concise.
`````

</details>

<sub>Reviews (1): Last reviewed commit: ["fix(test): restore metadata env vars saf..."](https://github.com/hiroki-org/openshelf/commit/0deb66ade64ed1468dc2334244c0b97e512755e9) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=28207514)</sub>

<!-- /greptile_comment -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Tests**
  * Improved test isolation by ensuring environment variables are properly restored and mocks are reset after each test execution, reducing potential side effects between test runs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->