### PR TITLE
🧪 Add test for invalid JSON on /api/papers/:id/description

### DIFF
--- a/apps/api/src/routes/__tests__/papers.test.ts
+++ b/apps/api/src/routes/__tests__/papers.test.ts
@@ -1177,19 +1177,10 @@ describe("papers routes", () => {
     });
 
     it.each([
-        {
-            name: "malformed JSON",
-            body: '{"description": "missing brace"',
-        },
-        {
-            name: "JSON array",
-            body: JSON.stringify([{ description: "updated" }]),
-        },
-        {
-            name: "non-object JSON",
-            body: JSON.stringify("just a string"),
-        },
-    ])("PUT /api/papers/:id/description rejects $name", async ({ body }) => {
+        { name: "malformed JSON", body: '{"description": "missing brace"' },
+        { name: "JSON array", body: JSON.stringify([{ description: "updated" }]) },
+        { name: "non-object JSON", body: JSON.stringify("just a string") },
+    ])("PUT /api/papers/:id/description handles invalid JSON body: $name", async ({ body }) => {
         const token = await createTestJWT({ sub: "user-1", githubId: "123", name: "Uploader" });
         const app = await createTestApp();
         const env = createTestEnv();
@@ -1206,7 +1197,6 @@ describe("papers routes", () => {
             },
             env as any,
         );
-
         expect(res.status).toBe(400);
         await expect(res.json()).resolves.toEqual({ error: "Invalid JSON body" });
     });

--- a/apps/api/src/routes/__tests__/papers.test.ts
+++ b/apps/api/src/routes/__tests__/papers.test.ts
@@ -1176,6 +1176,63 @@ describe("papers routes", () => {
         expect(res.status).toBe(403);
     });
 
