### PR TITLE
🧪 Testing improvement for Invalid JSON on /api/papers/:id/track

### DIFF
--- a/apps/api/src/routes/__tests__/papers.test.ts
+++ b/apps/api/src/routes/__tests__/papers.test.ts
@@ -2171,7 +2171,7 @@ describe("papers routes", () => {
             token = await createTestJWT({ sub: "user-test", githubId: "123", name: "Test" });
         });
 
-        it("POST /api/papers/:id/invites handles missing JSON body", async () => {
+        it("POST /api/papers/:id/invites handles malformed JSON body", async () => {
             const res = await app.request("http://localhost/api/papers/paper-1/invites", {
                 method: "POST",
                 headers: { Authorization: `Bearer ${token}`, "Content-Type": "application/json" },
@@ -2370,7 +2370,7 @@ describe("papers routes", () => {
             expect(json.url).toBe("https://fake-presigned-url");
         });
 
-        it("PUT /api/papers/:id/description handles missing JSON body", async () => {
+        it("PUT /api/papers/:id/description handles malformed JSON body", async () => {
             const res = await app.request("http://localhost/api/papers/paper-1/description", {
                 method: "PUT",
                 headers: { Authorization: `Bearer ${token}`, "Content-Type": "application/json" },
@@ -2390,7 +2390,7 @@ describe("papers routes", () => {
             expect(await res.json()).toEqual({ error: "Invalid JSON body" });
         });
 
-        it("PATCH /api/papers/:id handles missing JSON body", async () => {
+        it("PATCH /api/papers/:id handles malformed JSON body", async () => {
             const res = await app.request("http://localhost/api/papers/paper-1", {
                 method: "PATCH",
                 headers: { Authorization: `Bearer ${token}`, "Content-Type": "application/json" },

--- a/apps/api/src/routes/__tests__/papers.test.ts
+++ b/apps/api/src/routes/__tests__/papers.test.ts
@@ -2175,7 +2175,7 @@ describe("papers routes", () => {
             const res = await app.request("http://localhost/api/papers/paper-1/invites", {
                 method: "POST",
                 headers: { Authorization: `Bearer ${token}`, "Content-Type": "application/json" },
-                body: "{"
+                body: ""
             }, env as any);
             expect(res.status).toBe(400);
             expect(await res.json()).toEqual({ error: "Invalid JSON body" });
@@ -2374,7 +2374,7 @@ describe("papers routes", () => {
             const res = await app.request("http://localhost/api/papers/paper-1/description", {
                 method: "PUT",
                 headers: { Authorization: `Bearer ${token}`, "Content-Type": "application/json" },
-                body: "{"
+                body: ""
             }, env as any);
             expect(res.status).toBe(400);
             expect(await res.json()).toEqual({ error: "Invalid JSON body" });
@@ -2394,7 +2394,7 @@ describe("papers routes", () => {
             const res = await app.request("http://localhost/api/papers/paper-1", {
                 method: "PATCH",
                 headers: { Authorization: `Bearer ${token}`, "Content-Type": "application/json" },
-                body: "{"
+                body: ""
             }, env as any);
             expect(res.status).toBe(400);
             expect(await res.json()).toEqual({ error: "Invalid JSON body" });
@@ -2411,6 +2411,16 @@ describe("papers routes", () => {
         });
 
         it("POST /api/papers/:id/track handles missing json payload", async () => {
+            const res = await app.request("http://localhost/api/papers/paper-1/track", {
+                method: "POST",
+                headers: { "Content-Type": "application/json", "Origin": "http://localhost:3000" },
+                body: ""
+            }, env as any);
+            expect(res.status).toBe(400);
+            expect(await res.json()).toEqual({ error: "Invalid JSON body" });
+        });
+
+        it("POST /api/papers/:id/track handles invalid json payload", async () => {
             const res = await app.request("http://localhost/api/papers/paper-1/track", {
                 method: "POST",
                 headers: { "Content-Type": "application/json", "Origin": "http://localhost:3000" },

--- a/apps/api/src/routes/__tests__/papers.test.ts
+++ b/apps/api/src/routes/__tests__/papers.test.ts
@@ -2171,7 +2171,7 @@ describe("papers routes", () => {
             token = await createTestJWT({ sub: "user-test", githubId: "123", name: "Test" });
         });
 
-        it("POST /api/papers/:id/invites handles malformed JSON body", async () => {
+        it("POST /api/papers/:id/invites handles missing JSON body", async () => {
             const res = await app.request("http://localhost/api/papers/paper-1/invites", {
                 method: "POST",
                 headers: { Authorization: `Bearer ${token}`, "Content-Type": "application/json" },
@@ -2370,7 +2370,7 @@ describe("papers routes", () => {
             expect(json.url).toBe("https://fake-presigned-url");
         });
 
-        it("PUT /api/papers/:id/description handles malformed JSON body", async () => {
+        it("PUT /api/papers/:id/description handles missing JSON body", async () => {
             const res = await app.request("http://localhost/api/papers/paper-1/description", {
                 method: "PUT",
                 headers: { Authorization: `Bearer ${token}`, "Content-Type": "application/json" },
@@ -2390,7 +2390,7 @@ describe("papers routes", () => {
             expect(await res.json()).toEqual({ error: "Invalid JSON body" });
         });
 
-        it("PATCH /api/papers/:id handles malformed JSON body", async () => {
+        it("PATCH /api/papers/:id handles missing JSON body", async () => {
             const res = await app.request("http://localhost/api/papers/paper-1", {
                 method: "PATCH",
                 headers: { Authorization: `Bearer ${token}`, "Content-Type": "application/json" },

--- a/package-lock.json
+++ b/package-lock.json
@@ -8859,7 +8859,6 @@
       "os": [
         "android"
       ],
-      "peer": true,
       "engines": {
         "node": ">= 12.0.0"
       },
@@ -8881,7 +8880,6 @@
       "os": [
         "darwin"
       ],
-      "peer": true,
       "engines": {
         "node": ">= 12.0.0"
       },
@@ -8903,7 +8901,6 @@
       "os": [
         "darwin"
       ],
-      "peer": true,
       "engines": {
         "node": ">= 12.0.0"
       },
@@ -8925,7 +8922,6 @@
       "os": [
         "freebsd"
       ],
-      "peer": true,
       "engines": {
         "node": ">= 12.0.0"
       },
@@ -8947,7 +8943,6 @@
       "os": [
         "linux"
       ],
-      "peer": true,
       "engines": {
         "node": ">= 12.0.0"
       },
@@ -8969,7 +8964,6 @@
       "os": [
         "linux"
       ],
-      "peer": true,
       "engines": {
         "node": ">= 12.0.0"
       },
@@ -8991,7 +8985,6 @@
       "os": [
         "linux"
       ],
-      "peer": true,
       "engines": {
         "node": ">= 12.0.0"
       },
@@ -9013,7 +9006,6 @@
       "os": [
         "linux"
       ],
-      "peer": true,
       "engines": {
         "node": ">= 12.0.0"
       },
@@ -9035,7 +9027,6 @@
       "os": [
         "linux"
       ],
-      "peer": true,
       "engines": {
         "node": ">= 12.0.0"
       },
@@ -9057,7 +9048,6 @@
       "os": [
         "win32"
       ],
-      "peer": true,
       "engines": {
         "node": ">= 12.0.0"
       },
@@ -9079,7 +9069,6 @@
       "os": [
         "win32"
       ],
-      "peer": true,
       "engines": {
         "node": ">= 12.0.0"
       },
@@ -10813,7 +10802,6 @@
       "version": "2.3.2",
       "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
       "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
-      "dev": true,
       "hasInstallScript": true,
       "license": "MIT",
       "optional": true,

--- a/package-lock.json
+++ b/package-lock.json
@@ -8859,6 +8859,7 @@
       "os": [
         "android"
       ],
+      "peer": true,
       "engines": {
         "node": ">= 12.0.0"
       },
@@ -8880,6 +8881,7 @@
       "os": [
         "darwin"
       ],
+      "peer": true,
       "engines": {
         "node": ">= 12.0.0"
       },
@@ -8901,6 +8903,7 @@
       "os": [
         "darwin"
       ],
+      "peer": true,
       "engines": {
         "node": ">= 12.0.0"
       },
@@ -8922,6 +8925,7 @@
       "os": [
         "freebsd"
       ],
+      "peer": true,
       "engines": {
         "node": ">= 12.0.0"
       },
@@ -8943,6 +8947,7 @@
       "os": [
         "linux"
       ],
+      "peer": true,
       "engines": {
         "node": ">= 12.0.0"
       },
@@ -8964,6 +8969,7 @@
       "os": [
         "linux"
       ],
+      "peer": true,
       "engines": {
         "node": ">= 12.0.0"
       },
@@ -8985,6 +8991,7 @@
       "os": [
         "linux"
       ],
+      "peer": true,
       "engines": {
         "node": ">= 12.0.0"
       },
@@ -9006,6 +9013,7 @@
       "os": [
         "linux"
       ],
+      "peer": true,
       "engines": {
         "node": ">= 12.0.0"
       },
@@ -9027,6 +9035,7 @@
       "os": [
         "linux"
       ],
+      "peer": true,
       "engines": {
         "node": ">= 12.0.0"
       },
@@ -9048,6 +9057,7 @@
       "os": [
         "win32"
       ],
+      "peer": true,
       "engines": {
         "node": ">= 12.0.0"
       },
@@ -9069,6 +9079,7 @@
       "os": [
         "win32"
       ],
+      "peer": true,
       "engines": {
         "node": ">= 12.0.0"
       },
@@ -10802,6 +10813,7 @@
       "version": "2.3.2",
       "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
       "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
+      "dev": true,
       "hasInstallScript": true,
       "license": "MIT",
       "optional": true,


### PR DESCRIPTION
🎯 **What:** The testing gap addressed is a missing test case that validates error handling when the server receives malformed JSON on the `POST /api/papers/:id/track` endpoint. The original test for missing JSON was unintentionally relying on an invalid JSON format (`"{"`), so it was updated to test for truly empty payloads (`""`), and a separate test was added.
📊 **Coverage:** Specifically covers the `catch` branch of `await c.req.json()` when handling invalid JSON strings like `{"`. Existing related tests across different routes were also cleaned up to explicitly send `""` instead of `{"` for missing payloads.
✨ **Result:** Enhanced test coverage and clearer distinction between tests for "missing" versus "invalid" payload structures, fulfilling the testing gap requested.

---
*PR created automatically by Jules for task [11521177028801750305](https://jules.google.com/task/11521177028801750305) started by @is0692vs*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Updated tests for papers endpoints to ensure consistent handling of malformed JSON request bodies
  * Added validation test for `POST /api/papers/:id/track` to verify proper error handling for invalid JSON payloads

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

このPRは `POST /api/papers/:id/track` の不正JSON ペイロード処理のテストカバレッジを改善します。既存テスト3件の `body: "{"` を `""` に修正し、`/track` に「missing」と「invalid」の2ケースを明示的に分離して追加しました。機能コードの変更はなく、テストのみの変更です。テスト名の不一致（`/invites`・`/description`・`PATCH` の各テストが `""` を使用しているにもかかわらず "malformed JSON body" のままになっている点）は前回レビューコメントで既に指摘されています。
</details>


<details open><summary><h3>Confidence Score: 5/5</h3></summary>

テストのみの変更であり、機能コードへの影響はなし。マージ安全性は高い。

P0・P1の問題は検出されず、P2（テスト名の不一致）は前回レビューで既に指摘済み。テストのみの変更で機能コードへのリスクはない。

特になし。テスト名の修正（前回コメント参照）が残タスクとして残っている。
</details>


<details open><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| apps/api/src/routes/__tests__/papers.test.ts | 既存の3テストで `body: "{"` → `""` に変更し、`/track` エンドポイント向けに "missing" と "invalid" の2テストを追加。テスト名の不一致（"malformed" → "missing"への改名漏れ）は前回レビューで既に指摘済み。 |

</details>


</details>


<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant Test as テストケース
    participant App as Hono App
    participant Handler as /track ハンドラー

    Note over Test,Handler: missing payload テスト (body: "")
    Test->>App: POST /api/papers/:id/track body: ""
    App->>Handler: リクエスト転送
    Handler-->>App: catch → { error: "Invalid JSON body" }
    App-->>Test: 400 Bad Request

    Note over Test,Handler: invalid payload テスト (body: "{") ← 新規追加
    Test->>App: POST /api/papers/:id/track body: "{"
    App->>Handler: リクエスト転送
    Handler-->>App: catch → { error: "Invalid JSON body" }
    App-->>Test: 400 Bad Request
```

<!-- greptile_failed_comments -->
<details open><summary><h3>Comments Outside Diff (3)</h3></summary>

1. `apps/api/src/routes/__tests__/papers.test.ts`, line 2174-2179 ([link](https://github.com/hiroki-org/openshelf/blob/c4d451e9d2a0ca9f8e1c283a8405539eb910d480/apps/api/src/routes/__tests__/papers.test.ts#L2174-L2179)) 

   <a href="#"><img alt="P2" src="https://greptile-static-assets.s3.amazonaws.com/badges/p2.svg?v=7" align="top"></a> テスト名とテスト内容が不一致になっています。`body: ""` は空（missing）ペイロードであり、マルフォームドJSONではないため、"malformed JSON body" というテスト名は誤解を招きます。`/track` エンドポイントでは "missing" と "invalid" を正しく区別しているのに、`/invites`・`/description`・`PATCH` のテストではその整合性が保たれていません。

   

   <details><summary>Prompt To Fix With AI</summary>

   `````markdown
   This is a comment left during a code review.
   Path: apps/api/src/routes/__tests__/papers.test.ts
   Line: 2174-2179

   Comment:
   テスト名とテスト内容が不一致になっています。`body: ""` は空（missing）ペイロードであり、マルフォームドJSONではないため、"malformed JSON body" というテスト名は誤解を招きます。`/track` エンドポイントでは "missing" と "invalid" を正しく区別しているのに、`/invites`・`/description`・`PATCH` のテストではその整合性が保たれていません。

   

   How can I resolve this? If you propose a fix, please make it concise.
   `````
   </details>

2. `apps/api/src/routes/__tests__/papers.test.ts`, line 2373-2378 ([link](https://github.com/hiroki-org/openshelf/blob/c4d451e9d2a0ca9f8e1c283a8405539eb910d480/apps/api/src/routes/__tests__/papers.test.ts#L2373-L2378)) 

   <a href="#"><img alt="P2" src="https://greptile-static-assets.s3.amazonaws.com/badges/p2.svg?v=7" align="top"></a> 同様に、`body: ""` に変更されたにもかかわらずテスト名が "malformed JSON body" のままです。`/track` エンドポイントとの一貫性のために "missing JSON body" に変更することを推奨します。

   

   <details><summary>Prompt To Fix With AI</summary>

   `````markdown
   This is a comment left during a code review.
   Path: apps/api/src/routes/__tests__/papers.test.ts
   Line: 2373-2378

   Comment:
   同様に、`body: ""` に変更されたにもかかわらずテスト名が "malformed JSON body" のままです。`/track` エンドポイントとの一貫性のために "missing JSON body" に変更することを推奨します。

   

   How can I resolve this? If you propose a fix, please make it concise.
   `````
   </details>

   Note: If this suggestion doesn't match your team's coding style, reply to this and let me know. I'll remember it for next time!

3. `apps/api/src/routes/__tests__/papers.test.ts`, line 2393-2398 ([link](https://github.com/hiroki-org/openshelf/blob/c4d451e9d2a0ca9f8e1c283a8405539eb910d480/apps/api/src/routes/__tests__/papers.test.ts#L2393-L2398)) 

   <a href="#"><img alt="P2" src="https://greptile-static-assets.s3.amazonaws.com/badges/p2.svg?v=7" align="top"></a> `body: ""` に更新されましたが、テスト名は "malformed JSON body" のままです。`/track` のテストで採用された命名規則（"missing" vs "invalid"）に合わせて名前を揃えると、テストスイート全体の可読性が向上します。

   

   <details><summary>Prompt To Fix With AI</summary>

   `````markdown
   This is a comment left during a code review.
   Path: apps/api/src/routes/__tests__/papers.test.ts
   Line: 2393-2398

   Comment:
   `body: ""` に更新されましたが、テスト名は "malformed JSON body" のままです。`/track` のテストで採用された命名規則（"missing" vs "invalid"）に合わせて名前を揃えると、テストスイート全体の可読性が向上します。

   

   How can I resolve this? If you propose a fix, please make it concise.
   `````
   </details>

   Note: If this suggestion doesn't match your team's coding style, reply to this and let me know. I'll remember it for next time!
</details>

<!-- /greptile_failed_comments -->

<sub>Reviews (2): Last reviewed commit: ["🧪 Add testing improvement for invalid J..."](https://github.com/hiroki-org/openshelf/commit/d062466c33df3c80b0e2904a3d0f1886cf01044e) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=30582574)</sub>

<!-- /greptile_comment -->