### PR TITLE
chore: Dependabotの更新をグルーピング

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,31 +1,42 @@
 version: 2
+multi-ecosystem-groups:
+  infrastructure:
+    schedule:
+      interval: "weekly"
+
 updates:
   - package-ecosystem: "npm"
     directory: "/"
     schedule:
       interval: "weekly"
-    open-pull-requests-limit: 20
+    open-pull-requests-limit: 4
     commit-message:
       prefix: "chore"
       include: "scope"
+    groups:
+      npm-production:
+        dependency-type: "production"
+        patterns:
+          - "*"
+      npm-development:
+        dependency-type: "development"
+        patterns:
+          - "*"
   - package-ecosystem: "github-actions"
     directory: "/"
-    schedule:
-      interval: "weekly"
+    patterns:
+      - "*"
+    multi-ecosystem-group: "infrastructure"
     commit-message:
       prefix: "chore"
       include: "scope"
   - package-ecosystem: "docker"
-    directory: "/"
-    schedule:
-      interval: "weekly"
-    commit-message:
-      prefix: "chore"
-      include: "scope"
-  - package-ecosystem: "docker"
-    directory: "/apps/web"
-    schedule:
-      interval: "weekly"
+    directories:
+      - "/"
+      - "/apps/web"
+    patterns:
+      - "*"
+    multi-ecosystem-group: "infrastructure"
     commit-message:
       prefix: "chore"
       include: "scope"


### PR DESCRIPTION
## 概要
- npm の更新を production / development の2本に集約
- GitHub Actions と Docker の更新を infrastructure グループに集約
- open-pull-requests-limit を 4 に下げて同時多発を抑制

## 補足
- GitHub 公式の Dependabot grouping / multi-ecosystem grouping に沿った設定です
- 既存の open PR には影響せず、今後作られる Dependabot PR に反映されます

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

npm の依存関係を `production` / `development` の2グループへ集約し、GitHub Actions と Docker を `multi-ecosystem-groups` の `infrastructure` グループにまとめることで、Dependabot PR の同時多発を抑制する設定変更です。設定内容は GitHub 公式ドキュメントのサンプルと一致しており、構文・ロジックともに問題は見当たりません。
</details>

<details open><summary><h3>Confidence Score: 5/5</h3></summary>

マージ可能。設定内容は公式ドキュメントに準拠しており、問題なし。

変更は .github/dependabot.yml のみで、公式の multi-ecosystem-groups 構文に完全に準拠。P0/P1 相当の問題は存在しない。

特になし。
</details>

<details open><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| .github/dependabot.yml | Dependabot の更新設定を整理し、npm を production/development の2グループに集約、GitHub Actions と Docker を multi-ecosystem-groups の infrastructure グループにまとめ、open-pull-requests-limit を 20 → 4 に削減。構文・設定内容ともに公式ドキュメントに準拠。 |

</details>

</details>

<sub>Reviews (1): Last reviewed commit: ["chore: group dependabot updates"](https://github.com/hiroki-org/openshelf/commit/109859a7bb32b5f4bbf50dc718df7baae5ae74cd) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=29095797)</sub>

<!-- /greptile_comment -->