### PR TITLE
Add SECURITY.md for security policy and reporting

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,21 @@
+# Security Policy
+
+## Supported Versions
+
+Use this section to tell people about which versions of your project are
+currently being supported with security updates.
+
+| Version | Supported          |
+| ------- | ------------------ |
+| 5.1.x   | :white_check_mark: |
+| 5.0.x   | :x:                |
+| 4.0.x   | :white_check_mark: |
+| < 4.0   | :x:                |
+
+## Reporting a Vulnerability
+
+Use this section to tell people how to report a vulnerability.
+
+Tell them where to go, how often they can expect to get an update on a
+reported vulnerability, what to expect if the vulnerability is accepted or
+declined, etc.

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -2,20 +2,13 @@
 
 ## Supported Versions
 
-Use this section to tell people about which versions of your project are
-currently being supported with security updates.
-
 | Version | Supported          |
 | ------- | ------------------ |
-| 5.1.x   | :white_check_mark: |
-| 5.0.x   | :x:                |
-| 4.0.x   | :white_check_mark: |
-| < 4.0   | :x:                |
+| 1.0.x   | :white_check_mark: |
+| < 1.0   | :x:                |
 
 ## Reporting a Vulnerability
 
-Use this section to tell people how to report a vulnerability.
+Please report security vulnerabilities through [GitHub Security Advisories](https://github.com/Hiroki-org/OpenShelf/security/advisories/new) or by sending an email to security@openshelf.org.
 
-Tell them where to go, how often they can expect to get an update on a
-reported vulnerability, what to expect if the vulnerability is accepted or
-declined, etc.
+We will respond to your report within 48 hours and provide regular updates on the investigation and remediation process. Please include a summary, impact, reproduction steps, affected versions, and reporter contact in your report. Accepted vulnerabilities will be fixed and publicly disclosed in coordination with you. If a reported issue is determined not to be a security vulnerability, we will provide an explanation.


### PR DESCRIPTION
Added a security policy document outlining supported versions and vulnerability reporting.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added security policy document outlining supported release versions and providing guidelines for reporting security vulnerabilities.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

このPRは `SECURITY.md` を新規追加していますが、内容が GitHub のデフォルトテンプレートそのままであり、プロジェクト固有の情報に差し替えられていません。

- サポートバージョン表（5.1.x, 5.0.x, 4.0.x）はテンプレートのダミー値であり、openshelf の実際のバージョンと無関係です。
- 脆弱性の報告方法のセクションにはテンプレートの説明文しかなく、連絡先・対応SLA・対応フローが一切記載されていません。
</details>

<details open><summary><h3>Confidence Score: 3/5</h3></summary>

テンプレートのまま未完成の状態のため、マージ前にプロジェクト固有の情報への更新が必要です。

P1 の指摘が2件あります。サポートバージョンが実際のプロジェクトとかけ離れており、脆弱性の報告先が一切記載されていないため、このままでは誤解を招くセキュリティポリシーになってしまいます。

SECURITY.md 全体を要確認。テンプレート内容をプロジェクト固有の情報に更新が必要。
</details>

<details open><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| SECURITY.md | GitHub デフォルトテンプレートのまま追加されており、プロジェクト固有のバージョン情報と脆弱性報告先が未記入 |

</details>

</details>

<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[セキュリティ脆弱性を発見] --> B{SECURITY.md を確認}
    B --> C[報告先を確認]
    C --> D{報告先が記載されているか？}
    D -- いいえ（現状） --> E[報告できない ❌]
    D -- はい（修正後） --> F[脆弱性を報告]
    F --> G[メンテナーが調査・対応]
    G --> H[修正リリース]
```

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
This is a comment left during a code review.
Path: SECURITY.md
Line: 9-13

Comment:
**テンプレートのバージョン情報が残っています**

サポートバージョンの表（5.1.x, 5.0.x, 4.0.x など）は GitHub のデフォルトテンプレートのままです。openshelf プロジェクトの実際のバージョン体系と一致していないため、誤った情報を提供することになります。プロジェクトの実際のリリースバージョンと対応状況に置き換えてください。

How can I resolve this? If you propose a fix, please make it concise.

---

This is a comment left during a code review.
Path: SECURITY.md
Line: 17-21

Comment:
**脆弱性報告先の情報が未記入です**

「Reporting a Vulnerability」セクションがテンプレートの説明文のままで、実際の報告先（メールアドレス、GitHub の Private Vulnerability Reporting リンク、対応SLA など）が一切記載されていません。セキュリティポリシーとして機能するためには、具体的な連絡先と対応フローを記述する必要があります。

How can I resolve this? If you propose a fix, please make it concise.
`````

</details>

<sub>Reviews (1): Last reviewed commit: ["Add SECURITY.md for security policy and ..."](https://github.com/hiroki-org/openshelf/commit/59283c480f7e702b2ba8c5e2a13f705f6c76661e) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=29242830)</sub>

> Greptile also left **2 inline comments** on this PR.

<!-- /greptile_comment -->