### PR TITLE
🧪 test: add missing error handling tests for validateMagicNumbers

### DIFF
--- a/apps/api/src/utils/__tests__/file.test.ts
+++ b/apps/api/src/utils/__tests__/file.test.ts
@@ -223,4 +223,61 @@ describe("validateMagicNumbers", () => {
       validateMagicNumbers(modifiedPpt, "application/vnd.ms-powerpoint"),
     ).resolves.toBe(false);
   });
+
+  it("returns false when File.slice throws RangeError", async () => {
+    const errorFile = {
+      slice: () => ({
+        arrayBuffer: async () => {
+          throw new RangeError("Invalid range");
+        }
+      }),
+      size: 100,
+      type: "application/pdf"
+    } as unknown as File;
+
+    await expect(validateMagicNumbers(errorFile, "application/pdf")).resolves.toBe(false);
+  });
+
+  it("returns false when File.slice throws TypeError", async () => {
+    const errorFile = {
+      slice: () => ({
+        arrayBuffer: async () => {
+          throw new TypeError("Type error");
+        }
+      }),
+      size: 100,
+      type: "application/pdf"
+    } as unknown as File;
+
+    await expect(validateMagicNumbers(errorFile, "application/pdf")).resolves.toBe(false);
+  });
+
+  it("returns false when File.slice throws DOMException with InvalidStateError", async () => {
+    const errorFile = {
+      slice: () => ({
+        arrayBuffer: async () => {
+          throw new DOMException("Invalid state", "InvalidStateError");
+        }
+      }),
+      size: 100,
+      type: "application/pdf"
+    } as unknown as File;
+
+    await expect(validateMagicNumbers(errorFile, "application/pdf")).resolves.toBe(false);
+  });
+
+  it("throws the error when File.slice throws an unexpected error", async () => {
+    const customError = new Error("Unexpected error");
+    const errorFile = {
+      slice: () => ({
+        arrayBuffer: async () => {
+          throw customError;
+        }
+      }),
+      size: 100,
+      type: "application/pdf"
+    } as unknown as File;
+
+    await expect(validateMagicNumbers(errorFile, "application/pdf")).rejects.toThrow("Unexpected error");
+  });
 });

--- a/apps/api/src/utils/__tests__/file.test.ts
+++ b/apps/api/src/utils/__tests__/file.test.ts
@@ -224,7 +224,7 @@ describe("validateMagicNumbers", () => {
     ).resolves.toBe(false);
   });
 
