### PR TITLE
fix(deps): update postcss to address OSV vulnerability

### DIFF
--- a/apps/web/package-lock.json
+++ b/apps/web/package-lock.json
@@ -8539,7 +8539,7 @@
         "@swc/helpers": "0.5.15",
         "baseline-browser-mapping": "^2.9.19",
         "caniuse-lite": "^1.0.30001579",
-        "postcss": "8.4.31",
+        "postcss": "8.5.12",
         "styled-jsx": "5.1.6"
       },
       "bin": {
@@ -8583,9 +8583,9 @@
       }
     },
     "node_modules/next/node_modules/postcss": {
-      "version": "8.4.31",
-      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.4.31.tgz",
-      "integrity": "sha512-PS08Iboia9mts/2ygV3eLpY5ghnUcfLV/EXTOW1E2qYxJKGGBUtNjN76FYHnMs36RmARn41bC0AZmn+rR0OVpQ==",
+      "version": "8.5.12",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.12.tgz",
+      "integrity": "sha512-W62t/Se6rA0Az3DfCL0AqJwXuKwBeYg6nOaIgzP+xZ7N5BFCI7DYi1qs6ygUYT6rvfi6t9k65UMLJC+PHZpDAA==",
       "funding": [
         {
           "type": "opencollective",
@@ -8976,9 +8976,9 @@
       }
     },
     "node_modules/postcss": {
-      "version": "8.5.8",
-      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.8.tgz",
-      "integrity": "sha512-OW/rX8O/jXnm82Ey1k44pObPtdblfiuWnrd8X7GJ7emImCOstunGbXUpp7HdBrFQX6rJzn3sPT397Wp5aCwCHg==",
+      "version": "8.5.12",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.12.tgz",
+      "integrity": "sha512-W62t/Se6rA0Az3DfCL0AqJwXuKwBeYg6nOaIgzP+xZ7N5BFCI7DYi1qs6ygUYT6rvfi6t9k65UMLJC+PHZpDAA==",
       "dev": true,
       "funding": [
         {

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -36,6 +36,7 @@
     "eslint": "^10",
     "eslint-config-next": "16.2.4",
     "jsdom": "^27.0.1",
+    "postcss": "^8.5.12",
     "tailwindcss": "^4.2.3",
     "typescript": "^6",
     "vitest": "^3.2.4"

--- a/package-lock.json
+++ b/package-lock.json
@@ -3424,7 +3424,7 @@
         "@alloc/quick-lru": "^5.2.0",
         "@tailwindcss/node": "4.2.4",
         "@tailwindcss/oxide": "4.2.4",
-        "postcss": "^8.5.6",
+        "postcss": "8.5.12",
         "tailwindcss": "4.2.4"
       }
     },
@@ -10310,7 +10310,7 @@
         "@swc/helpers": "0.5.15",
         "baseline-browser-mapping": "^2.9.19",
         "caniuse-lite": "^1.0.30001579",
-        "postcss": "8.4.31",
+        "postcss": "8.5.12",
         "styled-jsx": "5.1.6"
       },
       "bin": {
@@ -10354,9 +10354,9 @@
       }
     },
     "node_modules/next/node_modules/postcss": {
-      "version": "8.4.31",
-      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.4.31.tgz",
-      "integrity": "sha512-PS08Iboia9mts/2ygV3eLpY5ghnUcfLV/EXTOW1E2qYxJKGGBUtNjN76FYHnMs36RmARn41bC0AZmn+rR0OVpQ==",
+      "version": "8.5.12",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.12.tgz",
+      "integrity": "sha512-W62t/Se6rA0Az3DfCL0AqJwXuKwBeYg6nOaIgzP+xZ7N5BFCI7DYi1qs6ygUYT6rvfi6t9k65UMLJC+PHZpDAA==",
       "funding": [
         {
           "type": "opencollective",
@@ -10821,9 +10821,9 @@
       }
     },
     "node_modules/postcss": {
-      "version": "8.5.6",
-      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.6.tgz",
-      "integrity": "sha512-3Ybi1tAuwAP9s0r1UQ2J4n5Y0G05bJkpUIO0/bI9MhwmD70S5aTWbXGBwxHrelT+XM1k6dM0pk+SwNkpTRN7Pg==",
+      "version": "8.5.12",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.12.tgz",
+      "integrity": "sha512-W62t/Se6rA0Az3DfCL0AqJwXuKwBeYg6nOaIgzP+xZ7N5BFCI7DYi1qs6ygUYT6rvfi6t9k65UMLJC+PHZpDAA==",
       "dev": true,
       "funding": [
         {
@@ -12729,7 +12729,7 @@
         "esbuild": "^0.27.0",
         "fdir": "^6.5.0",
         "picomatch": "^4.0.3",
-        "postcss": "^8.5.6",
+        "postcss": "8.5.12",
         "rollup": "^4.43.0",
         "tinyglobby": "^0.2.15"
       },

--- a/package.json
+++ b/package.json
@@ -23,6 +23,7 @@
     "@vitest/coverage-v8": "^3.2.4",
     "babel-plugin-react-compiler": "1.0.0",
     "eslint": "^10.2.1",
+    "postcss": "^8.5.12",
     "typescript": "^6.0.3",
     "vitest": "^3.2.4"
   },
@@ -36,7 +37,11 @@
     "micromatch": {
       "picomatch": "^2.3.2"
     },
-    "picomatch@^4.0.0": "^4.0.4"
+    "picomatch@^4.0.0": "^4.0.4",
+    "next": {
+      "postcss": "^8.5.12"
+    },
+    "postcss": "^8.5.12"
   },
   "license": "MIT"
 }


