### PR TITLE
🧹 refactor complex error handling in papers route (consolidates #541)

### DIFF
--- a/apps/api/src/routes/__tests__/papers.test.ts
+++ b/apps/api/src/routes/__tests__/papers.test.ts
@@ -756,6 +756,32 @@ describe("papers routes", () => {
         expect(res.status).toBe(204);
     });
 
+    it("DELETE /api/papers/:id handles R2 deletion failure", async () => {
+        const token = await createTestJWT({ sub: "user-1", githubId: "123", name: "Uploader" });
+        mockDb.select = vi
+            .fn()
+            .mockImplementationOnce(() => makeQuery({ getResult: { paperId: "paper-1", userId: "user-1", role: "uploader" } }))
+            .mockImplementationOnce(() => makeQuery({ allResult: [{ r2Key: "papers/paper-1/paper/file.pdf" }] }));
+
+        const app = await createTestApp();
+        const env = createTestEnv({ DB: mockDb as any });
+        vi.spyOn(env.BUCKET, "delete").mockRejectedValue(new Error("R2 failure"));
+
+        const res = await app.request(
+            "http://localhost/api/papers/paper-1",
+            {
+                method: "DELETE",
+                headers: {
+                    Authorization: `Bearer ${token}`,
+                    Origin: "http://localhost:3000"
+                }
+            },
+            env as any
+        );
+
+        expect(res.status).toBe(500);
+    });
+
     it("POST /api/papers/:id/track returns 404 when paper does not exist", async () => {
         mockDb.select = vi
             .fn()

--- a/apps/api/src/routes/papers.ts
+++ b/apps/api/src/routes/papers.ts
@@ -118,7 +118,6 @@ function normalizeReferrer(value: unknown): string | null {
     return trimmed.slice(0, MAX_REFERRER_LENGTH);
 }
 
-
 async function deleteKeysInBatches(
     bucket: Env["BUCKET"],
     keys: string[],

--- a/apps/api/src/routes/papers.ts
+++ b/apps/api/src/routes/papers.ts
@@ -118,6 +118,7 @@ function normalizeReferrer(value: unknown): string | null {
     return trimmed.slice(0, MAX_REFERRER_LENGTH);
 }
 
+
 async function deleteKeysInBatches(
     bucket: Env["BUCKET"],
     keys: string[],
@@ -135,18 +136,14 @@ async function deleteKeysInBatches(
             try {
                 await bucket.delete(chunk);
             } catch (error) {
-                const info = {
+                if (!onChunkError) throw error;
+                onChunkError({
                     chunkStart,
                     chunkEndExclusive: chunkStart + chunk.length,
                     chunkSize: chunk.length,
                     chunkSample: chunk.slice(0, 3),
                     error: error instanceof Error ? error.message : String(error),
-                };
-                if (onChunkError) {
-                    onChunkError(info);
-                    return;
-                }
-                throw error;
+                });
             }
         },
         { concurrency: MAX_CONCURRENT_R2_DELETES },


### PR DESCRIPTION
🎯 **What:** Refactored a nested error handling block in `apps/api/src/routes/papers.ts` to use an early return pattern.
💡 **Why:** This improves maintainability and readability by flattening the logic in the `deleteKeysInBatches` function.
✅ **Verification:** Manually verified the refactored logic for behavioral equivalence. Existing tests and linting were attempted but the environment had missing dependencies (vitest/eslint).
✨ **Result:** A cleaner, more idiomatic error handling implementation that avoids unnecessary nesting.

---
*PR created automatically by Jules for task [6906337353846620778](https://jules.google.com/task/6906337353846620778) started by @is0692vs*

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

`apps/api/src/routes/papers.ts` の `deleteKeysInBatches` 関数内のエラーハンドリングを、ネストした `if` ブロックからアーリーリターンパターンへリファクタリングしています。動作の等価性については、元の `return` 文はコールバック末尾に存在するため削除しても挙動に変化はなく、ロジックの変更はありません。
</details>

<details open><summary><h3>Confidence Score: 5/5</h3></summary>

動作の等価性が確認できる純粋なリファクタリングであり、マージ安全です。

変更は `deleteKeysInBatches` のコールバック末尾にある `return` の削除とインラインオブジェクト化のみで、ロジックに変更はありません。P0/P1 相当の問題は見当たりません。

特に注意が必要なファイルはありません。
</details>

<details open><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| apps/api/src/routes/papers.ts | `deleteKeysInBatches` のエラーハンドリングをアーリーリターンパターンへ変更。動作の等価性が確認できる純粋なリファクタリング。 |

</details>

</details>

<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[deleteKeysInBatches called] --> B[pMap: process each chunk concurrently]
    B --> C[bucket.delete chunk]
    C -->|success| D[next chunk]
    C -->|error thrown| E{onChunkError defined?}
    E -->|No| F[re-throw error]
    E -->|Yes| G[call onChunkError with error info]
    G --> D
    D --> H[all chunks done]
```

<sub>Reviews (1): Last reviewed commit: ["refactor: flatten complex error handling..."](https://github.com/hiroki-org/openshelf/commit/c3581a4588239e50362a6c068d3920080129044d) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=28896128)</sub>

<!-- /greptile_comment -->