### PR TITLE
🧪 Add test for invalid JSON on POST /api/papers/:id/invites

### DIFF
--- a/apps/api/src/routes/__tests__/invites.test.ts
+++ b/apps/api/src/routes/__tests__/invites.test.ts
@@ -141,15 +141,16 @@ describe("invites routes", () => {
         expect(res.status).toBe(400);
     });
 
-    it("POST /api/papers/:id/invites returns 400 for invalid JSON body", async () => {
+    it("PUT /api/invites/:id returns 400 for invalid JSON body", async () => {
         const token = await createTestJWT({ sub: "user-1", githubId: "123", name: "Uploader" });
         const app = await createTestApp();
         const env = createTestEnv();
 
+        // Malformed JSON should fail before invite lookup or authorization.
         const res = await app.request(
-            "http://localhost/api/papers/paper-1/invites",
+            "http://localhost/api/invites/inv-1",
             {
-                method: "POST",
+                method: "PUT",
                 headers: {
                     Authorization: `Bearer ${token}`,
                     "Content-Type": "application/json"
@@ -160,7 +161,7 @@ describe("invites routes", () => {
         );
 
         expect(res.status).toBe(400);
-        const data = (await res.json()) as any;
-        expect(data.error).toBe("Invalid JSON body");
+        await expect(res.json()).resolves.toEqual({ error: "Invalid JSON body" });
+        expect(mockDb.select).not.toHaveBeenCalled();
     });
 });

--- a/apps/api/src/routes/__tests__/invites.test.ts
+++ b/apps/api/src/routes/__tests__/invites.test.ts
@@ -140,4 +140,27 @@ describe("invites routes", () => {
 
         expect(res.status).toBe(400);
     });
+
+    it("POST /api/papers/:id/invites returns 400 for invalid JSON body", async () => {
+        const token = await createTestJWT({ sub: "user-1", githubId: "123", name: "Uploader" });
+        const app = await createTestApp();
+        const env = createTestEnv();
+
+        const res = await app.request(
+            "http://localhost/api/papers/paper-1/invites",
+            {
+                method: "POST",
+                headers: {
+                    Authorization: `Bearer ${token}`,
+                    "Content-Type": "application/json"
+                },
+                body: "{"
+            },
+            env as any
+        );
+
+        expect(res.status).toBe(400);
+        const data = (await res.json()) as any;
+        expect(data.error).toBe("Invalid JSON body");
+    });
 });


### PR DESCRIPTION
🎯 **What:** The testing gap addressed is the lack of unit test coverage for the error-handling branch when parsing invalid JSON from the request body in `POST /api/papers/:id/invites` endpoint.
📊 **Coverage:** A new test scenario now specifically simulates an invalid JSON string (`"{"`) being sent to the `POST /api/papers/:id/invites` endpoint, confirming it safely catches the exception and returns a 400 Bad Request with an `error: "Invalid JSON body"` message.
✨ **Result:** The improvement in test coverage prevents potential regressions where unhandled parsing exceptions might otherwise crash the request cycle or leak internal stack traces. It explicitly tests the `catch` block that was previously uncovered.

---
*PR created automatically by Jules for task [9234447920230339852](https://jules.google.com/task/9234447920230339852) started by @is0692vs*

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

`POST /api/papers/:id/invites` エンドポイントに不正な JSON ボディを送った際の 400 エラーを検証するテストを追加しています。これは `papers.ts` の catch ブロック（行 1161–1163）を対象とした、以前カバーされていなかったパスのテストです。
</details>

<details open><summary><h3>Confidence Score: 5/5</h3></summary>

テストのみの変更であり、プロダクションコードへの影響はなく、マージは安全です。

変更はテストファイル1件のみ。実装コード（papers.ts）の catch ブロックを正しくカバーしており、ステータスコードとエラーメッセージの両方を検証している。DB モック未設定は現在の実装では無害。P2 レベルのスタイル指摘のみで、機能的な問題はない。

特に注意が必要なファイルはありません。
</details>

<details open><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| apps/api/src/routes/__tests__/invites.test.ts | 不正JSON送信時に400を返すことを確認するテストを追加。実装上のcatchブロック（papers.ts:1161-1163）を正しくカバーしており、ステータスコードとエラーメッセージの両方を検証している。DBモック未設定は現実装では無害。 |

</details>

</details>

<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[テスト: 不正JSONボディ送信] --> B[authMiddleware: トークン検証]
    B --> C{検証成功?}
    C -- Yes --> D[ハンドラー: c.req.json 実行]
    C -- No --> E[401 Unauthorized]
    D --> F{JSONパース成功?}
    F -- No: SyntaxError --> G[catchブロック]
    G --> H[400 Invalid JSON body]
    F -- Yes --> I[DBアクセス: uploaderチェック等]
    I --> J[通常フロー]
    H --> K[テスト検証: status=400, error=Invalid JSON body ✓]
```

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 1 code review issue. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 1
apps/api/src/routes/__tests__/invites.test.ts:144-165
**DBモックなしへの暗黙の依存**

このテストは `mockDb.select` を上書きせず、`beforeEach` のデフォルト（空の結果を返す）に依存しています。現状は JSON パース失敗が `isUploader` のDB参照より先に起きるため問題ありませんが、将来ハンドラーの順序が変わった場合（例: 認可チェックを先に行うリファクタリング）、このテストは 400 ではなく 403 を返しながらも静かに失敗します。意図を明示するコメントがあると安全です。

`````

</details>

<sub>Reviews (1): Last reviewed commit: ["🧪 Add test for invalid JSON on POST /ap..."](https://github.com/hiroki-org/openshelf/commit/fddc7e60ec8d1383ab4a6439050ad91fafe0049d) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=30418454)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->