### PR TITLE
🎨 Palette: Toast通知のアクセシビリティ改善

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -1,0 +1,3 @@
+## 2024-05-02 - Toast Accessibility
+**Learning:** Toasts added dynamically to the DOM without `aria-live` are completely ignored by screen readers, meaning blind users miss critical feedback like success or error states.
+**Action:** Always add `aria-live="polite"` (or "assertive" for critical errors) to the static container wrapping the toasts, and `role="alert"` or `role="status"` on the dynamically inserted elements.

--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -1,3 +1,0 @@
-## 2024-05-02 - Toast Accessibility
-**Learning:** Toasts added dynamically to the DOM without `aria-live` are completely ignored by screen readers, meaning blind users miss critical feedback like success or error states.
-**Action:** Always add `aria-live="polite"` (or "assertive" for critical errors) to the static container wrapping the toasts, and `role="alert"` or `role="status"` on the dynamically inserted elements.

--- a/apps/web/src/components/toast.tsx
+++ b/apps/web/src/components/toast.tsx
@@ -23,7 +23,7 @@ function generateId(): string {
   if (typeof crypto !== "undefined" && typeof crypto.randomUUID === "function") {
     return crypto.randomUUID();
   }
-  return Math.random().toString(36).substring(2, 9);
+  return `${Date.now()}-${Math.random().toString(36).substring(2, 9)}`;
 }
 
 function addToast(message: string, type: ToastType) {
@@ -68,14 +68,14 @@ export function ToastContainer() {
 
   return (
     <div className="fixed bottom-4 right-4 z-50 flex flex-col gap-2 pointer-events-none">
-      <div aria-live="assertive" aria-atomic="false">
+      <div role="alert" aria-live="assertive" aria-atomic="false">
         {errorToasts.map((t) => (
           <div key={t.id} className={toastClass(t.type)}>
             {t.message}
           </div>
         ))}
       </div>
-      <div aria-live="polite" aria-atomic="false">
+      <div role="status" aria-live="polite" aria-atomic="false">
         {otherToasts.map((t) => (
           <div key={t.id} className={toastClass(t.type)}>
             {t.message}

--- a/apps/web/src/components/toast.tsx
+++ b/apps/web/src/components/toast.tsx
@@ -20,7 +20,7 @@ export const toast = {
 };
 
 function addToast(message: string, type: ToastType) {
-  const id = Math.random().toString(36).substring(2, 9);
+  const id = crypto.randomUUID();
   const newToast = { id, message, type };
   toasts = [...toasts, newToast];
   notify();
@@ -48,10 +48,14 @@ export function ToastContainer() {
   }, []);
 
   return (
-    <div className="fixed bottom-4 right-4 z-50 flex flex-col gap-2 pointer-events-none">
+    <div
+      className="fixed bottom-4 right-4 z-50 flex flex-col gap-2 pointer-events-none"
+      aria-live="polite"
+    >
       {currentToasts.map((t) => (
         <div
           key={t.id}
+          role={t.type === "error" ? "alert" : "status"}
           className={`px-4 py-2 rounded-md shadow-lg text-white text-sm transition-all animate-in fade-in slide-in-from-right-4 pointer-events-auto ${
             t.type === "success"
               ? "bg-green-600"

--- a/apps/web/src/components/toast.tsx
+++ b/apps/web/src/components/toast.tsx
@@ -19,8 +19,15 @@ export const toast = {
   info: (message: string) => addToast(message, "info"),
 };
 
+function generateId(): string {
+  if (typeof crypto !== "undefined" && typeof crypto.randomUUID === "function") {
+    return crypto.randomUUID();
+  }
+  return Math.random().toString(36).substring(2, 9);
+}
+
 function addToast(message: string, type: ToastType) {
-  const id = crypto.randomUUID();
+  const id = generateId();
   const newToast = { id, message, type };
   toasts = [...toasts, newToast];
   notify();
@@ -47,26 +54,34 @@ export function ToastContainer() {
     };
   }, []);
 
+  const errorToasts = currentToasts.filter((t) => t.type === "error");
+  const otherToasts = currentToasts.filter((t) => t.type !== "error");
+
+  const toastClass = (type: ToastType) =>
+    `px-4 py-2 rounded-md shadow-lg text-white text-sm transition-all animate-in fade-in slide-in-from-right-4 pointer-events-auto ${
+      type === "success"
+        ? "bg-green-600"
+        : type === "error"
+          ? "bg-red-600"
+          : "bg-blue-600"
+    }`;
+
   return (
-    <div
-      className="fixed bottom-4 right-4 z-50 flex flex-col gap-2 pointer-events-none"
-      aria-live="polite"
-    >
-      {currentToasts.map((t) => (
-        <div
-          key={t.id}
-          role={t.type === "error" ? "alert" : "status"}
-          className={`px-4 py-2 rounded-md shadow-lg text-white text-sm transition-all animate-in fade-in slide-in-from-right-4 pointer-events-auto ${
-            t.type === "success"
-              ? "bg-green-600"
-              : t.type === "error"
-                ? "bg-red-600"
-                : "bg-blue-600"
-          }`}
-        >
-          {t.message}
-        </div>
-      ))}
+    <div className="fixed bottom-4 right-4 z-50 flex flex-col gap-2 pointer-events-none">
+      <div aria-live="assertive" aria-atomic="false">
+        {errorToasts.map((t) => (
+          <div key={t.id} className={toastClass(t.type)}>
+            {t.message}
+          </div>
+        ))}
+      </div>
+      <div aria-live="polite" aria-atomic="false">
+        {otherToasts.map((t) => (
+          <div key={t.id} className={toastClass(t.type)}>
+            {t.message}
+          </div>
+        ))}
+      </div>
     </div>
   );
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -8859,6 +8859,7 @@
       "os": [
         "android"
       ],
+      "peer": true,
       "engines": {
         "node": ">= 12.0.0"
       },
@@ -8880,6 +8881,7 @@
       "os": [
         "darwin"
       ],
+      "peer": true,
       "engines": {
         "node": ">= 12.0.0"
       },
@@ -8901,6 +8903,7 @@
       "os": [
         "darwin"
       ],
+      "peer": true,
       "engines": {
         "node": ">= 12.0.0"
       },
@@ -8922,6 +8925,7 @@
       "os": [
         "freebsd"
       ],
+      "peer": true,
       "engines": {
         "node": ">= 12.0.0"
       },
@@ -8943,6 +8947,7 @@
       "os": [
         "linux"
       ],
+      "peer": true,
       "engines": {
         "node": ">= 12.0.0"
       },
@@ -8964,6 +8969,7 @@
       "os": [
         "linux"
       ],
+      "peer": true,
       "engines": {
         "node": ">= 12.0.0"
       },
@@ -8985,6 +8991,7 @@
       "os": [
         "linux"
       ],
+      "peer": true,
       "engines": {
         "node": ">= 12.0.0"
       },
@@ -9006,6 +9013,7 @@
       "os": [
         "linux"
       ],
+      "peer": true,
       "engines": {
         "node": ">= 12.0.0"
       },
@@ -9027,6 +9035,7 @@
       "os": [
         "linux"
       ],
+      "peer": true,
       "engines": {
         "node": ">= 12.0.0"
       },
@@ -9048,6 +9057,7 @@
       "os": [
         "win32"
       ],
+      "peer": true,
       "engines": {
         "node": ">= 12.0.0"
       },
@@ -9069,6 +9079,7 @@
       "os": [
         "win32"
       ],
+      "peer": true,
       "engines": {
         "node": ">= 12.0.0"
       },
@@ -10802,6 +10813,7 @@
       "version": "2.3.2",
       "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
       "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
+      "dev": true,
       "hasInstallScript": true,
       "license": "MIT",
       "optional": true,


### PR DESCRIPTION
💡 何をしたか:
Toast通知（`apps/web/src/components/toast.tsx`）のアクセシビリティを改善するため、コンテナに `aria-live="polite"` を追加し、個別のトースト要素に `role="alert"` (エラー時) または `role="status"` を付与しました。また、ID生成を `Math.random()` から、より安全で衝突耐性のある `crypto.randomUUID()` に変更しました。

🎯 なぜしたか:
現状のToast通知はスクリーンリーダーに検知されず、視覚障害のあるユーザーが成功やエラーの重要なフィードバックを見逃す状態でした。`aria-live` を設定することで、動的に追加される通知が適切に読み上げられるようになります。

📸 Before/After:
視覚的な変更はありません（非表示のARIA属性と内部ロジックの改善のみ）。

♿ アクセシビリティ:
スクリーンリーダー対応（`aria-live` および適切な `role` の設定）。

---
*PR created automatically by Jules for task [13378500114614380098](https://jules.google.com/task/13378500114614380098) started by @is0692vs*

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

以前のレビューで指摘された `aria-live=\"polite\"` と `role=\"alert\"` の競合問題を、エラー用・非エラー用の2コンテナ分離で正しく解決しています。ID生成を `crypto.randomUUID()` に変更した対応も適切で、フォールバックも実装されています。
</details>

<details open><summary><h3>Confidence Score: 5/5</h3></summary>

このPRはそのままマージ可能です。

以前指摘されたARIA属性の競合が正しく修正されており、2コンテナ分離パターンはWAI-ARIA仕様に準拠しています。crypto.randomUUID() への変更も安全で適切なフォールバックが備わっています。P1以上の問題は見当たりません。

特に注意が必要なファイルはありません。
</details>

<details open><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| apps/web/src/components/toast.tsx | エラートースト用 (role=alert + aria-live=assertive) と非エラートースト用 (role=status + aria-live=polite) の2コンテナ分離によりアクセシビリティを改善。crypto.randomUUID() へのID生成変更も含む。 |
| package-lock.json | ロックファイルの更新のみ。レビュー対象外。 |

</details>

</details>

<sub>Reviews (3): Last reviewed commit: ["🎨 Palette: Toast通知のアクセシビリティ改善とID生成の強化"](https://github.com/hiroki-org/openshelf/commit/a3ddda0b45d7d526fe374e9b36b65bf7a48d6705) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=30557961)</sub>

<!-- /greptile_comment -->