### PR TITLE
Add ruleset drift detection

### DIFF
--- a/.github/rulesets/required-status-checks.json
+++ b/.github/rulesets/required-status-checks.json
@@ -1,0 +1,62 @@
+{
+  "rulesets": [
+    {
+      "conditions": {
+        "ref_name": {
+          "exclude": [],
+          "include": [
+            "refs/heads/main"
+          ]
+        }
+      },
+      "enforcement": "active",
+      "name": "protect-main",
+      "required_status_checks": {
+        "contexts": [
+          "Setup",
+          "Lint",
+          "Type Check",
+          "Test API",
+          "Test Web",
+          "Upload Coverage",
+          "Build Web (Preview Check)",
+          "E2E Tests (1-of-2)",
+          "E2E Tests (2-of-2)",
+          "CodSpeed",
+          "require-staging-source"
+        ],
+        "do_not_enforce_on_create": false,
+        "strict_required_status_checks_policy": true
+      },
+      "target": "branch"
+    },
+    {
+      "conditions": {
+        "ref_name": {
+          "exclude": [],
+          "include": [
+            "refs/heads/staging"
+          ]
+        }
+      },
+      "enforcement": "active",
+      "name": "protect-staging",
+      "required_status_checks": {
+        "contexts": [
+          "Setup",
+          "Lint",
+          "Type Check",
+          "Test API",
+          "Test Web",
+          "Build Web (Preview Check)",
+          "E2E Tests (1-of-2)",
+          "E2E Tests (2-of-2)",
+          "Upload Coverage"
+        ],
+        "do_not_enforce_on_create": false,
+        "strict_required_status_checks_policy": false
+      },
+      "target": "branch"
+    }
+  ]
+}

--- a/.github/scripts/check-ruleset-drift.sh
+++ b/.github/scripts/check-ruleset-drift.sh
@@ -41,18 +41,26 @@ if [ ! -f "$manifest_path" ]; then
   exit 1
 fi
 
-repo=${GH_REPO:-}
+repo=${GH_REPO:-${GITHUB_REPOSITORY:-}}
 if [ -z "$repo" ] && [ -z "$live_json_path" ]; then
   repo=$(gh repo view --json nameWithOwner -q '.nameWithOwner')
 fi
 
