### PR TITLE
🧪 Add test file for utils/badge.ts

### DIFF
--- a/apps/api/src/utils/__tests__/badge.test.ts
+++ b/apps/api/src/utils/__tests__/badge.test.ts
@@ -1,0 +1,228 @@
+import { describe, expect, it } from "vitest";
+import {
+    escapeXml,
+    normalizeBadgeStyle,
+    normalizeBadgeLabel,
+    normalizeBadgeColor,
+    truncateBadgeText,
+    estimateTextWidth,
+    buildBadgeMessage,
+    buildLeftText,
+    buildBadgeSvg,
+    buildShieldsEndpointPayload,
+    buildNotFoundBadge,
+    createEtag,
+} from "../badge";
+
+describe("badge utils", () => {
+    describe("escapeXml", () => {
+        it("escapes special XML characters", () => {
+            expect(escapeXml('some text < > & " \'')).toBe("some text &lt; &gt; &amp; &quot; &#39;");
+            expect(escapeXml("normal text")).toBe("normal text");
+        });
+    });
+
+    describe("normalizeBadgeStyle", () => {
+        it('returns "compact" when value is "compact"', () => {
+            expect(normalizeBadgeStyle("compact")).toBe("compact");
+        });
+
+        it('returns "default" for other values', () => {
+            expect(normalizeBadgeStyle("default")).toBe("default");
+            expect(normalizeBadgeStyle("flat")).toBe("default");
+            expect(normalizeBadgeStyle(null)).toBe("default");
+            expect(normalizeBadgeStyle(undefined)).toBe("default");
+        });
+    });
+
+    describe("normalizeBadgeLabel", () => {
+        it("returns default label if empty or null", () => {
+            expect(normalizeBadgeLabel("")).toBe("OpenShelf");
+            expect(normalizeBadgeLabel(null)).toBe("OpenShelf");
+            expect(normalizeBadgeLabel(undefined)).toBe("OpenShelf");
+            expect(normalizeBadgeLabel("   ")).toBe("OpenShelf");
+        });
+
+        it("truncates long labels to 24 characters", () => {
+            const longLabel = "This is a very long label that should be truncated";
+            const result = normalizeBadgeLabel(longLabel);
+            expect(result).toBe("This is a very long lab…");
+            expect(result.length).toBe(24);
+        });
+
+        it("cleans up whitespace", () => {
+            expect(normalizeBadgeLabel("  hello   world  ")).toBe("hello world");
+        });
+    });
+
+    describe("normalizeBadgeColor", () => {
+        it("returns default color if empty or null", () => {
+            expect(normalizeBadgeColor("")).toBe("4c1");
+            expect(normalizeBadgeColor(null)).toBe("4c1");
+            expect(normalizeBadgeColor(undefined)).toBe("4c1");
+        });
+
+        it("normalizes hex colors", () => {
+            expect(normalizeBadgeColor("#FF0000")).toBe("ff0000");
+            expect(normalizeBadgeColor("FFF")).toBe("fff");
+            expect(normalizeBadgeColor("#12345678")).toBe("12345678");
+        });
+
+        it("normalizes named colors", () => {
+            expect(normalizeBadgeColor("Red")).toBe("red");
+            expect(normalizeBadgeColor("blue")).toBe("blue");
+        });
+
+        it("returns default color for invalid formats", () => {
+            expect(normalizeBadgeColor("12")).toBe("4c1"); // Too short for hex
+            expect(normalizeBadgeColor("invalid color format!")).toBe("4c1");
+        });
+
+        it("cleans up whitespace", () => {
+            expect(normalizeBadgeColor("  #ff0000  ")).toBe("ff0000");
+        });
+    });
+
+    describe("truncateBadgeText", () => {
+        it("returns original text if shorter than max length", () => {
+            expect(truncateBadgeText("hello", 10)).toBe("hello");
+        });
+
+        it("truncates text and appends ellipsis", () => {
+            expect(truncateBadgeText("hello world", 5)).toBe("hell…");
+        });
+
+        it("handles empty string", () => {
+            expect(truncateBadgeText("", 5)).toBe("");
+        });
+
+        it("returns ellipsis for maxLength 1 or less if text is longer", () => {
+            expect(truncateBadgeText("hello", 1)).toBe("…");
+            expect(truncateBadgeText("hello", 0)).toBe("…");
+            expect(truncateBadgeText("hello", -1)).toBe("…");
+        });
+
+        it("handles wide characters properly (surrogate pairs)", () => {
+            expect(truncateBadgeText("👨‍👩‍👧‍👦hello", 2)).toBe("👨…");
+        });
+    });
+
+    describe("estimateTextWidth", () => {
+        it("estimates width based on character types", () => {
+            // Lowercase/numbers: 6
+            expect(estimateTextWidth("a1")).toBe(12);
+            // Uppercase: 7
+            expect(estimateTextWidth("A")).toBe(7);
+            // Emojis: 12
+            expect(estimateTextWidth("🚀")).toBe(12);
+            // Wide chars: 11
+            expect(estimateTextWidth("한")).toBe(11);
+            // Default (e.g. space): 5
+            expect(estimateTextWidth(" ")).toBe(5);
+        });
+    });
+
+    describe("buildBadgeMessage", () => {
+        it('returns "Paper" if style is compact', () => {
+            expect(buildBadgeMessage("My Paper Title", 2023, "compact")).toBe("Paper");
+        });
+
+        it("includes year and truncates appropriately", () => {
+            // max length with year is 35
+            const longTitle = "This is a very very long paper title that should definitely be truncated";
+            const result = buildBadgeMessage(longTitle, 2023, "default");
+            // "This is a very very long paper tit…" (34 chars) + " (2023)"
+            expect(result).toBe("This is a very very long paper tit… (2023)");
+        });
+
+        it("truncates appropriately without year", () => {
+            // max length without year is 38
+            const longTitle = "This is a very very long paper title that should definitely be truncated";
+            const result = buildBadgeMessage(longTitle, null, "default");
+            expect(result).toBe("This is a very very long paper title …");
+        });
+
+        it("handles short titles", () => {
+            expect(buildBadgeMessage("Short", 2023, "default")).toBe("Short (2023)");
+            expect(buildBadgeMessage("Short", null, "default")).toBe("Short");
+        });
+
+        it('returns "Paper" if result is empty', () => {
+            expect(buildBadgeMessage("   ", null, "default")).toBe("Paper");
+        });
+    });
+
+    describe("buildLeftText", () => {
+        it("prepends document emoji", () => {
+            expect(buildLeftText("Label")).toBe("📄 Label");
+        });
+    });
+
+    describe("buildBadgeSvg", () => {
+        it("builds a valid SVG string", () => {
+            const svg = buildBadgeSvg("left", "right", "ff0000");
+            expect(svg).toContain("<svg");
+            expect(svg).toContain("left");
+            expect(svg).toContain("right");
+            expect(svg).toContain("#ff0000"); // normalized svg color
+        });
+
+        it("uses default values if empty text", () => {
+            const svg = buildBadgeSvg("", "", "");
+            expect(svg).toContain("📄 OpenShelf"); // default left
+            expect(svg).toContain("Paper"); // default right
+            expect(svg).toContain("4c1"); // default color
+        });
+
+        it("escapes special XML characters in SVG", () => {
+            const svg = buildBadgeSvg("<left>", "right&", "ff0000");
+            expect(svg).toContain("&lt;left&gt;");
+            expect(svg).toContain("right&amp;");
+        });
+    });
+
+    describe("buildShieldsEndpointPayload", () => {
+        it("builds payload with correct structure", () => {
+            const payload = buildShieldsEndpointPayload("left", "right", "ff0000");
+            expect(payload).toEqual({
+                schemaVersion: 1,
+                label: "left",
+                message: "right",
+                color: "ff0000",
+            });
+        });
+    });
+
+    describe("buildNotFoundBadge", () => {
+        it("returns SVG and JSON for not found state", () => {
+            const result = buildNotFoundBadge({ style: "default", label: "MyLabel", color: "ff0000" });
+
+            // JSON checks
+            expect(result.json.label).toBe("📄 MyLabel");
+            expect(result.json.message).toBe("not found");
+            expect(result.json.color).toBe("9f9f9f");
+
+            // SVG checks
+            expect(result.svg).toContain("📄 MyLabel");
+            expect(result.svg).toContain("not found");
+            expect(result.svg).toContain("9f9f9f");
+        });
+    });
+
+    describe("createEtag", () => {
+        it("creates a deterministic hash", () => {
+            const etag1 = createEtag("test-string");
+            const etag2 = createEtag("test-string");
+            expect(etag1).toBe(etag2);
+            expect(etag1).toMatch(/^"[0-9a-f]{16}"$/);
+        });
+
+        it("creates different hashes for different strings", () => {
+            expect(createEtag("test1")).not.toBe(createEtag("test2"));
+        });
+
+        it("handles empty strings", () => {
+            expect(createEtag("")).toMatch(/^"[0-9a-f]{16}"$/);
+        });
+    });
+});


