### PR TITLE
fix(ci): fix dependabot CI failures

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,7 +24,7 @@ jobs:
       - uses: actions/checkout@v6
       - uses: actions/setup-node@v6
         with:
-          node-version: 20
+          node-version: 22
           cache: npm
       - run: npm ci
       - name: Lint
@@ -36,7 +36,7 @@ jobs:
       - uses: actions/checkout@v6
       - uses: actions/setup-node@v6
         with:
-          node-version: 20
+          node-version: 22
           cache: npm
       - run: npm ci
       - name: Type Check
@@ -48,7 +48,7 @@ jobs:
       - uses: actions/checkout@v6
       - uses: actions/setup-node@v6
         with:
-          node-version: 20
+          node-version: 22
           cache: npm
       - run: npm ci
       - name: Test
@@ -74,7 +74,7 @@ jobs:
       - uses: actions/checkout@v6
       - uses: actions/setup-node@v6
         with:
-          node-version: 20
+          node-version: 22
           cache: npm
       - run: npm ci
       - name: Test
@@ -142,7 +142,7 @@ jobs:
       - uses: actions/checkout@v6
       - uses: actions/setup-node@v6
         with:
-          node-version: 20
+          node-version: 22
           cache: npm
       - run: npm ci
       - name: Build web app
@@ -166,7 +166,7 @@ jobs:
       - uses: actions/checkout@v6
       - uses: actions/setup-node@v6
         with:
-          node-version: 20
+          node-version: 22
           cache: npm
       - name: Install dependencies
         run: npm ci
@@ -222,7 +222,7 @@ jobs:
       - uses: actions/checkout@v6
       - uses: actions/setup-node@v6
         with:
-          node-version: 20
+          node-version: 22
           cache: npm
       - run: npm ci
       - name: Detect benchmark-relevant changes

--- a/.github/workflows/deploy-api.yml
+++ b/.github/workflows/deploy-api.yml
@@ -19,7 +19,7 @@ jobs:
       - uses: actions/checkout@v6
       - uses: actions/setup-node@v6
         with:
-          node-version: 20
+          node-version: 22
       - run: npm ci
       - name: Apply D1 migrations
         working-directory: apps/api

--- a/.github/workflows/osv-auto-fix.yml
+++ b/.github/workflows/osv-auto-fix.yml
@@ -26,7 +26,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v6
         with:
-          node-version: 20
+          node-version: 22
           cache: 'npm'
 
       - name: Fix NPM vulnerabilities


### PR DESCRIPTION
Fixes #633

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

Dependabot が更新したパッケージ（主に jsdom v29）が Node 22 を要求していたため CI が失敗していた問題を修正します。全 GitHub Actions ワークフローの `node-version` を `20` から `22` に揃え、ルート `package.json` に `jsdom@^29.1.1` を追加、`drizzle-kit` のプレリリースバージョンからキャレットを外して正確な固定にしています。

- `apps/web/package.json` の jsdom は `^27.0.1` のままで、ルートの v29 と非対称になっています。テスト環境を統一する場合は `apps/web` 側も更新が必要です。
- jsdom@29 の engines 要件が `^22.13.0` のため、`node-version: 22` でわずかに古い Node 22 が選ばれた場合に警告が出る可能性があります。
</details>


<details open><summary><h3>Confidence Score: 4/5</h3></summary>

CI の根本原因（Node バージョン不足）は正しく修正されており、マージは安全です。jsdom バージョンの非対称は P2 の懸念事項のみです。

P2 の指摘が2件あるのみで P0/P1 の問題はなし。CI 修正としての目的は達成されています。

apps/web/package.json（jsdom バージョンの更新を検討）
</details>


