### PR TITLE
ci: align build, e2e, and coverage dependencies

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -103,7 +103,7 @@ jobs:
           path: apps/web/coverage/
   upload-coverage:
     name: Upload Coverage
-    needs: [build-web-check, e2e]
+    needs: [test-api, test-web]
     runs-on: ubuntu-latest
     env:
       CODECOV_COMMIT_SHA: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.sha || github.sha }}
@@ -145,7 +145,6 @@ jobs:
           override_commit: ${{ env.CODECOV_COMMIT_SHA }}
   build-web-check:
     name: Build Web (Preview Check)
-    needs: [test-api, test-web]
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
@@ -158,7 +157,7 @@ jobs:
         run: npm run build -w apps/web
   e2e:
     name: E2E Tests (${{ matrix.shardLabel }})
-    needs: [test-api, test-web]
+    needs: [build-web-check]
     timeout-minutes: 15
     runs-on: ubuntu-latest
     strategy:


### PR DESCRIPTION
Refs #445

## Summary
- start Build Web independently instead of waiting for unit tests
- gate E2E on successful web build rather than unrelated unit-test completion
- let coverage upload finish as soon as API and Web coverage artifacts exist

## Validation
- GitHub Actions on this PR

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

CI ジョブの依存関係を再設計し、`build-web-check` をユニットテスト完了待ちから独立実行に変更、`e2e` を `build-web-check` の成功にゲート、`upload-coverage` の依存を `test-api`/`test-web` に直接紐付けました。全体的に意図は明確で実装も概ね正しいですが、`build-web-check` の `needs` を完全に削除したことで `lint` / `typecheck` が失敗しても E2E が走り続けるため、無駄な CI コストが発生する可能性があります。
</details>

<h3>Confidence Score: 5/5</h3>

マージ可能。P2 のコスト改善提案のみで、CI の正確性には問題なし。

変更はすべて P2 レベルの品質改善の指摘のみ。`upload-coverage` の依存関係修正と E2E ゲートの変更は意図通り正しく機能する。`lint`/`typecheck` ゲートの欠落は無駄な CI 実行につながる可能性はあるが、CI の正確性や成果物を壊すものではない。

.github/workflows/ci.yml の build-web-check ジョブ定義に注目。

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| .github/workflows/ci.yml | CI ジョブの依存関係を再整理：build-web-check を独立実行に変更、e2e を build-web-check にゲート、upload-coverage を test-api/test-web 完了後に変更。ただし build-web-check から lint/typecheck ゲートが失われた点に要注意。 |

</details>

</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
This is a comment left during a code review.
Path: .github/workflows/ci.yml
Line: 146-148

Comment:
**lint/typecheck ゲートが消えている**

`needs` を完全に削除したことで、`build-web-check`（およびそれに依存する `e2e`）が `lint`・`typecheck` と並行してスタートするようになりました。lint や型チェックが失敗しても、ビルドと E2E が最後まで実行されるため、CI コストが無駄になる可能性があります。

PR の目的（ユニットテストを待たずにビルドを開始する）は保ちつつ、`lint` / `typecheck` の品質ゲートは残すのが望ましいです。

```suggestion
  build-web-check:
    name: Build Web (Preview Check)
    needs: [lint, typecheck]
```

How can I resolve this? If you propose a fix, please make it concise.
`````

</details>

<sub>Reviews (1): Last reviewed commit: ["ci: align build, e2e, and coverage depen..."](https://github.com/hiroki-org/openshelf/commit/9b1de96735a38e6023af5d581cba8862093dd197) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=28223163)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->