### PR DESCRIPTION
🎯 What: The testing gap addressed
- Created missing test file for `apps/api/src/utils/badge.ts`.
- Verified behaviors of all exported functions (`escapeXml`, `normalizeBadgeStyle`, `normalizeBadgeLabel`, `normalizeBadgeColor`, `truncateBadgeText`, `estimateTextWidth`, `buildBadgeMessage`, `buildLeftText`, `buildBadgeSvg`, `buildShieldsEndpointPayload`, `buildNotFoundBadge`, `createEtag`).

📊 Coverage: What scenarios are now tested
- Happy paths for SVG and JSON structures
- Default and fallback value handling for label and colors
- Truncation of long badge texts and surrogate pair (wide character) handling
- Deterministic hashing via FNV-1a for etags
- XML sanitization to prevent XSS issues

✨ Result: The improvement in test coverage
- High confidence refactoring of badge generation utilities.
- Catch regressions quickly with robust unit tests.

---
*PR created automatically by Jules for task [5599890723014849217](https://jules.google.com/task/5599890723014849217) started by @is0692vs*

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

`apps/api/src/utils/badge.ts` に対するテストファイルを新規追加する PR です。`escapeXml`、`normalizeBadge*`、`truncateBadgeText`、`buildBadgeSvg` など全エクスポート関数を網羅しており、XSS エスケープ・デフォルト値・切り捨て・FNV-1a ハッシュなど主要なシナリオがカバーされています。

全ての指摘は P2（スタイル・コメント精度）であり、マージをブロックするものはありません。
</details>

<details open><summary><h3>Confidence Score: 5/5</h3></summary>

テストのみの変更でロジックバグはなく、マージは安全です。

全 3 件の指摘は P2（テスト名の誤解・コメントの文字数・toContain の精度）であり、実行時エラーやデータ不整合を引き起こすものはありません。実装コードへの変更はなし。

特になし。
</details>

<details open><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| apps/api/src/utils/__tests__/badge.test.ts | badge.ts のすべてのエクスポート関数を網羅するテストを新規追加。テスト名や一部コメントに軽微な不正確さあり（P2）だが、ロジック上の誤りはなし。 |

</details>

</details>

<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[badge.test.ts] --> B[escapeXml]
    A --> C[normalizeBadgeStyle]
    A --> D[normalizeBadgeLabel]
    A --> E[normalizeBadgeColor]
    A --> F[truncateBadgeText]
    A --> G[estimateTextWidth]
    A --> H[buildBadgeMessage]
    A --> I[buildLeftText]
    A --> J[buildBadgeSvg]
    A --> K[buildShieldsEndpointPayload]
    A --> L[buildNotFoundBadge]
    A --> M[createEtag]

    J -->|uses| B
    J -->|uses| G
    J -->|uses| I
    L -->|uses| I
    L -->|uses| J
    L -->|uses| K
    H -->|uses| F
    D -->|uses| F
```

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
This is a comment left during a code review.
Path: apps/api/src/utils/__tests__/badge.test.ts
Line: 105-107

Comment:
**テスト名の説明が不正確**

テスト名 `"handles wide characters properly (surrogate pairs)"` は誤解を招きます。`"surrogate pairs"（サロゲートペア）` は UTF-16 の符号化に関する概念ですが、ここでテストしているのは ZWJ シーケンス（`👨‍👩‍👧‍👦` は複数のコードポイントを ZWJ U+200D でつないだもの）です。`[...str]` はコードポイント単位で分割するため、`👨‍👩‍👧‍👦` は `["👨", "‍", "👩", "‍", "👧", "‍", "👦"]` に分解され、`maxLength=2` で切り取ると `"👨…"` となります。つまり ZWJ シーケンスが意図せず分断されており、"properly handles" と言えない挙動が含まれています。テスト名を実際の挙動を示すものに修正することを推奨します。

```suggestion
        it("splits ZWJ emoji sequences at code point boundaries", () => {
            expect(truncateBadgeText("👨‍👩‍👧‍👦hello", 2)).toBe("👨…");
        });
```

How can I resolve this? If you propose a fix, please make it concise.

---

This is a comment left during a code review.
Path: apps/api/src/utils/__tests__/badge.test.ts
Line: 134

Comment:
**コメントの文字数が不正確**

`truncateBadgeText(title, 35)` が返す `"This is a very very long paper tit…"` は ASCII 34 文字 + `"…"` 1 文字で合計 **35 文字**です。コメントの `(34 chars)` は切り捨て後の ASCII 部分だけを指しているため、`"…"` を含めた実際の文字数と一致せず紛らわしいです。

```suggestion
            // truncateBadgeText(title, 35) → "This is a very very long paper tit…" (35 chars) + " (2023)"
```

How can I resolve this? If you propose a fix, please make it concise.

---

This is a comment left during a code review.
Path: apps/api/src/utils/__tests__/badge.test.ts
Line: 174

Comment:
**色のアサーションが曖昧**

`buildBadgeSvg("", "", "")` では内部で `toSvgColor("4c1")` が呼ばれ、SVG に `fill="#4c1"` として埋め込まれます。`toContain("4c1")` は `"#4c1"` の部分文字列として偶発的に成立するため、色として正しく使われているかをより明確に検証するには `"#4c1"` を確認する方が精確です。

```suggestion
            expect(svg).toContain("#4c1"); // default color (with # prefix for SVG)
```

How can I resolve this? If you propose a fix, please make it concise.
`````

</details>

<sub>Reviews (1): Last reviewed commit: ["🧪 Add test file for utils/badge.ts"](https://github.com/hiroki-org/openshelf/commit/7d14f0d52f0f90c8d751171609e17cbb18bbf0e6) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=28880926)</sub>

> Greptile also left **3 inline comments** on this PR.

<!-- /greptile_comment -->