### PR TITLE
test(api): add codspeed benchmarks for utils

### DIFF
--- a/apps/api/src/utils/__tests__/badge.bench.ts
+++ b/apps/api/src/utils/__tests__/badge.bench.ts
@@ -1,0 +1,19 @@
+import { bench, describe } from "vitest";
+import { buildBadgeSvg, estimateTextWidth } from "../badge";
+
+const benchmarkOptions = {
+    time: 2000,
+    warmupTime: 500,
+    iterations: 25,
+    warmupIterations: 10,
+};
+
+describe("badge benchmark", () => {
+    bench("buildBadgeSvg", () => {
+        buildBadgeSvg("📄 OpenShelf", "Balance Boundary Explorer (2026)", "4c1");
+    }, benchmarkOptions);
+
+    bench("estimateTextWidth", () => {
+        estimateTextWidth("Balance Boundary Explorer (2026) 📄 OpenShelf 👍");
+    }, benchmarkOptions);
+});

--- a/apps/api/src/utils/__tests__/badge.bench.ts
+++ b/apps/api/src/utils/__tests__/badge.bench.ts
@@ -1,12 +1,6 @@
 import { bench, describe } from "vitest";
 import { buildBadgeSvg, estimateTextWidth } from "../badge";
-
-const benchmarkOptions = {
-    time: 2000,
-    warmupTime: 500,
-    iterations: 25,
-    warmupIterations: 10,
-};
+import { benchmarkOptions } from "./bench-utils";
 
 describe("badge benchmark", () => {
     bench("buildBadgeSvg", () => {

--- a/apps/api/src/utils/__tests__/bench-utils.ts
+++ b/apps/api/src/utils/__tests__/bench-utils.ts
@@ -1,0 +1,6 @@
+export const benchmarkOptions = {
+    time: 2000,
+    warmupTime: 500,
+    iterations: 25,
+    warmupIterations: 10,
+};

--- a/apps/api/src/utils/__tests__/citation.bench.ts
+++ b/apps/api/src/utils/__tests__/citation.bench.ts
@@ -1,12 +1,6 @@
 import { bench, describe } from "vitest";
 import { buildCitation } from "../citation";
-
-const benchmarkOptions = {
-    time: 2000,
-    warmupTime: 500,
-    iterations: 25,
-    warmupIterations: 10,
-};
+import { benchmarkOptions } from "./bench-utils";
 
 describe("citation benchmark", () => {
     const paperBase = {
@@ -31,6 +25,10 @@ describe("citation benchmark", () => {
         buildCitation(paperBase, authors, "bibtex", frontendUrl);
     }, benchmarkOptions);
 
+    bench("buildCitation biblatex", () => {
+        buildCitation(paperBase, authors, "biblatex", frontendUrl);
+    }, benchmarkOptions);
+
     bench("buildCitation apa", () => {
         buildCitation(paperBase, authors, "apa", frontendUrl);
     }, benchmarkOptions);
@@ -41,5 +39,9 @@ describe("citation benchmark", () => {
 
     bench("buildCitation mla", () => {
         buildCitation(paperBase, authors, "mla", frontendUrl);
+    }, benchmarkOptions);
+
+    bench("buildCitation plain", () => {
+        buildCitation(paperBase, authors, "plain", frontendUrl);
     }, benchmarkOptions);
 });

--- a/apps/api/src/utils/__tests__/citation.bench.ts
+++ b/apps/api/src/utils/__tests__/citation.bench.ts
@@ -1,0 +1,45 @@
+import { bench, describe } from "vitest";
+import { buildCitation } from "../citation";
+
+const benchmarkOptions = {
+    time: 2000,
+    warmupTime: 500,
+    iterations: 25,
+    warmupIterations: 10,
+};
+
+describe("citation benchmark", () => {
+    const paperBase = {
+        id: "paper-1",
+        title: "Balance Boundary Explorer",
+        venue: "ASE",
+        venueType: "conference" as const,
+        year: 2026,
+        category: "other" as const,
+        doi: "10.1145/xxxxxxx.xxxxxxx",
+        externalUrl: null,
+    };
+
+    const authors = [
+        { name: "hiroki", displayName: "Hiroki Mukai" },
+        { name: "kato", displayName: "Yusaku Kato" },
+    ];
+
+    const frontendUrl = "https://openshelf.example";
+
+    bench("buildCitation bibtex", () => {
+        buildCitation(paperBase, authors, "bibtex", frontendUrl);
+    }, benchmarkOptions);
+
+    bench("buildCitation apa", () => {
+        buildCitation(paperBase, authors, "apa", frontendUrl);
+    }, benchmarkOptions);
+
+    bench("buildCitation ieee", () => {
+        buildCitation(paperBase, authors, "ieee", frontendUrl);
+    }, benchmarkOptions);
+
+    bench("buildCitation mla", () => {
+        buildCitation(paperBase, authors, "mla", frontendUrl);
+    }, benchmarkOptions);
+});

--- a/apps/api/src/utils/__tests__/file.bench.ts
+++ b/apps/api/src/utils/__tests__/file.bench.ts
@@ -1,12 +1,6 @@
 import { bench, describe } from "vitest";
 import { validateMagicNumbers } from "../file";
-
-const benchmarkOptions = {
-    time: 2000,
-    warmupTime: 500,
-    iterations: 25,
-    warmupIterations: 10,
-};
+import { benchmarkOptions } from "./bench-utils";
 
 describe("file extensions benchmark", () => {
     // Create dummy File objects once so the benchmark measures validation only.

--- a/apps/api/src/utils/__tests__/origin.bench.ts
+++ b/apps/api/src/utils/__tests__/origin.bench.ts
@@ -1,0 +1,25 @@
+import { bench, describe } from "vitest";
+import { isAllowedOrigin } from "../origin";
+
+const benchmarkOptions = {
+    time: 2000,
+    warmupTime: 500,
+    iterations: 25,
+    warmupIterations: 10,
+};
+
+describe("origin benchmark", () => {
+    const allowedOrigins = [
+        "https://openshelf.example",
+        "https://*.openshelf.example",
+        "http://localhost:3000",
+    ];
+
+    bench("isAllowedOrigin exact match", () => {
+        isAllowedOrigin("https://openshelf.example", "https://openshelf.example", allowedOrigins);
+    }, benchmarkOptions);
+
+    bench("isAllowedOrigin wildcard match", () => {
+        isAllowedOrigin("https://app.openshelf.example", "https://openshelf.example", allowedOrigins);
+    }, benchmarkOptions);
+});

--- a/apps/api/src/utils/__tests__/origin.bench.ts
+++ b/apps/api/src/utils/__tests__/origin.bench.ts
@@ -1,12 +1,6 @@
 import { bench, describe } from "vitest";
 import { isAllowedOrigin } from "../origin";
-
-const benchmarkOptions = {
-    time: 2000,
-    warmupTime: 500,
-    iterations: 25,
-    warmupIterations: 10,
-};
+import { benchmarkOptions } from "./bench-utils";
 
 describe("origin benchmark", () => {
     const allowedOrigins = [

--- a/apps/api/src/utils/__tests__/tags.bench.ts
+++ b/apps/api/src/utils/__tests__/tags.bench.ts
@@ -1,0 +1,27 @@
+import { bench, describe } from "vitest";
+import { parseStoredTags } from "../tags";
+
+const benchmarkOptions = {
+    time: 2000,
+    warmupTime: 500,
+    iterations: 25,
+    warmupIterations: 10,
+};
+
+describe("tags benchmark", () => {
+    bench("parseStoredTags with valid JSON array", () => {
+        parseStoredTags('["tag1", "tag2", "tag3"]');
+    }, benchmarkOptions);
+
+    bench("parseStoredTags with empty string", () => {
+        parseStoredTags("");
+    }, benchmarkOptions);
+
+    bench("parseStoredTags with null", () => {
+        parseStoredTags(null);
+    }, benchmarkOptions);
+
+    bench("parseStoredTags with invalid JSON", () => {
+        parseStoredTags('["tag1", "tag2", "tag3"');
+    }, benchmarkOptions);
+});

--- a/apps/api/src/utils/__tests__/tags.bench.ts
+++ b/apps/api/src/utils/__tests__/tags.bench.ts
@@ -1,12 +1,6 @@
 import { bench, describe } from "vitest";
 import { parseStoredTags } from "../tags";
-
-const benchmarkOptions = {
-    time: 2000,
-    warmupTime: 500,
-    iterations: 25,
-    warmupIterations: 10,
-};
+import { benchmarkOptions } from "./bench-utils";
 
 describe("tags benchmark", () => {
     bench("parseStoredTags with valid JSON array", () => {

--- a/apps/api/vitest.config.ts
+++ b/apps/api/vitest.config.ts
@@ -16,7 +16,7 @@ export default defineConfig(async (): Promise<UserConfig> => {
             reporter: ["text", "lcov"],
             reportsDirectory: "./coverage",
             include: ["src/**/*.ts"],
-            exclude: ["src/types.ts", "**/coverage/**"],
+            exclude: ["**/*.bench.ts", "src/**/bench-utils.ts", "src/types.ts", "**/coverage/**"],
         }
     }
     };


### PR DESCRIPTION
I have created several CodSpeed benchmark files for the utility functions in the `apps/api/src/utils/` directory:
- `apps/api/src/utils/__tests__/badge.bench.ts`: Benchmarks `buildBadgeSvg` and `estimateTextWidth`.
- `apps/api/src/utils/__tests__/citation.bench.ts`: Benchmarks `buildCitation` across different formats (`bibtex`, `apa`, `ieee`, `mla`).
- `apps/api/src/utils/__tests__/origin.bench.ts`: Benchmarks `isAllowedOrigin` with exact match and wildcard match.
- `apps/api/src/utils/__tests__/tags.bench.ts`: Benchmarks `parseStoredTags` with valid JSON, empty string, null, and invalid JSON inputs.

Tested locally using `npx vitest bench --run --config apps/api/vitest.config.ts --passWithNoTests`.

---
*PR created automatically by Jules for task [2298691787030383717](https://jules.google.com/task/2298691787030383717) started by @is0692vs*

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

4 つのユーティリティ関数（`buildBadgeSvg`・`estimateTextWidth`、`buildCitation`、`isAllowedOrigin`、`parseStoredTags`）に対して CodSpeed 対応の Vitest ベンチマークを追加するPRです。入力値の型は実装の型定義と一致しており、各関数の代表的なコードパスをカバーしています。
</details>

<details open><summary><h3>Confidence Score: 5/5</h3></summary>

すべての指摘が P2 以下であり、マージに問題ありません。

P0/P1 の問題は存在せず、ベンチマークの入力値も実装の型定義と合致しています。biblatex/plain の未カバーや benchmarkOptions の重複はスタイル上の改善提案に留まります。

citation.bench.ts — biblatex / plain フォーマットの追加を検討してください。
</details>

<details open><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| apps/api/src/utils/__tests__/badge.bench.ts | buildBadgeSvg と estimateTextWidth のベンチマーク。入力値は絵文字・ASCII・スペースを含む妥当な文字列で、両関数を適切にカバーしている。 |
| apps/api/src/utils/__tests__/citation.bench.ts | bibtex/apa/ieee/mla の 4 フォーマットをベンチマーク。CitationFormat に含まれる biblatex と plain が未カバー。入力値自体は型的に問題なし。 |
| apps/api/src/utils/__tests__/origin.bench.ts | 完全一致とワイルドカード一致の 2 ケースをベンチマーク。matchesOriginPattern 内で毎回 RegExp を生成するコストも計測対象に含まれるが、実装の実態を反映している。 |
| apps/api/src/utils/__tests__/tags.bench.ts | 有効 JSON / 空文字 / null / 不正 JSON の 4 ケースで parseStoredTags を網羅的にベンチマーク。問題なし。 |

</details>

</details>

<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A["vitest bench --run"] --> B["@codspeed/vitest-plugin"]
    B --> C1["badge.bench.ts"]
    B --> C2["citation.bench.ts"]
    B --> C3["origin.bench.ts"]
    B --> C4["tags.bench.ts"]
    C1 --> D1["buildBadgeSvg()"]
    C1 --> D2["estimateTextWidth()"]
    C2 --> D3["buildCitation() × 4 formats"]
    C2 -.->|"未カバー"| D4["biblatex / plain"]
    C3 --> D5["isAllowedOrigin() exact"]
    C3 --> D6["isAllowedOrigin() wildcard\n(RegExp compile each call)"]
    C4 --> D7["parseStoredTags() × 4 inputs"]
```

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
This is a comment left during a code review.
Path: apps/api/src/utils/__tests__/citation.bench.ts
Line: 29-45

Comment:
**biblatex / plain フォーマットがベンチマーク未カバー**

`CitationFormat` には `"bibtex" | "biblatex" | "apa" | "ieee" | "mla" | "plain"` の 6 種類が定義されていますが、このファイルでは `biblatex` と `plain` が計測されていません。特に `biblatex` は内部で `toBibLaTeXEntryTypeAndFields` が呼ばれる分岐があり、`bibtex` とは異なるコードパスを通ります。将来的に `buildCitation` のリファクタリングを行う際、これらのフォーマットの性能変化を追跡できなくなります。

```typescript
bench("buildCitation biblatex", () => {
    buildCitation(paperBase, authors, "biblatex", frontendUrl);
}, benchmarkOptions);

bench("buildCitation plain", () => {
    buildCitation(paperBase, authors, "plain", frontendUrl);
}, benchmarkOptions);
```

How can I resolve this? If you propose a fix, please make it concise.

---

This is a comment left during a code review.
Path: apps/api/src/utils/__tests__/badge.bench.ts
Line: 3-8

Comment:
**benchmarkOptions が全ファイルで重複定義**

`badge.bench.ts`・`citation.bench.ts`・`origin.bench.ts`・`tags.bench.ts` の 4 ファイルすべてで全く同一の `benchmarkOptions` オブジェクトが定義されています。将来パラメータを変更する際に 4 箇所を修正する必要があります。共有ヘルパーファイル（例: `__tests__/bench-utils.ts`）に切り出すことで DRY になります。

```typescript
// apps/api/src/utils/__tests__/bench-utils.ts
export const benchmarkOptions = {
    time: 2000,
    warmupTime: 500,
    iterations: 25,
    warmupIterations: 10,
};
```

How can I resolve this? If you propose a fix, please make it concise.
`````

</details>

<sub>Reviews (1): Last reviewed commit: ["test(api): add codspeed benchmarks for u..."](https://github.com/hiroki-org/openshelf/commit/1543b9bd95558ed75dfc816418887b2d87079c8d) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=28848038)</sub>

> Greptile also left **2 inline comments** on this PR.

<!-- /greptile_comment -->