### PR TITLE
fix: resolve open issues #621, #622, #623, #572, #573

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -28,11 +28,14 @@ updates:
     directory: "/"
     schedule:
       interval: "weekly"
+    open-pull-requests-limit: 4
     commit-message:
       prefix: "chore"
       include: "scope"
     groups:
-      github-actions-minor-patch:
+      # github-actions ecosystem does not support update-types filtering,
+      # so this group captures ALL version bumps (including major).
+      github-actions-all:
         patterns:
           - "**"
   - package-ecosystem: "docker"
@@ -41,6 +44,7 @@ updates:
       - "/apps/web"
     schedule:
       interval: "weekly"
+    open-pull-requests-limit: 4
     commit-message:
       prefix: "chore"
       include: "scope"

--- a/apps/api/src/routes/collections.ts
+++ b/apps/api/src/routes/collections.ts
@@ -15,11 +15,11 @@ import {
 } from "../db/schema";
 import { authMiddleware } from "../middleware/auth";
 import type { Env, Variables } from "../types";
+import { ID_MAX_LENGTH } from "../utils/constants";
 
 const collectionsRoute = new Hono<{ Bindings: Env; Variables: Variables }>();
 const SLUG_RE = /^[a-z0-9][a-z0-9-]*[a-z0-9]$|^[a-z0-9]$/;
 const VALID_VISIBILITY = ["public", "org_only", "private"] as const;
-const ID_MAX_LENGTH = 128;
 
 type Visibility = (typeof VALID_VISIBILITY)[number];
 type CurrentUser = { id: string } | null;
