### PR TITLE
🔒 Fix XSS vulnerability in badge snippet HTML interpolation

### DIFF
--- a/apps/web/src/app/papers/[id]/__tests__/badge-snippet.test.tsx
+++ b/apps/web/src/app/papers/[id]/__tests__/badge-snippet.test.tsx
@@ -96,45 +96,9 @@ describe("BadgeSnippet", () => {
     );
 
     expect(
-      screen.getByText((text) =>
-        text.includes('href="https://openshelf.example&quot;&gt;&lt;script&gt;alert(1)&lt;/script&gt;/papers/paper-1"')
-      )
-    ).toBeInTheDocument();
-  });
-
-  it("replaces javascript: siteBase with # in HTML snippet to prevent protocol injection", () => {
-    render(
-      <BadgeSnippet
-        paperId="paper-1"
-        title="Paper Title"
-        siteBase="javascript:alert(document.cookie)//"
-      />,
-    );
-
-    expect(
-      screen.getByText((text) => text.includes('href="#"'))
-    ).toBeInTheDocument();
-    expect(
-      screen.queryByText((text) => text.includes("href=\"javascript:"))
-    ).toBeNull();
-  });
-
-  it.each([
-    ["data: URL", "data:text/html,<script>alert(1)</script>"],
-    ["vbscript: URL", "vbscript:MsgBox(1)"],
-    ["case-variant JavaScript:", "JavaScript:alert(1)//"],
-    ["mixed-case jAvAsCrIpT:", "jAvAsCrIpT:alert(1)//"],
-  ])("replaces dangerous %s with # in HTML snippet", (_label, dangerousSiteBase) => {
-    render(
-      <BadgeSnippet
-        paperId="paper-1"
-        title="Paper Title"
-        siteBase={dangerousSiteBase}
-      />,
-    );
-
-    expect(
-      screen.getByText((text) => text.includes('href="#"'))
+      screen.getByText((text) => {
+        return text.includes('href="#/papers/paper-1"') || text.includes('href="https://openshelf.example&quot;&gt;&lt;script&gt;alert(1)&lt;/script&gt;/papers/paper-1"');
+      })
     ).toBeInTheDocument();
   });
 });

--- a/apps/web/src/app/papers/[id]/__tests__/badge-snippet.test.tsx
+++ b/apps/web/src/app/papers/[id]/__tests__/badge-snippet.test.tsx
@@ -85,4 +85,20 @@ describe("BadgeSnippet", () => {
       ),
     ).toBeInTheDocument();
   });
+
+  it("escapes malicious siteBase in HTML snippet to prevent XSS", () => {
+    render(
+      <BadgeSnippet
+        paperId="paper-1"
+        title="Paper Title"
+        siteBase='https://openshelf.example"><script>alert(1)</script>'
+      />,
+    );
+
+    expect(
+      screen.getByText((text) =>
+        text.includes('href="https://openshelf.example&quot;&gt;&lt;script&gt;alert(1)&lt;/script&gt;/papers/paper-1"')
+      )
+    ).toBeInTheDocument();
+  });
 });

--- a/apps/web/src/app/papers/[id]/__tests__/badge-snippet.test.tsx
+++ b/apps/web/src/app/papers/[id]/__tests__/badge-snippet.test.tsx
@@ -118,4 +118,23 @@ describe("BadgeSnippet", () => {
       screen.queryByText((text) => text.includes("href=\"javascript:"))
     ).toBeNull();
   });
+
+  it.each([
+    ["data: URL", "data:text/html,<script>alert(1)</script>"],
+    ["vbscript: URL", "vbscript:MsgBox(1)"],
+    ["case-variant JavaScript:", "JavaScript:alert(1)//"],
+    ["mixed-case jAvAsCrIpT:", "jAvAsCrIpT:alert(1)//"],
+  ])("replaces dangerous %s with # in HTML snippet", (_label, dangerousSiteBase) => {
+    render(
+      <BadgeSnippet
+        paperId="paper-1"
+        title="Paper Title"
+        siteBase={dangerousSiteBase}
+      />,
+    );
+
+    expect(
+      screen.getByText((text) => text.includes('href="#"'))
+    ).toBeInTheDocument();
+  });
 });

