### PR TITLE
test: add missing tests to collections.ts for ~100% coverage

### DIFF
--- a/apps/api/src/routes/__tests__/collections.test.ts
+++ b/apps/api/src/routes/__tests__/collections.test.ts
@@ -148,9 +148,9 @@ describe("collections routes", () => {
         expect(await res.json()).toEqual({ error: "Collection not found" });
     });
 
-    it("GET /api/collections/:id returns collection when collection is member org collection and user is member", async () => {
+    it("GET /api/collections/:id returns collection when collection is org_only org collection and user is member", async () => {
         queueSelectResponses([
-            { getResult: { id: "c1", ownerType: "org", ownerId: "org1", visibility: "member" } },
+            { getResult: { id: "c1", ownerType: "org", ownerId: "org1", visibility: "org_only" } },
             { getResult: { role: "member" } },
         ]);
         const app = await createTestApp();
@@ -162,9 +162,9 @@ describe("collections routes", () => {
         expect(res.status).toBe(200);
     });
 
-    it("GET /api/collections/:id returns 404 when collection is member org collection and user is not member", async () => {
+    it("GET /api/collections/:id returns 404 when collection is org_only org collection and user is not member", async () => {
         queueSelectResponses([
-            { getResult: { id: "c1", ownerType: "org", ownerId: "org1", visibility: "member" } },
+            { getResult: { id: "c1", ownerType: "org", ownerId: "org1", visibility: "org_only" } },
             { getResult: null },
         ]);
         const app = await createTestApp();
@@ -903,21 +903,6 @@ describe("collections routes", () => {
         expect(await res.json()).toEqual({ error: "Forbidden" });
     });
 
-    it("POST /api/collections/:id/papers handles invalid JSON body", async () => {
-        queueSelectResponses([
-            { getResult: { id: "c1", ownerType: "user", ownerId: "user-1" } }
-        ]);
-        const app = await createTestApp();
-        const env = createTestEnv();
-        const res = await app.request("http://localhost/api/collections/c1/papers", {
-            method: "POST",
-            headers: { Authorization: `Bearer ${await createTestJWT({ sub: "user-1" })}` },
-            body: "{invalid-json}",
-        }, env);
-        expect(res.status).toBe(400);
-        expect(await res.json()).toEqual({ error: "Invalid JSON body" });
-    });
-
     it("POST /api/collections/:id/papers returns 404 when paper not found", async () => {
         queueSelectResponses([
             { getResult: { id: "c1", ownerType: "user", ownerId: "user-1" } },
@@ -1031,22 +1016,6 @@ describe("collections routes", () => {
         expect(await res.json()).toEqual({ error: "Forbidden" });
     });
 
-    it("PATCH /api/collections/:id/papers returns 400 when missing existing papers", async () => {
-        queueSelectResponses([
-            { getResult: { id: "c1", ownerType: "user", ownerId: "user-1" } },
-            { allResult: [{ paperId: "p1" }, { paperId: "p2" }] }
-        ]);
-        const app = await createTestApp();
-        const env = createTestEnv();
-        const res = await app.request("http://localhost/api/collections/c1/papers", {
-            method: "PATCH",
-            headers: { Authorization: `Bearer ${await createTestJWT({ sub: "user-1" })}` },
-            body: JSON.stringify({ paper_ids: ["p1"] }),
-        }, env);
-        expect(res.status).toBe(400);
-        expect(await res.json()).toEqual({ error: "paper_ids must include all papers in collection" });
-    });
-
     it("PATCH /api/collections/:id/papers returns 400 when paper not in collection", async () => {
         queueSelectResponses([
             { getResult: { id: "c1", ownerType: "user", ownerId: "user-1" } },
@@ -1122,11 +1091,10 @@ describe("collections routes", () => {
         expect(data.papers[0].id).toBe("p1");
     });
 
-    it("GET /api/collections/:id/papers filters out private papers for authenticated users who don\'t have access", async () => {
+    it("GET /api/collections/:id/papers filters out private papers for authenticated users who don't have access", async () => {
         queueSelectResponses([
             { getResult: { id: "c1", visibility: "public", ownerType: "user", ownerId: "u1" } },
             { allResult: [{ id: "p1", visibility: "private" }, { id: "p2", visibility: "public" }] },
-            { allResult: [] },
             { allResult: [] },
         ]);
         const app = await createTestApp();

--- a/apps/api/src/routes/__tests__/collections.test.ts
+++ b/apps/api/src/routes/__tests__/collections.test.ts
@@ -52,6 +52,185 @@ describe("collections routes", () => {
     });
 
 
+
+    it("POST /api/collections ignores general db insert errors", async () => {
+        const err = new Error("General insert error");
+        mockDb.insert = vi.fn().mockReturnValue({
+            values: vi.fn().mockRejectedValue(err)
+        });
+        const app = await createTestApp();
+        const env = createTestEnv();
+        const res = await app.request("http://localhost/api/collections", {
+            method: "POST",
+            headers: { Authorization: `Bearer ${await createTestJWT({ sub: "user-1" })}` },
+            body: JSON.stringify({ name: "C1", slug: "col-1", owner_type: "user" }),
+        }, env);
+        expect(res.status).toBe(500);
+    });
+
+    it("POST /api/collections returns 409 if slug already in use", async () => {
+        const err = new Error("UNIQUE constraint failed: collections.slug");
+        mockDb.insert = vi.fn().mockReturnValue({
+            values: vi.fn().mockRejectedValue(err)
+        });
+        const app = await createTestApp();
+        const env = createTestEnv();
+        const res = await app.request("http://localhost/api/collections", {
+            method: "POST",
+            headers: { Authorization: `Bearer ${await createTestJWT({ sub: "user-1" })}` },
+            body: JSON.stringify({ name: "C1", slug: "col-1", owner_type: "user" }),
+        }, env);
+        expect(res.status).toBe(409);
+        expect(await res.json()).toEqual({ error: "slug already in use" });
+    });
+
+    it("GET /api/collections/:id ignores invalid authorization headers", async () => {
+        queueSelectResponses([
+            { getResult: { id: "c1", visibility: "public" } }
+        ]);
+        const app = await createTestApp();
+        const env = createTestEnv();
+        const res = await app.request("http://localhost/api/collections/c1", {
+            method: "GET",
+            headers: { Authorization: "Bearer INVALID_TOKEN_HERE" },
+        }, env);
+        expect(res.status).toBe(200);
+    });
+
+    it("POST /api/collections returns 400 when name is invalid", async () => {
+        const app = await createTestApp();
+        const env = createTestEnv();
+        const res = await app.request("http://localhost/api/collections", {
+            method: "POST",
+            headers: { Authorization: `Bearer ${await createTestJWT({ sub: "user-1" })}` },
+            body: JSON.stringify({ name: "", slug: "col-1", owner_type: "user" }),
+        }, env);
+        expect(res.status).toBe(400);
+        expect(await res.json()).toHaveProperty("error");
+    });
+
+    it("POST /api/collections returns 400 when slug is invalid", async () => {
+        const app = await createTestApp();
+        const env = createTestEnv();
+        const res = await app.request("http://localhost/api/collections", {
+            method: "POST",
+            headers: { Authorization: `Bearer ${await createTestJWT({ sub: "user-1" })}` },
+            body: JSON.stringify({ name: "C1", slug: "invalid slug!", owner_type: "user" }),
+        }, env);
+        expect(res.status).toBe(400);
+        expect(await res.json()).toHaveProperty("error");
+    });
+
+    it("POST /api/collections returns 400 when description is invalid", async () => {
+        const app = await createTestApp();
+        const env = createTestEnv();
+        const res = await app.request("http://localhost/api/collections", {
+            method: "POST",
+            headers: { Authorization: `Bearer ${await createTestJWT({ sub: "user-1" })}` },
+            body: JSON.stringify({ name: "C1", slug: "col-1", owner_type: "user", description: "a".repeat(1001) }),
+        }, env);
+        expect(res.status).toBe(400);
+        expect(await res.json()).toHaveProperty("error");
+    });
+
+    it("GET /api/collections/:id returns 404 when collection is private org collection and user is not admin", async () => {
+        queueSelectResponses([
+            { getResult: { id: "c1", ownerType: "org", ownerId: "org1", visibility: "private" } },
+            { getResult: { role: "member" } },
+        ]);
+        const app = await createTestApp();
+        const env = createTestEnv();
+        const res = await app.request("http://localhost/api/collections/c1", {
+            method: "GET",
+            headers: { Authorization: `Bearer ${await createTestJWT({ sub: "user-1" })}` },
+        }, env);
+        expect(res.status).toBe(404);
+        expect(await res.json()).toEqual({ error: "Collection not found" });
+    });
+
+    it("GET /api/collections/:id returns collection when collection is member org collection and user is member", async () => {
+        queueSelectResponses([
+            { getResult: { id: "c1", ownerType: "org", ownerId: "org1", visibility: "member" } },
+            { getResult: { role: "member" } },
+        ]);
+        const app = await createTestApp();
+        const env = createTestEnv();
+        const res = await app.request("http://localhost/api/collections/c1", {
+            method: "GET",
+            headers: { Authorization: `Bearer ${await createTestJWT({ sub: "user-1" })}` },
+        }, env);
+        expect(res.status).toBe(200);
+    });
+
+    it("GET /api/collections/:id returns 404 when collection is member org collection and user is not member", async () => {
+        queueSelectResponses([
+            { getResult: { id: "c1", ownerType: "org", ownerId: "org1", visibility: "member" } },
+            { getResult: null },
+        ]);
+        const app = await createTestApp();
+        const env = createTestEnv();
+        const res = await app.request("http://localhost/api/collections/c1", {
+            method: "GET",
+            headers: { Authorization: `Bearer ${await createTestJWT({ sub: "user-1" })}` },
+        }, env);
+        expect(res.status).toBe(404);
+        expect(await res.json()).toEqual({ error: "Collection not found" });
+    });
+
+    it("POST /api/collections returns 404 if owner org not found by slug", async () => {
+        queueSelectResponses([
+            { getResult: null }
+        ]);
+        const app = await createTestApp();
+        const env = createTestEnv();
+        const res = await app.request("http://localhost/api/collections", {
+            method: "POST",
+            headers: { Authorization: `Bearer ${await createTestJWT({ sub: "user-1" })}` },
+            body: JSON.stringify({ name: "C1", slug: "col-1", owner_type: "org", org_slug: "nonexistent" }),
+        }, env);
+        expect(res.status).toBe(404);
+    });
+
+    it("POST /api/collections handles org finding by owner_id", async () => {
+        queueSelectResponses([
+            { getResult: { id: "org1", slug: "org-slug" } },
+            { getResult: { role: "admin" } },
+            { getResult: { id: "c1" } },
+        ]);
+        mockDb.insert = vi.fn().mockReturnValue({ values: vi.fn().mockResolvedValue({}) });
+        const app = await createTestApp();
+        const env = createTestEnv();
+        const res = await app.request("http://localhost/api/collections", {
+            method: "POST",
+            headers: { Authorization: `Bearer ${await createTestJWT({ sub: "user-1" })}` },
+            body: JSON.stringify({ name: "C1", slug: "org-col-1", owner_type: "org", owner_id: "org1" }),
+        }, env);
+        expect(res.status).toBe(201);
+    });
+
+    it("POST /api/collections returns 400 for invalid visibility", async () => {
+        const app = await createTestApp();
+        const env = createTestEnv();
+        const res = await app.request("http://localhost/api/collections", {
+            method: "POST",
+            headers: { Authorization: `Bearer ${await createTestJWT({ sub: "user-1" })}` },
+            body: JSON.stringify({ name: "C1", slug: "col-1", owner_type: "user", visibility: 123 }),
+        }, env);
+        expect(res.status).toBe(400);
+        expect(await res.json()).toEqual({ error: "Invalid visibility" });
+    });
+
+    it("POST /api/collections returns 400 for invalid owner_type", async () => {
+        const app = await createTestApp();
+        const env = createTestEnv();
+        const res = await app.request("http://localhost/api/collections", {
+            method: "POST",
+            headers: { Authorization: `Bearer ${await createTestJWT({ sub: "user-1" })}` },
+            body: JSON.stringify({ name: "C1", slug: "col-1", owner_type: "invalid-type" }),
+        }, env);
+        expect(res.status).toBe(400);
+        expect(await res.json()).toEqual({ error: "owner_type must be 'user' or 'org'" });
+    });
     it("POST /api/collections returns 400 for invalid JSON body", async () => {
         const token = await createTestJWT({ sub: "user-1" });
         const app = await createTestApp();
@@ -84,6 +263,19 @@ describe("collections routes", () => {
         expect(res.status).toBe(404);
     });
 
+
+    it("GET /api/users/:id/collections filters out non-public collections when unauthenticated", async () => {
+        queueSelectResponses([
+            { allResult: [{ id: "c1", visibility: "private", ownerType: "user", ownerId: "user2" }, { id: "c2", visibility: "public", ownerType: "user", ownerId: "user2" }] },
+        ]);
+        const app = await createTestApp();
+        const env = createTestEnv();
+        const res = await app.request("http://localhost/api/users/user2/collections", {
+            method: "GET",
+        }, env);
+        expect(res.status).toBe(200);
+        expect(await res.json()).toEqual({ collections: [{ id: "c2", visibility: "public", ownerType: "user", ownerId: "user2" }] });
+    });
     it("GET /api/users/:id/collections returns list", async () => {
         mockDb.select = vi.fn(() =>
             makeQuery({
@@ -245,6 +437,212 @@ describe("collections routes", () => {
         expect(((await res.json()) as any).collection.id).toBe("col-1");
     });
 
+
+    it("PATCH /api/collections/:id returns 404 when collection not found", async () => {
+        queueSelectResponses([
+            { getResult: null }
+        ]);
+        const app = await createTestApp();
+        const env = createTestEnv();
+        const res = await app.request("http://localhost/api/collections/c1", {
+            method: "PATCH",
+            headers: { Authorization: `Bearer ${await createTestJWT({ sub: "user-1" })}` },
+            body: JSON.stringify({ name: "C2", slug: "col-2", description: "desc", visibility: "public" }),
+        }, env);
+        expect(res.status).toBe(404);
+        expect(await res.json()).toEqual({ error: "Collection not found" });
+    });
+
+    it("PATCH /api/collections/:id returns 403 when forbidden", async () => {
+        queueSelectResponses([
+            { getResult: { id: "c1", ownerType: "user", ownerId: "user2" } },
+        ]);
+        const app = await createTestApp();
+        const env = createTestEnv();
+        const res = await app.request("http://localhost/api/collections/c1", {
+            method: "PATCH",
+            headers: { Authorization: `Bearer ${await createTestJWT({ sub: "user-1" })}` },
+            body: JSON.stringify({ name: "C2", slug: "col-2", description: "desc", visibility: "public" }),
+        }, env);
+        expect(res.status).toBe(403);
+        expect(await res.json()).toEqual({ error: "Forbidden" });
+    });
+
+    it("PATCH /api/collections/:id handles invalid JSON body", async () => {
+        queueSelectResponses([
+            { getResult: { id: "c1", ownerType: "user", ownerId: "user-1" } },
+        ]);
+        const app = await createTestApp();
+        const env = createTestEnv();
+        const res = await app.request("http://localhost/api/collections/c1", {
+            method: "PATCH",
+            headers: { Authorization: `Bearer ${await createTestJWT({ sub: "user-1" })}` },
+            body: "{invalid-json}",
+        }, env);
+        expect(res.status).toBe(400);
+        expect(await res.json()).toEqual({ error: "Invalid JSON body" });
+    });
+
+    it("PATCH /api/collections/:id returns 400 for invalid visibility", async () => {
+        queueSelectResponses([
+            { getResult: { id: "c1", ownerType: "user", ownerId: "user-1" } },
+        ]);
+        const app = await createTestApp();
+        const env = createTestEnv();
+        const res = await app.request("http://localhost/api/collections/c1", {
+            method: "PATCH",
+            headers: { Authorization: `Bearer ${await createTestJWT({ sub: "user-1" })}` },
+            body: JSON.stringify({ visibility: 123 }),
+        }, env);
+        expect(res.status).toBe(400);
+        expect(await res.json()).toEqual({ error: "Invalid visibility" });
+    });
+
+    it("PATCH /api/collections/:id ignores general db update errors", async () => {
+        queueSelectResponses([
+            { getResult: { id: "c1", ownerType: "user", ownerId: "user-1" } },
+        ]);
+        const err = new Error("General update error");
+        mockDb.update = vi.fn().mockReturnValue({
+            set: vi.fn().mockReturnValue({
+                where: vi.fn().mockRejectedValue(err)
+            })
+        });
+        const app = await createTestApp();
+        const env = createTestEnv();
+        const res = await app.request("http://localhost/api/collections/c1", {
+            method: "PATCH",
+            headers: { Authorization: `Bearer ${await createTestJWT({ sub: "user-1" })}` },
+            body: JSON.stringify({ name: "C2", slug: "col-2", description: "desc", visibility: "public" }),
+        }, env);
+        expect(res.status).toBe(500);
+    });
+
+    it("PATCH /api/collections/:id returns 409 if slug already in use", async () => {
+        queueSelectResponses([
+            { getResult: { id: "c1", ownerType: "user", ownerId: "user-1" } },
+        ]);
+        const err = new Error("UNIQUE constraint failed: collections.slug");
+        mockDb.update = vi.fn().mockReturnValue({
+            set: vi.fn().mockReturnValue({
+                where: vi.fn().mockRejectedValue(err)
+            })
+        });
+        const app = await createTestApp();
+        const env = createTestEnv();
+        const res = await app.request("http://localhost/api/collections/c1", {
+            method: "PATCH",
+            headers: { Authorization: `Bearer ${await createTestJWT({ sub: "user-1" })}` },
+            body: JSON.stringify({ name: "C2", slug: "col-2", description: "desc", visibility: "public" }),
+        }, env);
+        expect(res.status).toBe(409);
+        expect(await res.json()).toEqual({ error: "slug already in use" });
+    });
+
+    it("PATCH /api/collections/:id returns 400 when name is invalid", async () => {
+        queueSelectResponses([
+            { getResult: { id: "c1", ownerType: "user", ownerId: "user-1" } }, // get collection
+        ]);
+        const app = await createTestApp();
+        const env = createTestEnv();
+        const res = await app.request("http://localhost/api/collections/c1", {
+            method: "PATCH",
+            headers: { Authorization: `Bearer ${await createTestJWT({ sub: "user-1" })}` },
+            body: JSON.stringify({ name: "" }),
+        }, env);
+        expect(res.status).toBe(400);
+        expect(await res.json()).toHaveProperty("error");
+    });
+
+    it("PATCH /api/collections/:id returns 400 when slug is invalid", async () => {
+        queueSelectResponses([
+            { getResult: { id: "c1", ownerType: "user", ownerId: "user-1" } }, // get collection
+        ]);
+        const app = await createTestApp();
+        const env = createTestEnv();
+        const res = await app.request("http://localhost/api/collections/c1", {
+            method: "PATCH",
+            headers: { Authorization: `Bearer ${await createTestJWT({ sub: "user-1" })}` },
+            body: JSON.stringify({ slug: "invalid slug!" }),
+        }, env);
+        expect(res.status).toBe(400);
+        expect(await res.json()).toHaveProperty("error");
+    });
+
+    it("PATCH /api/collections/:id returns 400 when description is invalid", async () => {
+        queueSelectResponses([
+            { getResult: { id: "c1", ownerType: "user", ownerId: "user-1" } }, // get collection
+        ]);
+        const app = await createTestApp();
+        const env = createTestEnv();
+        const res = await app.request("http://localhost/api/collections/c1", {
+            method: "PATCH",
+            headers: { Authorization: `Bearer ${await createTestJWT({ sub: "user-1" })}` },
+            body: JSON.stringify({ description: "a".repeat(1001) }),
+        }, env);
+        expect(res.status).toBe(400);
+        expect(await res.json()).toHaveProperty("error");
+    });
+
+    it("DELETE /api/collections/:id returns 404 when collection not found", async () => {
+        queueSelectResponses([
+            { getResult: null }
+        ]);
+        const app = await createTestApp();
+        const env = createTestEnv();
+        const res = await app.request("http://localhost/api/collections/c1", {
+            method: "DELETE",
+            headers: { Authorization: `Bearer ${await createTestJWT({ sub: "user-1" })}` },
+        }, env);
+        expect(res.status).toBe(404);
+        expect(await res.json()).toEqual({ error: "Collection not found" });
+    });
+
+    it("DELETE /api/collections/:id returns 403 when forbidden", async () => {
+        queueSelectResponses([
+            { getResult: { id: "c1", ownerType: "user", ownerId: "user2" } },
+        ]);
+        const app = await createTestApp();
+        const env = createTestEnv();
+        const res = await app.request("http://localhost/api/collections/c1", {
+            method: "DELETE",
+            headers: { Authorization: `Bearer ${await createTestJWT({ sub: "user-1" })}` },
+        }, env);
+        expect(res.status).toBe(403);
+        expect(await res.json()).toEqual({ error: "Forbidden" });
+    });
+
+    it("PATCH /api/collections/:id returns 403 when user cannot manage org collection", async () => {
+        queueSelectResponses([
+            { getResult: { id: "c1", ownerType: "org", ownerId: "org1" } },
+            { getResult: null },
+        ]);
+        const app = await createTestApp();
+        const env = createTestEnv();
+        const res = await app.request("http://localhost/api/collections/c1", {
+            method: "PATCH",
+            headers: { Authorization: `Bearer ${await createTestJWT({ sub: "user-1" })}` },
+            body: JSON.stringify({ name: "C2" }),
+        }, env);
+        expect(res.status).toBe(403);
+        expect(await res.json()).toEqual({ error: "Forbidden" });
+    });
+
+    it("PATCH /api/collections/:id allows org admin to update collection", async () => {
+        queueSelectResponses([
+            { getResult: { id: "c1", ownerType: "org", ownerId: "org1" } },
+            { getResult: { role: "admin" } },
+            { getResult: { id: "c1", name: "C2" } }
+        ]);
+        const app = await createTestApp();
+        const env = createTestEnv();
+        const res = await app.request("http://localhost/api/collections/c1", {
+            method: "PATCH",
+            headers: { Authorization: `Bearer ${await createTestJWT({ sub: "user-1" })}` },
+            body: JSON.stringify({ name: "C2", slug: "col-2", description: "desc2", visibility: "public" }),
+        }, env);
+        expect(res.status).toBe(200);
+    });
     it("PATCH /api/collections/:id updates collection details for the owner", async () => {
         const token = await createTestJWT({ sub: "user-1" });
         const existingCollection = {
@@ -367,6 +765,19 @@ describe("collections routes", () => {
         expect(deleteWhere).toHaveBeenCalled();
     });
 
+
+    it("GET /api/orgs/:slug/collections returns empty array when org not found", async () => {
+        queueSelectResponses([
+            { getResult: null },
+        ]);
+        const app = await createTestApp();
+        const env = createTestEnv();
+        const res = await app.request("http://localhost/api/orgs/nonexistent/collections", {
+            method: "GET",
+        }, env);
+        expect(res.status).toBe(200);
+        expect(await res.json()).toEqual({ collections: [] });
+    });
     it("GET /api/orgs/:slug/collections returns admin-visible collections", async () => {
         const token = await createTestJWT({ sub: "user-1" });
         queueSelectResponses([
@@ -461,6 +872,289 @@ describe("collections routes", () => {
         await expect(res.json()).resolves.toEqual({ error: "Invalid JSON body" });
     });
 
+
+    it("POST /api/collections/:id/papers returns 404 when collection not found", async () => {
+        queueSelectResponses([
+            { getResult: null }
+        ]);
+        const app = await createTestApp();
+        const env = createTestEnv();
+        const res = await app.request("http://localhost/api/collections/c1/papers", {
+            method: "POST",
+            headers: { Authorization: `Bearer ${await createTestJWT({ sub: "user-1" })}` },
+            body: JSON.stringify({ paper_id: "p1" }),
+        }, env);
+        expect(res.status).toBe(404);
+        expect(await res.json()).toEqual({ error: "Collection not found" });
+    });
+
+    it("POST /api/collections/:id/papers returns 403 when forbidden", async () => {
+        queueSelectResponses([
+            { getResult: { id: "c1", ownerType: "user", ownerId: "user2" } }
+        ]);
+        const app = await createTestApp();
+        const env = createTestEnv();
+        const res = await app.request("http://localhost/api/collections/c1/papers", {
+            method: "POST",
+            headers: { Authorization: `Bearer ${await createTestJWT({ sub: "user-1" })}` },
+            body: JSON.stringify({ paper_id: "p1" }),
+        }, env);
+        expect(res.status).toBe(403);
+        expect(await res.json()).toEqual({ error: "Forbidden" });
+    });
+
+    it("POST /api/collections/:id/papers handles invalid JSON body", async () => {
+        queueSelectResponses([
+            { getResult: { id: "c1", ownerType: "user", ownerId: "user-1" } }
+        ]);
+        const app = await createTestApp();
+        const env = createTestEnv();
+        const res = await app.request("http://localhost/api/collections/c1/papers", {
+            method: "POST",
+            headers: { Authorization: `Bearer ${await createTestJWT({ sub: "user-1" })}` },
+            body: "{invalid-json}",
+        }, env);
+        expect(res.status).toBe(400);
+        expect(await res.json()).toEqual({ error: "Invalid JSON body" });
+    });
+
+    it("POST /api/collections/:id/papers returns 404 when paper not found", async () => {
+        queueSelectResponses([
+            { getResult: { id: "c1", ownerType: "user", ownerId: "user-1" } },
+            { getResult: null }
+        ]);
+        const app = await createTestApp();
+        const env = createTestEnv();
+        const res = await app.request("http://localhost/api/collections/c1/papers", {
+            method: "POST",
+            headers: { Authorization: `Bearer ${await createTestJWT({ sub: "user-1" })}` },
+            body: JSON.stringify({ paper_id: "p1" }),
+        }, env);
+        expect(res.status).toBe(404);
+        expect(await res.json()).toEqual({ error: "Paper not found" });
+    });
+
+    it("POST /api/collections/:id/papers ignores general db insert errors", async () => {
+        queueSelectResponses([
+            { getResult: { id: "c1", ownerType: "user", ownerId: "user-1" } },
+            { getResult: { id: "p1" } },
+            { getResult: null },
+            { getResult: { c: 0 } },
+            { getResult: null },
+        ]);
+        const err = new Error("General insert paper error");
+        mockDb.insert = vi.fn().mockReturnValue({
+            values: vi.fn().mockRejectedValue(err)
+        });
+        const app = await createTestApp();
+        const env = createTestEnv();
+        const res = await app.request("http://localhost/api/collections/c1/papers", {
+            method: "POST",
+            headers: { Authorization: `Bearer ${await createTestJWT({ sub: "user-1" })}` },
+            body: JSON.stringify({ paper_id: "p1" }),
+        }, env);
+        expect(res.status).toBe(500);
+    });
+
+    it("DELETE /api/collections/:id/papers/:paperId returns 404 when collection not found", async () => {
+        queueSelectResponses([
+            { getResult: null }
+        ]);
+        const app = await createTestApp();
+        const env = createTestEnv();
+        const res = await app.request("http://localhost/api/collections/c1/papers/p1", {
+            method: "DELETE",
+            headers: { Authorization: `Bearer ${await createTestJWT({ sub: "user-1" })}` },
+        }, env);
+        expect(res.status).toBe(404);
+        expect(await res.json()).toEqual({ error: "Collection not found" });
+    });
+
+    it("DELETE /api/collections/:id/papers/:paperId returns 403 when forbidden", async () => {
+        queueSelectResponses([
+            { getResult: { id: "c1", ownerType: "user", ownerId: "user2" } }
+        ]);
+        const app = await createTestApp();
+        const env = createTestEnv();
+        const res = await app.request("http://localhost/api/collections/c1/papers/p1", {
+            method: "DELETE",
+            headers: { Authorization: `Bearer ${await createTestJWT({ sub: "user-1" })}` },
+        }, env);
+        expect(res.status).toBe(403);
+        expect(await res.json()).toEqual({ error: "Forbidden" });
+    });
+
+    it("DELETE /api/collections/:id/papers/:paperId returns 404 when paper is not in collection", async () => {
+        queueSelectResponses([
+            { getResult: { id: "c1", ownerType: "user", ownerId: "user-1" } },
+        ]);
+        mockDb.delete = vi.fn().mockReturnValue({
+            where: vi.fn().mockResolvedValue({ meta: { changes: 0 } })
+        });
+        const app = await createTestApp();
+        const env = createTestEnv();
+        const res = await app.request("http://localhost/api/collections/c1/papers/p1", {
+            method: "DELETE",
+            headers: { Authorization: `Bearer ${await createTestJWT({ sub: "user-1" })}` },
+        }, env);
+        expect(res.status).toBe(404);
+        expect(await res.json()).toEqual({ error: "Paper not in collection" });
+    });
+
+    it("PATCH /api/collections/:id/papers returns 404 when collection not found", async () => {
+        queueSelectResponses([
+            { getResult: null }
+        ]);
+        const app = await createTestApp();
+        const env = createTestEnv();
+        const res = await app.request("http://localhost/api/collections/c1/papers", {
+            method: "PATCH",
+            headers: { Authorization: `Bearer ${await createTestJWT({ sub: "user-1" })}` },
+            body: JSON.stringify({ paper_ids: ["p1"] }),
+        }, env);
+        expect(res.status).toBe(404);
+        expect(await res.json()).toEqual({ error: "Collection not found" });
+    });
+
+    it("PATCH /api/collections/:id/papers returns 403 when forbidden", async () => {
+        queueSelectResponses([
+            { getResult: { id: "c1", ownerType: "user", ownerId: "user2" } }
+        ]);
+        const app = await createTestApp();
+        const env = createTestEnv();
+        const res = await app.request("http://localhost/api/collections/c1/papers", {
+            method: "PATCH",
+            headers: { Authorization: `Bearer ${await createTestJWT({ sub: "user-1" })}` },
+            body: JSON.stringify({ paper_ids: ["p1"] }),
+        }, env);
+        expect(res.status).toBe(403);
+        expect(await res.json()).toEqual({ error: "Forbidden" });
+    });
+
+    it("PATCH /api/collections/:id/papers returns 400 when missing existing papers", async () => {
+        queueSelectResponses([
+            { getResult: { id: "c1", ownerType: "user", ownerId: "user-1" } },
+            { allResult: [{ paperId: "p1" }, { paperId: "p2" }] }
+        ]);
+        const app = await createTestApp();
+        const env = createTestEnv();
+        const res = await app.request("http://localhost/api/collections/c1/papers", {
+            method: "PATCH",
+            headers: { Authorization: `Bearer ${await createTestJWT({ sub: "user-1" })}` },
+            body: JSON.stringify({ paper_ids: ["p1"] }),
+        }, env);
+        expect(res.status).toBe(400);
+        expect(await res.json()).toEqual({ error: "paper_ids must include all papers in collection" });
+    });
+
+    it("PATCH /api/collections/:id/papers returns 400 when paper not in collection", async () => {
+        queueSelectResponses([
+            { getResult: { id: "c1", ownerType: "user", ownerId: "user-1" } },
+            { allResult: [{ paperId: "p1" }] }
+        ]);
+        const app = await createTestApp();
+        const env = createTestEnv();
+        const res = await app.request("http://localhost/api/collections/c1/papers", {
+            method: "PATCH",
+            headers: { Authorization: `Bearer ${await createTestJWT({ sub: "user-1" })}` },
+            body: JSON.stringify({ paper_ids: ["p2"] }),
+        }, env);
+        expect(res.status).toBe(400);
+        expect(await res.json()).toEqual({ error: "paper_ids contains paper not in collection" });
+    });
+
+    it("PATCH /api/collections/:id/papers updates sort order successfully via batch", async () => {
+        queueSelectResponses([
+            { getResult: { id: "c1", ownerType: "user", ownerId: "user-1" } },
+            { allResult: [{ paperId: "p1" }, { paperId: "p2" }] }
+        ]);
+        mockDb.batch = vi.fn().mockResolvedValue([]);
+        mockDb.update = vi.fn().mockImplementation(() => ({ set: vi.fn().mockImplementation(() => ({ where: vi.fn().mockImplementation(() => ("UPDATE_STATEMENT")) })) }));
+        const app = await createTestApp();
+        const env = createTestEnv();
+        const res = await app.request("http://localhost/api/collections/c1/papers", {
+            method: "PATCH",
+            headers: { Authorization: `Bearer ${await createTestJWT({ sub: "user-1" })}` },
+            body: JSON.stringify({ paper_ids: ["p2", "p1"] }),
+        }, env);
+        expect(res.status).toBe(200);
+        expect(await res.json()).toEqual({ ok: true });
+        expect(mockDb.batch).toHaveBeenCalled();
+    });
+
+    it("GET /api/collections/:id/papers returns only user authored papers when some are restricted", async () => {
+        queueSelectResponses([
+            { getResult: { id: "c1", visibility: "public", ownerType: "user", ownerId: "u1" } },
+            { allResult: [{ id: "p1", visibility: "private" }, { id: "p2", visibility: "public" }] },
+            { allResult: [{ paperId: "p1" }] },
+            { allResult: [] },
+        ]);
+        const app = await createTestApp();
+        const env = createTestEnv();
+        const res = await app.request("http://localhost/api/collections/c1/papers", {
+            method: "GET",
+            headers: { Authorization: `Bearer ${await createTestJWT({ sub: "user-1" })}` },
+        }, env);
+        expect(res.status).toBe(200);
+        const data = await res.json();
+        expect(data.papers.length).toBe(2);
+        const ids = data.papers.map((p) => p.id);
+        expect(ids).toContain("p1");
+        expect(ids).toContain("p2");
+    });
+
+    it("GET /api/collections/:id/papers handles org_only visibility papers via membership", async () => {
+        queueSelectResponses([
+            { getResult: { id: "c1", visibility: "public", ownerType: "user", ownerId: "u1" } },
+            { allResult: [{ id: "p1", visibility: "org_only" }] },
+            { allResult: [] },
+            { allResult: [{ paperId: "p1" }] },
+        ]);
+        const app = await createTestApp();
+        const env = createTestEnv();
+        const res = await app.request("http://localhost/api/collections/c1/papers", {
+            method: "GET",
+            headers: { Authorization: `Bearer ${await createTestJWT({ sub: "user-1" })}` },
+        }, env);
+        expect(res.status).toBe(200);
+        const data = await res.json();
+        expect(data.papers.length).toBe(1);
+        expect(data.papers[0].id).toBe("p1");
+    });
+
+    it("GET /api/collections/:id/papers filters out private papers for authenticated users who don\'t have access", async () => {
+        queueSelectResponses([
+            { getResult: { id: "c1", visibility: "public", ownerType: "user", ownerId: "u1" } },
+            { allResult: [{ id: "p1", visibility: "private" }, { id: "p2", visibility: "public" }] },
+            { allResult: [] },
+            { allResult: [] },
+        ]);
+        const app = await createTestApp();
+        const env = createTestEnv();
+        const res = await app.request("http://localhost/api/collections/c1/papers", {
+            method: "GET",
+            headers: { Authorization: `Bearer ${await createTestJWT({ sub: "user-1" })}` },
+        }, env);
+        expect(res.status).toBe(200);
+        const data = await res.json();
+        expect(data.papers.length).toBe(1);
+        expect(data.papers[0].id).toBe("p2");
+    });
+
+    it("PATCH /api/collections/:id/papers rejects paper_ids with empty strings or non-strings", async () => {
+        queueSelectResponses([
+            { getResult: { id: "c1", ownerType: "user", ownerId: "user-1" } },
+        ]);
+        const app = await createTestApp();
+        const env = createTestEnv();
+        const res = await app.request("http://localhost/api/collections/c1/papers", {
+            method: "PATCH",
+            headers: { Authorization: `Bearer ${await createTestJWT({ sub: "user-1" })}` },
+            body: JSON.stringify({ paper_ids: ["p1", "  ", 123] }),
+        }, env);
+        expect(res.status).toBe(400);
+        expect(await res.json()).toEqual({ error: "paper_ids must be an array of non-empty strings" });
+    });
     it("POST /api/collections/:id/papers adds a visible paper with the next sort order", async () => {
         const token = await createTestJWT({ sub: "user-1" });
         const collection = {

--- a/apps/api/src/routes/__tests__/collections.test.ts
+++ b/apps/api/src/routes/__tests__/collections.test.ts
@@ -1056,7 +1056,6 @@ describe("collections routes", () => {
             { getResult: { id: "c1", visibility: "public", ownerType: "user", ownerId: "u1" } },
             { allResult: [{ id: "p1", visibility: "private" }, { id: "p2", visibility: "public" }] },
             { allResult: [{ paperId: "p1" }] },
-            { allResult: [] },
         ]);
         const app = await createTestApp();
         const env = createTestEnv();
@@ -1065,7 +1064,7 @@ describe("collections routes", () => {
             headers: { Authorization: `Bearer ${await createTestJWT({ sub: "user-1" })}` },
         }, env);
         expect(res.status).toBe(200);
-        const data = await res.json();
+        const data = (await res.json()) as { papers: Array<{ id: string }> };
         expect(data.papers.length).toBe(2);
         const ids = data.papers.map((p) => p.id);
         expect(ids).toContain("p1");
@@ -1086,7 +1085,7 @@ describe("collections routes", () => {
             headers: { Authorization: `Bearer ${await createTestJWT({ sub: "user-1" })}` },
         }, env);
         expect(res.status).toBe(200);
-        const data = await res.json();
+        const data = (await res.json()) as { papers: Array<{ id: string }> };
         expect(data.papers.length).toBe(1);
         expect(data.papers[0].id).toBe("p1");
     });
@@ -1104,7 +1103,7 @@ describe("collections routes", () => {
             headers: { Authorization: `Bearer ${await createTestJWT({ sub: "user-1" })}` },
         }, env);
         expect(res.status).toBe(200);
-        const data = await res.json();
+        const data = (await res.json()) as { papers: Array<{ id: string }> };
         expect(data.papers.length).toBe(1);
         expect(data.papers[0].id).toBe("p2");
     });


### PR DESCRIPTION
Adds unit tests to `apps/api/src/routes/__tests__/collections.test.ts` to cover error handling paths, unique constraints, and org specific permission logic that were previously uncovered. This brings statement and branch coverage in `collections.ts` up to ~99% / 89% respectively.

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

このPRは `collections.ts` ルートのテストカバレッジを大幅に拡充し、エラーハンドリング（400/403/404/409/500）、org 権限ロジック、ペーパーフィルタリング、ソート順一括更新など未カバーだったパスを網羅しています。テスト自体の品質面では、2つのテストで無効な visibility 値 `\"member\"` が使われているほか、未使用のモックレスポンスと重複テストがいくつか見られます。
</details>

<details open><summary><h3>Confidence Score: 4/5</h3></summary>

テストのみの変更でプロダクションコードへの影響なし。P2 のみのため安全にマージ可能。

P2 が複数あるが P0/P1 は存在しない。新規テストはいずれも誤った動作を許容するものではなく、カバレッジ向上に実質的に貢献している。

apps/api/src/routes/__tests__/collections.test.ts（visibility "member" の修正、重複テストの整理、余分なモックレスポンスの削除）
</details>

<details open><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| apps/api/src/routes/__tests__/collections.test.ts | コレクションルートのユニットテストを大幅拡充（185行→648行追加）。エラーハンドリング、権限制御、org コレクションなど多数のパスをカバー。無効な visibility 値（"member"）の使用、未使用モックレスポンス、重複テストの3点が要改善。 |

</details>

</details>

<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[新規テストケース群] --> B{エンドポイント}

    B --> C[POST /collections]
    B --> D[GET /collections/:id]
    B --> E[PATCH /collections/:id]
    B --> F[DELETE /collections/:id]
    B --> G[GET /users/:id/collections]
    B --> H[GET /orgs/:slug/collections]
    B --> I[POST /collections/:id/papers]
    B --> J[DELETE /collections/:id/papers/:paperId]
    B --> K[PATCH /collections/:id/papers]
    B --> L[GET /collections/:id/papers]

    C --> C1[owner_type バリデーション]
    C --> C2[name/slug/description バリデーション]
    C --> C3[visibility バリデーション]
    C --> C4[org オーナー取得 org_slug/owner_id]
    C --> C5[UNIQUE制約エラー → 409]
    C --> C6[一般DBエラー → 500]

    D --> D1[無効トークン → 公開コレクションは200]
    D --> D2[private org → 非adminは404]
    D --> D3[org_only → memberは200]

    E --> E1[404 not found]
    E --> E2[403 forbidden user/org]
    E --> E3[400 invalid JSON/fields]
    E --> E4[409 slug重複]
    E --> E5[500 一般エラー]

    K --> K1[400 missing/extra paper_ids]
    K --> K2[200 batch sort order更新]

    L --> L1[private paper → author/org_onlyでフィルタ]
```

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 4 code review issues. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 4
apps/api/src/routes/__tests__/collections.test.ts:151-178
**無効な `visibility` 値を使用している**

2つのテスト（lines 151–163, 165–178）のモックデータに `visibility: "member"` が設定されていますが、プロダクションコードの `VALID_VISIBILITY = ["public", "org_only", "private"]` にこの値は存在しません。本来テストしたいのは `"org_only"` コレクションに対する org メンバーのアクセス制御のはずです。

現状のコードは `canViewCollection` 内で `"public"` でも `"private"` でもない場合のフォールスルーが `isOrgMember(...)` を呼ぶため、偶然にテストが通ります。しかし将来プロダクションコードが有効な visibility 値のみを明示的に処理するよう変更された場合、テストが意図しない方向で壊れる可能性があります。

同様に 165–178 行目の `visibility: "member"` も `"org_only"` に変更してください。

```suggestion
            { getResult: { id: "c1", ownerType: "org", ownerId: "org1", visibility: "org_only" } },
```

### Issue 2 of 4
apps/api/src/routes/__tests__/collections.test.ts:906-919
**既存テストと重複している**

この `"handles invalid JSON body"` テスト（line 906–919）は、842行目に既存の `"POST /api/collections/:id/papers rejects invalid JSON"` テストとまったく同じコードパス（コレクション取得→権限チェック→JSON パース失敗→400）を検証しています。意図的に追加されたものであれば問題ありませんが、カバレッジ向上を意図して追加したなら削除を検討してください。

### Issue 3 of 4
apps/api/src/routes/__tests__/collections.test.ts:1085-1104
**未使用のモックレスポンスがキューされている**

4番目の `{ allResult: [] }` は実際には消費されません。`restrictedRows` には `{ id: "p1", visibility: "private" }` の1件のみが含まれ、`orgOnlyIds` は空（`"private"` は `"org_only"` ではない）となるため、プロダクションコードの `if (orgOnlyIds.length > 0)` ガードにより4回目の `select()` は呼ばれません。この余分なキューはテストの読者を混乱させます。削除して3つのレスポンスに整理してください。

```suggestion
        queueSelectResponses([
            { getResult: { id: "c1", visibility: "public", ownerType: "user", ownerId: "u1" } },
            { allResult: [{ id: "p1", visibility: "private" }, { id: "p2", visibility: "public" }] },
            { allResult: [{ paperId: "p1" }] },
        ]);
```

### Issue 4 of 4
apps/api/src/routes/__tests__/collections.test.ts:1034-1048
**既存テストと重複している**

このテスト（line 1034–1048）は 1393–1429 行目の `"requires every existing paper to be included"` と同一のコードパスを検証しています（`paperIds.length !== existingRows.length` → 400 `"paper_ids must include all papers in collection"`）。削除してもカバレッジへの影響はありません。

`````

</details>

<sub>Reviews (1): Last reviewed commit: ["test: add missing tests to collections.t..."](https://github.com/hiroki-org/openshelf/commit/77bebc5535420dcebfca23d3217e8dee927caf09) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=30418618)</sub>

> Greptile also left **4 inline comments** on this PR.

<!-- /greptile_comment -->