-  it("returns false when File.slice throws RangeError", async () => {
+it("returns false when File.slice throws RangeError", async () => {
     const errorFile = {
       slice: () => ({
         arrayBuffer: async () => {
@@ -238,7 +238,7 @@ describe("validateMagicNumbers", () => {
     await expect(validateMagicNumbers(errorFile, "application/pdf")).resolves.toBe(false);
   });
 
-  it("returns false when File.slice throws TypeError", async () => {
+it("returns false when File.slice throws TypeError", async () => {
     const errorFile = {
       slice: () => ({
         arrayBuffer: async () => {
@@ -252,7 +252,7 @@ describe("validateMagicNumbers", () => {
     await expect(validateMagicNumbers(errorFile, "application/pdf")).resolves.toBe(false);
   });
 
-  it("returns false when File.slice throws DOMException with InvalidStateError", async () => {
+it("returns false when File.slice throws DOMException with InvalidStateError", async () => {
     const errorFile = {
       slice: () => ({
         arrayBuffer: async () => {
@@ -266,22 +266,7 @@ describe("validateMagicNumbers", () => {
     await expect(validateMagicNumbers(errorFile, "application/pdf")).resolves.toBe(false);
   });
 
-  it("throws the error when File.slice throws DOMException with non-InvalidStateError name", async () => {
-    const domError = new DOMException("Aborted", "AbortError");
-    const errorFile = {
-      slice: () => ({
-        arrayBuffer: async () => {
-          throw domError;
-        },
-      }),
-      size: 100,
-      type: "application/pdf",
-    } as unknown as File;
-
-    await expect(validateMagicNumbers(errorFile, "application/pdf")).rejects.toThrow("Aborted");
-  });
-
-  it("throws the error when File.slice throws an unexpected error", async () => {
+it("throws the error when File.slice throws an unexpected error", async () => {
     const customError = new Error("Unexpected error");
     const errorFile = {
       slice: () => ({
@@ -294,5 +279,20 @@ describe("validateMagicNumbers", () => {
     } as unknown as File;
 
     await expect(validateMagicNumbers(errorFile, "application/pdf")).rejects.toThrow("Unexpected error");
+  });
+
+  it("throws the error when File.slice throws DOMException with AbortError", async () => {
+    const customError = new DOMException("Aborted", "AbortError");
+    const errorFile = {
+      slice: () => ({
+        arrayBuffer: async () => {
+          throw customError;
+        },
+      }),
+      size: 100,
+      type: "application/pdf",
+    } as unknown as File;
+
+    await expect(validateMagicNumbers(errorFile, "application/pdf")).rejects.toThrow(customError);
   });
 });

--- a/apps/api/src/utils/__tests__/file.test.ts
+++ b/apps/api/src/utils/__tests__/file.test.ts
@@ -229,10 +229,10 @@ describe("validateMagicNumbers", () => {
       slice: () => ({
         arrayBuffer: async () => {
           throw new RangeError("Invalid range");
-        }
+        },
       }),
       size: 100,
-      type: "application/pdf"
+      type: "application/pdf",
     } as unknown as File;
 
     await expect(validateMagicNumbers(errorFile, "application/pdf")).resolves.toBe(false);
@@ -243,10 +243,10 @@ describe("validateMagicNumbers", () => {
       slice: () => ({
         arrayBuffer: async () => {
           throw new TypeError("Type error");
-        }
+        },
       }),
       size: 100,
-      type: "application/pdf"
+      type: "application/pdf",
     } as unknown as File;
 
     await expect(validateMagicNumbers(errorFile, "application/pdf")).resolves.toBe(false);
@@ -257,13 +257,28 @@ describe("validateMagicNumbers", () => {
       slice: () => ({
         arrayBuffer: async () => {
           throw new DOMException("Invalid state", "InvalidStateError");
-        }
+        },
       }),
       size: 100,
-      type: "application/pdf"
+      type: "application/pdf",
     } as unknown as File;
 
     await expect(validateMagicNumbers(errorFile, "application/pdf")).resolves.toBe(false);
+  });
+
+  it("throws the error when File.slice throws DOMException with non-InvalidStateError name", async () => {
+    const domError = new DOMException("Aborted", "AbortError");
+    const errorFile = {
+      slice: () => ({
+        arrayBuffer: async () => {
+          throw domError;
+        },
+      }),
+      size: 100,
+      type: "application/pdf",
+    } as unknown as File;
+
+    await expect(validateMagicNumbers(errorFile, "application/pdf")).rejects.toThrow("Aborted");
   });
 
   it("throws the error when File.slice throws an unexpected error", async () => {
@@ -272,10 +287,10 @@ describe("validateMagicNumbers", () => {
       slice: () => ({
         arrayBuffer: async () => {
           throw customError;
-        }
+        },
       }),
       size: 100,
-      type: "application/pdf"
+      type: "application/pdf",
     } as unknown as File;
 
     await expect(validateMagicNumbers(errorFile, "application/pdf")).rejects.toThrow("Unexpected error");


### PR DESCRIPTION
### 🎯 **What:** 
Added the missing tests for the `catch` block inside `validateMagicNumbers` in `apps/api/src/utils/file.ts`. The catch block specifically ignores `RangeError`, `TypeError`, and `DOMException` (with name `InvalidStateError`), returning `false` for them, but propagates any other type of error.

### 📊 **Coverage:**
The following scenarios have been covered by mocking `File.slice().arrayBuffer()` to throw errors:
*   Throwing a `RangeError` (now expects to resolve to `false`)
*   Throwing a `TypeError` (now expects to resolve to `false`)
*   Throwing a `DOMException` with the name `InvalidStateError` (now expects to resolve to `false`)
*   Throwing an unexpected generic `Error` (now expects to reject and throw the error).

### ✨ **Result:**
The `validateMagicNumbers` utility function now has 100% test coverage for its error handling paths, ensuring any modifications to error processing are safely caught in automated CI tests. This gives confidence when changing magic number or byte-level parsing in the future.

---
*PR created automatically by Jules for task [219585733249149096](https://jules.google.com/task/219585733249149096) started by @is0692vs*

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

`validateMagicNumbers` のキャッチブロックに対するエラーハンドリングテストを追加するPRです。`RangeError`、`TypeError`、`DOMException(InvalidStateError)` を `false` として処理し、それ以外のエラーを再スローすることを検証する4つのテストケースが追加されており、実装との対応関係は正確です。
</details>

<details open><summary><h3>Confidence Score: 5/5</h3></summary>

テスト追加のみのPRであり、実装との対応関係も正確なため、安全にマージできます。

P0/P1の問題は存在せず、全ての指摘はP2（スタイル・カバレッジ改善提案）です。既存テストを壊さず、正確にキャッチブロックの挙動を検証しているため最高スコアを付与します。

特に注意が必要なファイルはありません。
</details>

<details open><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| apps/api/src/utils/__tests__/file.test.ts | エラーハンドリングの4つの新テストを追加。実装との対応関係は正確だが、末尾カンマの欠落など軽微なスタイルの不一致がある。 |

</details>

</details>

<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A["validateMagicNumbers(file, declaredMime)"] --> B["file.slice(0,8).arrayBuffer()"]
    B -->|成功| C["マジックナンバー判定"]
    B -->|RangeError| D["return false ✅ テスト追加"]
    B -->|TypeError| E["return false ✅ テスト追加"]
    B -->|"DOMException(InvalidStateError)"| F["return false ✅ テスト追加"]
    B -->|"その他のError"| G["throw error ✅ テスト追加"]
    C --> H{"detectedType?"}
    H -->|"null"| I["return false"]
    H -->|あり| J{"MIME互換性チェック"}
    J -->|"不一致"| K["return false"]
    J -->|"一致"| L{"深層チェック対象?"}
    L -->|"PPTX"| M["hasZipEntry()"]
    L -->|"PPT"| N["hasOleStream()"]
    L -->|"その他"| O["return true"]
```

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
This is a comment left during a code review.
Path: apps/api/src/utils/__tests__/file.test.ts
Line: 227-282

Comment:
**末尾カンマの欠落**

追加されたモックオブジェクト内の複数箇所で、既存コードのスタイルと異なり末尾カンマが欠落しています。`arrayBuffer` メソッド定義の末尾と、最後のプロパティ `type: "application/pdf"` の末尾が該当します。

例（RangeErrorのテスト）:
```suggestion
  it("returns false when File.slice throws RangeError", async () => {
    const errorFile = {
      slice: () => ({
        arrayBuffer: async () => {
          throw new RangeError("Invalid range");
        },
      }),
      size: 100,
      type: "application/pdf",
    } as unknown as File;

    await expect(validateMagicNumbers(errorFile, "application/pdf")).resolves.toBe(false);
  });
```

同様の修正が `TypeError`、`DOMException`、`unexpected error` の各テストにも必要です。

How can I resolve this? If you propose a fix, please make it concise.

---

This is a comment left during a code review.
Path: apps/api/src/utils/__tests__/file.test.ts
Line: 255-267

Comment:
**InvalidStateError以外のDOMExceptionの再スロー確認テストの不足**

現在の実装では `DOMException` でも `error.name !== "InvalidStateError"` の場合は再スローされますが、このケースのテストが存在しません。`AbortError` などを投げた場合が再スローされることを確認するテストを追加すると、`InvalidStateError` の判定が今後変更された際に安全ネットになります。

```ts
it("throws the error when File.slice throws DOMException with non-InvalidStateError name", async () => {
  const domError = new DOMException("Aborted", "AbortError");
  const errorFile = {
    slice: () => ({
      arrayBuffer: async () => { throw domError; },
    }),
    size: 100,
    type: "application/pdf",
  } as unknown as File;

  await expect(validateMagicNumbers(errorFile, "application/pdf")).rejects.toThrow(domError);
});
```

How can I resolve this? If you propose a fix, please make it concise.
`````

</details>

<sub>Reviews (1): Last reviewed commit: ["🧪 test: add missing error handling test..."](https://github.com/hiroki-org/openshelf/commit/619ea038fe312fa0c5809466ec7de353e7cf4be1) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=28880928)</sub>

> Greptile also left **2 inline comments** on this PR.

<!-- /greptile_comment -->