### PR TITLE
🧹 Avoid using any in cached results data structure

### DIFF
--- a/apps/api/src/routes/users.ts
+++ b/apps/api/src/routes/users.ts
@@ -1,7 +1,6 @@
 import { Hono } from "hono";
 import { drizzle } from "drizzle-orm/d1";
-import { eq, like, or, and, ne } from "drizzle-orm";
-import type { InferSelectModel } from "drizzle-orm";
+import { eq, like, or, and, ne, type InferSelectModel } from "drizzle-orm";
 import { users, enableForeignKeys } from "../db/schema";
 import type { Env, Variables } from "../types";
 import { authMiddleware } from "../middleware/auth";

--- a/apps/api/src/routes/users.ts
+++ b/apps/api/src/routes/users.ts
@@ -1,6 +1,7 @@
 import { Hono } from "hono";
 import { drizzle } from "drizzle-orm/d1";
 import { eq, like, or, and, ne } from "drizzle-orm";
+import type { InferSelectModel } from "drizzle-orm";
 import { users, enableForeignKeys } from "../db/schema";
 import type { Env, Variables } from "../types";
 import { authMiddleware } from "../middleware/auth";
@@ -66,13 +67,10 @@ usersRoute.put("/me", authMiddleware, updateMeHandler);
 
 
 // Simple in-memory cache for user search
-type UserSearchResult = {
-    id: string;
-    name: string;
-    displayName: string | null;
-    githubId: string;
-    avatarUrl: string | null;
-};
+type UserSearchResult = Pick<
+    InferSelectModel<typeof users>,
+    "id" | "name" | "displayName" | "githubId" | "avatarUrl"
+>;
 
 type CachedSearchResult = {
     data: UserSearchResult[];

--- a/apps/api/src/routes/users.ts
+++ b/apps/api/src/routes/users.ts
@@ -66,15 +66,23 @@ usersRoute.put("/me", authMiddleware, updateMeHandler);
 
 
 // Simple in-memory cache for user search
+type UserSearchResult = {
+    id: string;
+    name: string;
+    displayName: string | null;
+    githubId: string;
+    avatarUrl: string | null;
+};
+
 type CachedSearchResult = {
-    data: any[];
+    data: UserSearchResult[];
     timestamp: number;
 };
 const searchCache = new Map<string, CachedSearchResult>();
 const CACHE_TTL_MS = 60 * 1000; // 1 minute
 const MAX_CACHE_SIZE = 1000;
 
-function getCachedResults(key: string): any[] | null {
+function getCachedResults(key: string): UserSearchResult[] | null {
     const cached = searchCache.get(key);
     if (cached && Date.now() - cached.timestamp < CACHE_TTL_MS) {
         return cached.data;
@@ -82,7 +90,7 @@ function getCachedResults(key: string): any[] | null {
     return null;
 }
 
-function setCachedResults(key: string, data: any[]) {
+function setCachedResults(key: string, data: UserSearchResult[]) {
     searchCache.delete(key);
 
     // Prune expired entries in insertion order and stop once the cache reaches fresh data.


### PR DESCRIPTION
🎯 **What:** Replaced the generic `any[]` type in the `searchCache` data structure in `apps/api/src/routes/users.ts` with a strongly-typed `UserSearchResult[]`.
💡 **Why:** Using `any` bypasses TypeScript's type checking, reducing code health and maintainability. Typing it ensures that modifications to user search schemas or data returned to the client are checked at compile time, preventing regressions.
✅ **Verification:** Verified by checking type errors in the api workspace with `npm run typecheck`, executing the full api and web test suites (`npm run test --workspaces --if-present`), and verifying the linting output via `npm run lint`.
✨ **Result:** Enhanced the type safety of `searchCache` in user searches without altering functionality.

---
*PR created automatically by Jules for task [13567321453734510178](https://jules.google.com/task/13567321453734510178) started by @is0692vs*

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

このPRは `apps/api/src/routes/users.ts` の `searchCache` データ構造における `any[]` 型を、新たに定義した `UserSearchResult[]` 型に置き換えることで型安全性を向上させています。スキーマの各フィールドとの型整合性も確認されており、ロジックの変更はありません。
</details>

<details open><summary><h3>Confidence Score: 4/5</h3></summary>

P2の改善提案のみで、ロジック変更なし。マージ可能。

変更内容はシンプルな型の強化のみで、スキーマとの整合性も正確。ロジック・セキュリティ・ランタイム上の問題はなし。P2の提案（`$inferSelect` を使った型導出）があるが、マージを妨げるものではない。

特に注意が必要なファイルはありません。
</details>

<details open><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| apps/api/src/routes/users.ts | searchCache の `any[]` を `UserSearchResult[]` に置き換えるシンプルな型安全化。スキーマとの整合性は正確だが、手動定義の型がスキーマと乖離するリスクがある。 |

</details>

</details>

<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant Client
    participant SearchRoute as GET /api/users/search
    participant Cache as searchCache (Map)
    participant DB as D1 Database

    Client->>SearchRoute: GET /api/users/search?q=xxx
    SearchRoute->>Cache: getCachedResults(cacheKey)
    alt キャッシュヒット (TTL内)
        Cache-->>SearchRoute: UserSearchResult[]
        SearchRoute-->>Client: { users: UserSearchResult[] }
    else キャッシュミス
        Cache-->>SearchRoute: null
        SearchRoute->>DB: SELECT id,name,displayName,githubId,avatarUrl FROM users WHERE ...
        DB-->>SearchRoute: UserSearchResult[]
        SearchRoute->>Cache: setCachedResults(cacheKey, UserSearchResult[])
        SearchRoute-->>Client: { users: UserSearchResult[] }
    end
```

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 1 code review issue. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 1
apps/api/src/routes/users.ts:69-75
**スキーマから型を導出することを推奨**

`UserSearchResult` を手動で定義しているため、スキーマが変更された際に型定義との乖離が生じる可能性があります。Drizzle の `$inferSelect` と `Pick` を使って型を自動導出すると、スキーマの変更が型に自動で反映され、メンテナンスコストを下げられます。

```typescript
import type { InferSelectModel } from "drizzle-orm";

type UserSearchResult = Pick<
    InferSelectModel<typeof users>,
    "id" | "name" | "displayName" | "githubId" | "avatarUrl"
>;
```

現状でも TypeScript がコンパイル時に型の互換性をチェックするため動作上の問題はありませんが、将来のスキーマ変更への追従がより確実になります。

`````

</details>

<sub>Reviews (1): Last reviewed commit: ["🧹 Avoid using any in cached results dat..."](https://github.com/hiroki-org/openshelf/commit/e9b3a2d09047790a399a015ed12eddb61f310b2b) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=30418123)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->