### PR TITLE
ci: add stale workflow cleanup maintenance

### DIFF
--- a/.github/scripts/cleanup-stale-workflows.sh
+++ b/.github/scripts/cleanup-stale-workflows.sh
@@ -1,0 +1,71 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+GH_REPO=${GH_REPO:?GH_REPO is required}
+DRY_RUN=${DRY_RUN:-1}
+
+default_branch="$(
+  gh api "repos/$GH_REPO" --jq '.default_branch'
+)"
+
+if [ -z "$default_branch" ]; then
+  echo "Could not determine the default branch for $GH_REPO." >&2
+  exit 1
+fi
+
+workflow_rows="$(
+  gh api --paginate "repos/$GH_REPO/actions/workflows" \
+    --jq '.workflows[]
+      | select(.state == "active")
+      | [.id, .name, .path] | @tsv'
+)"
+
+if [ -z "$workflow_rows" ]; then
+  echo "No active workflows found."
+  exit 0
+fi
+
+stale_count=0
+disabled_count=0
+
+workflow_exists_on_default_branch() {
+  local workflow_path="$1"
+
+  gh api "repos/$GH_REPO/contents/$workflow_path?ref=$default_branch" >/dev/null 2>&1
+}
+
+disable_workflow() {
+  local workflow_id="$1"
+  gh api --method PUT "repos/$GH_REPO/actions/workflows/$workflow_id/disable" >/dev/null
+}
+
+while IFS=$'\t' read -r workflow_id workflow_name workflow_path; do
+  if [ -z "$workflow_id" ]; then
+    continue
+  fi
+
+  if [[ "$workflow_path" != .github/workflows/* ]]; then
+    echo "Skipping non-file-backed workflow: $workflow_name ($workflow_path)"
+    continue
+  fi
+
+  if workflow_exists_on_default_branch "$workflow_path"; then
+    echo "OK: $workflow_name ($workflow_path)"
+    continue
+  fi
+
+  stale_count=$((stale_count + 1))
+  echo "Stale: $workflow_name ($workflow_path)"
+
+  if [ "$DRY_RUN" = "1" ]; then
+    echo "Dry run: would disable workflow id $workflow_id"
+    continue
+  fi
+
+  disable_workflow "$workflow_id"
+  disabled_count=$((disabled_count + 1))
+  echo "Disabled workflow id $workflow_id"
+done <<<"$workflow_rows"
+
+echo "Summary: stale=$stale_count disabled=$disabled_count dry_run=$DRY_RUN"

--- a/.github/scripts/cleanup-stale-workflows.sh
+++ b/.github/scripts/cleanup-stale-workflows.sh
@@ -2,12 +2,20 @@
 
 set -euo pipefail
 
-GH_REPO=${GH_REPO:?GH_REPO is required}
+GH_REPO=${GH_REPO:-${GITHUB_REPOSITORY:-}}
 DRY_RUN=${DRY_RUN:-1}
+
+if [ -z "$GH_REPO" ]; then
+  echo "GH_REPO or GITHUB_REPOSITORY is required." >&2
+  exit 1
+fi
 
 default_branch="$(
   gh api "repos/$GH_REPO" --jq '.default_branch'
-)"
+)" || {
+  echo "Could not determine the default branch for $GH_REPO (gh api failed)." >&2
+  exit 1
+}
 
 if [ -z "$default_branch" ]; then
   echo "Could not determine the default branch for $GH_REPO." >&2
@@ -31,8 +39,19 @@ disabled_count=0
 
 workflow_exists_on_default_branch() {
   local workflow_path="$1"
+  local output
 
-  gh api "repos/$GH_REPO/contents/$workflow_path?ref=$default_branch" >/dev/null 2>&1
+  if output="$(gh api "repos/$GH_REPO/contents/$workflow_path?ref=$default_branch" 2>&1)"; then
+    return 0
+  fi
+
+  if printf '%s\n' "$output" | grep -Eq '(^|[^0-9])404([^0-9]|$)|Not Found'; then
+    return 1
+  fi
+
+  echo "Warning: failed to check $workflow_path on $default_branch; treating it as present to avoid accidental disable." >&2
+  echo "$output" >&2
+  return 0
 }
 
 disable_workflow() {

--- a/.github/workflows/cleanup-stale-workflows.yml
+++ b/.github/workflows/cleanup-stale-workflows.yml
@@ -1,0 +1,32 @@
+name: Cleanup Stale Workflows
+
+on:
+  workflow_dispatch:
+    inputs:
+      dry_run:
+        description: Report stale workflows without disabling them
+        type: boolean
+        default: true
+  schedule:
+    - cron: '13 3 1 * *'
+
+permissions:
+  actions: write
+  contents: read
+
+concurrency:
+  group: cleanup-stale-workflows
+  cancel-in-progress: true
+
+jobs:
+  cleanup:
+    name: Cleanup stale registered workflows
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
+      - name: Detect and clean up stale workflows
+        env:
+          GH_TOKEN: ${{ github.token }}
+          GH_REPO: ${{ github.repository }}
+          DRY_RUN: ${{ github.event_name == 'schedule' && '0' || (github.event.inputs.dry_run == 'true' && '1' || '0') }}
+        run: bash .github/scripts/cleanup-stale-workflows.sh


### PR DESCRIPTION
Refs #448

## Summary
- add a maintenance script that finds active workflow registrations whose file no longer exists on the default branch
- add a scheduled / manual workflow to disable stale registrations with actions:write permission
- keep dynamic GitHub-managed workflows out of the cleanup path

## Validation
- bash -n .github/scripts/cleanup-stale-workflows.sh
- YAML parse for .github/workflows/cleanup-stale-workflows.yml
- dry-run and live cleanup were both exercised from the branch worktree

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

月次スケジュール（毎月1日 3:13 UTC）および手動トリガーで実行される、デフォルトブランチ上にファイルが存在しないアクティブワークフロー登録を無効化するメンテナンス機能を追加します。スクリプト・ワークフロー定義ともに構成は概ね適切ですが、存在チェック関数で API エラーを 404 と区別しない点が本番実行時のリスクになります。

- `workflow_exists_on_default_branch` が 404 以外の API エラー（レート制限・タイムアウト等）も「ファイル未存在」と誤判定するため、スケジュール実行（`DRY_RUN=0`）時に正常なワークフローが意図せず無効化される可能性があります（P1）。
</details>

<h3>Confidence Score: 4/5</h3>

P1 の修正（API エラー識別）を行えばマージ可能です。

スケジュール実行時に一時的な API 障害で正常なワークフローが誤って無効化されるリスクがある P1 が残っているため 4/5 としました。YAML 側の設計（パーミッション・concurrency・DRY_RUN 式）は正しく、修正箇所は限定的です。

.github/scripts/cleanup-stale-workflows.sh の `workflow_exists_on_default_branch` 関数に注目してください。

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| .github/scripts/cleanup-stale-workflows.sh | アクティブワークフローの stale 検出・無効化スクリプト。`workflow_exists_on_default_branch` が 404 と他の API エラーを区別しないため、一時的な障害時にライブ実行で正常なワークフローを誤って無効化するリスクあり（P1）。 |
| .github/workflows/cleanup-stale-workflows.yml | 月次スケジュール＋手動トリガーのワークフロー定義。パーミッション・concurrency・DRY_RUN 式はいずれも正しく設定されている。 |

</details>

</details>

<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A([開始]) --> B[GH_REPO / DRY_RUN 読み込み]
    B --> C[gh api: デフォルトブランチ取得]
    C --> D{default_branch が空?}
    D -- Yes --> E([エラー終了])
    D -- No --> F[gh api --paginate: active ワークフロー一覧取得]
    F --> G{ワークフローなし?}
    G -- Yes --> H([正常終了])
    G -- No --> I[各ワークフローをループ]
    I --> J{workflow_id が空?}
    J -- Yes --> I
    J -- No --> K{path が .github/workflows/* ?}
    K -- No --> L[Skip: 非ファイルベースワークフロー]
    L --> I
    K -- Yes --> M[workflow_exists_on_default_branch を呼び出し]
    M --> N[gh api: contents API 呼び出し]
    N --> O{終了コード = 0?}
    O -- Yes --> P[OK: ログ出力してスキップ]
    P --> I
    O -- No --> Q[⚠️ 404 / その他エラー両方ここに来る]
    Q --> R[stale_count++, ログ出力]
    R --> S{DRY_RUN = 1?}
    S -- Yes --> T[Dry-run ログ出力してスキップ]
    T --> I
    S -- No --> U[disable_workflow を呼び出し]
    U --> V[disabled_count++]
    V --> I
    I --> W[ループ終了]
    W --> X([Summary 出力して終了])
```

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
This is a comment left during a code review.
Path: .github/scripts/cleanup-stale-workflows.sh
Line: 32-36

Comment:
**API エラーと 404 を区別せず、誤って無効化されるリスク**

`gh api` の終了コードは 404（ファイル未存在）だけでなく、429（レート制限）・5xx（サーバーエラー）・ネットワークタイムアウトでも非ゼロになります。stderr は `/dev/null` に捨てているため、一時的な API 障害が発生するとすべてのワークフローが「stale」と誤判定され、`DRY_RUN=0` のスケジュール実行では**実際にワークフローが無効化されてしまいます**。

`gh api` の終了コードを見て 404 のみを「ファイルなし」として扱うよう修正することを推奨します。

```bash
workflow_exists_on_default_branch() {
  local workflow_path="$1"
  local output
  local exit_code
  output=$(gh api "repos/$GH_REPO/contents/$workflow_path?ref=$default_branch" 2>&1)
  exit_code=$?
  if [[ $exit_code -eq 0 ]]; then
    return 0
  fi
  # 404 以外のエラー（レート制限・ネットワーク障害など）は安全のために skip
  if echo "$output" | grep -q '"status":"404"'; then
    return 1
  fi
  echo "Warning: API error checking $workflow_path — skipping to avoid false positive" >&2
  return 0  # 存在するとみなして無効化を回避
}
```

How can I resolve this? If you propose a fix, please make it concise.

---

This is a comment left during a code review.
Path: .github/scripts/cleanup-stale-workflows.sh
Line: 8-15

Comment:
**`set -e` により友好的エラーメッセージが表示されない**

`set -euo pipefail` が有効なため、`gh api` が非ゼロで終了した場合（認証失敗など）はスクリプトが即座に終了し、`if [ -z "$default_branch" ]` のチェックに到達しません。エラーメッセージは表示されず `gh` のデフォルトエラー出力のみとなります。

```suggestion
default_branch="$(
  gh api "repos/$GH_REPO" --jq '.default_branch'
)" || {
  echo "Could not determine the default branch for $GH_REPO (gh api failed)." >&2
  exit 1
}

if [ -z "$default_branch" ]; then
  echo "Could not determine the default branch for $GH_REPO." >&2
  exit 1
fi
```

How can I resolve this? If you propose a fix, please make it concise.
`````

</details>

<sub>Reviews (1): Last reviewed commit: ["ci: add stale workflow cleanup maintenan..."](https://github.com/hiroki-org/openshelf/commit/b345a88c5a0d6a384e0ad5c399b4818de6604eaf) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=28223477)</sub>

> Greptile also left **2 inline comments** on this PR.

<!-- /greptile_comment -->