### PR TITLE
🧹 simplify error handling and improve test coverage in papers route

### DIFF
--- a/apps/api/src/routes/__tests__/papers.test.ts
+++ b/apps/api/src/routes/__tests__/papers.test.ts
@@ -756,6 +756,32 @@ describe("papers routes", () => {
         expect(res.status).toBe(204);
     });
 
+    it("DELETE /api/papers/:id handles R2 deletion failure", async () => {
+        const token = await createTestJWT({ sub: "user-1", githubId: "123", name: "Uploader" });
+        mockDb.select = vi
+            .fn()
+            .mockImplementationOnce(() => makeQuery({ getResult: { paperId: "paper-1", userId: "user-1", role: "uploader" } }))
+            .mockImplementationOnce(() => makeQuery({ allResult: [{ r2Key: "papers/paper-1/paper/file.pdf" }] }));
+
+        const app = await createTestApp();
+        const env = createTestEnv({ DB: mockDb as any });
+        vi.spyOn(env.BUCKET, "delete").mockRejectedValue(new Error("R2 failure"));
+
+        const res = await app.request(
+            "http://localhost/api/papers/paper-1",
+            {
+                method: "DELETE",
+                headers: {
+                    Authorization: `Bearer ${token}`,
+                    Origin: "http://localhost:3000"
+                }
+            },
+            env as any
+        );
+
+        expect(res.status).toBe(500);
+    });
+
     it("POST /api/papers/:id/track returns 404 when paper does not exist", async () => {
         mockDb.select = vi
             .fn()

--- a/apps/api/src/routes/papers.ts
+++ b/apps/api/src/routes/papers.ts
@@ -118,6 +118,7 @@ function normalizeReferrer(value: unknown): string | null {
     return trimmed.slice(0, MAX_REFERRER_LENGTH);
 }
 
+
 async function deleteKeysInBatches(
     bucket: Env["BUCKET"],
     keys: string[],
@@ -135,18 +136,14 @@ async function deleteKeysInBatches(
             try {
                 await bucket.delete(chunk);
             } catch (error) {
-                const info = {
+                if (!onChunkError) throw error;
+                onChunkError({
                     chunkStart,
                     chunkEndExclusive: chunkStart + chunk.length,
                     chunkSize: chunk.length,
                     chunkSample: chunk.slice(0, 3),
                     error: error instanceof Error ? error.message : String(error),
-                };
-                if (onChunkError) {
-                    onChunkError(info);
-                    return;
-                }
-                throw error;
+                });
             }
         },
         { concurrency: MAX_CONCURRENT_R2_DELETES },


### PR DESCRIPTION
🎯 **What:** Simplified a nested error handling block in `apps/api/src/routes/papers.ts` and added a corresponding unit test.
💡 **Why:** This improves maintainability by reducing nesting and ensures robust error handling behavior. The added test prevents CI failures related to patch coverage.
✅ **Verification:** Manually verified the refactored logic and the new test case. The logic is behaviorally equivalent, and the test exercises the previously uncovered early-throw branch.
✨ **Result:** Cleaner code and improved test coverage in the papers route.

---
*PR created automatically by Jules for task [6906337353846620778](https://jules.google.com/task/6906337353846620778) started by @is0692vs*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved error handling for paper deletion operations to ensure failures are properly reported to users.

* **Tests**
  * Added test coverage for deletion failure scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

`deleteKeysInBatches` 内のエラーハンドリングを、ネストを減らしたアーリーリターン形式にリファクタリングし、R2削除失敗時の未カバーブランチに対応するユニットテストを追加しています。元コードの `return` はキャッチブロック末尾に位置し後続コードが存在しないため、動作は等価です。
</details>

<details open><summary><h3>Confidence Score: 5/5</h3></summary>

このPRはマージして安全です。動作等価なリファクタリングとカバレッジ向上のみです。

P0/P1の問題は存在しません。リファクタリングは論理的に等価であり、追加テストも正確に意図したブランチをカバーしています。

特に注意が必要なファイルはありません。
</details>

<details open><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| apps/api/src/routes/papers.ts | `deleteKeysInBatches` のネスト削除リファクタリング。元の `return` はキャッチブロック末尾で後続コードがなく、動作は等価。 |
| apps/api/src/routes/__tests__/papers.test.ts | R2削除失敗時に500が返ることを検証するテストを追加。`onChunkError` なしの throw パスを正しくカバー。 |

</details>

</details>

<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A["DELETE /api/papers/:id"] --> B{アップローダー確認}
    B -- 403 --> Z1["Forbidden"]
    B -- OK --> C["ファイル一覧取得"]
    C --> D["deleteKeysInBatches(bucket, keys)"]
    D --> E{チャンク削除ループ}
    E --> F["bucket.delete(chunk)"]
    F -- 成功 --> G{次のチャンク}
    G -- あり --> E
    G -- なし --> H["db.delete(papers)"]
    H --> I["200 { ok: true }"]
    F -- エラー --> J{onChunkError?}
    J -- なし --> K["throw error → 500"]
    J -- あり --> L["onChunkError(info) → 継続"]
    L --> G
```

<sub>Reviews (1): Last reviewed commit: ["refactor: simplify error handling in del..."](https://github.com/hiroki-org/openshelf/commit/bfa384a199ca9209f157cb8003a255cb22c4d424) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=28939370)</sub>

<!-- /greptile_comment -->