### PR TITLE
test: improve test coverage for apps/api orgs routes

### DIFF
--- a/apps/api/src/routes/__tests__/orgs.test.ts
+++ b/apps/api/src/routes/__tests__/orgs.test.ts
@@ -33,6 +33,61 @@ describe("orgs routes", () => {
 
     // ─── POST /api/orgs ────────────────────────────────────────
     describe("POST /api/orgs", () => {
+        it("returns 400 for invalid description", async () => {
+            const token = await createTestJWT({ sub: "user-1", githubId: "123", name: "Tester" });
+            const app = await createTestApp();
+            const env = createTestEnv();
+
+            const res = await app.request(
+                "http://localhost/api/orgs",
+                {
+                    method: "POST",
+                    headers: {
+                        Authorization: `Bearer ${token}`,
+                        "Content-Type": "application/json",
+                    },
+                    body: JSON.stringify({ name: "Lab", slug: "lab", description: 123 }),
+                },
+                env as any,
+            );
+
+            expect(res.status).toBe(400);
+            await expect(res.json()).resolves.toEqual({ error: "description must be a string" });
+        });
+
+        it("throws generic error during insert if not UNIQUE constraint", async () => {
+            const token = await createTestJWT({ sub: "user-1", githubId: "123", name: "Tester" });
+
+            mockDb.select = vi.fn(() => makeQuery({ getResult: null }));
+
+            mockDb.insert = vi.fn()
+                .mockImplementationOnce(() => ({
+                    values: vi.fn(async () => {
+                        throw new Error("Some other DB error");
+                    })
+                }));
+
+            const app = await createTestApp();
+            const env = createTestEnv();
+
+
+            const res = await app.request(
+                    "http://localhost/api/orgs",
+                    {
+                        method: "POST",
+                        headers: {
+                            Authorization: `Bearer ${token}`,
+                            "Content-Type": "application/json",
+                        },
+                        body: JSON.stringify({ name: "Lab", slug: "lab" }),
+                    },
+                    env as any,
+                );
+            expect(res.status).toBe(500);
+            const text = await res.text();
+            expect(text).toContain("Internal Server Error");
+        });
+
         it("returns 409 for UNIQUE constraint violation race condition", async () => {
             const token = await createTestJWT({ sub: "user-1", githubId: "123", name: "Tester" });
 
@@ -262,6 +317,142 @@ describe("orgs routes", () => {
     });
 
     describe("PATCH /api/orgs/:slug", () => {
+        it("returns 400 when no fields to update", async () => {
+            const token = await createTestJWT({ sub: "user-1", githubId: "123", name: "Tester" });
+            queueSelectResponses([
+                { getResult: { id: "org-1", slug: "my-lab", name: "My Lab", description: null } },
+                { getResult: { orgId: "org-1", userId: "user-1", role: "owner" } },
+            ]);
+
+            const app = await createTestApp();
+            const env = createTestEnv();
+
+            const res = await app.request(
+                "http://localhost/api/orgs/my-lab",
+                {
+                    method: "PATCH",
+                    headers: {
+                        Authorization: `Bearer ${token}`,
+                        "Content-Type": "application/json",
+                    },
+                    body: JSON.stringify({}),
+                },
+                env as any,
+            );
+
+            expect(res.status).toBe(400);
+            await expect(res.json()).resolves.toEqual({ error: "No fields to update" });
+        });
+
+        it("returns 400 for invalid slug", async () => {
+            const token = await createTestJWT({ sub: "user-1", githubId: "123", name: "Tester" });
+            queueSelectResponses([
+                { getResult: { id: "org-1", slug: "my-lab", name: "My Lab", description: null } },
+                { getResult: { orgId: "org-1", userId: "user-1", role: "owner" } },
+            ]);
+
+            const app = await createTestApp();
+            const env = createTestEnv();
+
+            const res = await app.request(
+                "http://localhost/api/orgs/my-lab",
+                {
+                    method: "PATCH",
+                    headers: {
+                        Authorization: `Bearer ${token}`,
+                        "Content-Type": "application/json",
+                    },
+                    body: JSON.stringify({ slug: "ab" }),
+                },
+                env as any,
+            );
+
+            expect(res.status).toBe(400);
+            await expect(res.json()).resolves.toEqual({ error: "slug must be 3–40 characters" });
+        });
+
+        it("returns 409 if new slug already in use", async () => {
+            const token = await createTestJWT({ sub: "user-1", githubId: "123", name: "Tester" });
+            queueSelectResponses([
+                { getResult: { id: "org-1", slug: "my-lab", name: "My Lab", description: null } },
+                { getResult: { orgId: "org-1", userId: "user-1", role: "owner" } },
+                { getResult: { id: "org-2", slug: "taken-lab" } },
+            ]);
+
+            const app = await createTestApp();
+            const env = createTestEnv();
+
+            const res = await app.request(
+                "http://localhost/api/orgs/my-lab",
+                {
+                    method: "PATCH",
+                    headers: {
+                        Authorization: `Bearer ${token}`,
+                        "Content-Type": "application/json",
+                    },
+                    body: JSON.stringify({ slug: "taken-lab" }),
+                },
+                env as any,
+            );
+
+            expect(res.status).toBe(409);
+            await expect(res.json()).resolves.toEqual({ error: "slug already in use" });
+        });
+
+        it("returns 400 for invalid name update", async () => {
+            const token = await createTestJWT({ sub: "user-1", githubId: "123", name: "Tester" });
+            queueSelectResponses([
+                { getResult: { id: "org-1", slug: "my-lab", name: "My Lab", description: null } },
+                { getResult: { orgId: "org-1", userId: "user-1", role: "owner" } },
+            ]);
+
+            const app = await createTestApp();
+            const env = createTestEnv();
+
+            const res = await app.request(
+                "http://localhost/api/orgs/my-lab",
+                {
+                    method: "PATCH",
+                    headers: {
+                        Authorization: `Bearer ${token}`,
+                        "Content-Type": "application/json",
+                    },
+                    body: JSON.stringify({ name: "" }),
+                },
+                env as any,
+            );
+
+            expect(res.status).toBe(400);
+            await expect(res.json()).resolves.toEqual({ error: "name is required" });
+        });
+
+        it("returns 400 for invalid description update", async () => {
+            const token = await createTestJWT({ sub: "user-1", githubId: "123", name: "Tester" });
+            queueSelectResponses([
+                { getResult: { id: "org-1", slug: "my-lab", name: "My Lab", description: null } },
+                { getResult: { orgId: "org-1", userId: "user-1", role: "owner" } },
+            ]);
+
+            const app = await createTestApp();
+            const env = createTestEnv();
+
+            const res = await app.request(
+                "http://localhost/api/orgs/my-lab",
+                {
+                    method: "PATCH",
+                    headers: {
+                        Authorization: `Bearer ${token}`,
+                        "Content-Type": "application/json",
+                    },
+                    body: JSON.stringify({ description: 123 }),
+                },
+                env as any,
+            );
+
+            expect(res.status).toBe(400);
+            await expect(res.json()).resolves.toEqual({ error: "description must be a string" });
+        });
+
         it("updates the org for admins", async () => {
             const token = await createTestJWT({ sub: "user-1", githubId: "123", name: "Tester" });
             queueSelectResponses([
@@ -387,6 +578,150 @@ describe("orgs routes", () => {
 
     // ─── Member management ────────────────────────────────────
     describe("POST /api/orgs/:slug/members", () => {
+        it("returns 400 for invalid JSON body", async () => {
+            const token = await createTestJWT({ sub: "user-1", githubId: "123", name: "Tester" });
+            queueSelectResponses([
+                { getResult: { id: "org-1", slug: "my-lab" } },
+                { getResult: { orgId: "org-1", userId: "user-1", role: "admin" } },
+            ]);
+
+            const app = await createTestApp();
+            const env = createTestEnv();
+
+            const res = await app.request(
+                "http://localhost/api/orgs/my-lab/members",
+                {
+                    method: "POST",
+                    headers: {
+                        Authorization: `Bearer ${token}`,
+                        "Content-Type": "application/json",
+                    },
+                    body: "{",
+                },
+                env as any,
+            );
+
+            expect(res.status).toBe(400);
+            await expect(res.json()).resolves.toEqual({ error: "Invalid JSON body" });
+        });
+
+        it("returns 400 for missing userId", async () => {
+            const token = await createTestJWT({ sub: "user-1", githubId: "123", name: "Tester" });
+            queueSelectResponses([
+                { getResult: { id: "org-1", slug: "my-lab" } },
+                { getResult: { orgId: "org-1", userId: "user-1", role: "admin" } },
+            ]);
+
+            const app = await createTestApp();
+            const env = createTestEnv();
+
+            const res = await app.request(
+                "http://localhost/api/orgs/my-lab/members",
+                {
+                    method: "POST",
+                    headers: {
+                        Authorization: `Bearer ${token}`,
+                        "Content-Type": "application/json",
+                    },
+                    body: JSON.stringify({ role: "member" }),
+                },
+                env as any,
+            );
+
+            expect(res.status).toBe(400);
+            await expect(res.json()).resolves.toEqual({ error: "userId is required" });
+        });
+
+        it("returns 400 for invalid role", async () => {
+            const token = await createTestJWT({ sub: "user-1", githubId: "123", name: "Tester" });
+            queueSelectResponses([
+                { getResult: { id: "org-1", slug: "my-lab" } },
+                { getResult: { orgId: "org-1", userId: "user-1", role: "admin" } },
+            ]);
+
+            const app = await createTestApp();
+            const env = createTestEnv();
+
+            const res = await app.request(
+                "http://localhost/api/orgs/my-lab/members",
+                {
+                    method: "POST",
+                    headers: {
+                        Authorization: `Bearer ${token}`,
+                        "Content-Type": "application/json",
+                    },
+                    body: JSON.stringify({ userId: "user-2", role: "superadmin" }),
+                },
+                env as any,
+            );
+
+            expect(res.status).toBe(400);
+            await expect(res.json()).resolves.toEqual({ error: "role must be 'admin' or 'member'" });
+        });
+
+        it("returns 404 when target user is not found", async () => {
+            const token = await createTestJWT({ sub: "user-1", githubId: "123", name: "Tester" });
+            queueSelectResponses([
+                { getResult: { id: "org-1", slug: "my-lab" } },
+                { getResult: { orgId: "org-1", userId: "user-1", role: "admin" } },
+                { getResult: null },
+            ]);
+
+            const app = await createTestApp();
+            const env = createTestEnv();
+
+            const res = await app.request(
+                "http://localhost/api/orgs/my-lab/members",
+                {
+                    method: "POST",
+                    headers: {
+                        Authorization: `Bearer ${token}`,
+                        "Content-Type": "application/json",
+                    },
+                    body: JSON.stringify({ userId: "user-2", role: "member" }),
+                },
+                env as any,
+            );
+
+            expect(res.status).toBe(404);
+            await expect(res.json()).resolves.toEqual({ error: "User not found" });
+        });
+
+        it("throws generic error during insert if not UNIQUE constraint", async () => {
+            const token = await createTestJWT({ sub: "user-1", githubId: "123", name: "Tester" });
+            queueSelectResponses([
+                { getResult: { id: "org-1", slug: "my-lab" } },
+                { getResult: { orgId: "org-1", userId: "user-1", role: "admin" } },
+                { getResult: { id: "user-2" } },
+                { getResult: null },
+            ]);
+
+            mockDb.insert = vi.fn()
+                .mockImplementationOnce(() => ({
+                    values: vi.fn(async () => {
+                        throw new Error("Some other DB error");
+                    })
+                }));
+
+            const app = await createTestApp();
+            const env = createTestEnv();
+
+            const res = await app.request(
+                "http://localhost/api/orgs/my-lab/members",
+                {
+                    method: "POST",
+                    headers: {
+                        Authorization: `Bearer ${token}`,
+                        "Content-Type": "application/json",
+                    },
+                    body: JSON.stringify({ userId: "user-2", role: "member" }),
+                },
+                env as any,
+            );
+
+            expect(res.status).toBe(500);
+        });
+
         it("returns 403 without auth (CSRF blocks before auth middleware)", async () => {
             const app = await createTestApp();
             const env = createTestEnv();
@@ -435,6 +770,65 @@ describe("orgs routes", () => {
     });
 
     describe("PATCH /api/orgs/:slug/members/:userId", () => {
+        it("returns 400 for invalid JSON body", async () => {
+            const token = await createTestJWT({ sub: "user-1", githubId: "123", name: "Tester" });
+            const org = { id: "org-1", slug: "my-lab" };
+
+            queueSelectResponses([
+                { getResult: org },
+                { getResult: { orgId: "org-1", userId: "user-1", role: "admin" } },
+            ]);
+
+            const app = await createTestApp();
+            const env = createTestEnv();
+
+            const res = await app.request(
+                "http://localhost/api/orgs/my-lab/members/user-2",
+                {
+                    method: "PATCH",
+                    headers: {
+                        Authorization: `Bearer ${token}`,
+                        "Content-Type": "application/json",
+                    },
+                    body: "{",
+                },
+                env as any,
+            );
+
+            expect(res.status).toBe(400);
+            await expect(res.json()).resolves.toEqual({ error: "Invalid JSON body" });
+        });
+
+        it("returns 404 when the target membership does not exist", async () => {
+            const token = await createTestJWT({ sub: "user-1", githubId: "123", name: "Tester" });
+            const org = { id: "org-1", slug: "my-lab" };
+
+            queueSelectResponses([
+                { getResult: org },
+                { getResult: { orgId: "org-1", userId: "user-1", role: "admin" } },
+                { getResult: null },
+            ]);
+
+            const app = await createTestApp();
+            const env = createTestEnv();
+
+            const res = await app.request(
+                "http://localhost/api/orgs/my-lab/members/user-2",
+                {
+                    method: "PATCH",
+                    headers: {
+                        Authorization: `Bearer ${token}`,
+                        "Content-Type": "application/json",
+                    },
+                    body: JSON.stringify({ role: "member" }),
+                },
+                env as any,
+            );
+
+            expect(res.status).toBe(404);
+            await expect(res.json()).resolves.toEqual({ error: "Member not found" });
+        });
+
         it("returns 200 when an owner modifies another owner role", async () => {
             const token = await createTestJWT({ sub: "owner-1", githubId: "123", name: "Owner 1" });
             const org = { id: "org-1", slug: "my-lab" };
@@ -580,6 +974,150 @@ describe("orgs routes", () => {
 
     // ─── Paper association ────────────────────────────────────
     describe("POST /api/orgs/:slug/papers", () => {
+        it("returns 400 for invalid JSON body", async () => {
+            const token = await createTestJWT({ sub: "user-1", githubId: "123", name: "Tester" });
+            queueSelectResponses([
+                { getResult: { id: "org-1", slug: "my-lab" } },
+            ]);
+
+            const app = await createTestApp();
+            const env = createTestEnv();
+
+            const res = await app.request(
+                "http://localhost/api/orgs/my-lab/papers",
+                {
+                    method: "POST",
+                    headers: {
+                        Authorization: `Bearer ${token}`,
+                        "Content-Type": "application/json",
+                    },
+                    body: "{",
+                },
+                env as any,
+            );
+
+            expect(res.status).toBe(400);
+            await expect(res.json()).resolves.toEqual({ error: "Invalid JSON body" });
+        });
+
+        it("returns 400 for missing paperId", async () => {
+            const token = await createTestJWT({ sub: "user-1", githubId: "123", name: "Tester" });
+            queueSelectResponses([
+                { getResult: { id: "org-1", slug: "my-lab" } },
+            ]);
+
+            const app = await createTestApp();
+            const env = createTestEnv();
+
+            const res = await app.request(
+                "http://localhost/api/orgs/my-lab/papers",
+                {
+                    method: "POST",
+                    headers: {
+                        Authorization: `Bearer ${token}`,
+                        "Content-Type": "application/json",
+                    },
+                    body: JSON.stringify({ }),
+                },
+                env as any,
+            );
+
+            expect(res.status).toBe(400);
+            await expect(res.json()).resolves.toEqual({ error: "paperId is required" });
+        });
+
+        it("returns 404 when paper is not found", async () => {
+            const token = await createTestJWT({ sub: "user-1", githubId: "123", name: "Tester" });
+            queueSelectResponses([
+                { getResult: { id: "org-1", slug: "my-lab" } },
+                { getResult: null }, // paper
+            ]);
+
+            const app = await createTestApp();
+            const env = createTestEnv();
+
+            const res = await app.request(
+                "http://localhost/api/orgs/my-lab/papers",
+                {
+                    method: "POST",
+                    headers: {
+                        Authorization: `Bearer ${token}`,
+                        "Content-Type": "application/json",
+                    },
+                    body: JSON.stringify({ paperId: "paper-1" }),
+                },
+                env as any,
+            );
+
+            expect(res.status).toBe(404);
+            await expect(res.json()).resolves.toEqual({ error: "Paper not found" });
+        });
+
+        it("returns 403 when not org admin or paper author", async () => {
+            const token = await createTestJWT({ sub: "user-1", githubId: "123", name: "Tester" });
+            queueSelectResponses([
+                { getResult: { id: "org-1", slug: "my-lab" } },
+                { getResult: { id: "paper-1" } }, // paper
+                { getResult: null }, // not org admin
+                { getResult: null }, // not paper author
+            ]);
+
+            const app = await createTestApp();
+            const env = createTestEnv();
+
+            const res = await app.request(
+                "http://localhost/api/orgs/my-lab/papers",
+                {
+                    method: "POST",
+                    headers: {
+                        Authorization: `Bearer ${token}`,
+                        "Content-Type": "application/json",
+                    },
+                    body: JSON.stringify({ paperId: "paper-1" }),
+                },
+                env as any,
+            );
+
+            expect(res.status).toBe(403);
+            await expect(res.json()).resolves.toEqual({ error: "Forbidden: must be org admin or paper author" });
+        });
+
+        it("throws generic error during insert if not UNIQUE constraint", async () => {
+            const token = await createTestJWT({ sub: "user-1", githubId: "123", name: "Tester" });
+            queueSelectResponses([
+                { getResult: { id: "org-1", slug: "my-lab" } },
+                { getResult: { id: "paper-1", title: "Paper" } },
+                { getResult: { orgId: "org-1", userId: "user-1", role: "admin" } },
+                { getResult: null }, // author check
+                { getResult: null }, // not already associated
+            ]);
+
+            mockDb.insert = vi.fn()
+                .mockImplementationOnce(() => ({
+                    values: vi.fn(async () => {
+                        throw new Error("Some other DB error");
+                    })
+                }));
+
+            const app = await createTestApp();
+            const env = createTestEnv();
+
+            const res = await app.request(
+                "http://localhost/api/orgs/my-lab/papers",
+                {
+                    method: "POST",
+                    headers: {
+                        Authorization: `Bearer ${token}`,
+                        "Content-Type": "application/json",
+                    },
+                    body: JSON.stringify({ paperId: "paper-1" }),
+                },
+                env as any,
+            );
+
+            expect(res.status).toBe(500);
+        });
+
         it("returns 403 without auth (CSRF blocks before auth middleware)", async () => {
             const app = await createTestApp();
             const env = createTestEnv();
@@ -850,8 +1388,73 @@ describe("orgs routes", () => {
             });
             expect(body.filterOptions.years).toEqual([{ value: 2023, count: 1 }]);
         });
-    });
 
+        it("returns 400 for invalid venue query", async () => {
+            queueSelectResponses([
+                { getResult: { id: "org-1", slug: "my-lab" } },
+            ]);
+
+            const app = await createTestApp();
+            const env = createTestEnv();
+
+            const res = await app.request(
+                "http://localhost/api/orgs/my-lab/papers?venue=" + "a".repeat(101),
+                {},
+                env as any,
+            );
+
+            expect(res.status).toBe(400);
+            await expect(res.json()).resolves.toEqual({ error: "venue must be 100 characters or less" });
+        });
+
+        it("returns 400 for invalid category query", async () => {
+            queueSelectResponses([
+                { getResult: { id: "org-1", slug: "my-lab" } },
+            ]);
+
+            const app = await createTestApp();
+            const env = createTestEnv();
+
+            const res = await app.request(
+                "http://localhost/api/orgs/my-lab/papers?category=invalid",
+                {},
+                env as any,
+            );
+
+            expect(res.status).toBe(400);
+            await expect(res.json()).resolves.toEqual({ error: "Invalid category" });
+        });
+
+        it("returns properly filtered papers for non-members who are authors", async () => {
+            const token = await createTestJWT({ sub: "user-1", githubId: "123", name: "Author" });
+            queueSelectResponses([
+                { getResult: { id: "org-1", slug: "my-lab" } },
+                { getResult: null }, // not a member
+                {
+                    allResult: [{ paperId: "paper-org" }, { paperId: "paper-private" }], // authored papers
+                },
+                {
+                    allResult: [
+                        { id: "paper-public", visibility: "public" },
+                        { id: "paper-org", visibility: "org_only" },
+                        { id: "paper-private", visibility: "private" },
+                    ],
+                },
+            ]);
+
+            const app = await createTestApp();
+            const env = createTestEnv();
+
+            const res = await app.request(
+                "http://localhost/api/orgs/my-lab/papers",
+                { headers: { Authorization: `Bearer ${token}` } },
+                env as any,
+            );
+
+            expect(res.status).toBe(200);
+            const body = (await res.json()) as any;
+            expect(body.papers).toBeDefined();
+        });
 
         it("returns 400 for invalid page query", async () => {
             queueSelectResponses([
@@ -888,8 +1491,30 @@ describe("orgs routes", () => {
             expect(res.status).toBe(400);
             await expect(res.json()).resolves.toEqual({ error: "Invalid year" });
         });
+    });
 
     describe("GET /api/orgs/:slug/tags", () => {
+        it("handles invalid JWT payload in hasJwtSub", async () => {
+            const app = await createTestApp();
+            const env = createTestEnv();
+
+            // Setup jwt.verify to return an invalid object instead of a valid token
+            const token = await createTestJWT({ invalid: true });
+
+            queueSelectResponses([
+                { getResult: { id: "org-1", slug: "my-lab" } },
+                { allResult: [] }, // org papers
+            ]);
+
+            const res = await app.request(
+                "http://localhost/api/orgs/my-lab/tags",
+                { headers: { Authorization: `Bearer ${token}` } },
+                env as any,
+            );
+
+            expect(res.status).toBe(200);
+        });
+
         it("returns tags from visible org papers", async () => {
             queueSelectResponses([
                 { getResult: { id: "org-1", slug: "my-lab" } },
@@ -1072,6 +1697,59 @@ describe("orgs routes", () => {
     });
 
     describe("DELETE /api/orgs/:slug/papers/:paperId", () => {
+        it("deletes the association for admins", async () => {
+            const token = await createTestJWT({ sub: "user-1", githubId: "123", name: "Admin" });
+            queueSelectResponses([
+                { getResult: { id: "org-1", slug: "my-lab" } },
+                { getResult: { orgId: "org-1", userId: "user-1", role: "admin" } },
+                { getResult: null }, // not author
+                { getResult: { paperId: "paper-1", orgId: "org-1" } }, // existing association
+            ]);
+
+            const deleteWhere = vi.fn(async () => ({ meta: { changes: 1 } }));
+            mockDb.delete = vi.fn(() => ({ where: deleteWhere }));
+
+            const app = await createTestApp();
+            const env = createTestEnv();
+
+            const res = await app.request(
+                "http://localhost/api/orgs/my-lab/papers/paper-1",
+                {
+                    method: "DELETE",
+                    headers: { Authorization: `Bearer ${token}` },
+                },
+                env as any,
+            );
+
+            expect(res.status).toBe(200);
+            await expect(res.json()).resolves.toEqual({ ok: true });
+            expect(deleteWhere).toHaveBeenCalled();
+        });
+
+        it("returns 403 when not org admin or paper author", async () => {
+            const token = await createTestJWT({ sub: "user-1", githubId: "123", name: "Tester" });
+            queueSelectResponses([
+                { getResult: { id: "org-1", slug: "my-lab" } },
+                { getResult: null }, // not admin
+                { getResult: null }, // not paper author
+            ]);
+
+            const app = await createTestApp();
+            const env = createTestEnv();
+
+            const res = await app.request(
+                "http://localhost/api/orgs/my-lab/papers/paper-1",
+                {
+                    method: "DELETE",
+                    headers: { Authorization: `Bearer ${token}` },
+                },
+                env as any,
+            );
+
+            expect(res.status).toBe(403);
+            await expect(res.json()).resolves.toEqual({ error: "Forbidden: must be org admin or paper author" });
+        });
+
         it("returns 404 when the association does not exist", async () => {
             const token = await createTestJWT({ sub: "user-2", githubId: "456", name: "Author" });
             queueSelectResponses([

--- a/apps/api/src/routes/__tests__/orgs.test.ts
+++ b/apps/api/src/routes/__tests__/orgs.test.ts
@@ -72,17 +72,17 @@ describe("orgs routes", () => {
 
 
             const res = await app.request(
-                    "http://localhost/api/orgs",
-                    {
-                        method: "POST",
-                        headers: {
-                            Authorization: `Bearer ${token}`,
-                            "Content-Type": "application/json",
-                        },
-                        body: JSON.stringify({ name: "Lab", slug: "lab" }),
+                "http://localhost/api/orgs",
+                {
+                    method: "POST",
+                    headers: {
+                        Authorization: `Bearer ${token}`,
+                        "Content-Type": "application/json",
                     },
-                    env as any,
-                );
+                    body: JSON.stringify({ name: "Lab", slug: "lab" }),
+                },
+                env as any,
+            );
             expect(res.status).toBe(500);
             const text = await res.text();
             expect(text).toContain("Internal Server Error");

--- a/apps/api/src/routes/__tests__/orgs.test.ts
+++ b/apps/api/src/routes/__tests__/orgs.test.ts
@@ -72,17 +72,17 @@ describe("orgs routes", () => {
 
 
             const res = await app.request(
-                "http://localhost/api/orgs",
-                {
-                    method: "POST",
-                    headers: {
-                        Authorization: `Bearer ${token}`,
-                        "Content-Type": "application/json",
+                    "http://localhost/api/orgs",
+                    {
+                        method: "POST",
+                        headers: {
+                            Authorization: `Bearer ${token}`,
+                            "Content-Type": "application/json",
+                        },
+                        body: JSON.stringify({ name: "Lab", slug: "lab" }),
                     },
-                    body: JSON.stringify({ name: "Lab", slug: "lab" }),
-                },
-                env as any,
-            );
+                    env as any,
+                );
             expect(res.status).toBe(500);
             const text = await res.text();
             expect(text).toContain("Internal Server Error");


### PR DESCRIPTION
Adds missing unit test coverage for apps/api/src/routes/orgs.ts route logic, including permissions blocks, data edge cases, and unexpected DB errors.

---
*PR created automatically by Jules for task [9203649208671370512](https://jules.google.com/task/9203649208671370512) started by @is0692vs*

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

このPRは `apps/api/src/routes/orgs.ts` に対するテストカバレッジを大幅に拡充しており、バリデーション失敗・権限チェック・DB エラー（非 UNIQUE 制約）など多くの未カバーブランチにテストを追加しています。全体的な構成は正しく、モックのセットアップも概ね適切です。
</details>


<details open><summary><h3>Confidence Score: 5/5</h3></summary>

本PRはテストファイルのみの変更であり、プロダクションコードに影響はなく安全にマージできます。

P1/P0 の問題は見つかりませんでした。P2 の指摘（アサーションの弱さ・mockDb 直接上書きの不統一）があるものの、いずれも非ブロッキングな改善提案です。

特に注意が必要なファイルはありません。
</details>


<details open><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| apps/api/src/routes/__tests__/orgs.test.ts | org ルートのテストカバレッジを大幅拡充（バリデーション・権限・DB エラー系）。モックのセットアップが一部不統一で、可視性フィルタリングテストのアサーションが弱い。 |

</details>


</details>


<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[POST /api/orgs] --> A1[バリデーション: description, slug, name]
    A1 -->|エラー| A2[400]
    A1 -->|OK| A3[slug 重複チェック]
    A3 -->|重複| A4[409]
    A3 -->|OK| A5[INSERT orgs + orgMembers]
    A5 -->|DB エラー UNIQUE| A4
    A5 -->|DB エラー その他| A6[500 ★新テスト]
    A5 -->|成功| A7[201]

    B[PATCH /api/orgs/:slug] --> B1[getOrgBySlug]
    B1 -->|null| B2[404 ★未テスト]
    B1 -->|OK| B3[requireOrgAdmin]
    B3 -->|失敗| B4[403]
    B3 -->|OK| B5[バリデーション ★新テスト]
    B5 -->|エラー| B6[400]
    B5 -->|OK| B7[UPDATE]

    C[POST /api/orgs/:slug/members] --> C1[getOrgBySlug + requireOrgAdmin]
    C1 --> C2[バリデーション ★新テスト]
    C2 -->|userId/role エラー| C3[400]
    C2 -->|OK| C4[ユーザー存在確認 ★新テスト]
    C4 -->|null| C5[404]
    C4 -->|OK| C6[INSERT orgMembers]
    C6 -->|UNIQUE| C7[409]
    C6 -->|その他 DB エラー| C8[500 ★新テスト]
```

<!-- greptile_failed_comments -->
<details open><summary><h3>Comments Outside Diff (3)</h3></summary>

1. `apps/api/src/routes/__tests__/orgs.test.ts`, line 253-274 ([link](https://github.com/hiroki-org/openshelf/blob/ecb00425119cc97787015c808780b5d113218167/apps/api/src/routes/__tests__/orgs.test.ts#L253-L274)) 

   <a href="#"><img alt="P2" src="https://greptile-static-assets.s3.amazonaws.com/badges/p2.svg?v=7" align="top"></a> **重複するテストケース**

   `"returns 400 for invalid JSON body"` (163行目) と `"returns 400 for invalid JSON bodies"` (253行目) の2つのテストは、同じコードパス（`POST /api/orgs` のJSON解析失敗）を異なる無効な入力値（`"invalid json string"` vs `"{"`)でテストしているだけで、実質的に重複しています。どちらか一方を削除するか、またはより意味のある差別化（例: 境界値）が必要です。

   <details><summary>Prompt To Fix With AI</summary>

   `````markdown
   This is a comment left during a code review.
   Path: apps/api/src/routes/__tests__/orgs.test.ts
   Line: 253-274

   Comment:
   **重複するテストケース**

   `"returns 400 for invalid JSON body"` (163行目) と `"returns 400 for invalid JSON bodies"` (253行目) の2つのテストは、同じコードパス（`POST /api/orgs` のJSON解析失敗）を異なる無効な入力値（`"invalid json string"` vs `"{"`)でテストしているだけで、実質的に重複しています。どちらか一方を削除するか、またはより意味のある差別化（例: 境界値）が必要です。

   How can I resolve this? If you propose a fix, please make it concise.
   `````
   </details>

2. `apps/api/src/routes/__tests__/orgs.test.ts`, line 897-924 ([link](https://github.com/hiroki-org/openshelf/blob/ecb00425119cc97787015c808780b5d113218167/apps/api/src/routes/__tests__/orgs.test.ts#L897-L924)) 

   <a href="#"><img alt="P2" src="https://greptile-static-assets.s3.amazonaws.com/badges/p2.svg?v=7" align="top"></a> **対象ユーザーのロールが誤ってモックされている**

   `selectCallCount >= 2` 以降は全て `{ role: "admin" }` を返しているため、select #3（`getOrgMembership` でターゲットユーザーのメンバーシップ取得）も `"admin"` を返します。今回は `"superadmin"` というロールが渡されるためバリデーションで先に 400 が返り偶然通過しますが、モックのセットアップが意図を正確に表していません。ターゲットの membership に `{ role: "member" }` を明示的に返すよう修正することを検討してください。

   <details><summary>Prompt To Fix With AI</summary>

   `````markdown
   This is a comment left during a code review.
   Path: apps/api/src/routes/__tests__/orgs.test.ts
   Line: 897-924

   Comment:
   **対象ユーザーのロールが誤ってモックされている**

   `selectCallCount >= 2` 以降は全て `{ role: "admin" }` を返しているため、select #3（`getOrgMembership` でターゲットユーザーのメンバーシップ取得）も `"admin"` を返します。今回は `"superadmin"` というロールが渡されるためバリデーションで先に 400 が返り偶然通過しますが、モックのセットアップが意図を正確に表していません。ターゲットの membership に `{ role: "member" }` を明示的に返すよう修正することを検討してください。

   How can I resolve this? If you propose a fix, please make it concise.
   `````
   </details>

3. `apps/api/src/routes/__tests__/orgs.test.ts`, line 319-521 ([link](https://github.com/hiroki-org/openshelf/blob/ecb00425119cc97787015c808780b5d113218167/apps/api/src/routes/__tests__/orgs.test.ts#L319-L521)) 

   <a href="#"><img alt="P2" src="https://greptile-static-assets.s3.amazonaws.com/badges/p2.svg?v=7" align="top"></a> **`PATCH /api/orgs/:slug` に org-not-found のテストケースがない**

   `PATCH /api/orgs/:slug` のルートは `getOrgBySlug` が null を返した場合に 404 を返しますが（`orgs.ts` 338行目）、このテストスイートにはその分岐をカバーするテストケースが存在しません。同様に `DELETE /api/orgs/:slug` の 404 ケースも未テストです。

   <details><summary>Prompt To Fix With AI</summary>

   `````markdown
   This is a comment left during a code review.
   Path: apps/api/src/routes/__tests__/orgs.test.ts
   Line: 319-521

   Comment:
   **`PATCH /api/orgs/:slug` に org-not-found のテストケースがない**

   `PATCH /api/orgs/:slug` のルートは `getOrgBySlug` が null を返した場合に 404 を返しますが（`orgs.ts` 338行目）、このテストスイートにはその分岐をカバーするテストケースが存在しません。同様に `DELETE /api/orgs/:slug` の 404 ケースも未テストです。

   How can I resolve this? If you propose a fix, please make it concise.
   `````
   </details>
</details>

<!-- /greptile_failed_comments -->

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 2 code review issues. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 2
apps/api/src/routes/__tests__/orgs.test.ts:642-671
**可視性フィルタリングのアサーションが弱い**

テスト名「returns properly filtered papers for non-members who are authors」はメンバーでない著者に対する可視性フィルタリングを検証するものですが、`expect(body.papers).toBeDefined()` しか確認していません。DB がモックされているため実際のフィルタ条件は適用されず、`paper-public`・`paper-org`・`paper-private` の各論文が正しく含まれているかどうかが検証されていません。テスト名に即した意味のあるアサーションを追加してください。

```suggestion
            expect(res.status).toBe(200);
            const body = (await res.json()) as any;
            expect(body.papers).toBeDefined();
            // 著者であるため org_only・private の論文も含まれていることを確認
            expect(body.papers.map((p: any) => p.id).sort()).toEqual(
                ["paper-org", "paper-private", "paper-public"].sort(),
            );
```

### Issue 2 of 2
apps/api/src/routes/__tests__/orgs.test.ts:58-89
**`queueSelectResponses` を使わず直接 `mockDb.select` を書き換えている**

このテストだけ `mockDb.select = vi.fn(() => makeQuery({ getResult: null }))` と直接上書きしていますが、ファイル内の他のテストはすべて `queueSelectResponses` を使っています。同じヘルパーを使って記述すると一貫性が向上します。

```suggestion
            queueSelectResponses([{ getResult: null }]);
```


`````

</details>

<sub>Reviews (2): Last reviewed commit: ["test(api): finalize orgs route coverage ..."](https://github.com/hiroki-org/openshelf/commit/20cdb31d4fa922092a0125aabde116137229b70b) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=30339151)</sub>

<!-- /greptile_comment -->