### PR TITLE
Fix CodSpeed performance regression in validateMagicNumbers

### DIFF
--- a/apps/api/src/utils/file.ts
+++ b/apps/api/src/utils/file.ts
@@ -232,19 +232,16 @@ export async function validateMagicNumbers(
     const bytes = new Uint8Array(buffer);
 
     let detectedType: string | null = null;
-    for (const [signature, mimeType] of MAGIC_NUMBER_MAP) {
-      if (bytes.length < signature.length) continue;
-      let match = true;
-      for (let i = 0; i < signature.length; i++) {
-        if (bytes[i] !== signature[i]) {
-          match = false;
-          break;
-        }
-      }
-      if (match) {
-        detectedType = mimeType;
-        break;
-      }
+    if (bytes.length >= 5 && bytes[0] === 0x25 && bytes[1] === 0x50 && bytes[2] === 0x44 && bytes[3] === 0x46 && bytes[4] === 0x2d) {
+      detectedType = "application/pdf";
+    } else if (bytes.length >= 8 && bytes[0] === 0x89 && bytes[1] === 0x50 && bytes[2] === 0x4e && bytes[3] === 0x47 && bytes[4] === 0x0d && bytes[5] === 0x0a && bytes[6] === 0x1a && bytes[7] === 0x0a) {
+      detectedType = "image/png";
+    } else if (bytes.length >= 3 && bytes[0] === 0xff && bytes[1] === 0xd8 && bytes[2] === 0xff) {
+      detectedType = "image/jpeg";
+    } else if (bytes.length >= 8 && bytes[0] === 0xd0 && bytes[1] === 0xcf && bytes[2] === 0x11 && bytes[3] === 0xe0 && bytes[4] === 0xa1 && bytes[5] === 0xb1 && bytes[6] === 0x1a && bytes[7] === 0xe1) {
+      detectedType = "application/x-ole-storage";
+    } else if (bytes.length >= 4 && bytes[0] === 0x50 && bytes[1] === 0x4b && bytes[2] === 0x03 && bytes[3] === 0x04) {
+      detectedType = "application/zip";
     }
 
     if (!detectedType) return false;


### PR DESCRIPTION
This PR addresses the performance regression caught by CodSpeed in the `staging` -> `main` PR (#468).

**Issue:**
The `validateMagicNumbers` PDF benchmark dropped by ~23.26% on `staging` compared to `main`. This regression occurred because the highly optimized, unrolled byte comparison logic (which existed in `main` via commit `8a4edc9`) was overwritten by an array-loop-based iteration (`for (const [signature, mimeType] of MAGIC_NUMBER_MAP)`) in `staging`.

**Fix:**
- Replaced the `for...of` loop in `validateMagicNumbers` (`apps/api/src/utils/file.ts`) with the unrolled `if/else if` byte-by-byte comparisons.
- This eliminates the V8 callback and loop overhead, restoring the fast execution path.
- The `MAGIC_NUMBER_MAP` is retained to dynamically calculate `MAX_MAGIC_SIZE` at module scope.
- Verified locally that the CodSpeed benchmark runs smoothly and performance is fully restored.

---
*PR created automatically by Jules for task [12572737317895825197](https://jules.google.com/task/12572737317895825197) started by @is0692vs*

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

CodSpeed ベンチマークで検出されたパフォーマンス回帰（約 23%）を修正するため、`validateMagicNumbers` 内の `for...of` ループをアンロールされた `if/else if` バイト比較に置き換えました。現在のバイト値はすべて `MAGIC_NUMBER_MAP` と一致しており、機能的な正確性は保たれています。
</details>

<details open><summary><h3>Confidence Score: 5/5</h3></summary>

- 全バイト値は MAGIC_NUMBER_MAP と一致しており、機能的な正確性に問題はなく、マージ可能です。
- 残る指摘は P2（将来の保守性に関するスタイル提案）のみで、現時点での動作に影響はありません。バイト値の正確性を確認済みであり、パフォーマンス改善の目的も適切です。
- 特に注意が必要なファイルはありません。
</details>

<details open><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| apps/api/src/utils/file.ts | ループベースの検出ロジックをアンロールされた if/else if チェーンに置き換え。現在のバイト値はすべて MAGIC_NUMBER_MAP と一致しているが、MAP とアンロールブロックの二重管理が将来の同期ズレを招く可能性がある。 |

</details>

</details>

<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[validateMagicNumbers 呼び出し] --> B[先頭 MAX_MAGIC_SIZE バイト読み込み]
    B --> C{PDF シグネチャ?\n0x25 50 44 46 2D}
    C -- Yes --> D[detectedType = application/pdf]
    C -- No --> E{PNG シグネチャ?\n0x89 50 4E 47 ...}
    E -- Yes --> F[detectedType = image/png]
    E -- No --> G{JPEG シグネチャ?\n0xFF D8 FF}
    G -- Yes --> H[detectedType = image/jpeg]
    G -- No --> I{OLE シグネチャ?\n0xD0 CF 11 E0 ...}
    I -- Yes --> J[detectedType = application/x-ole-storage]
    I -- No --> K{ZIP シグネチャ?\n0x50 4B 03 04}
    K -- Yes --> L[detectedType = application/zip]
    K -- No --> M[detectedType = null → return false]
    D & F & H & J & L --> N{MIME_COMPATIBILITY チェック}
    N -- 不一致 --> O[return false]
    N -- 一致 --> P{PPTX?}
    P -- Yes --> Q[hasZipEntry チェック]
    P -- No --> R{PPT?}
    R -- Yes --> S[hasOleStream チェック]
    R -- No --> T[return true]
    Q & S --> T
```

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
This is a comment left during a code review.
Path: apps/api/src/utils/file.ts
Line: 235-245

Comment:
**MAGIC_NUMBER_MAP との二重管理リスク**

`MAGIC_NUMBER_MAP` は `MAX_MAGIC_SIZE` の計算にのみ使われるようになりましたが、実際の検出ロジックはアンロールされた `if/else if` ブロックに重複しています。将来、新しいフォーマット（例：WebP や GIF）を `MAGIC_NUMBER_MAP` に追加した場合、このブロックに対応するブランチを手動で追加しなければ、そのフォーマットは検出されないまま `false` を返します。コメントで「このブロックは MAGIC_NUMBER_MAP と同期して更新すること」と明記するか、あるいは `MAGIC_NUMBER_MAP` から `MAX_MAGIC_SIZE` だけを抽出する定数に分離すると、意図がより明確になります。

How can I resolve this? If you propose a fix, please make it concise.
`````

</details>

<sub>Reviews (1): Last reviewed commit: ["perf(api): restore unrolled magic number..."](https://github.com/hiroki-org/openshelf/commit/13c1b93f6063cff650a764140fa305fcc3ca9573) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=28333435)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->