### PR TITLE
chore: configure CodeRabbit auto-review for staging PRs

### DIFF
--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -1,0 +1,8 @@
+# yaml-language-server: $schema=https://coderabbit.ai/integrations/schema.v2.json
+reviews:
+  auto_review:
+    enabled: true
+    drafts: false
+    # Default branch is always included; add staging-target PRs explicitly.
+    base_branches:
+      - "^staging$"

--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -3,6 +3,7 @@ reviews:
   auto_review:
     enabled: true
     drafts: false
-    # Default branch is always included; add staging-target PRs explicitly.
+    # Keep default-branch and staging-target PRs under automatic review.
     base_branches:
+      - "^main$"
       - "^staging$"


### PR DESCRIPTION
## Summary
- add root .coderabbit.yaml configuration
- enable auto review for PRs targeting staging via reviews.auto_review.base_branches
- keep draft PR auto-review disabled

## Why
CodeRabbit auto-review defaults to default-branch targets only. This repository uses a staging-first flow, so staging-target PRs also need automatic review coverage.

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

CodeRabbit の自動レビュー設定ファイル (`.coderabbit.yaml`) を新規追加し、`staging` ブランチへのPRにも自動レビューが適用されるよう構成しています。公式ドキュメントの仕様（`base_branches` はデフォルトブランチを置き換えず、追加するだけ）とコード内コメントの説明が一致しており、設定内容は正確です。
</details>

<h3>Confidence Score: 5/5</h3>

設定ファイルの追加のみであり、マージしても安全です。

変更は1ファイルのみで、CodeRabbit の公式スキーマ・ドキュメントに準拠した正確な設定です。P0/P1 相当の問題は見当たりません。

特になし

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| .coderabbit.yaml | CodeRabbit の自動レビュー設定を追加。`enabled: true`、ドラフトPR除外、`^staging$` をターゲットブランチとして追加。公式ドキュメントに従い正確に設定されている。 |

</details>

</details>

<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[PR が作成される] --> B{ドラフト PR?}
    B -- はい --> C[自動レビュー スキップ]
    B -- いいえ --> D{ターゲットブランチの判定}
    D -- デフォルトブランチ main/master --> E[自動レビュー実行]
    D -- staging ブランチ --> E
    D -- その他のブランチ --> C
```

<sub>Reviews (1): Last reviewed commit: ["chore: enable CodeRabbit auto-review on ..."](https://github.com/hiroki-org/openshelf/commit/5b37ac3b8a83b2a9b6d14ae15d4185736cf70495) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=28211052)</sub>

<!-- /greptile_comment -->