### PR TITLE
🧪 Add tests for utils/badge.ts (consolidates #526)

### DIFF
--- a/apps/api/src/utils/__tests__/badge.test.ts
+++ b/apps/api/src/utils/__tests__/badge.test.ts
@@ -1,0 +1,219 @@
+import { describe, expect, it } from "vitest";
+import {
+    escapeXml,
+    normalizeBadgeStyle,
+    normalizeBadgeLabel,
+    normalizeBadgeColor,
+    truncateBadgeText,
+    estimateTextWidth,
+    buildBadgeMessage,
+    buildLeftText,
+    buildBadgeSvg,
+    buildShieldsEndpointPayload,
+    buildNotFoundBadge,
+    createEtag,
+} from "../badge";
+
+describe("badge utils", () => {
+    describe("escapeXml", () => {
+        it("escapes special characters", () => {
+            expect(escapeXml('a & b < c > d " e \' f')).toBe(
+                "a &amp; b &lt; c &gt; d &quot; e &#39; f",
+            );
+        });
+        it("handles empty strings", () => {
+            expect(escapeXml("")).toBe("");
+        });
+        it("handles strings without special characters", () => {
+            expect(escapeXml("hello world")).toBe("hello world");
+        });
+    });
+
+    describe("normalizeBadgeStyle", () => {
+        it("returns compact for compact input", () => {
+            expect(normalizeBadgeStyle("compact")).toBe("compact");
+        });
+        it("returns default for other string inputs", () => {
+            expect(normalizeBadgeStyle("flat")).toBe("default");
+            expect(normalizeBadgeStyle("")).toBe("default");
+        });
+        it("returns default for null/undefined", () => {
+            expect(normalizeBadgeStyle(null)).toBe("default");
+            expect(normalizeBadgeStyle(undefined)).toBe("default");
+        });
+    });
+
+    describe("normalizeBadgeLabel", () => {
+        it("returns the label trimmed and whitespace-normalized", () => {
+            expect(normalizeBadgeLabel("  hello   world  ")).toBe("hello world");
+        });
+        it("returns default label for empty, null, or undefined", () => {
+            expect(normalizeBadgeLabel("")).toBe("OpenShelf");
+            expect(normalizeBadgeLabel("   ")).toBe("OpenShelf");
+            expect(normalizeBadgeLabel(null)).toBe("OpenShelf");
+            expect(normalizeBadgeLabel(undefined)).toBe("OpenShelf");
+        });
+        it("truncates long labels", () => {
+            const longLabel = "this is a very long label that exceeds the limit";
+            const normalized = normalizeBadgeLabel(longLabel);
+            expect(normalized.length).toBeLessThanOrEqual(24);
+            expect(normalized.endsWith("…")).toBe(true);
+        });
+    });
+
+    describe("normalizeBadgeColor", () => {
+        it("returns lowercase standard hex colors without #", () => {
+            expect(normalizeBadgeColor("FF0000")).toBe("ff0000");
+            expect(normalizeBadgeColor("#00FF00")).toBe("00ff00");
+            expect(normalizeBadgeColor("123")).toBe("123");
+        });
+        it("returns lowercase named colors", () => {
+            expect(normalizeBadgeColor("Red")).toBe("red");
+            expect(normalizeBadgeColor("blue")).toBe("blue");
+        });
+        it("returns default color for invalid, empty, null, or undefined", () => {
+            expect(normalizeBadgeColor("invalid color!")).toBe("4c1");
+            expect(normalizeBadgeColor("")).toBe("4c1");
+            expect(normalizeBadgeColor(null)).toBe("4c1");
+            expect(normalizeBadgeColor(undefined)).toBe("4c1");
+        });
+    });
+
+    describe("truncateBadgeText", () => {
+        it("does not truncate if within max length", () => {
+            expect(truncateBadgeText("hello", 10)).toBe("hello");
+            expect(truncateBadgeText("hello", 5)).toBe("hello");
+        });
+        it("truncates and adds ellipsis if exceeding max length", () => {
+            expect(truncateBadgeText("hello world", 8)).toBe("hello w…");
+        });
+        it("handles max length <= 1", () => {
+            expect(truncateBadgeText("hello", 1)).toBe("…");
+            expect(truncateBadgeText("hello", 0)).toBe("…");
+        });
+        it("normalizes whitespace before truncating", () => {
+            expect(truncateBadgeText("hello   world", 8)).toBe("hello w…");
+        });
+    });
+
+    describe("estimateTextWidth", () => {
+        it("estimates width for basic alphanumeric characters", () => {
+            expect(estimateTextWidth("a")).toBe(6);
+            expect(estimateTextWidth("A")).toBe(7);
+            expect(estimateTextWidth("1")).toBe(6);
+        });
+        it("estimates width for wide characters", () => {
+            expect(estimateTextWidth("あ")).toBe(11);
+        });
+        it("estimates width for emojis", () => {
+            expect(estimateTextWidth("😀")).toBe(12);
+        });
+        it("estimates width for other characters (e.g., symbols, spaces)", () => {
+            expect(estimateTextWidth(" ")).toBe(5);
+            expect(estimateTextWidth("-")).toBe(5);
+        });
+        it("estimates total width", () => {
+            expect(estimateTextWidth("aA1 あ😀 ")).toBe(6+7+6+5+11+12+5);
+        });
+    });
+
+    describe("buildBadgeMessage", () => {
+        it("returns 'Paper' for compact style", () => {
+            expect(buildBadgeMessage("Some Title", 2024, "compact")).toBe("Paper");
+        });
+        it("includes title and year for default style", () => {
+            expect(buildBadgeMessage("Some Title", 2024, "default")).toBe("Some Title (2024)");
+        });
+        it("omits year if null", () => {
+            expect(buildBadgeMessage("Some Title", null, "default")).toBe("Some Title");
+        });
+        it("truncates long titles with year", () => {
+            const title = "This is a very long title that should definitely be truncated";
+            const message = buildBadgeMessage(title, 2024, "default");
+            expect(message).toContain("… (2024)");
+            expect(message.length).toBeLessThanOrEqual(35 + 7); // 35 for title + 7 for " (2024)"
+        });
+        it("truncates long titles without year", () => {
+            const title = "This is a very long title that should definitely be truncated because it is long";
+            const message = buildBadgeMessage(title, null, "default");
+            expect(message).toContain("…");
+            expect(message.length).toBeLessThanOrEqual(38);
+        });
+        it("returns 'Paper' if result is empty", () => {
+            expect(buildBadgeMessage("   ", null, "default")).toBe("Paper");
+        });
+    });
+
+    describe("buildLeftText", () => {
+        it("prepends document emoji", () => {
+            expect(buildLeftText("Label")).toBe("📄 Label");
+        });
+    });
+
+    describe("buildBadgeSvg", () => {
+        it("generates a valid SVG string", () => {
+            const svg = buildBadgeSvg("left", "right", "ff0000");
+            expect(svg).toContain("<svg");
+            expect(svg).toContain("</svg>");
+            expect(svg).toContain("left");
+            expect(svg).toContain("right");
+            expect(svg).toContain("#ff0000"); // color is transformed to hex
+        });
+        it("handles empty inputs by using defaults", () => {
+            const svg = buildBadgeSvg("", "", "");
+            expect(svg).toContain("📄 OpenShelf");
+            expect(svg).toContain("Paper");
+            expect(svg).toContain("#4c1");
+        });
+        it("handles named colors", () => {
+            const svg = buildBadgeSvg("left", "right", "red");
+            expect(svg).toContain(`fill="red"`);
+        });
+    });
+
+    describe("buildShieldsEndpointPayload", () => {
+        it("returns a Shields.io compatible payload", () => {
+            const payload = buildShieldsEndpointPayload("left", "right", "ff0000");
+            expect(payload).toEqual({
+                schemaVersion: 1,
+                label: "left",
+                message: "right",
+                color: "ff0000",
+            });
+        });
+    });
+
+    describe("buildNotFoundBadge", () => {
+        it("returns SVG and JSON for not found badge", () => {
+            const result = buildNotFoundBadge({
+                style: "default",
+                label: "MyLabel",
+                color: "123",
+            });
+            expect(result.svg).toContain("📄 MyLabel");
+            expect(result.svg).toContain("not found");
+            expect(result.svg).toContain("#9f9f9f");
+
+            expect(result.json).toEqual({
+                schemaVersion: 1,
+                label: "📄 MyLabel",
+                message: "not found",
+                color: "9f9f9f",
+            });
+        });
+    });
+
+    describe("createEtag", () => {
+        it("generates a stable 16-character hex string enclosed in quotes", () => {
+            const etag1 = createEtag("hello world");
+            const etag2 = createEtag("hello world");
+            expect(etag1).toBe(etag2);
+            expect(etag1).toMatch(/^"[0-9a-f]{16}"$/);
+        });
+        it("generates different hashes for different inputs", () => {
+            const etag1 = createEtag("hello world");
+            const etag2 = createEtag("hello world!");
+            expect(etag1).not.toBe(etag2);
+        });
+    });
+});

--- a/apps/api/src/utils/__tests__/badge.test.ts
+++ b/apps/api/src/utils/__tests__/badge.test.ts
@@ -127,7 +127,7 @@ describe("badge utils", () => {
         it("omits year if null", () => {
             expect(buildBadgeMessage("Some Title", null, "default")).toBe("Some Title");
         });
-        it("omits year if 0 (falsy check)", () => {
+        it("omits year if year is 0", () => {
             expect(buildBadgeMessage("Some Title", 0, "default")).toBe("Some Title");
         });
         it("truncates long titles with year", () => {
@@ -188,10 +188,13 @@ describe("badge utils", () => {
 
     describe("buildNotFoundBadge", () => {
         it("returns SVG and JSON for not found badge", () => {
+        // NOTE: color and style options are intentionally ignored by buildNotFoundBadge.
+        // It always uses the default NOT_FOUND_COLOR (#9f9f9f) and default style layout.
+
             const result = buildNotFoundBadge({
                 style: "default",
                 label: "MyLabel",
-                color: "123", // color/style options are intentionally ignored; always uses NOT_FOUND_COLOR
+                color: "123",
             });
             expect(result.svg).toContain("📄 MyLabel");
             expect(result.svg).toContain("not found");

--- a/apps/api/src/utils/__tests__/badge.test.ts
+++ b/apps/api/src/utils/__tests__/badge.test.ts
@@ -113,7 +113,7 @@ describe("badge utils", () => {
             expect(estimateTextWidth("-")).toBe(5);
         });
         it("estimates total width", () => {
-            expect(estimateTextWidth("aA1 あ😀 ")).toBe(6+7+6+5+11+12+5);
+            expect(estimateTextWidth("aA1 あ😀 ")).toBe(52);
         });
     });
 
@@ -126,6 +126,9 @@ describe("badge utils", () => {
         });
         it("omits year if null", () => {
             expect(buildBadgeMessage("Some Title", null, "default")).toBe("Some Title");
+        });
+        it("omits year if 0 (falsy check)", () => {
+            expect(buildBadgeMessage("Some Title", 0, "default")).toBe("Some Title");
         });
         it("truncates long titles with year", () => {
             const title = "This is a very long title that should definitely be truncated";
@@ -188,7 +191,7 @@ describe("badge utils", () => {
             const result = buildNotFoundBadge({
                 style: "default",
                 label: "MyLabel",
-                color: "123",
+                color: "123", // color/style options are intentionally ignored; always uses NOT_FOUND_COLOR
             });
             expect(result.svg).toContain("📄 MyLabel");
             expect(result.svg).toContain("not found");


### PR DESCRIPTION
🎯 **What:** The testing gap addressed
- Missing unit tests for the pure utility functions in `apps/api/src/utils/badge.ts`.

📊 **Coverage:** What scenarios are now tested
- Added 35 unit test cases covering all exported functions in `badge.ts`.
- Tested `escapeXml`, `normalizeBadgeStyle`, `normalizeBadgeLabel`, `normalizeBadgeColor`, `truncateBadgeText`, `estimateTextWidth`, `buildBadgeMessage`, `buildLeftText`, `buildBadgeSvg`, `buildShieldsEndpointPayload`, `buildNotFoundBadge`, and `createEtag`.
- Covers edge cases such as empty strings, null/undefined values, string normalization, truncation of long texts, width estimation of various character types (emojis, wide characters), handling of invalid color inputs, SVG markup generation, and JSON payload building.

✨ **Result:** The improvement in test coverage
- Confirms the robustness of badge utility operations. Catching potential regressions when badge manipulation code changes in the future.

---
*PR created automatically by Jules for task [13598776291663482583](https://jules.google.com/task/13598776291663482583) started by @is0692vs*

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

`apps/api/src/utils/__tests__/badge.test.ts` を新規作成し、`badge.ts` からエクスポートされる12個のユーティリティ関数に対して合計35ケースのユニットテストを追加した PR です。各関数の主要パスおよびエッジケース（空文字・null・undefined・長文字列のトランケーション・ワイド文字・絵文字など）を概ねカバーしており、テストの内容は実装と整合しています。

- `buildBadgeMessage` に `year = 0` を渡すと実装側の真偽判定 (`year ? suffix : ""`) によって年号が無音で省略されますが、このケースがテストされていません（`null` のみテスト済み）。
</details>

<details open><summary><h3>Confidence Score: 5/5</h3></summary>

テストのみの追加でプロダクションコードへの変更はなし。残存する指摘は全て P2 であり、マージをブロックする問題はない。

実装ファイルの変更ゼロ、テストロジックの誤りも見当たらず、全35ケースは実装と整合している。P0/P1 は存在しない。

特になし。`badge.test.ts` の `buildBadgeMessage` 周辺（year=0 ケース）は追加テストを検討する価値があるが必須ではない。
</details>

<details open><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| apps/api/src/utils/__tests__/badge.test.ts | badge.ts の全エクスポート関数に対する新規テストファイル。35ケースで主要パスとエッジケースを概ねカバーするが、`buildBadgeMessage(year=0)` の未テスト・`buildNotFoundBadge` の無視されるオプションの不明瞭さ・期待値の算術式という3点のマイナー改善余地がある。 |

</details>

</details>

<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    subgraph Tests["badge.test.ts (35 ケース)"]
        T1[escapeXml 3ケース]
        T2[normalizeBadgeStyle 3ケース]
        T3[normalizeBadgeLabel 3ケース]
        T4[normalizeBadgeColor 3ケース]
        T5[truncateBadgeText 4ケース]
        T6[estimateTextWidth 5ケース]
        T7[buildBadgeMessage 6ケース]
        T8[buildLeftText 1ケース]
        T9[buildBadgeSvg 3ケース]
        T10[buildShieldsEndpointPayload 1ケース]
        T11[buildNotFoundBadge 1ケース]
        T12[createEtag 2ケース]
    end
    subgraph Impl["badge.ts 実装"]
        F1[escapeXml]
        F2[normalizeBadgeStyle]
        F3[normalizeBadgeLabel]
        F4[normalizeBadgeColor]
        F5[truncateBadgeText]
        F6[estimateTextWidth]
        F7[buildBadgeMessage]
        F8[buildLeftText]
        F9[buildBadgeSvg]
        F10[buildShieldsEndpointPayload]
        F11[buildNotFoundBadge]
        F12[createEtag]
    end
    T1-->F1
    T2-->F2
    T3-->F3
    T4-->F4
    T5-->F5
    T6-->F6
    T7-->F7
    T8-->F8
    T9-->F9
    T10-->F10
    T11-->F11
    T12-->F12
    F3-->F5
    F7-->F5
    F9-->F1
    F9-->F6
    F9-->F8
    F11-->F8
    F11-->F9
    F11-->F10
```

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
This is a comment left during a code review.
Path: apps/api/src/utils/__tests__/badge.test.ts
Line: 127-129

Comment:
**`year = 0` のエッジケースが未テスト**

実装側の `const yearSuffix = year ? \` (${year})\` : "";` は JavaScript の真偽判定を使っており、`year = 0` は **falsy** として扱われ年号が無音で省略されます。関数のシグネチャは `year: number | null` を受け付けるため `0` は型的に有効な値ですが、テストは `null` のみを確認しており、`0` を渡した場合の動作を検証していません。

```suggestion
        it("omits year if null", () => {
            expect(buildBadgeMessage("Some Title", null, "default")).toBe("Some Title");
        });
        it("omits year if 0 (falsy check)", () => {
            expect(buildBadgeMessage("Some Title", 0, "default")).toBe("Some Title");
        });
```

How can I resolve this? If you propose a fix, please make it concise.

---

This is a comment left during a code review.
Path: apps/api/src/utils/__tests__/badge.test.ts
Line: 188-192

Comment:
**`color` / `style` オプションが実際には無視されることが不明瞭**

`buildNotFoundBadge` の実装は `options.label` のみを使用し、`options.color` と `options.style` は無視して常に `NOT_FOUND_COLOR = "9f9f9f"` を使います。テストで `color: "123"` を渡すと、まるでその値が影響するかのように読めてしまいます。コメントを追加するか、意味を持たない値を使うと意図が明確になります。

```suggestion
            const result = buildNotFoundBadge({
                style: "default",
                label: "MyLabel",
                color: "123", // color/style options are intentionally ignored; always uses NOT_FOUND_COLOR
            });
```

How can I resolve this? If you propose a fix, please make it concise.

---

This is a comment left during a code review.
Path: apps/api/src/utils/__tests__/badge.test.ts
Line: 116

Comment:
**期待値に算術式を使用している**

`6+7+6+5+11+12+5` はランタイムで `52` に評価されるため動作上は問題ありませんが、リテラル値の方が一目で読みやすくなります。

```suggestion
            expect(estimateTextWidth("aA1 あ😀 ")).toBe(52);
```

How can I resolve this? If you propose a fix, please make it concise.
`````

</details>

<sub>Reviews (1): Last reviewed commit: ["🧪 Add tests for utils/badge.ts"](https://github.com/hiroki-org/openshelf/commit/891ee8a97b5ab2420706c8ca1ca9c10251a864d4) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=28880939)</sub>

> Greptile also left **3 inline comments** on this PR.

<!-- /greptile_comment -->