<details open><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| .github/workflows/ci.yml | 全7ジョブで Node.js バージョンを 20 → 22 に統一更新。変更は機械的で問題なし。 |
| .github/workflows/deploy-api.yml | deploy ジョブの Node.js バージョンを 20 → 22 に更新。`cache: npm` は元から存在せず、回帰なし。 |
| .github/workflows/osv-auto-fix.yml | Setup Node.js ステップの Node.js バージョンを 20 → 22 に更新。問題なし。 |
| package.json | ルートに `jsdom@^29.1.1` を追加。apps/web の `^27.0.1` と非対称になり、2バージョンが共存する。 |
| package-lock.json | jsdom@29.1.1（root）と jsdom@27.4.0（apps/web ネスト）が共存。drizzle-kit のキャレット削除、各種パッチバージョン更新を含む。 |

</details>


</details>


<!-- greptile_failed_comments -->
<details open><summary><h3>Comments Outside Diff (1)</h3></summary>

1. `package-lock.json`, line 402-404 ([link](https://github.com/hiroki-org/openshelf/blob/84ee3bbba9e9b981d2e362185d151236500241bc/package-lock.json#L402-L404)) 

   <a href="#"><img alt="P2" src="https://greptile-static-assets.s3.amazonaws.com/badges/p2.svg?v=7" align="top"></a> **jsdom@29.1.1 の engines が Node `^22.13.0` を要求**

   `node_modules/jsdom@29.1.1` のエンジン要件は `"node": "^20.19.0 || ^22.13.0 || >=24.0.0"` です。CI では `node-version: 22` を指定していますが、これは Node 22 系の最新版がインストールされる保証であり、`22.13.0` 未満の旧マイナーが選ばれた場合は npm の engines 警告が発生する可能性があります。`node-version: 22.13` または `node-version-file` を使うことで要件を明示的に満たせます（現状 npm は警告のみで失敗はしないため、実害は限定的です）。

   <details><summary>Prompt To Fix With AI</summary>

   `````markdown
   This is a comment left during a code review.
   Path: package-lock.json
   Line: 402-404

   Comment:
   **jsdom@29.1.1 の engines が Node `^22.13.0` を要求**

   `node_modules/jsdom@29.1.1` のエンジン要件は `"node": "^20.19.0 || ^22.13.0 || >=24.0.0"` です。CI では `node-version: 22` を指定していますが、これは Node 22 系の最新版がインストールされる保証であり、`22.13.0` 未満の旧マイナーが選ばれた場合は npm の engines 警告が発生する可能性があります。`node-version: 22.13` または `node-version-file` を使うことで要件を明示的に満たせます（現状 npm は警告のみで失敗はしないため、実害は限定的です）。

   How can I resolve this? If you propose a fix, please make it concise.
   `````
   </details>

</details>

<!-- /greptile_failed_comments -->

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 2 code review issues. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 2
package.json:26
**apps/web の jsdom バージョンが更新されていない**

ルート `package.json` に `jsdom@^29.1.1` が追加されましたが、`apps/web/package.json` には `"jsdom": "^27.0.1"` のままになっています。これにより npm は `apps/web/node_modules/jsdom@27.4.0` をネストインストールし、`apps/web` の vitest テストは jsdom v27 上で動き続けます。Dependabot の更新で jsdom v29 が必要になった場合、`apps/web` 側も合わせて更新しないと CI でのテスト環境が分断されます。

### Issue 2 of 2
package-lock.json:402-404
**jsdom@29.1.1 の engines が Node `^22.13.0` を要求**

`node_modules/jsdom@29.1.1` のエンジン要件は `"node": "^20.19.0 || ^22.13.0 || >=24.0.0"` です。CI では `node-version: 22` を指定していますが、これは Node 22 系の最新版がインストールされる保証であり、`22.13.0` 未満の旧マイナーが選ばれた場合は npm の engines 警告が発生する可能性があります。`node-version: 22.13` または `node-version-file` を使うことで要件を明示的に満たせます（現状 npm は警告のみで失敗はしないため、実害は限定的です）。


`````

</details>

<sub>Reviews (1): Last reviewed commit: ["fix(ci): fix dependabot CI failures (fix..."](https://github.com/hiroki-org/openshelf/commit/84ee3bbba9e9b981d2e362185d151236500241bc) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=30541811)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->