### PR TITLE
chore: include precise hour/minute time in staging-to-main promotion PR title

### DIFF
--- a/.github/scripts/create-staging-to-main-pr.sh
+++ b/.github/scripts/create-staging-to-main-pr.sh
@@ -7,8 +7,6 @@ HEAD_BRANCH=${HEAD_BRANCH:-staging}
 BASE_BRANCH=${BASE_BRANCH:-main}
 DRY_RUN=${DRY_RUN:-0}
 UPDATE_EXISTING_PR=${UPDATE_EXISTING_PR:-1}
-PROMOTION_DATE=${PROMOTION_DATE:-$(date +%F)}
-PROMOTION_PR_TITLE=${PROMOTION_PR_TITLE:-Release: $HEAD_BRANCH -> $BASE_BRANCH ($PROMOTION_DATE)}
 
 trim() {
   local value="$1"
@@ -117,6 +115,9 @@ git fetch "$REMOTE_NAME" "$BASE_BRANCH" "$HEAD_BRANCH" --quiet
 
 base_ref="${REMOTE_NAME}/${BASE_BRANCH}"
 head_ref="${REMOTE_NAME}/${HEAD_BRANCH}"
+
+PROMOTION_DATE=${PROMOTION_DATE:-$(git log -1 --format="%cd" --date=format:"%Y-%m-%d %H:%M" "$head_ref")}
+PROMOTION_PR_TITLE=${PROMOTION_PR_TITLE:-Release: $HEAD_BRANCH -> $BASE_BRANCH ($PROMOTION_DATE)}
 
 if ! git rev-parse --verify "$base_ref" >/dev/null 2>&1; then
   echo "Base ref not found: $base_ref" >&2

--- a/.github/scripts/create-staging-to-main-pr.sh
+++ b/.github/scripts/create-staging-to-main-pr.sh
@@ -116,7 +116,7 @@ git fetch "$REMOTE_NAME" "$BASE_BRANCH" "$HEAD_BRANCH" --quiet
 base_ref="${REMOTE_NAME}/${BASE_BRANCH}"
 head_ref="${REMOTE_NAME}/${HEAD_BRANCH}"
 
-PROMOTION_DATE=${PROMOTION_DATE:-$(git log -1 --format="%cd" --date=format:"%Y-%m-%d %H:%M" "$head_ref")}
+PROMOTION_DATE=${PROMOTION_DATE:-$(git log -1 --format="%cd" --date=format-local:"%Y-%m-%d %H:%M" "$head_ref")}
 PROMOTION_PR_TITLE=${PROMOTION_PR_TITLE:-Release: $HEAD_BRANCH -> $BASE_BRANCH ($PROMOTION_DATE)}
 
 if ! git rev-parse --verify "$base_ref" >/dev/null 2>&1; then


### PR DESCRIPTION
The `.github/scripts/create-staging-to-main-pr.sh` workflow script currently creates a release PR with only the date in the title (e.g., `Release: staging -> main (2026-04-15)`).

This commit updates the `PROMOTION_DATE` variable definition to retrieve the exact timestamp (`%Y-%m-%d %H:%M`) of the latest commit on the `staging` branch after the repository is fetched. The PR title will now look like `Release: staging -> main (2026-04-15 08:31)`, satisfying the requirement to use the latest staging commit time and distinguish between multiple releases created on the same day.

---
*PR created automatically by Jules for task [5597171597304429679](https://jules.google.com/task/5597171597304429679) started by @is0692vs*

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

`PROMOTION_DATE` の定義を `git fetch` 後に移動し、現在日付（`date +%F`）の代わりに staging ブランチの最新コミット日時（`git log -1 --format="%cd"`）を使うよう変更しています。これにより、PR タイトルに `(2026-04-15 08:31)` のような時刻が含まれ、同日複数リリース時の識別が可能になります。
</details>

<details open><summary><h3>Confidence Score: 5/5</h3></summary>

このPRはマージ可能です。変更内容はシンプルかつ意図どおりに動作します。

変更は1ファイル・3行のみで、`PROMOTION_DATE` の定義を `git fetch` 後に移動して最新コミットの日時を利用するという明確な改善です。P0/P1 の問題はなく、残る指摘（タイムゾーンの一貫性）は P2 レベルのスタイル提案です。

特に注意が必要なファイルはありません。
</details>

<details open><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| .github/scripts/create-staging-to-main-pr.sh | `PROMOTION_DATE` の定義を `git fetch` 後に移動し、`date +%F`（現在日付）から `git log` による最新コミットの正確な日時（HH:MM）へ変更。タイムゾーン表示が commit オブジェクト依存になる点は P2 レベルの懸念。 |

</details>

</details>

<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[スクリプト開始] --> B[git fetch origin main staging]
    B --> C[base_ref / head_ref を設定]
    C --> D{"PROMOTION_DATE\n環境変数セット済み？"}
    D -- はい --> E[既存の値を使用]
    D -- いいえ --> F["git log -1 --format='%cd'\n--date=format:'%Y-%m-%d %H:%M'\nhead_ref"]
    F --> G["PROMOTION_DATE = '2026-04-15 08:31'"]
    E --> H["PROMOTION_PR_TITLE = 'Release: staging → main (DATE)'"]
    G --> H
    H --> I[PR 作成 / 更新 / 直接マージ]
```

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
This is a comment left during a code review.
Path: .github/scripts/create-staging-to-main-pr.sh
Line: 119

Comment:
**コミット日時のタイムゾーンが不明確**

`%cd`（コミッター日付）を `--date=format:` で出力すると、コミットに埋め込まれたタイムゾーン（コミット者のローカルタイムゾーン）が使われます。コントリビューターによって UTC+9 や UTC-8 などがバラバラになるため、PR タイトルに時刻が含まれていてもどのタイムゾーンかが不明です。CI 環境（GitHub Actions）は通常 UTC で動作するため、`format-local:` を使うと常にマシンのローカルタイム（＝UTC）で統一されます。

```suggestion
PROMOTION_DATE=${PROMOTION_DATE:-$(git log -1 --format="%cd" --date=format-local:"%Y-%m-%d %H:%M" "$head_ref")}
```

How can I resolve this? If you propose a fix, please make it concise.
`````

</details>

<sub>Reviews (1): Last reviewed commit: ["chore: include precise hour/minute time ..."](https://github.com/hiroki-org/openshelf/commit/f0c6f29d6ac9bf27923f210aa5dea12b49c2e222) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=28433945)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->