### PR TITLE
fix: align test error message + update OSV auto-fix action

### DIFF
--- a/.github/workflows/osv-auto-fix.yml
+++ b/.github/workflows/osv-auto-fix.yml
@@ -51,7 +51,7 @@ jobs:
           fi
 
       - name: Create Pull Request
-        uses: peter-evans/create-pull-request@67df0571927e887e4d593f7a4b15a4b86b8d4fac # v6.0.6
+        uses: peter-evans/create-pull-request@5f6978faf089d4d20b00c7766989d076bb2fc7f1 # v8.1.1
         with:
           token: ${{ secrets.OSV_AUTO_FIX_TOKEN || secrets.SYNC_PR_TOKEN }}
           commit-message: "chore(security): fix vulnerabilities detected by OSV-Scanner"

--- a/apps/api/src/routes/__tests__/collections.test.ts
+++ b/apps/api/src/routes/__tests__/collections.test.ts
@@ -1120,7 +1120,7 @@ describe("collections routes", () => {
             body: JSON.stringify({ paper_ids: ["p1", "  ", 123] }),
         }, env);
         expect(res.status).toBe(400);
-        expect(await res.json()).toEqual({ error: "paper_ids must be an array of non-empty strings" });
+        expect(await res.json()).toEqual({ error: "paper_ids must be an array of valid strings" });
     });
     it("POST /api/collections/:id/papers adds a visible paper with the next sort order", async () => {
         const token = await createTestJWT({ sub: "user-1" });


### PR DESCRIPTION
## Changes

### 1. Fix Test API CI failure (PR #619 blocker)
- **File**: `apps/api/src/routes/__tests__/collections.test.ts`
- The route handler uses `normalizePaperId` which returns `"paper_ids must be an array of valid strings"`, but the test expected the old message `"paper_ids must be an array of non-empty strings"`.
- Updated the test expectation to match the actual API response.

### 2. Fix OSV Auto Fix workflow
- **File**: `.github/workflows/osv-auto-fix.yml`
- The `peter-evans/create-pull-request` action was pinned to commit `67df0571...` (v6.0.6) which no longer exists in the upstream repo, causing all runs to fail with `unable to find version`.
- Updated to v8.1.1 (SHA `5f6978f`), the latest stable release.

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

このPRはCI失敗を引き起こしていた2つの問題を修正します。テストの期待エラーメッセージを実装の実際の出力（`normalizePaperId` が返す文字列）に合わせ、OSV自動修正ワークフローで参照できなくなっていたアクションのSHAを最新安定版（v8.1.1）に更新しています。
</details>

<details open><summary><h3>Confidence Score: 5/5</h3></summary>

このPRは安全にマージできます。

変更は2件のみで、どちらも単純な修正です。テストのエラーメッセージは実装コード（collections.ts:641）と一致することを確認済み、peter-evans/create-pull-request の SHA は GitHub リリースページで v8.1.1 と一致することを確認済みです。

特に注意が必要なファイルはありません。
</details>

<details open><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| apps/api/src/routes/__tests__/collections.test.ts | テストの期待値を実装の実際のエラーメッセージ「paper_ids must be an array of valid strings」に合わせて修正。変更は正確で、collections.ts の実装と一致している。 |
| .github/workflows/osv-auto-fix.yml | peter-evans/create-pull-request を v6.0.6 (存在しないコミット SHA) から v8.1.1 (SHA: 5f6978f、GitHub にて確認済み) に更新。 |

</details>

</details>

<sub>Reviews (1): Last reviewed commit: ["fix(ci): update peter-evans/create-pull-..."](https://github.com/hiroki-org/openshelf/commit/3e1fbbe3c7c5d20e0618ac00e68d5a9839123992) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=30446304)</sub>

<!-- /greptile_comment -->