### PR TITLE
🧪 Add test for invalid JSON on PUT /api/invites/:inviteId

### DIFF
--- a/apps/api/src/routes/__tests__/invites.test.ts
+++ b/apps/api/src/routes/__tests__/invites.test.ts
@@ -138,7 +138,8 @@ describe("invites routes", () => {
         );
 
         expect(res.status).toBe(400);
-        await expect(res.json()).resolves.toEqual({ error: "Invalid JSON body" });
+        const body = await res.json() as any;
+        expect(body).toEqual({ error: "Invalid JSON body" });
     });
 
     it("POST /api/papers/:id/invites returns 400 when inviting self", async () => {

--- a/apps/api/src/routes/__tests__/invites.test.ts
+++ b/apps/api/src/routes/__tests__/invites.test.ts
@@ -118,7 +118,7 @@ describe("invites routes", () => {
         expect(res.status).toBe(200);
     });
 
-        it("PUT /api/invites/:id returns 400 for invalid JSON", async () => {
+    it("PUT /api/invites/:id returns 400 for invalid JSON", async () => {
         const token = await createTestJWT({ sub: "user-2", githubId: "456", name: "Invitee" });
 
         const app = await createTestApp();

--- a/apps/api/src/routes/__tests__/invites.test.ts
+++ b/apps/api/src/routes/__tests__/invites.test.ts
@@ -118,6 +118,30 @@ describe("invites routes", () => {
         expect(res.status).toBe(200);
     });
 
+        it("PUT /api/invites/:id returns 400 for invalid JSON", async () => {
+        const token = await createTestJWT({ sub: "user-2", githubId: "456", name: "Invitee" });
+
+        const app = await createTestApp();
+        const env = createTestEnv();
+
+        const res = await app.request(
+            "http://localhost/api/invites/inv-1",
+            {
+                method: "PUT",
+                headers: {
+                    Authorization: `Bearer ${token}`,
+                    "Content-Type": "application/json"
+                },
+                body: "{ invalid }"
+            },
+            env as any
+        );
+
+        expect(res.status).toBe(400);
+        const body = await res.json() as any;
+        expect(body).toEqual({ error: "Invalid JSON body" });
+    });
+
     it("POST /api/papers/:id/invites returns 400 when inviting self", async () => {
         const token = await createTestJWT({ sub: "user-1", githubId: "123", name: "Uploader" });
         mockDb.select = vi.fn().mockImplementationOnce(() => makeQuery({ getResult: { paperId: "paper-1", userId: "user-1", role: "uploader" } }));

--- a/apps/api/src/routes/__tests__/invites.test.ts
+++ b/apps/api/src/routes/__tests__/invites.test.ts
@@ -138,8 +138,7 @@ describe("invites routes", () => {
         );
 
         expect(res.status).toBe(400);
-        const body = await res.json() as any;
-        expect(body).toEqual({ error: "Invalid JSON body" });
+        await expect(res.json()).resolves.toEqual({ error: "Invalid JSON body" });
     });
 
     it("POST /api/papers/:id/invites returns 400 when inviting self", async () => {


### PR DESCRIPTION
🎯 **What:** Adds a missing test case in `invites.test.ts` to verify that `PUT /api/invites/:inviteId` handles malformed JSON requests gracefully and returns a 400 Bad Request error.

📊 **Coverage:** Specifically covers the `catch` block in `respondInviteHandler` where Vercel's `c.req.json()` fails to parse the invalid JSON.

✨ **Result:** Enhanced test suite reliability, protecting against regressions where the endpoint might crash on invalid inputs instead of returning an appropriate HTTP error response.

---
*PR created automatically by Jules for task [3295689197569793041](https://jules.google.com/task/3295689197569793041) started by @is0692vs*

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

`PUT /api/invites/:inviteId` エンドポイントに不正な JSON を送信した場合に 400 を返すことを検証するテストを `invites.test.ts` に追加した PR です。ハンドラーの `catch` ブロックが正しく動作することをカバーしており、テストロジック自体は正確です。
</details>

<details open><summary><h3>Confidence Score: 4/5</h3></summary>

テスト追加のみで実装コードへの変更はなく、マージしても安全です。

P2 のスタイル指摘（インデントのずれ）が1件のみで、ロジックや動作への影響はありません。

特に注意が必要なファイルはありません。
</details>

<details open><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| apps/api/src/routes/__tests__/invites.test.ts | `PUT /api/invites/:inviteId` に不正な JSON を送信した際に 400 を返すことを検証するテストを追加。ロジックは正しいが、`it()` のインデントが他のテストケースと揃っていない。 |

</details>

</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 1 code review issue. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 1
apps/api/src/routes/__tests__/invites.test.ts:121-143
**インデントが他のテストと揃っていない**

`it(...)` の呼び出しが8スペースでインデントされており、ファイル内の他のすべてのテストケース（4スペース）と揃っていません。本文内のコードは正しく8スペースになっているため、`it(` だけが1段余分にインデントされている状態です。

```suggestion
    it("PUT /api/invites/:id returns 400 for invalid JSON", async () => {
```

`````

</details>

<sub>Reviews (1): Last reviewed commit: ["🧪 Add test for invalid JSON on PUT /api..."](https://github.com/hiroki-org/openshelf/commit/e33f24228df1045c5d8c4185dabd18fe23302e44) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=30417937)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->