### PR TITLE
🛡️ Sentinel: [HIGH] OAuthコールバックにおけるオープンリダイレクト脆弱性の修正

### DIFF
--- a/apps/api/src/index.ts
+++ b/apps/api/src/index.ts
@@ -25,7 +25,7 @@ app.use(
                 const requestOrigin = normalizeOrigin(origin ?? undefined);
                 const frontendOrigin = normalizeOrigin(c.env.FRONTEND_URL);
 
-                if (isAllowedOrigin(requestOrigin, frontendOrigin, allowedOrigins)) {
+                if (isAllowedOrigin(requestOrigin, frontendOrigin, allowedOrigins, { allowWildcard: false })) {
                     return origin;
                 }
             } catch (err) {

--- a/apps/api/src/routes/auth.ts
+++ b/apps/api/src/routes/auth.ts
@@ -25,6 +25,7 @@ auth.get("/github", async (c) => {
         [requestSignalOrigin, requestedFrontendOrigin],
         c.env.FRONTEND_URL,
         parseOriginList(c.env.ALLOWED_ORIGINS),
+        { allowWildcard: false },
     );
 
     // Opportunistically clean up expired states to prevent unbounded growth.
@@ -239,6 +240,7 @@ auth.get("/github/callback", async (c) => {
         [flowOrigin],
         c.env.FRONTEND_URL,
         parseOriginList(c.env.ALLOWED_ORIGINS),
+        { allowWildcard: false },
     );
     if (!frontendUrl) {
         console.error("FATAL: FRONTEND_URL environment variable is not set.");

--- a/apps/api/src/utils/__tests__/origin.test.ts
+++ b/apps/api/src/utils/__tests__/origin.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "vitest";
-import { isAllowedOrigin, matchesOriginPattern, normalizeOrigin } from "../origin";
+import { isAllowedOrigin, matchesOriginPattern, normalizeOrigin, resolveAllowedOrigin } from "../origin";
 
 describe("origin utils", () => {
     it("allows request when origin matches the normalized frontend origin", () => {
@@ -92,6 +92,58 @@ describe("origin utils", () => {
                 { allowWildcard: true },
             ),
         ).toBe(false);
+    });
+
+    describe("resolveAllowedOrigin", () => {
+        it("returns the exact match from allowed origins", () => {
+            expect(
+                resolveAllowedOrigin(
+                    ["https://app.example.com"],
+                    "https://frontend.example.com",
+                    ["https://app.example.com", "https://other.example.com"]
+                )
+            ).toBe("https://app.example.com");
+        });
+
+        it("returns frontendUrl as fallback if no matches", () => {
+            expect(
+                resolveAllowedOrigin(
+                    ["https://evil.com"],
+                    "https://frontend.example.com",
+                    ["https://app.example.com"]
+                )
+            ).toBe("https://frontend.example.com");
+        });
+
+        it("respects allowWildcard: false option and falls back to frontendUrl", () => {
+            expect(
+                resolveAllowedOrigin(
+                    ["https://malicious.example.com"],
+                    "https://frontend.example.com",
+                    ["https://*.example.com"],
+                    { allowWildcard: false }
+                )
+            ).toBe("https://frontend.example.com");
+        });
+
+        it("matches wildcard pattern if allowWildcard: true is explicitly passed or defaulted", () => {
+            expect(
+                resolveAllowedOrigin(
+                    ["https://app.example.com"],
+                    "https://frontend.example.com",
+                    ["https://*.example.com"]
+                )
+            ).toBe("https://app.example.com");
+
+            expect(
+                resolveAllowedOrigin(
+                    ["https://app.example.com"],
+                    "https://frontend.example.com",
+                    ["https://*.example.com"],
+                    { allowWildcard: true }
+                )
+            ).toBe("https://app.example.com");
+        });
     });
 
 });

--- a/apps/api/src/utils/origin.ts
+++ b/apps/api/src/utils/origin.ts
@@ -59,11 +59,12 @@ export function resolveAllowedOrigin(
     candidates: Array<string | undefined>,
     frontendUrl: string,
     allowedOrigins: string[],
+    options: { allowWildcard?: boolean } = {},
 ): string {
     const frontendOrigin = normalizeOrigin(frontendUrl);
     for (const candidate of candidates) {
         const normalized = normalizeOrigin(candidate);
-        if (isAllowedOrigin(normalized, frontendOrigin, allowedOrigins)) {
+        if (isAllowedOrigin(normalized, frontendOrigin, allowedOrigins, options)) {
             return normalized as string;
         }
     }


### PR DESCRIPTION
このPRは、OAuthコールバック（`/api/auth/github` および `/api/auth/github/callback`）において、クライアントが指定するフロントエンドのOrigin検証時にワイルドカードマッチを無効化するセキュリティ修正を含みます。

これにより、悪意のあるアクターがワイルドカード付きの `ALLOWED_ORIGINS`（例: `https://*.example.com`）を悪用し、正規表現を通過する任意のサブドメインへユーザーをリダイレクトさせるオープンリダイレクト脆弱性を防止します。

**変更点:**
- `apps/api/src/utils/origin.ts`: `resolveAllowedOrigin` および内部で呼ばれる関数に `{ allowWildcard?: boolean }` オプションを追加
- `apps/api/src/routes/auth.ts`: `resolveAllowedOrigin` の呼び出しに `{ allowWildcard: false }` を渡し、ワイルドカードのマッチをブロック

---
*PR created automatically by Jules for task [18182259895388118220](https://jules.google.com/task/18182259895388118220) started by @is0692vs*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Made origin validation stricter for GitHub OAuth redirects and for CORS/CSRF checks to prevent overly permissive matches.
* **Tests**
  * Added tests covering origin resolution behavior, including exact-match, fallback, and wildcard-matching scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

このPRは、OAuthコールバック（`/api/auth/github` および `/api/auth/github/callback`）において、`resolveAllowedOrigin` に `{ allowWildcard: false }` オプションを渡すことで、`ALLOWED_ORIGINS` のワイルドカードパターンを経由したオープンリダイレクト脆弱性を修正します。`origin.ts` の変更は最小限かつ後方互換性があり、既存のデフォルト動作（`allowWildcard: true`）は他のユースケースで維持されています。
</details>


<details open><summary><h3>Confidence Score: 4/5</h3></summary>

セキュリティ修正の実装は正確で、P0/P1の問題はありません。マージ可能です。

変更は的確でロジックに誤りはなく、既存テストも `allowWildcard: false` の動作を検証済みです。P2指摘（CORSミドルウェアの不一致・`resolveAllowedOrigin` のテスト不足）はマージブロッカーではありません。

`apps/api/src/index.ts` のCORSミドルウェア（28行目）は本PRの対象外ですが、ワイルドカード制御の一貫性の観点でフォローアップを推奨します。
</details>


<details open><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| apps/api/src/utils/origin.ts | `resolveAllowedOrigin` に `options: { allowWildcard?: boolean }` を追加し、呼び出し元から `isAllowedOrigin` へ正しく引き継ぐ実装。既存ロジックへの影響はなく、デフォルト値 `true` で後方互換性を維持している。 |
| apps/api/src/routes/auth.ts | OAuthフロー（`/github` と `/github/callback`）の両 `resolveAllowedOrigin` 呼び出しに `{ allowWildcard: false }` を追加。これによりワイルドカードパターン経由のオープンリダイレクトを防止する。 |

</details>


</details>


<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant Browser
    participant Init as API /github
    participant CB as API /github/callback
    participant GitHub
    participant Resolver as resolveAllowedOrigin

    Browser->>Init: OAuthフロー開始
    Init->>Resolver: candidates, allowWildcard:false
    Note over Resolver: ワイルドカード無効で検証
    Resolver-->>Init: 検証済みorigin
    Init->>Browser: Cookieにoriginを保存
    Init->>GitHub: GitHubへリダイレクト

    GitHub->>CB: OAuthコールバック
    CB->>CB: CookieからoriginをRead
    CB->>Resolver: [cookieOrigin], allowWildcard:false
    Note over Resolver: ワイルドカード無効で再検証
    Resolver-->>CB: 検証済みfrontendUrl
    CB->>Browser: frontendUrlへリダイレクト
```

<!-- greptile_failed_comments -->
<details open><summary><h3>Comments Outside Diff (2)</h3></summary>

1. `apps/api/src/index.ts`, line 22-30 ([link](https://github.com/hiroki-org/openshelf/blob/4ca2b97aef72b635eb3596f5b09def21a561c4cb/apps/api/src/index.ts#L22-L30)) 

   <a href="#"><img alt="P2" src="https://greptile-static-assets.s3.amazonaws.com/badges/p2.svg?v=7" align="top"></a> **CORSミドルウェアのワイルドカード制限が未適用**

   CSRF保護（67〜68行目）とOAuthリダイレクト（`auth.ts`）では `allowWildcard: false` が設定されていますが、CORSミドルウェア（28行目）の `isAllowedOrigin` 呼び出しはデフォルトの `allowWildcard: true` のままです。`ALLOWED_ORIGINS` にワイルドカードパターン（例: `https://*.example.com`）が含まれている場合、任意のサブドメインからのクロスオリジンリクエストを許可するレスポンスヘッダー (`Access-Control-Allow-Origin`) が返され、サブドメイン乗っ取りと組み合わせるとCORSバイパスにつながる可能性があります。このPRの変更とは別箇所ですが、同じ `isAllowedOrigin` の使い方の一貫性が課題です。

   <details><summary>Prompt To Fix With AI</summary>

   `````markdown
   This is a comment left during a code review.
   Path: apps/api/src/index.ts
   Line: 22-30

   Comment:
   **CORSミドルウェアのワイルドカード制限が未適用**

   CSRF保護（67〜68行目）とOAuthリダイレクト（`auth.ts`）では `allowWildcard: false` が設定されていますが、CORSミドルウェア（28行目）の `isAllowedOrigin` 呼び出しはデフォルトの `allowWildcard: true` のままです。`ALLOWED_ORIGINS` にワイルドカードパターン（例: `https://*.example.com`）が含まれている場合、任意のサブドメインからのクロスオリジンリクエストを許可するレスポンスヘッダー (`Access-Control-Allow-Origin`) が返され、サブドメイン乗っ取りと組み合わせるとCORSバイパスにつながる可能性があります。このPRの変更とは別箇所ですが、同じ `isAllowedOrigin` の使い方の一貫性が課題です。

   How can I resolve this? If you propose a fix, please make it concise.
   `````
   </details>


2. `apps/api/src/utils/origin.ts`, line 58-73 ([link](https://github.com/hiroki-org/openshelf/blob/4ca2b97aef72b635eb3596f5b09def21a561c4cb/apps/api/src/utils/origin.ts#L58-L73)) 

   <a href="#"><img alt="P2" src="https://greptile-static-assets.s3.amazonaws.com/badges/p2.svg?v=7" align="top"></a> **`resolveAllowedOrigin` の `options` パラメータに対するテストが欠落**

   `isAllowedOrigin` 単体では `allowWildcard: false` のテストケースが追加されていますが、`resolveAllowedOrigin` に対して `options` を渡した際のエンドツーエンドのテストがありません。例えば「ワイルドカードパターンのみを持つ `ALLOWED_ORIGINS` に対して `allowWildcard: false` を渡したとき、フォールバックとして `frontendUrl` が返る」ケースが未カバーです。将来のリファクタリングで `options` の引き渡しが欠落するリスクを防ぐためにも、`resolveAllowedOrigin` レベルでの回帰テストを追加することをお勧めします。

   <details><summary>Prompt To Fix With AI</summary>

   `````markdown
   This is a comment left during a code review.
   Path: apps/api/src/utils/origin.ts
   Line: 58-73

   Comment:
   **`resolveAllowedOrigin` の `options` パラメータに対するテストが欠落**

   `isAllowedOrigin` 単体では `allowWildcard: false` のテストケースが追加されていますが、`resolveAllowedOrigin` に対して `options` を渡した際のエンドツーエンドのテストがありません。例えば「ワイルドカードパターンのみを持つ `ALLOWED_ORIGINS` に対して `allowWildcard: false` を渡したとき、フォールバックとして `frontendUrl` が返る」ケースが未カバーです。将来のリファクタリングで `options` の引き渡しが欠落するリスクを防ぐためにも、`resolveAllowedOrigin` レベルでの回帰テストを追加することをお勧めします。

   How can I resolve this? If you propose a fix, please make it concise.
   `````
   </details>

</details>

<!-- /greptile_failed_comments -->

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 2 code review issues. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 2
apps/api/src/index.ts:22-30
**CORSミドルウェアのワイルドカード制限が未適用**

CSRF保護（67〜68行目）とOAuthリダイレクト（`auth.ts`）では `allowWildcard: false` が設定されていますが、CORSミドルウェア（28行目）の `isAllowedOrigin` 呼び出しはデフォルトの `allowWildcard: true` のままです。`ALLOWED_ORIGINS` にワイルドカードパターン（例: `https://*.example.com`）が含まれている場合、任意のサブドメインからのクロスオリジンリクエストを許可するレスポンスヘッダー (`Access-Control-Allow-Origin`) が返され、サブドメイン乗っ取りと組み合わせるとCORSバイパスにつながる可能性があります。このPRの変更とは別箇所ですが、同じ `isAllowedOrigin` の使い方の一貫性が課題です。

### Issue 2 of 2
apps/api/src/utils/origin.ts:58-73
**`resolveAllowedOrigin` の `options` パラメータに対するテストが欠落**

`isAllowedOrigin` 単体では `allowWildcard: false` のテストケースが追加されていますが、`resolveAllowedOrigin` に対して `options` を渡した際のエンドツーエンドのテストがありません。例えば「ワイルドカードパターンのみを持つ `ALLOWED_ORIGINS` に対して `allowWildcard: false` を渡したとき、フォールバックとして `frontendUrl` が返る」ケースが未カバーです。将来のリファクタリングで `options` の引き渡しが欠落するリスクを防ぐためにも、`resolveAllowedOrigin` レベルでの回帰テストを追加することをお勧めします。


`````

</details>

<sub>Reviews (1): Last reviewed commit: ["fix(api): OAuthコールバックにおけるワイルドカードOriginマッ..."](https://github.com/hiroki-org/openshelf/commit/4ca2b97aef72b635eb3596f5b09def21a561c4cb) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=30606083)</sub>

<!-- /greptile_comment -->