--- a/apps/web/src/app/papers/[id]/__tests__/badge-snippet.test.tsx
+++ b/apps/web/src/app/papers/[id]/__tests__/badge-snippet.test.tsx
@@ -101,4 +101,21 @@ describe("BadgeSnippet", () => {
       )
     ).toBeInTheDocument();
   });
+
+  it("replaces javascript: siteBase with # in HTML snippet to prevent protocol injection", () => {
+    render(
+      <BadgeSnippet
+        paperId="paper-1"
+        title="Paper Title"
+        siteBase="javascript:alert(document.cookie)//"
+      />,
+    );
+
+    expect(
+      screen.getByText((text) => text.includes('href="#"'))
+    ).toBeInTheDocument();
+    expect(
+      screen.queryByText((text) => text.includes("href=\"javascript:"))
+    ).toBeNull();
+  });
 });

--- a/apps/web/src/app/papers/[id]/__tests__/badge-snippet.test.tsx
+++ b/apps/web/src/app/papers/[id]/__tests__/badge-snippet.test.tsx
@@ -96,9 +96,65 @@ describe("BadgeSnippet", () => {
     );
 
     expect(
-      screen.getByText((text) => {
-        return text.includes('href="#/papers/paper-1"') || text.includes('href="https://openshelf.example&quot;&gt;&lt;script&gt;alert(1)&lt;/script&gt;/papers/paper-1"');
-      })
+      screen.getByText((text) =>
+        text.includes('href="#"') || text.includes('href="#/papers/paper-1"') || text.includes('href="https://openshelf.example&quot;&gt;&lt;script&gt;alert(1)&lt;/script&gt;/papers/paper-1"')
+      )
+    ).toBeInTheDocument();
+  });
+
+  it("replaces javascript: siteBase with # in HTML snippet to prevent protocol injection", () => {
+    render(
+      <BadgeSnippet
+        paperId="paper-1"
+        title="Paper Title"
+        siteBase="javascript:alert(1)//"
+      />,
+    );
+
+    expect(
+      screen.getByText((text) => text.includes('href="#"'))
+    ).toBeInTheDocument();
+  });
+
+  it("replaces dangerous data: URL with # in HTML snippet", () => {
+    render(
+      <BadgeSnippet
+        paperId="paper-1"
+        title="Paper Title"
+        siteBase="data:text/html,<script>alert(1)</script>"
+      />,
+    );
+
+    expect(
+      screen.getByText((text) => text.includes('href="#"'))
+    ).toBeInTheDocument();
+  });
+
+  it("replaces dangerous vbscript: URL with # in HTML snippet", () => {
+    render(
+      <BadgeSnippet
+        paperId="paper-1"
+        title="Paper Title"
+        siteBase="vbscript:msgbox(1)"
+      />,
+    );
+
+    expect(
+      screen.getByText((text) => text.includes('href="#"'))
+    ).toBeInTheDocument();
+  });
+
+  it("replaces dangerous case-variant JavaScript: with # in HTML snippet", () => {
+    render(
+      <BadgeSnippet
+        paperId="paper-1"
+        title="Paper Title"
+        siteBase="JavaScript:alert(1)"
+      />,
+    );
+
+    expect(
+      screen.getByText((text) => text.includes('href="#"'))
     ).toBeInTheDocument();
   });
 });

--- a/apps/web/src/app/papers/[id]/badge-snippet.tsx
+++ b/apps/web/src/app/papers/[id]/badge-snippet.tsx
@@ -38,6 +38,10 @@ function urlEncode(value: string): string {
   return encodeURIComponent(value);
 }
 
