### PR TITLE
fix(api): prevent empty author string in Atom feed when authors list is empty

### DIFF
--- a/apps/api/src/routes/feed.ts
+++ b/apps/api/src/routes/feed.ts
@@ -205,11 +205,13 @@ function buildAtomFeed(meta: FeedMeta, entries: FeedEntry[]): string {
         lines.push(`    <published>${escapeXml(entry.published)}</published>`);
         lines.push(`    <updated>${escapeXml(entry.updated)}</updated>`);
         lines.push(`    <summary>${escapeXml(entry.summary)}</summary>`);
-        lines.push(
-            entry.authors
-                .map((author) => `    <author><name>${escapeXml(author)}</name></author>`)
-                .join("\n")
-        );
+        if (entry.authors.length > 0) {
+            lines.push(
+                entry.authors
+                    .map((author) => `    <author><name>${escapeXml(author)}</name></author>`)
+                    .join("\n")
+            );
+        }
         if (entry.category) {
             lines.push(`    <category term="${escapeXml(entry.category)}"/>`);
         }


### PR DESCRIPTION
Fixes #634

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

著者リストが空の場合に `buildAtomFeed` が空文字列を `lines` に push してしまう問題を修正するシンプルな変更です。`entry.authors.length > 0` によるガード追加により、不要な空行が Atom XML に混入するのを防ぎます。なお、実際の呼び出しパス (`buildPaperEntries`) では `entryAuthors = authors.length > 0 ? authors : [fallback]` によってフォールバック著者が設定されるため、`entry.authors` が空になることは現時点ではありません。今回の修正は `buildAtomFeed` を単体で呼び出す将来のコードに対しても有効な防御的実装です。
</details>

<details open><summary><h3>Confidence Score: 5/5</h3></summary>

マージ安全。変更は小さく、既存の動作を壊すリスクはありません。

修正は正確で副作用がなく、P1/P0 の問題は見当たりません。実際の呼び出しパスでは著者が空になることはないため、ランタイムの挙動変化は軽微（空行の除去のみ）です。

特に注意が必要なファイルはありません。
</details>

<details open><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| apps/api/src/routes/feed.ts | `buildAtomFeed` の著者リストが空のとき空文字列を push しないよう guard を追加。実際には `buildPaperEntries` がフォールバックを設定するため空になることはないが、防御的な修正として適切。 |

</details>

</details>

<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant Client
    participant feedRoute
    participant buildFeedResponse
    participant buildPaperEntries
    participant buildAtomFeed

    Client->>feedRoute: GET /orgs/:slug/atom.xml
    feedRoute->>buildFeedResponse: buildOrgFeedResponse(c, slug)
    buildFeedResponse->>buildPaperEntries: papersRows, authorsByPaperId, fallbackAuthorName
    Note over buildPaperEntries: entryAuthors = authors.length > 0 ? authors : [fallback]
    buildPaperEntries-->>buildFeedResponse: entries (authors always non-empty)
    buildFeedResponse->>buildAtomFeed: meta, entries
    Note over buildAtomFeed: Fixed: only push author elements when authors.length > 0
    buildAtomFeed-->>buildFeedResponse: XML string
    buildFeedResponse-->>Client: 200 application/atom+xml
```

<sub>Reviews (1): Last reviewed commit: ["fix(api): prevent empty author string in..."](https://github.com/hiroki-org/openshelf/commit/682afb034718f2d74ab2bcfb4ca4dabd35a713d7) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=30541686)</sub>

<!-- /greptile_comment -->