### PR TITLE
🧹 refactor(api): improve authorizePaperAccess type safety and avoid as any casting

### DIFF
--- a/apps/api/src/routes/papers.ts
+++ b/apps/api/src/routes/papers.ts
@@ -1,4 +1,5 @@
 import { Hono, type Context } from "hono";
+import type { ContentfulStatusCode } from "hono/utils/http-status";
 import { drizzle } from "drizzle-orm/d1";
 import { eq, and, gte, sql } from "drizzle-orm";
 import {
@@ -341,7 +342,7 @@ async function authorizePaperAccess(
     c: Context<{ Bindings: Env; Variables: Variables }>,
     db: ReturnType<typeof drizzle>,
     paper: { visibility: string; id: string },
-) {
+): Promise<{ ok: true; user?: { sub: string } } | { ok: false; status: ContentfulStatusCode; error: string }> {
     if (paper.visibility === "public") return { ok: true };
 
     const authHeader = c.req.header("Authorization");
@@ -781,7 +782,7 @@ papersRoute.get("/:id", async (c) => {
 
     const access = await authorizePaperAccess(c, db, paper);
     if (!access.ok) {
-        return c.json({ error: access.error }, access.status as any);
+        return c.json({ error: access.error }, access.status);
     }
 
     const [rawFiles, authors] = (await db.batch([
@@ -856,7 +857,7 @@ papersRoute.get("/:id/cite", async (c) => {
 
     const access = await authorizePaperAccess(c, db, paper);
     if (!access.ok) {
-        return c.json({ error: access.error }, access.status as any);
+        return c.json({ error: access.error }, access.status);
     }
 
     const authors = await db
@@ -917,7 +918,7 @@ papersRoute.post("/:id/track", async (c) => {
 
     const access = await authorizePaperAccess(c, db, paper);
     if (!access.ok) {
-        return c.json({ error: access.error }, access.status as any);
+        return c.json({ error: access.error }, access.status);
     }
 
     if (isBotUserAgent(c.req.header("User-Agent"))) {
@@ -1038,7 +1039,7 @@ papersRoute.get("/:id/files/:fileId/download", async (c) => {
 
     const access = await authorizePaperAccess(c, db, paper);
     if (!access.ok) {
-        return c.json({ error: access.error }, access.status as any);
+        return c.json({ error: access.error }, access.status);
     }
 
     const file = await db
@@ -1084,7 +1085,7 @@ papersRoute.get("/:id/files/:fileId/preview", async (c) => {
 
     const access = await authorizePaperAccess(c, db, paper);
     if (!access.ok) {
-        return c.json({ error: access.error }, access.status as any);
+        return c.json({ error: access.error }, access.status);
     }
 
     const file = await db
@@ -1119,7 +1120,7 @@ papersRoute.get("/:id/files/:fileId/stream", async (c) => {
 
     const access = await authorizePaperAccess(c, db, paper);
     if (!access.ok) {
-        return c.json({ error: access.error }, access.status as any);
+        return c.json({ error: access.error }, access.status);
     }
 
     const file = await db

--- a/package-lock.json
+++ b/package-lock.json
@@ -21,7 +21,6 @@
         "@vitest/coverage-v8": "^3.2.4",
         "babel-plugin-react-compiler": "1.0.0",
         "eslint": "^10.2.1",
-        "postcss": "^8.5.12",
         "typescript": "^6.0.3",
         "vitest": "^3.2.4"
       }
@@ -37,7 +36,7 @@
       "devDependencies": {
         "@cloudflare/workers-types": "^4.20260426.1",
         "@codspeed/vitest-plugin": "^5.3.0",
-        "drizzle-kit": "1.0.0-beta.23",
+        "drizzle-kit": "^1.0.0-beta.23",
         "typescript": "^6.0.3",
         "vitest": "^3.2.4",
         "wrangler": "^4.85.0"
@@ -92,7 +91,6 @@
         "eslint": "^10",
         "eslint-config-next": "16.2.4",
         "jsdom": "^27.0.1",
-        "postcss": "^8.5.12",
         "tailwindcss": "^4.2.3",
         "typescript": "^6",
         "vitest": "^3.2.4"

--- a/package-lock.json
+++ b/package-lock.json
@@ -21,6 +21,7 @@
         "@vitest/coverage-v8": "^3.2.4",
         "babel-plugin-react-compiler": "1.0.0",
         "eslint": "^10.2.1",
+        "postcss": "^8.5.12",
         "typescript": "^6.0.3",
         "vitest": "^3.2.4"
       }
@@ -36,7 +37,7 @@
       "devDependencies": {
         "@cloudflare/workers-types": "^4.20260426.1",
         "@codspeed/vitest-plugin": "^5.3.0",
-        "drizzle-kit": "^1.0.0-beta.23",
+        "drizzle-kit": "1.0.0-beta.23",
         "typescript": "^6.0.3",
         "vitest": "^3.2.4",
         "wrangler": "^4.85.0"
@@ -91,6 +92,7 @@
         "eslint": "^10",
         "eslint-config-next": "16.2.4",
         "jsdom": "^27.0.1",
+        "postcss": "^8.5.12",
         "tailwindcss": "^4.2.3",
         "typescript": "^6",
         "vitest": "^3.2.4"


### PR DESCRIPTION
🎯 **What:** 
The code health issue addressed is the duplicated `as any` casting for the error response status codes in the numerous locations `authorizePaperAccess` is used in `apps/api/src/routes/papers.ts`.

💡 **Why:** 
By updating the return type of `authorizePaperAccess` to explicitly specify the return values, specifically `{ ok: false; status: ContentfulStatusCode; error: string }`, the use of `as any` casting becomes unnecessary. This comprehensive typing improves code health by ensuring type-safety in JSON response status codes without needing unsafe `any` casts.

✅ **Verification:** 
I successfully validated this change by:
- Running type checks across the API workspace (`npm run typecheck -w apps/api`) and verifying they complete without failures related to these return types.
- Running unit tests to ensure that these type-level modifications didn't break any functionality or introduce systemic regressions (`npm run test --workspaces`).

✨ **Result:** 
The codebase has fewer usages of `as any`, and `authorizePaperAccess` return values correctly flow into standard API endpoint responses using explicit, expected status code typings.

---
*PR created automatically by Jules for task [10493933051642258872](https://jules.google.com/task/10493933051642258872) started by @is0692vs*

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

本PRは、`authorizePaperAccess` の戻り値の型を明示的に定義し（`{ ok: false; status: ContentfulStatusCode; error: string }`）、`papers.ts` 内で6箇所使われていた `as any` キャストを除去するリファクタリングです。型安全性の向上のみを目的とした変更であり、実行時の動作に影響はありません。

`package-lock.json` にも `postcss` の追加と `drizzle-kit` バージョンのキャレット削除が含まれていますが、これらは既存の `package.json` に合わせたロックファイルの同期であり、問題はありません。
</details>

<details open><summary><h3>Confidence Score: 5/5</h3></summary>

このPRはマージして安全です。型レベルのみの変更であり、実行時の動作への影響はありません。

変更は `authorizePaperAccess` の戻り型への明示的な型注釈追加と、それに伴う `as any` キャストの除去のみです。実際に返されるステータスコード（401・403）はいずれも `ContentfulStatusCode` として有効であり、動作ロジックの変更は一切ありません。

特に注意が必要なファイルはありません。
</details>

<details open><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| apps/api/src/routes/papers.ts | `authorizePaperAccess` の戻り型に `ContentfulStatusCode` を明示し、6箇所の `as any` キャストを除去。型安全性の向上のみで、実行時ロジックへの影響なし。 |
| package-lock.json | `postcss` の devDependency 追加と `drizzle-kit` のバージョン固定（`^` 削除）を反映したロックファイルの同期。既存の `package.json` との整合性を取るための変更。 |

</details>

</details>

<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[APIエンドポイント呼び出し] --> B[authorizePaperAccess]
    B --> C{paper.visibility === 'public'?}
    C -- Yes --> D["{ ok: true }"]
    C -- No --> E{AuthorizationヘッダーあるBearerトークン?}
    E -- No --> F["{ ok: false, status: 401, error: 'Unauthorized' }"]
    E -- Yes --> G{JWTトークン検証}
    G -- 失敗 --> H["{ ok: false, status: 401, error: 'Invalid token' }"]
    G -- 成功 --> I{論文の著者?}
    I -- Yes --> J["{ ok: true, user }"]
    I -- No --> K{visibility === 'private'?}
    K -- Yes --> L["{ ok: false, status: 403, error: 'Forbidden' }"]
    K -- No --> M{visibility === 'org_only'?}
    M -- Yes --> N{組織メンバー?}
    N -- No --> O["{ ok: false, status: 403, error: 'Forbidden' }"]
    N -- Yes --> P["{ ok: true, user }"]
    M -- No --> Q["{ ok: false, status: 403, error: 'Forbidden' }"]
    D & J & P --> R["c.json(...) — as any 不要に"]
    F & H & L & O & Q --> S["c.json(error, status) — ContentfulStatusCode で型安全"]
```

<sub>Reviews (1): Last reviewed commit: ["refactor(api): use ContentfulStatusCode ..."](https://github.com/hiroki-org/openshelf/commit/10b938936ce71e2934a74beec44b82998f834c80) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=30418808)</sub>

<!-- /greptile_comment -->