@@ -221,7 +221,8 @@ collectionsRoute.post("/collections", authMiddleware, async (c) => {
     slug?: unknown;
     description?: unknown;
     visibility?: unknown;
-    owner_org_id?: unknown;
+    org_slug?: unknown;
+    owner_id?: unknown;
   };
   const payload = body as CreateCollectionBody;
 
@@ -252,12 +253,12 @@ collectionsRoute.post("/collections", authMiddleware, async (c) => {
   let ownerOrgSlug: string | null = null;
   if (ownerType === "org") {
     const inputOrgSlug =
-      typeof (body as any)?.org_slug === "string"
-        ? (body as any).org_slug.trim().toLowerCase()
+      typeof payload.org_slug === "string"
+        ? payload.org_slug.trim().toLowerCase()
         : "";
     const inputOwnerId =
-      typeof (body as any)?.owner_id === "string"
-        ? (body as any).owner_id.trim()
+      typeof payload.owner_id === "string"
+        ? payload.owner_id.trim()
         : "";
 
     let org = null;
@@ -286,10 +287,10 @@ collectionsRoute.post("/collections", authMiddleware, async (c) => {
       ownerType,
       ownerId,
       orgSlug: ownerOrgSlug,
-      name: ((body as any).name as string).trim(),
+      name: (payload.name as string).trim(),
       slug,
-      description: (body as any)?.description
-        ? ((body as any).description as string).trim()
+      description: payload.description
+        ? (payload.description as string).trim()
         : null,
       visibility,
     });
@@ -371,7 +372,7 @@ collectionsRoute.patch("/collections/:id", authMiddleware, async (c) => {
   if (payload.slug !== undefined) {
     const e = validateSlug(payload.slug);
     if (e) return c.json({ error: e }, 400);
-    updates.slug = ((body as any).slug as string).trim().toLowerCase();
+    updates.slug = (payload.slug as string).trim().toLowerCase();
   }
 
   if (payload.description !== undefined) {
@@ -383,10 +384,10 @@ collectionsRoute.patch("/collections/:id", authMiddleware, async (c) => {
   }
 
   if (payload.visibility !== undefined) {
-    if (!VALID_VISIBILITY.includes((body as any).visibility)) {
+    if (!VALID_VISIBILITY.includes(payload.visibility as any)) {
       return c.json({ error: "Invalid visibility" }, 400);
     }
-    updates.visibility = (body as any).visibility;
+    updates.visibility = payload.visibility;
   }
 
   if (Object.keys(updates).length === 0) {

--- a/apps/api/src/routes/orgs.ts
+++ b/apps/api/src/routes/orgs.ts
@@ -17,11 +17,11 @@ import {
 import type { Env, JwtPayload, Variables } from "../types";
 import { authMiddleware } from "../middleware/auth";
 import { parseStoredTags } from "../utils/tags";
+import { ID_MAX_LENGTH } from "../utils/constants";
 
 const orgsRoute = new Hono<{ Bindings: Env; Variables: Variables }>();
 const ORG_TAGS_LIMIT = 100;
 const ORG_PAPERS_PAGE_SIZE = 20;
-const ID_MAX_LENGTH = 128;
 
 function normalizeFilterValue(value: string | undefined): string | null {
   if (typeof value !== "string") return null;

--- a/apps/api/src/utils/constants.ts
+++ b/apps/api/src/utils/constants.ts
@@ -1,0 +1,6 @@
+/**
+ * Shared constants used across multiple route modules.
+ */
+
+/** Maximum length for entity IDs (papers, collections, orgs, etc.). */
+export const ID_MAX_LENGTH = 128;


### PR DESCRIPTION
## Summary
Resolves 5 open issues in a single PR.

### Code Health: Type safety in collections.ts (#621, #622, #623)

- **#621** — `ID_MAX_LENGTH` was duplicated in `collections.ts` and `orgs.ts`. Extracted to `apps/api/src/utils/constants.ts` as a shared module.
- **#622** — PATCH `/collections/:id` used `(body as any).slug` and `(body as any).visibility` instead of the typed `payload.*`. Replaced all casts with proper typed access.
- **#623** — `CreateCollectionBody` had an incorrect `owner_org_id` field instead of the actually-used `org_slug` and `owner_id`. Fixed the type, and replaced all `(body as any)` casts in POST `/collections` with typed `payload.*` access.

### Dependabot configuration (#572, #573)

- **#572** — Added `open-pull-requests-limit: 4` to `github-actions` and `docker` ecosystems (was only set for npm).
- **#573** — Renamed misleading `github-actions-minor-patch` group to `github-actions-all` with an explanatory comment, since the github-actions ecosystem does not support `update-types` filtering.

## Validation
- `npm run typecheck` ✅
- `npm run test` — 501 tests passed ✅

Closes #621, closes #622, closes #623, closes #572, closes #573

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

このPRは5つのオープンイシューをまとめて修正します。`collections.ts` の型定義ミス（`owner_org_id` → `org_slug` + `owner_id`）と `(body as any)` キャストを型付き `payload` アクセスへ統一し、重複していた `ID_MAX_LENGTH` 定数を `utils/constants.ts` に集約。Dependabot 設定では `github-actions` と `docker` エコシステムへの `open-pull-requests-limit` 追加と、誤解を招くグループ名のリネームが行われています。いずれの変更も正確で、501テスト・型チェックが通過しています。
</details>

<details open><summary><h3>Confidence Score: 5/5</h3></summary>

特段の問題なし。マージ可能。

P0・P1 相当の問題は見当たらない。型修正はロジックと一致しており、定数の共通化も正確。501テスト・型チェックいずれも通過。

特に注意が必要なファイルはありません。
</details>

<details open><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| apps/api/src/utils/constants.ts | ID_MAX_LENGTH を共有定数として抽出した新規ファイル。シンプルで正しい実装。 |
| apps/api/src/routes/collections.ts | CreateCollectionBody の型修正 (owner_org_id → org_slug + owner_id)、(body as any) キャストを型付き payload アクセスに置換。修正内容は正確。 |
| apps/api/src/routes/orgs.ts | ローカル ID_MAX_LENGTH を削除し共有定数をインポート。単純かつ正しいリファクタリング。 |
| .github/dependabot.yml | github-actions と docker エコシステムに open-pull-requests-limit: 4 を追加、誤解を招くグループ名を修正。 |

</details>

</details>

<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[POST /collections] --> B[body をパース]
    B --> C{payload.owner_type?}
    C -- user --> D[validateName / validateSlug / validateDescription]
    C -- org --> E[payload.org_slug / payload.owner_id で org を解決]
    E --> F{org 存在?}
    F -- No --> G[404 Org not found]
    F -- Yes --> H{isOrgAdmin?}
    H -- No --> I[403 Forbidden]
    H -- Yes --> D
    D --> J[collections.insert]

    K[PATCH /collections/:id] --> L[body をパース]
    L --> M{payload.slug?}
    M -- defined --> N[validateSlug → payload.slug as string .trim]
    L --> O{payload.visibility?}
    O -- defined --> P[VALID_VISIBILITY.includes validation → updates.visibility = payload.visibility]
    N --> Q[db.update collections]
    P --> Q

    R[apps/api/src/utils/constants.ts] -- export ID_MAX_LENGTH=128 --> S[collections.ts]
    R -- export ID_MAX_LENGTH=128 --> T[orgs.ts]
```

<sub>Reviews (1): Last reviewed commit: ["fix: resolve open issues #621, #622, #62..."](https://github.com/hiroki-org/openshelf/commit/e1f74bd407bf1aeec1ac28e2bcca620ce8df611e) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=30446765)</sub>

<!-- /greptile_comment -->