### PR DESCRIPTION
This PR updates postcss to version 8.5.12 to address an OSV vulnerability (GHSA-qx2v-qp2m-jg93). The vulnerability was present in postcss <= 8.5.8. Next.js's embedded postcss dependencies have also been overridden in the lockfile to ensure the vulnerability is fully patched.

Changes from previous PR:
- Targets  branch per the repo workflow.
- Avoids completely regenerating the lockfile, which fixes the missing optional dependencies error (e.g. `@rollup/rollup-linux-x64-gnu`) that broke CI.

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

GHSA-qx2v-qp2m-jg93 の対応として postcss を 8.5.12 へ更新し、Next.js 内部の埋め込み依存も `overrides` でパッチしています。lockfile の完全再生成を避けることで `@rollup/rollup-linux-x64-gnu` などのオプション依存が欠落する問題を回避しています。

- `package-lock.json` にて `apps/api` の `drizzle-kit` 指定子からキャレット（`^`）が削除されており（`apps/api/package.json` は未変更）、意図しないロックファイルの不整合が生じています。次回 `npm install` 時に差分が再生成される可能性があります。
</details>

<details open><summary><h3>Confidence Score: 3/5</h3></summary>

セキュリティ修正の意図は正しいが、ロックファイルに意図しない drizzle-kit の変更が混入しており、調査・修正が必要。

P1 の drizzle-kit 指定子の不整合がロックファイルに含まれており、将来の npm install 実行時に意図しない挙動を引き起こす可能性がある。P2 の overrides の重複・root dependencies の追加はコードスメルに留まる。

package-lock.json（drizzle-kit の指定子変更）および apps/web/package.json（無効な overrides ブロック）
</details>

<details open><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| apps/web/package.json | postcss 8.5.12 を直接依存に追加し overrides を設定。ただし npm ワークスペースでは子パッケージの overrides は無視されるため、overrides ブロックは冗長。 |
| package.json | ルートに overrides（next > postcss, postcss）を追加。加えて dependencies にも postcss を追加しているが、overrides だけで脆弱性対応には十分であり dependencies は不要。 |
| package-lock.json | postcss を 8.4.31/8.5.6 → 8.5.12 に更新。lightningcss の多数のプラットフォーム固有パッケージが削除。drizzle-kit の指定子が ^ なしに変更（意図しない副作用）。 |
| apps/web/package-lock.json | apps/web 内の postcss を 8.4.31/8.5.8 → 8.5.12 に更新。変更範囲は postcss のみで影響が限定的。 |

</details>

</details>

<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[OSV脆弱性 GHSA-qx2v-qp2m-jg93\npostcss <= 8.5.8] --> B{修正アプローチ}
    B --> C[ルート package.json\noverrides: postcss 8.5.12\nnext > postcss 8.5.12]
    B --> D[apps/web/package.json\ndependencies: postcss 8.5.12\noverrides: postcss 8.5.12 ※無視される]
    C --> E[package-lock.json\npostcss 8.5.12 に解決]
    D --> F[apps/web/package-lock.json\npostcss 8.5.12 に解決]
    E --> G[✅ next が内包する postcss も 8.5.12 に上書き]
    F --> G
    E --> H[⚠️ drizzle-kit キャレット削除\n意図しない副作用]
```

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
This is a comment left during a code review.
Path: apps/web/package.json
Line: 45-50

Comment:
**ワークスペースパッケージの `overrides` は npm では無視される**

npm ワークスペース環境では、`overrides` フィールドは**ルートの `package.json` のみ**が有効であり、子ワークスペース（`apps/web/package.json`）に記述された `overrides` は npm によって無視されます。この設定は実質的に効果がなく、誤解を招く可能性があります。

ルート `package.json` に既に同じ `overrides` が追加されているため、セキュリティ修正としては問題ありませんが、この `overrides` ブロックは削除することを推奨します。

How can I resolve this? If you propose a fix, please make it concise.

---

This is a comment left during a code review.
Path: package.json
Line: 45-47

Comment:
**ルート `dependencies` への `postcss` 追加は意図が不明確**

モノレポのルート `package.json` は通常ランタイム依存関係を持ちません。`overrides` フィールドが既に全ネスト依存関係を `8.5.12` に強制解決するため、`dependencies` への追加は不要です。脆弱性対策としては `overrides` のみで十分であり、この `dependencies` ブロックがあると将来のメンテナンスで混乱を招く可能性があります。

How can I resolve this? If you propose a fix, please make it concise.

---

This is a comment left during a code review.
Path: package-lock.json
Line: 41

Comment:
**`drizzle-kit` バージョン指定子の意図しない変更**

ロックファイルの `apps/api` ワークスペース相当のエントリで、`drizzle-kit` のバージョン指定が `"^1.0.0-beta.23"` から `"1.0.0-beta.23"` に変更されています（キャレットが削除）。`apps/api/package.json` 自体は本 PR で変更されていないため、これはロックファイルの部分的な再生成による意図しない副作用と考えられます。

この不整合が残ると、次回 `npm install` を実行した際にロックファイルが再生成され、CI の挙動が変わる可能性があります。`apps/api/package.json` の元の指定（`^1.0.0-beta.23`）と一致させる必要があります。

How can I resolve this? If you propose a fix, please make it concise.
`````

</details>

<sub>Reviews (1): Last reviewed commit: ["fix(deps): update postcss to address OSV..."](https://github.com/hiroki-org/openshelf/commit/a7fb92b66280f28fd5ac8b910f8fac4e19df5910) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=29943978)</sub>

> Greptile also left **3 inline comments** on this PR.

<!-- /greptile_comment -->