### PR TITLE
fix(github): handle disable_workflow failure and output summary

### DIFF
--- a/.github/scripts/cleanup-stale-workflows.sh
+++ b/.github/scripts/cleanup-stale-workflows.sh
@@ -82,7 +82,10 @@ while IFS=$'\t' read -r workflow_id workflow_name workflow_path; do
     continue
   fi
 
-  disable_workflow "$workflow_id"
+  if ! disable_workflow "$workflow_id"; then
+    echo "Warning: failed to disable workflow id $workflow_id; skipping." >&2
+    continue
+  fi
   disabled_count=$((disabled_count + 1))
   echo "Disabled workflow id $workflow_id"
 done <<<"$workflow_rows"


### PR DESCRIPTION
This PR fixes an issue where the `.github/scripts/cleanup-stale-workflows.sh` script exits immediately without outputting the summary if `disable_workflow` fails due to an API error, because `set -euo pipefail` is enabled.

By changing the block to `if ! disable_workflow "$workflow_id"; then ...`, we catch the error, log a warning, and `continue` to the next iteration. This ensures `disabled_count` accurately reflects successful operations and the summary is still printed.

---
*PR created automatically by Jules for task [6208900155255734722](https://jules.google.com/task/6208900155255734722) started by @is0692vs*

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

`disable_workflow` がAPIエラーで失敗した場合に `set -euo pipefail` によってスクリプトが即終了してしまう問題を修正しています。`if ! disable_workflow "$workflow_id"; then` パターンに変更することで、失敗時に警告ログを出力して次のイテレーションへ `continue` し、最後のサマリー出力を常に保証します。
</details>

<details open><summary><h3>Confidence Score: 5/5</h3></summary>

- 変更は最小限・正確であり、そのままマージ可能です。
- 修正内容は明確で正しい bash の慣用パターン（`if !` で `set -e` の伝播を防ぐ）を使っており、既存ロジックへの副作用もありません。残る指摘事項はすべて P2 以下のスタイル改善です。
- 特に注意が必要なファイルはありません。
</details>

<details open><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| .github/scripts/cleanup-stale-workflows.sh | disable_workflow の失敗を if ! パターンで捕捉するよう修正。set -euo pipefail 下でも summary が必ず出力されるようになった。 |

</details>

</details>

<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[ワークフロー一覧取得] --> B{active なし?}
    B -- Yes --> C[No active workflows / exit 0]
    B -- No --> D[各ワークフローをループ]
    D --> E{path が .github/workflows/* ?}
    E -- No --> F[スキップ]
    E -- Yes --> G{default branch に存在?}
    G -- Yes --> H[OK: スキップ]
    G -- No --> I[stale_count++]
    I --> J{DRY_RUN=1?}
    J -- Yes --> K[Dry run メッセージ / continue]
    J -- No --> L[disable_workflow 呼び出し]
    L --> M{成功?}
    M -- No --> N[Warning ログ / continue]
    M -- Yes --> O[disabled_count++ / Disabled ログ]
    F --> D
    H --> D
    K --> D
    N --> D
    O --> D
    D -- ループ終了 --> P[Summary 出力]
```

<sub>Reviews (1): Last reviewed commit: ["fix(github): handle disable\_workflow fai..."](https://github.com/hiroki-org/openshelf/commit/96b7729dca204e5303853954406125a9616b25c4) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=28319022)</sub>

<!-- /greptile_comment -->