+    it("PUT /api/papers/:id/description handles invalid JSON body", async () => {
+        const token = await createTestJWT({ sub: "user-1", githubId: "123", name: "Uploader" });
+        const app = await createTestApp();
+        const env = createTestEnv();
+
+        // Test malformed JSON
+        let res = await app.request(
+            "http://localhost/api/papers/paper-1/description",
+            {
+                method: "PUT",
+                headers: {
+                    Authorization: `Bearer ${token}`,
+                    "Content-Type": "application/json",
+                },
+                body: '{"description": "missing brace"',
+            },
+            env as any,
+        );
+        expect(res.status).toBe(400);
+        let body = (await res.json()) as any;
+        expect(body.error).toBe("Invalid JSON body");
+
+        // Test JSON array instead of object
+        res = await app.request(
+            "http://localhost/api/papers/paper-1/description",
+            {
+                method: "PUT",
+                headers: {
+                    Authorization: `Bearer ${token}`,
+                    "Content-Type": "application/json",
+                },
+                body: JSON.stringify([{ description: "updated" }]),
+            },
+            env as any,
+        );
+        expect(res.status).toBe(400);
+        body = (await res.json()) as any;
+        expect(body.error).toBe("Invalid JSON body");
+
+        // Test non-object JSON
+        res = await app.request(
+            "http://localhost/api/papers/paper-1/description",
+            {
+                method: "PUT",
+                headers: {
+                    Authorization: `Bearer ${token}`,
+                    "Content-Type": "application/json",
+                },
+                body: JSON.stringify("just a string"),
+            },
+            env as any,
+        );
+        expect(res.status).toBe(400);
+        body = (await res.json()) as any;
+        expect(body.error).toBe("Invalid JSON body");
+    });
+
     it("PUT /api/papers/:id/description validates description length", async () => {
         const token = await createTestJWT({ sub: "user-1", githubId: "123", name: "Uploader" });
 

--- a/apps/api/src/routes/__tests__/papers.test.ts
+++ b/apps/api/src/routes/__tests__/papers.test.ts
@@ -1176,13 +1176,25 @@ describe("papers routes", () => {
         expect(res.status).toBe(403);
     });
 
-    it("PUT /api/papers/:id/description handles invalid JSON body", async () => {
+    it.each([
+        {
+            name: "malformed JSON",
+            body: '{"description": "missing brace"',
+        },
+        {
+            name: "JSON array",
+            body: JSON.stringify([{ description: "updated" }]),
+        },
+        {
+            name: "non-object JSON",
+            body: JSON.stringify("just a string"),
+        },
+    ])("PUT /api/papers/:id/description rejects $name", async ({ body }) => {
         const token = await createTestJWT({ sub: "user-1", githubId: "123", name: "Uploader" });
         const app = await createTestApp();
         const env = createTestEnv();
 
-        // Test malformed JSON
-        let res = await app.request(
+        const res = await app.request(
             "http://localhost/api/papers/paper-1/description",
             {
                 method: "PUT",
@@ -1190,47 +1202,13 @@ describe("papers routes", () => {
                     Authorization: `Bearer ${token}`,
                     "Content-Type": "application/json",
                 },
-                body: '{"description": "missing brace"',
+                body,
             },
             env as any,
         );
-        expect(res.status).toBe(400);
-        let body = (await res.json()) as any;
-        expect(body.error).toBe("Invalid JSON body");
 
-        // Test JSON array instead of object
-        res = await app.request(
-            "http://localhost/api/papers/paper-1/description",
-            {
-                method: "PUT",
-                headers: {
-                    Authorization: `Bearer ${token}`,
-                    "Content-Type": "application/json",
-                },
-                body: JSON.stringify([{ description: "updated" }]),
-            },
-            env as any,
-        );
         expect(res.status).toBe(400);
-        body = (await res.json()) as any;
-        expect(body.error).toBe("Invalid JSON body");
-
-        // Test non-object JSON
-        res = await app.request(
-            "http://localhost/api/papers/paper-1/description",
-            {
-                method: "PUT",
-                headers: {
-                    Authorization: `Bearer ${token}`,
-                    "Content-Type": "application/json",
-                },
-                body: JSON.stringify("just a string"),
-            },
-            env as any,
-        );
-        expect(res.status).toBe(400);
-        body = (await res.json()) as any;
-        expect(body.error).toBe("Invalid JSON body");
+        await expect(res.json()).resolves.toEqual({ error: "Invalid JSON body" });
     });
 
     it("PUT /api/papers/:id/description validates description length", async () => {

--- a/package-lock.json
+++ b/package-lock.json
@@ -21,6 +21,7 @@
         "@vitest/coverage-v8": "^3.2.4",
         "babel-plugin-react-compiler": "1.0.0",
         "eslint": "^10.2.1",
+        "postcss": "^8.5.12",
         "typescript": "^6.0.3",
         "vitest": "^3.2.4"
       }
@@ -36,7 +37,7 @@
       "devDependencies": {
         "@cloudflare/workers-types": "^4.20260426.1",
         "@codspeed/vitest-plugin": "^5.3.0",
-        "drizzle-kit": "^1.0.0-beta.23",
+        "drizzle-kit": "1.0.0-beta.23",
         "typescript": "^6.0.3",
         "vitest": "^3.2.4",
         "wrangler": "^4.85.0"
@@ -91,6 +92,7 @@
         "eslint": "^10",
         "eslint-config-next": "16.2.4",
         "jsdom": "^27.0.1",
+        "postcss": "^8.5.12",
         "tailwindcss": "^4.2.3",
         "typescript": "^6",
         "vitest": "^3.2.4"


### PR DESCRIPTION
🎯 **What:** The `PUT /api/papers/:id/description` endpoint handles JSON input, and falls back gracefully when provided invalid or malformed JSON, returning a 400 response. This ensures the endpoint doesn't crash on bad inputs. A test gap existed where these validations were missing from tests.

📊 **Coverage:** Added test cases covering:
1. Malformed JSON input.
2. JSON array input (should be an object).
3. Non-object JSON input (e.g. string).

✨ **Result:** Improved robustness by asserting error structures correctly fallback to `400 Bad Request` with `{ error: "Invalid JSON body" }` ensuring API contracts hold on edge cases.

---
*PR created automatically by Jules for task [7680723326508020692](https://jules.google.com/task/7680723326508020692) started by @is0692vs*

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

このPRは `PUT /api/papers/:id/description` エンドポイントに対し、不正なJSONボディ（malformed JSON / 配列 / 文字列）を送信した場合に400を返すことを確認するテストを追加します。ルートハンドラはDBクエリ前に早期リターンするため、テストの `mockDb` セットアップが不要な点は正しく設計されています。
</details>


<details open><summary><h3>Confidence Score: 4/5</h3></summary>

テストロジック自体は正しく、P2のスタイル指摘のみのためマージ可能。

P2のみ（テスト構造のスタイルとpackage-lock.jsonへの無関係な変更）。P1以上の問題はなし。

package-lock.json — 意図しない差分が混入している可能性があるため要確認。
</details>


<details open><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| apps/api/src/routes/__tests__/papers.test.ts | PUT /api/papers/:id/description の不正JSON入力に対するテストを追加。ルートが400を返す前にDBクエリを発行しないため、mockDb のセットアップなしでも正しく動作する。ただし3ケースが1つの it() に詰め込まれており、テスト独立性に欠ける。 |
| package-lock.json | テストと無関係な postcss の追加・drizzle-kit のバージョン表記変更が混入しており、意図しない変更の可能性あり。 |

</details>


</details>


<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant Test as テスト
    participant App as Hono App
    participant Auth as authMiddleware
    participant Route as PUT /papers/:id/description

    Test->>App: PUT (malformed JSON)
    App->>Auth: JWT検証
    Auth-->>App: OK (user set)
    App->>Route: ハンドラ呼び出し
    Route->>Route: c.req.json() → throws
    Route-->>Test: 400 { error: "Invalid JSON body" }

    Test->>App: PUT (JSON array)
    App->>Auth: JWT検証
    Auth-->>App: OK
    App->>Route: ハンドラ呼び出し
    Route->>Route: Array.isArray(body) === true
    Route-->>Test: 400 { error: "Invalid JSON body" }

    Test->>App: PUT (JSON string)
    App->>Auth: JWT検証
    Auth-->>App: OK
    App->>Route: ハンドラ呼び出し
    Route->>Route: typeof body !== "object"
    Route-->>Test: 400 { error: "Invalid JSON body" }
```

<!-- greptile_failed_comments -->
<details open><summary><h3>Comments Outside Diff (1)</h3></summary>

1. `package-lock.json`, line 21-44 ([link](https://github.com/hiroki-org/openshelf/blob/c51398cde48408f642b9cb075ac27dcf897a4b88/package-lock.json#L21-L44)) 

   <a href="#"><img alt="P2" src="https://greptile-static-assets.s3.amazonaws.com/badges/p2.svg?v=7" align="top"></a> **テストとは無関係な `package-lock.json` の変更**

   このPRはテスト追加が目的ですが、`package-lock.json` にはテストと無関係な差分が2点含まれています。

   1. ルートワークスペースおよび `apps/web` に `postcss: ^8.5.12` が追加（`package.json` 側にも `devDependencies` として記載されているため自動解決されたものと思われますが、意図的な変更かを確認してください）。
   2. `apps/api` の `drizzle-kit` バージョン表記が `^1.0.0-beta.23` → `1.0.0-beta.23` に変更（キャレットが除去）。

   これらがJulesの自動コミットで混入した意図しない変更であれば、切り出して別PRで管理することを推奨します。

   <details><summary>Prompt To Fix With AI</summary>

   `````markdown
   This is a comment left during a code review.
   Path: package-lock.json
   Line: 21-44

   Comment:
   **テストとは無関係な `package-lock.json` の変更**

   このPRはテスト追加が目的ですが、`package-lock.json` にはテストと無関係な差分が2点含まれています。

   1. ルートワークスペースおよび `apps/web` に `postcss: ^8.5.12` が追加（`package.json` 側にも `devDependencies` として記載されているため自動解決されたものと思われますが、意図的な変更かを確認してください）。
   2. `apps/api` の `drizzle-kit` バージョン表記が `^1.0.0-beta.23` → `1.0.0-beta.23` に変更（キャレットが除去）。

   これらがJulesの自動コミットで混入した意図しない変更であれば、切り出して別PRで管理することを推奨します。

   How can I resolve this? If you propose a fix, please make it concise.
   `````
   </details>

</details>

<!-- /greptile_failed_comments -->

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 2 code review issues. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 2
apps/api/src/routes/__tests__/papers.test.ts:1179-1234
**1つの `it()` に複数ケースをまとめている**

3つのサブケース（malformed JSON / array / string）が1つの `it()` ブロック内で逐次実行されています。最初の `expect` が失敗した時点でテストが中断し、残りのケースは実行されません。テストの独立性・失敗時の診断のしやすさを高めるため、ケースごとに `it()` を分割することを推奨します。

### Issue 2 of 2
package-lock.json:21-44
**テストとは無関係な `package-lock.json` の変更**

このPRはテスト追加が目的ですが、`package-lock.json` にはテストと無関係な差分が2点含まれています。

1. ルートワークスペースおよび `apps/web` に `postcss: ^8.5.12` が追加（`package.json` 側にも `devDependencies` として記載されているため自動解決されたものと思われますが、意図的な変更かを確認してください）。
2. `apps/api` の `drizzle-kit` バージョン表記が `^1.0.0-beta.23` → `1.0.0-beta.23` に変更（キャレットが除去）。

これらがJulesの自動コミットで混入した意図しない変更であれば、切り出して別PRで管理することを推奨します。


`````

</details>

<sub>Reviews (1): Last reviewed commit: ["🧪 Add test for invalid JSON on /api/pap..."](https://github.com/hiroki-org/openshelf/commit/c51398cde48408f642b9cb075ac27dcf897a4b88) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=30418488)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->