+manifest_names_json="$(jq -c '[.rulesets[].name]' "$manifest_path")"
+if [ "$manifest_names_json" = "[]" ]; then
+  echo "::error::No rulesets were defined in $manifest_path" >&2
+  exit 1
+fi
+
 normalize_rulesets() {
-  jq -S '
+  local manifest_names_json="$1"
+
+  jq -S --argjson manifest_names "$manifest_names_json" '
     (if type == "object" and has("rulesets") then .rulesets else . end)
     | {
       rulesets: [
         .[]
-        | select(.name == "protect-main" or .name == "protect-staging")
+        | select(.name as $name | $manifest_names | index($name))
         | {
             conditions: {
               ref_name: {
@@ -64,12 +72,12 @@ normalize_rulesets() {
             name,
             required_status_checks: (if has("required_status_checks") then
               {
-                contexts: (.required_status_checks.contexts | sort),
+                contexts: (.required_status_checks.contexts // [] | sort),
                 do_not_enforce_on_create: .required_status_checks.do_not_enforce_on_create,
                 strict_required_status_checks_policy: .required_status_checks.strict_required_status_checks_policy
               }
             else
-              (
+              ([
                 (.rules // [])[]
                 | select(.type == "required_status_checks")
                 | {
@@ -81,13 +89,37 @@ normalize_rulesets() {
                     do_not_enforce_on_create: .parameters.do_not_enforce_on_create,
                     strict_required_status_checks_policy: .parameters.strict_required_status_checks_policy
                   }
-              )
+              ] | first // {
+                contexts: [],
+                do_not_enforce_on_create: null,
+                strict_required_status_checks_policy: null
+              })
             end),
             target
           }
       ] | sort_by(.name)
     }
   '
+}
+
+fetch_live_rulesets() {
+  local ruleset_ids
+
+  ruleset_ids="$(
+    gh api "repos/$repo/rulesets?per_page=100" \
+      --jq '.[] | .id'
+  )"
+
+  if [ -z "$ruleset_ids" ]; then
+    printf '[]\n'
+    return 0
+  fi
+
+  while IFS= read -r ruleset_id; do
+    if [ -n "$ruleset_id" ]; then
+      gh api "repos/$repo/rulesets/$ruleset_id"
+    fi
+  done <<<"$ruleset_ids" | jq -s '.'
 }
 
 expected_normalized=$(mktemp)
@@ -97,12 +129,12 @@ cleanup() {
 }
 trap cleanup EXIT
 
-jq -S '.' "$manifest_path" | normalize_rulesets >"$expected_normalized"
+normalize_rulesets "$manifest_names_json" <"$manifest_path" >"$expected_normalized"
 
 if [ -n "$live_json_path" ]; then
-  jq -S '.' "$live_json_path" | normalize_rulesets >"$actual_normalized"
+  normalize_rulesets "$manifest_names_json" <"$live_json_path" >"$actual_normalized"
 else
-  gh api "repos/$repo/rulesets?per_page=100" | normalize_rulesets >"$actual_normalized"
+  fetch_live_rulesets | normalize_rulesets "$manifest_names_json" >"$actual_normalized"
 fi
 
 expected_count=$(jq '.rulesets | length' "$expected_normalized")
@@ -112,7 +144,14 @@ if [ "$expected_count" -gt 0 ] && [ "$actual_count" -eq 0 ]; then
   exit 1
 fi
 
-if diff -u "$expected_normalized" "$actual_normalized"; then
+diff_exit=0
+diff -u "$expected_normalized" "$actual_normalized" || diff_exit=$?
+if [ "$diff_exit" -eq 2 ]; then
+  echo "::error::diff failed unexpectedly while comparing normalized rulesets." >&2
+  exit 2
+fi
+
+if [ "$diff_exit" -eq 0 ]; then
   echo "✅ Ruleset manifest matches live GitHub state."
   exit 0
 fi

--- a/.github/scripts/check-ruleset-drift.sh
+++ b/.github/scripts/check-ruleset-drift.sh
@@ -1,0 +1,114 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+manifest_path=".github/rulesets/required-status-checks.json"
+live_json_path=""
+
+usage() {
+  cat <<'EOF'
+Usage: check-ruleset-drift.sh [--manifest PATH] [--live-json PATH]
+
+Compares the checked-in ruleset manifest with the live GitHub ruleset state.
+When --live-json is omitted, the script fetches live state with gh api.
+EOF
+}
+
+while [ "$#" -gt 0 ]; do
+  case "$1" in
+    --manifest)
+      manifest_path=${2:?--manifest requires a path}
+      shift 2
+      ;;
+    --live-json)
+      live_json_path=${2:?--live-json requires a path}
+      shift 2
+      ;;
+    -h|--help)
+      usage
+      exit 0
+      ;;
+    *)
+      echo "Unknown argument: $1" >&2
+      usage >&2
+      exit 2
+      ;;
+  esac
+done
+
+if [ ! -f "$manifest_path" ]; then
+  echo "::error::Manifest not found: $manifest_path" >&2
+  exit 1
+fi
+
+repo=${GH_REPO:-}
+if [ -z "$repo" ] && [ -z "$live_json_path" ]; then
+  repo=$(gh repo view --json nameWithOwner -q '.nameWithOwner')
+fi
+
+normalize_rulesets() {
+  jq -S '
+    (if type == "object" and has("rulesets") then .rulesets else . end)
+    | {
+      rulesets: [
+        .[]
+        | select(.name == "protect-main" or .name == "protect-staging")
+        | {
+            conditions: {
+              ref_name: {
+                exclude: (.conditions.ref_name.exclude // [] | sort),
+                include: (.conditions.ref_name.include // [] | sort)
+              }
+            },
+            enforcement,
+            name,
+            required_status_checks: (if has("required_status_checks") then
+              {
+                contexts: (.required_status_checks.contexts | sort),
+                do_not_enforce_on_create: .required_status_checks.do_not_enforce_on_create,
+                strict_required_status_checks_policy: .required_status_checks.strict_required_status_checks_policy
+              }
+            else
+              (
+                .rules[]
+                | select(.type == "required_status_checks")
+                | {
+                    contexts: (
+                      .parameters.required_status_checks
+                      | map(.context)
+                      | sort
+                    ),
+                    do_not_enforce_on_create: .parameters.do_not_enforce_on_create,
+                    strict_required_status_checks_policy: .parameters.strict_required_status_checks_policy
+                  }
+              )
+            end),
+            target
+          }
+      ] | sort_by(.name)
+    }
+  '
+}
+
+expected_normalized=$(mktemp)
+actual_normalized=$(mktemp)
+cleanup() {
+  rm -f "$expected_normalized" "$actual_normalized"
+}
+trap cleanup EXIT
+
+jq -S '.' "$manifest_path" | normalize_rulesets >"$expected_normalized"
+
+if [ -n "$live_json_path" ]; then
+  jq -S '.' "$live_json_path" | normalize_rulesets >"$actual_normalized"
+else
+  gh api "repos/$repo/rulesets?per_page=100" | normalize_rulesets >"$actual_normalized"
+fi
+
+if diff -u "$expected_normalized" "$actual_normalized"; then
+  echo "✅ Ruleset manifest matches live GitHub state."
+  exit 0
+fi
+
+echo "::error::Ruleset drift detected. Update .github/rulesets/required-status-checks.json to match live state." >&2
+exit 1

--- a/.github/scripts/check-ruleset-drift.sh
+++ b/.github/scripts/check-ruleset-drift.sh
@@ -70,11 +70,11 @@ normalize_rulesets() {
               }
             else
               (
-                .rules[]
+                (.rules // [])[]
                 | select(.type == "required_status_checks")
                 | {
                     contexts: (
-                      .parameters.required_status_checks
+                      (.parameters.required_status_checks // [])
                       | map(.context)
                       | sort
                     ),

--- a/.github/scripts/check-ruleset-drift.sh
+++ b/.github/scripts/check-ruleset-drift.sh
@@ -105,6 +105,13 @@ else
   gh api "repos/$repo/rulesets?per_page=100" | normalize_rulesets >"$actual_normalized"
 fi
 
+expected_count=$(jq '.rulesets | length' "$expected_normalized")
+actual_count=$(jq '.rulesets | length' "$actual_normalized")
+if [ "$expected_count" -gt 0 ] && [ "$actual_count" -eq 0 ]; then
+  echo "::error::No repository rulesets were visible to the token used by this workflow. Verify the token can read repository rulesets." >&2
+  exit 1
+fi
+
 if diff -u "$expected_normalized" "$actual_normalized"; then
   echo "✅ Ruleset manifest matches live GitHub state."
   exit 0

--- a/.github/workflows/check-ruleset-drift.yml
+++ b/.github/workflows/check-ruleset-drift.yml
@@ -28,6 +28,6 @@ jobs:
       - uses: actions/checkout@v4
       - name: Validate live rulesets against manifest
         env:
-          GH_TOKEN: ${{ github.token }}
+          GH_TOKEN: ${{ secrets.SYNC_PR_TOKEN || github.token }}
           GH_REPO: ${{ github.repository }}
         run: bash .github/scripts/check-ruleset-drift.sh

--- a/.github/workflows/check-ruleset-drift.yml
+++ b/.github/workflows/check-ruleset-drift.yml
@@ -1,0 +1,33 @@
+name: Check Ruleset Drift
+
+on:
+  pull_request:
+    paths:
+      - ".github/rulesets/**"
+      - ".github/scripts/check-ruleset-drift.sh"
+      - ".github/workflows/check-ruleset-drift.yml"
+  push:
+    branches:
+      - main
+    paths:
+      - ".github/rulesets/**"
+      - ".github/scripts/check-ruleset-drift.sh"
+      - ".github/workflows/check-ruleset-drift.yml"
+  schedule:
+    - cron: "23 3 * * *"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  check:
+    name: Validate ruleset manifest
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Validate live rulesets against manifest
+        env:
+          GH_TOKEN: ${{ github.token }}
+          GH_REPO: ${{ github.repository }}
+        run: bash .github/scripts/check-ruleset-drift.sh


### PR DESCRIPTION
Implements issue #447.

Summary:
- Adds a checked-in ruleset manifest for required status checks.
- Adds a validator that compares the manifest with live GitHub rulesets.
- Adds a workflow that runs the validator on PRs, push-to-main, and a schedule.

Validation:
- bash -n .github/scripts/check-ruleset-drift.sh
- bash .github/scripts/check-ruleset-drift.sh --live-json .github/rulesets/required-status-checks.json
- Negative drift test with a modified fixture correctly failed.

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

ルールセットのドリフト検出機能を追加するPRです。チェックイン済みマニフェスト（`required-status-checks.json`）、バリデータスクリプト（`check-ruleset-drift.sh`）、および GitHub Actions ワークフローの3ファイルで構成されています。

過去スレッドで指摘されたハードコードされたルールセット名の問題と `diff` exit code 2 の誤検知はいずれも対応済みです。残存する指摘は設計上の考慮点（スコープとページネーション）のみで、P2レベルです。
</details>

<h3>Confidence Score: 5/5</h3>

すべての残存指摘が P2 であり、マージに支障はありません。

過去スレッドで挙がった主要な P1 問題（ハードコード名・diff exit code 2）はいずれも修正済み。新規に見つかった問題はページネーション未対応と required_status_checks 以外のルールタイプが比較から除外される設計上の制約のみで、いずれも P2 相当。機能としての基本動作は正しく実装されている。

.github/scripts/check-ruleset-drift.sh（ページネーションとルールタイプ比較スコープ）

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| .github/rulesets/required-status-checks.json | 2つのブランチ（main / staging）のルールセットマニフェストを新規追加。フォーマット・内容ともに問題なし。 |
| .github/scripts/check-ruleset-drift.sh | ドリフト検出スクリプトを新規追加。マニフェスト名の動的読み取りおよび diff exit code 2 の処理は対応済み。ルールセット一覧取得にページネーションが未対応、また required_status_checks 以外のルールタイプが比較から除外される設計上の制約あり。 |
| .github/workflows/check-ruleset-drift.yml | PR・push-to-main・スケジュール・手動実行のトリガーを持つワークフローを新規追加。権限設定・トークンフォールバックともに適切。 |

</details>

</details>

<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant WF as GitHub Actions Workflow
    participant Script as check-ruleset-drift.sh
    participant Manifest as required-status-checks.json
    participant GH as GitHub Rulesets API

    WF->>Script: bash check-ruleset-drift.sh
    Script->>Manifest: jq '[.rulesets[].name]'
    Manifest-->>Script: manifest_names_json

    Script->>Manifest: normalize_rulesets (stdin)
    Manifest-->>Script: expected_normalized (sorted JSON)

    Script->>GH: GET /repos/{repo}/rulesets?per_page=100
    GH-->>Script: ruleset IDs list

    loop 各 ruleset_id
        Script->>GH: GET /repos/{repo}/rulesets/{id}
        GH-->>Script: ruleset detail (rules[] format)
    end

    Script->>Script: jq -s '.' → array
    Script->>Script: normalize_rulesets (else branch)
    Script-->>Script: actual_normalized (sorted JSON)

    Script->>Script: diff expected_normalized actual_normalized
    alt diff_exit == 0
        Script-->>WF: ✅ Ruleset manifest matches live state
    else diff_exit == 1
        Script-->>WF: ❌ Ruleset drift detected (exit 1)
    else diff_exit == 2
        Script-->>WF: ❌ diff tool error (exit 2)
    end
```

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
This is a comment left during a code review.
Path: .github/scripts/check-ruleset-drift.sh
Line: 108-111

Comment:
**ルールセット一覧取得にページネーションが未対応**

`per_page=100` はクエリに含まれているものの `--paginate` フラグが指定されていないため、ルールセット数が 100 を超えるリポジトリでは超過分の ID がサイレントにスキップされ、ドリフト検出から漏れます。`gh api` の `--paginate` を使うと全ページを自動で取得できます。

```suggestion
  ruleset_ids="$(
    gh api --paginate "repos/$repo/rulesets" \
      --jq '.[] | .id'
  )"
```

How can I resolve this? If you propose a fix, please make it concise.

---

This is a comment left during a code review.
Path: .github/scripts/check-ruleset-drift.sh
Line: 80-97

Comment:
**`required_status_checks` 以外のルールタイプが比較対象から除外される**

`else` ブランチ（GitHub API フォーマット）では `rules[]` から `type == "required_status_checks"` のエントリのみを抽出しています。そのため、ライブルールセットに `required_signatures`・`non_fast_forward`・`deletion`・`pull_request` 等のルールが追加・変更されても検出されません。

マニフェストのファイル名が `required-status-checks.json` であることから意図的なスコープ設定とも読めますが、現状では「ルールセットのドリフト検出」と銘打ちながら status checks 以外の変更を静かに見逃します。スコープを明示するコメントを追加するか、将来的に他ルールタイプもマニフェストに含める場合は正規化ロジックの拡張が必要です。

How can I resolve this? If you propose a fix, please make it concise.
`````

</details>

<sub>Reviews (2): Last reviewed commit: ["fix(ci): harden ruleset drift normalizat..."](https://github.com/hiroki-org/openshelf/commit/7ea45cdb86b67abb998f6d48fa86dd960a924be6) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=28223089)</sub>

<!-- /greptile_comment -->