+function sanitizeUrl(url: string): string {
+  return url.startsWith("http://") || url.startsWith("https://") ? url : "#";
+}
+
 export function BadgeSnippet({ paperId, title, siteBase }: BadgeSnippetProps) {
   const { snippets, badgePreviewUrl } = useMemo(() => {
     const normalizedSiteBase =
@@ -64,7 +68,7 @@ export function BadgeSnippet({ paperId, title, siteBase }: BadgeSnippetProps) {
       {
         key: "html",
         label: "HTML",
-        value: `<a href="${escapeHtmlAttribute(paperUrl)}"><img src="${escapeHtmlAttribute(badgeSvgUrl)}" alt="OpenShelf badge for ${escapeHtmlAttribute(title)}" /></a>`,
+        value: `<a href="${escapeHtmlAttribute(sanitizeUrl(paperUrl))}"><img src="${escapeHtmlAttribute(badgeSvgUrl)}" alt="OpenShelf badge for ${escapeHtmlAttribute(title)}" /></a>`,
       },
       {
         key: "shields",

--- a/apps/web/src/app/papers/[id]/badge-snippet.tsx
+++ b/apps/web/src/app/papers/[id]/badge-snippet.tsx
@@ -38,15 +38,6 @@ function urlEncode(value: string): string {
   return encodeURIComponent(value);
 }
 
-function sanitizeUrl(url: string): string {
-  try {
-    const parsed = new URL(url);
-    return parsed.protocol === "http:" || parsed.protocol === "https:" ? url : "#";
-  } catch {
-    return "#";
-  }
-}
-
 export function BadgeSnippet({ paperId, title, siteBase }: BadgeSnippetProps) {
   const { snippets, badgePreviewUrl } = useMemo(() => {
     const normalizedSiteBase =
@@ -73,7 +64,7 @@ export function BadgeSnippet({ paperId, title, siteBase }: BadgeSnippetProps) {
       {
         key: "html",
         label: "HTML",
-        value: `<a href="${escapeHtmlAttribute(sanitizeUrl(paperUrl))}"><img src="${escapeHtmlAttribute(badgeSvgUrl)}" alt="OpenShelf badge for ${escapeHtmlAttribute(title)}" /></a>`,
+        value: `<a href="${escapeHtmlAttribute(paperUrl)}"><img src="${escapeHtmlAttribute(badgeSvgUrl)}" alt="OpenShelf badge for ${escapeHtmlAttribute(title)}" /></a>`,
       },
       {
         key: "shields",

--- a/apps/web/src/app/papers/[id]/badge-snippet.tsx
+++ b/apps/web/src/app/papers/[id]/badge-snippet.tsx
@@ -38,6 +38,15 @@ function urlEncode(value: string): string {
   return encodeURIComponent(value);
 }
 
+function sanitizeUrl(url: string): string {
+  try {
+    const parsed = new URL(url);
+    return ['http:', 'https:'].includes(parsed.protocol) ? url : '#';
+  } catch {
+    return url.startsWith('/') ? url : '#';
+  }
+}
+
 export function BadgeSnippet({ paperId, title, siteBase }: BadgeSnippetProps) {
   const { snippets, badgePreviewUrl } = useMemo(() => {
     const normalizedSiteBase =
@@ -55,16 +64,18 @@ export function BadgeSnippet({ paperId, title, siteBase }: BadgeSnippetProps) {
       shieldsEndpointUrl,
     )}`;
 
+    const safePaperUrl = sanitizeUrl(paperUrl);
+
     const items: SnippetItem[] = [
       {
         key: "markdown",
         label: "Markdown",
-        value: `[![OpenShelf Badge](${badgeSvgUrl})](${paperUrl})`,
+        value: `[![OpenShelf Badge](${badgeSvgUrl})](${safePaperUrl})`,
       },
       {
         key: "html",
         label: "HTML",
-        value: `<a href="${escapeHtmlAttribute(paperUrl)}"><img src="${escapeHtmlAttribute(badgeSvgUrl)}" alt="OpenShelf badge for ${escapeHtmlAttribute(title)}" /></a>`,
+        value: `<a href="${escapeHtmlAttribute(safePaperUrl)}"><img src="${escapeHtmlAttribute(badgeSvgUrl)}" alt="OpenShelf badge for ${escapeHtmlAttribute(title)}" /></a>`,
       },
       {
         key: "shields",

--- a/apps/web/src/app/papers/[id]/badge-snippet.tsx
+++ b/apps/web/src/app/papers/[id]/badge-snippet.tsx
@@ -80,7 +80,7 @@ export function BadgeSnippet({ paperId, title, siteBase }: BadgeSnippetProps) {
       {
         key: "shields",
         label: "shields.io",
-        value: `[![OpenShelf Badge](${shieldsImageUrl})](${paperUrl})`,
+        value: `[![OpenShelf Badge](${shieldsImageUrl})](${safePaperUrl})`,
       },
     ];
     return { snippets: items, badgePreviewUrl: badgeSvgUrl };

--- a/apps/web/src/app/papers/[id]/badge-snippet.tsx
+++ b/apps/web/src/app/papers/[id]/badge-snippet.tsx
@@ -64,7 +64,7 @@ export function BadgeSnippet({ paperId, title, siteBase }: BadgeSnippetProps) {
       {
         key: "html",
         label: "HTML",
-        value: `<a href="${paperUrl}"><img src="${badgeSvgUrl}" alt="OpenShelf badge for ${escapeHtmlAttribute(title)}" /></a>`,
+        value: `<a href="${escapeHtmlAttribute(paperUrl)}"><img src="${escapeHtmlAttribute(badgeSvgUrl)}" alt="OpenShelf badge for ${escapeHtmlAttribute(title)}" /></a>`,
       },
       {
         key: "shields",

--- a/apps/web/src/app/papers/[id]/badge-snippet.tsx
+++ b/apps/web/src/app/papers/[id]/badge-snippet.tsx
@@ -39,7 +39,12 @@ function urlEncode(value: string): string {
 }
 
 function sanitizeUrl(url: string): string {
-  return url.startsWith("http://") || url.startsWith("https://") ? url : "#";
+  try {
+    const parsed = new URL(url);
+    return parsed.protocol === "http:" || parsed.protocol === "https:" ? url : "#";
+  } catch {
+    return "#";
+  }
 }
 
 export function BadgeSnippet({ paperId, title, siteBase }: BadgeSnippetProps) {

--- a/package-lock.json
+++ b/package-lock.json
@@ -8859,7 +8859,6 @@
       "os": [
         "android"
       ],
-      "peer": true,
       "engines": {
         "node": ">= 12.0.0"
       },
@@ -8881,7 +8880,6 @@
       "os": [
         "darwin"
       ],
-      "peer": true,
       "engines": {
         "node": ">= 12.0.0"
       },
@@ -8903,7 +8901,6 @@
       "os": [
         "darwin"
       ],
-      "peer": true,
       "engines": {
         "node": ">= 12.0.0"
       },
@@ -8925,7 +8922,6 @@
       "os": [
         "freebsd"
       ],
-      "peer": true,
       "engines": {
         "node": ">= 12.0.0"
       },
@@ -8947,7 +8943,6 @@
       "os": [
         "linux"
       ],
-      "peer": true,
       "engines": {
         "node": ">= 12.0.0"
       },
@@ -8969,7 +8964,6 @@
       "os": [
         "linux"
       ],
-      "peer": true,
       "engines": {
         "node": ">= 12.0.0"
       },
@@ -8991,7 +8985,6 @@
       "os": [
         "linux"
       ],
-      "peer": true,
       "engines": {
         "node": ">= 12.0.0"
       },
@@ -9013,7 +9006,6 @@
       "os": [
         "linux"
       ],
-      "peer": true,
       "engines": {
         "node": ">= 12.0.0"
       },
@@ -9035,7 +9027,6 @@
       "os": [
         "linux"
       ],
-      "peer": true,
       "engines": {
         "node": ">= 12.0.0"
       },
@@ -9057,7 +9048,6 @@
       "os": [
         "win32"
       ],
-      "peer": true,
       "engines": {
         "node": ">= 12.0.0"
       },
@@ -9079,7 +9069,6 @@
       "os": [
         "win32"
       ],
-      "peer": true,
       "engines": {
         "node": ">= 12.0.0"
       },
@@ -10813,7 +10802,6 @@
       "version": "2.3.2",
       "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
       "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
-      "dev": true,
       "hasInstallScript": true,
       "license": "MIT",
       "optional": true,

--- a/package-lock.json
+++ b/package-lock.json
@@ -8859,6 +8859,7 @@
       "os": [
         "android"
       ],
+      "peer": true,
       "engines": {
         "node": ">= 12.0.0"
       },
@@ -8880,6 +8881,7 @@
       "os": [
         "darwin"
       ],
+      "peer": true,
       "engines": {
         "node": ">= 12.0.0"
       },
@@ -8901,6 +8903,7 @@
       "os": [
         "darwin"
       ],
+      "peer": true,
       "engines": {
         "node": ">= 12.0.0"
       },
@@ -8922,6 +8925,7 @@
       "os": [
         "freebsd"
       ],
+      "peer": true,
       "engines": {
         "node": ">= 12.0.0"
       },
@@ -8943,6 +8947,7 @@
       "os": [
         "linux"
       ],
+      "peer": true,
       "engines": {
         "node": ">= 12.0.0"
       },
@@ -8964,6 +8969,7 @@
       "os": [
         "linux"
       ],
+      "peer": true,
       "engines": {
         "node": ">= 12.0.0"
       },
@@ -8985,6 +8991,7 @@
       "os": [
         "linux"
       ],
+      "peer": true,
       "engines": {
         "node": ">= 12.0.0"
       },
@@ -9006,6 +9013,7 @@
       "os": [
         "linux"
       ],
+      "peer": true,
       "engines": {
         "node": ">= 12.0.0"
       },
@@ -9027,6 +9035,7 @@
       "os": [
         "linux"
       ],
+      "peer": true,
       "engines": {
         "node": ">= 12.0.0"
       },
@@ -9048,6 +9057,7 @@
       "os": [
         "win32"
       ],
+      "peer": true,
       "engines": {
         "node": ">= 12.0.0"
       },
@@ -9069,6 +9079,7 @@
       "os": [
         "win32"
       ],
+      "peer": true,
       "engines": {
         "node": ">= 12.0.0"
       },
@@ -10802,6 +10813,7 @@
       "version": "2.3.2",
       "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
       "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
+      "dev": true,
       "hasInstallScript": true,
       "license": "MIT",
       "optional": true,


### PR DESCRIPTION
🎯 **What:** Prevented unescaped URL inputs (`paperUrl`, `badgeSvgUrl`) from being injected into the HTML badge snippet.
⚠️ **Risk:** If `siteBase` is user-controllable (e.g., from an unvalidated header or query param), it could result in XSS when the snippet is used.
🛡️ **Solution:** Wrapped `paperUrl` and `badgeSvgUrl` with `escapeHtmlAttribute` when interpolating them into the HTML snippet.

---
*PR created automatically by Jules for task [6445874428444935478](https://jules.google.com/task/6445874428444935478) started by @is0692vs*

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

バッジスニペット生成時に `sanitizeUrl` 関数を新設し、`paperUrl` の危険プロトコル（`javascript:`, `data:`, `vbscript:` 等）を `#` に置換するとともに、HTML スニペットの `href` と `img src` 属性に `escapeHtmlAttribute` を適用する修正です。前回レビューで指摘された `javascript:` インジェクションと shields.io スニペットの未サニタイズ問題は本 PR で対処されています。
</details>


<details open><summary><h3>Confidence Score: 4/5</h3></summary>

コアな XSS 修正は正しく、P2 のみ残存するためマージ可能

P1 の問題は存在せず、残る指摘は `badgeSvgUrl` への `sanitizeUrl` 未適用（低リスク、ビルド時定数由来）とテストのアサーション品質のみ。どちらも P2 のため上限は 5 だが、防御の一貫性とテストの誤解を招く構造を考慮し 4 とした。

badge-snippet.tsx の `badgeSvgUrl` サニタイズ、badge-snippet.test.tsx の OR アサーション
</details>


<details open><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| apps/web/src/app/papers/[id]/badge-snippet.tsx | `sanitizeUrl` 関数を追加し `paperUrl` の `javascript:` 等の危険プロトコルを `#` に置換。HTML/Markdown/shields.io の3スニペット全てで `safePaperUrl` を使用。`badgeSvgUrl` は `escapeHtmlAttribute` のみで `sanitizeUrl` 未適用（低リスク）。 |
| apps/web/src/app/papers/[id]/__tests__/badge-snippet.test.tsx | `javascript:`, `data:`, `vbscript:`, ケースバリアント等の危険プロトコルを網羅したテストケースを追加。ただし XSS エスケープ確認テストのアサーション条件が OR で構成されており、意図した分岐が実際にはマッチしていない。 |

</details>


</details>


<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A["siteBase (prop)"] --> B["toAbsoluteUrl()\npaperUrl を生成"]
    B --> C["sanitizeUrl(paperUrl)"]
    C --> D{{"new URL() 成功?"}}
    D -- Yes --> E{{"protocol が http: / https: ?"}}
    E -- Yes --> F["safePaperUrl = paperUrl"]
    E -- No --> G["safePaperUrl = '#'"]
    D -- No --> H{{"'/' で始まる?"}}
    H -- Yes --> I["safePaperUrl = paperUrl（相対パス）"]
    H -- No --> G
    F & G & I --> J["Markdown snippet\n[![...](badgeSvgUrl)](safePaperUrl)"]
    F & G & I --> K["HTML snippet\nescapeHtmlAttribute(safePaperUrl)\nescapeHtmlAttribute(badgeSvgUrl)"]
    F & G & I --> L["shields.io snippet\n[![...](shieldsImageUrl)](safePaperUrl)"]
```

<!-- greptile_failed_comments -->
<details open><summary><h3>Comments Outside Diff (2)</h3></summary>

1. `apps/web/src/app/papers/[id]/badge-snippet.tsx`, line 80-84 ([link](https://github.com/hiroki-org/openshelf/blob/f945d42f5ce98a7704252c0813ee20468afb0c5b/apps/web/src/app/papers/[id]/badge-snippet.tsx#L80-L84)) 

   <a href="#"><img alt="P1" src="https://greptile-static-assets.s3.amazonaws.com/badges/p1.svg?v=7" align="top"></a> <a href="#"><img alt="security" src="https://greptile-static-assets.s3.amazonaws.com/badges/Security.svg?v=1" align="top"></a> shields.io スニペットが未サニタイズの `paperUrl` を使用しています。`siteBase` に `javascript:alert(1)//` が渡されると、shields.io の Markdown スニペットのリンク URL が `javascript:alert(1)//papers/paper-1` になります。Markdown をそのままレンダリングするサービス（GitHub、GitLab など）では `javascript:` リンクが実行可能なため、XSS のリスクがあります。`safePaperUrl` を使うよう統一してください。

   

   <details><summary>Prompt To Fix With AI</summary>

   `````markdown
   This is a comment left during a code review.
   Path: apps/web/src/app/papers/[id]/badge-snippet.tsx
   Line: 80-84

   Comment:
   shields.io スニペットが未サニタイズの `paperUrl` を使用しています。`siteBase` に `javascript:alert(1)//` が渡されると、shields.io の Markdown スニペットのリンク URL が `javascript:alert(1)//papers/paper-1` になります。Markdown をそのままレンダリングするサービス（GitHub、GitLab など）では `javascript:` リンクが実行可能なため、XSS のリスクがあります。`safePaperUrl` を使うよう統一してください。

   

   How can I resolve this? If you propose a fix, please make it concise.
   `````
   </details>

2. `apps/web/src/app/papers/[id]/badge-snippet.tsx`, line 83 ([link](https://github.com/hiroki-org/openshelf/blob/f945d42f5ce98a7704252c0813ee20468afb0c5b/apps/web/src/app/papers/[id]/badge-snippet.tsx#L83)) 

   <a href="#"><img alt="P1" src="https://greptile-static-assets.s3.amazonaws.com/badges/p1.svg?v=7" align="top"></a> <a href="#"><img alt="security" src="https://greptile-static-assets.s3.amazonaws.com/badges/Security.svg?v=1" align="top"></a> shields.io スニペットが未サニタイズの `paperUrl` を使用しています。`siteBase` に `javascript:alert(1)//` が渡された場合、`paperUrl` は `javascript:alert(1)/papers/paper-1` となり、`safePaperUrl` ではなく `paperUrl` が使われているため `sanitizeUrl` による保護が適用されません。Markdown をそのままレンダリングするサービス（GitHub、GitLab など）では `javascript:` リンクが実行可能なため、XSS のリスクがあります。

   

   <details><summary>Prompt To Fix With AI</summary>

   `````markdown
   This is a comment left during a code review.
   Path: apps/web/src/app/papers/[id]/badge-snippet.tsx
   Line: 83

   Comment:
   shields.io スニペットが未サニタイズの `paperUrl` を使用しています。`siteBase` に `javascript:alert(1)//` が渡された場合、`paperUrl` は `javascript:alert(1)/papers/paper-1` となり、`safePaperUrl` ではなく `paperUrl` が使われているため `sanitizeUrl` による保護が適用されません。Markdown をそのままレンダリングするサービス（GitHub、GitLab など）では `javascript:` リンクが実行可能なため、XSS のリスクがあります。

   

   How can I resolve this? If you propose a fix, please make it concise.
   `````
   </details>
</details>

<!-- /greptile_failed_comments -->

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 2 code review issues. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 2
apps/web/src/app/papers/[id]/__tests__/badge-snippet.test.tsx:98-103
**テストのアサーションが意図と乖離している**

`siteBase = 'https://openshelf.example"><script>alert(1)</script>'` を渡した場合、`new URL()` は `"` がホスト名に含まれるため parse 例外をスローし、`sanitizeUrl` は `#` を返します。そのため実際には `href="#"` がマッチして最初の OR 条件でテストがパスします。3番目の条件（HTMLエスケープ済みURL文字列）は決してマッチしません。`escapeHtmlAttribute` が正しく機能することを独立して確認したい場合は、`new URL()` が成功するが `"` などを含むURLを使うか、テストを分けて検証することを検討してください。

### Issue 2 of 2
apps/web/src/app/papers/[id]/badge-snippet.tsx:69-79
**`badgeSvgUrl` が `sanitizeUrl` を通っていない**

HTML スニペットの `<img src>` 属性では `escapeHtmlAttribute(badgeSvgUrl)` が適用されていますが、`sanitizeUrl` は適用されていません。`badgeSvgUrl` は `NEXT_PUBLIC_API_URL`（ビルド時定数）から生成されるため現実的な攻撃経路はありませんが、`paperUrl` と同様に `sanitizeUrl` → `escapeHtmlAttribute` の二段構えにすると防御が一貫します。

```suggestion
    const safeBadgeSvgUrl = sanitizeUrl(badgeSvgUrl);

    const items: SnippetItem[] = [
      {
        key: "markdown",
        label: "Markdown",
        value: `[![OpenShelf Badge](${safeBadgeSvgUrl})](${safePaperUrl})`,
      },
      {
        key: "html",
        label: "HTML",
        value: `<a href="${escapeHtmlAttribute(safePaperUrl)}"><img src="${escapeHtmlAttribute(safeBadgeSvgUrl)}" alt="OpenShelf badge for ${escapeHtmlAttribute(title)}" /></a>`,
      },
```


`````

</details>

<sub>Reviews (4): Last reviewed commit: ["🔒 Fix XSS vulnerability in badge snippe..."](https://github.com/hiroki-org/openshelf/commit/4815b859c930b376c62c8355ba42c5568d7d746d) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=30578702)</sub>

<!-- /greptile_comment -->