### PR TITLE
chore: dependabot.ymlの整備

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,30 @@
+version: 2
+updates:
+  - package-ecosystem: "npm"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    commit-message:
+      prefix: "chore"
+      include: "scope"
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    commit-message:
+      prefix: "chore"
+      include: "scope"
+  - package-ecosystem: "docker"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    commit-message:
+      prefix: "chore"
+      include: "scope"
+  - package-ecosystem: "docker"
+    directory: "/apps/web"
+    schedule:
+      interval: "weekly"
+    commit-message:
+      prefix: "chore"
+      include: "scope"

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,6 +4,7 @@ updates:
     directory: "/"
     schedule:
       interval: "weekly"
+    open-pull-requests-limit: 20
     commit-message:
       prefix: "chore"
       include: "scope"


### PR DESCRIPTION
## 概要

Dependabotの基本設定を追加しました。

## 変更内容

以下のパッケージエコシステムに対して定期的な依存関係の更新を行うよう `.github/dependabot.yml` を整備しました。

*   **npm**: モノレポルート (`/`)
*   **github-actions**: GitHubワークフロー (`/`)
*   **docker**: Dockerfile (`/` および `/apps/web`)

**共通設定**:
*   `schedule.interval`: `weekly`（週次で更新をチェック）
*   `commit-message.prefix`: `chore`
*   `commit-message.include`: `scope` （例: `chore(deps): bump ...`）

---
*PR created automatically by Jules for task [4345490187590925483](https://jules.google.com/task/4345490187590925483) started by @is0692vs*

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

`.github/dependabot.yml` を新規追加し、npm（モノレポルート）・github-actions・docker（ルート＋`apps/web`）の4エントリに対して週次の依存関係自動更新を設定しています。`apps/web/Dockerfile` と `docker-compose.yml`（ルート）のカバレッジも適切で、npm ワークスペース構成も正しく認識される設定です。
</details>

<details open><summary><h3>Confidence Score: 5/5</h3></summary>

- このPRはマージ可能です。設定ファイルの追加のみで、動作に影響するコード変更はありません。
- P0・P1相当の問題は存在しません。唯一のフィードバックはP2レベルの `open-pull-requests-limit` 未設定であり、即時マージを妨げる問題ではありません。
- 特に注意が必要なファイルはありません。
</details>

<details open><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| .github/dependabot.yml | 新規追加されたDependabot設定。npm（ワークスペース対応）、github-actions、docker（ルートとapps/web）の4エントリを週次スケジュールで構成。open-pull-requests-limitが未設定でデフォルト5件となる点に注意。 |

</details>

</details>

<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    D[dependabot.yml]

    D --> E1["npm @ /\n（ワークスペース: apps/api, apps/web, apps/e2e）"]
    D --> E2["github-actions @ /\n（.github/workflows/*.yml）"]
    D --> E3["docker @ /\n（docker-compose.yml）"]
    D --> E4["docker @ /apps/web\n（Dockerfile）"]

    E1 --> S1["週次スケジュール\ncommit prefix: chore"]
    E2 --> S2["週次スケジュール\ncommit prefix: chore"]
    E3 --> S3["週次スケジュール\ncommit prefix: chore"]
    E4 --> S4["週次スケジュール\ncommit prefix: chore"]

    S1 --> PR[Dependabot PR作成\nデフォルト上限: 5件/エントリ]
    S2 --> PR
    S3 --> PR
    S4 --> PR
```

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
This is a comment left during a code review.
Path: .github/dependabot.yml
Line: 3-9

Comment:
**open-pull-requests-limitの未設定について**

`open-pull-requests-limit` が未設定のため、デフォルト値の **5件** が適用されます。このリポジトリは `apps/api`・`apps/web`・`apps/e2e` の3ワークスペースを持つモノレポであり、更新対象の依存関係が多い場合、Dependabotが一度に作成できるPR数が制限され、古いパッケージの更新が滞る可能性があります。

```suggestion
  - package-ecosystem: "npm"
    directory: "/"
    schedule:
      interval: "weekly"
    open-pull-requests-limit: 20
    commit-message:
      prefix: "chore"
      include: "scope"
```

How can I resolve this? If you propose a fix, please make it concise.
`````

</details>

<sub>Reviews (1): Last reviewed commit: ["chore: dependabot.ymlの整備"](https://github.com/hiroki-org/openshelf/commit/427f4468e2d85201c007aa914f98a75ac555732b) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=28311627)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->