### PR TITLE
fix: align frame blocking headers

### DIFF
--- a/apps/api/src/index.ts
+++ b/apps/api/src/index.ts
@@ -24,6 +24,7 @@ const app = new Hono<{ Bindings: Env; Variables: Variables }>();
 app.use(
   "*",
   secureHeaders({
+    xFrameOptions: "DENY",
     referrerPolicy: "strict-origin-when-cross-origin",
     contentSecurityPolicy: {
       defaultSrc: ["'none'"],

--- a/apps/api/src/routes/__tests__/cors.test.ts
+++ b/apps/api/src/routes/__tests__/cors.test.ts
@@ -72,16 +72,6 @@ describe("CORS configuration", () => {
         };
     });
 
-    it("sets frame blocking headers consistently", async () => {
-        const app = await createTestApp();
-        const env = createTestEnv();
-
-        const res = await app.request("http://localhost/", {}, env as any);
-
-        expect(res.headers.get("x-frame-options")).toBe("DENY");
-        expect(res.headers.get("content-security-policy")).toContain("frame-ancestors 'none'");
-    });
-
     it("uses FRONTEND_URL as fallback when ALLOWED_ORIGINS is not set", async () => {
         const app = await createTestApp();
         const env = createTestEnv({

--- a/apps/api/src/routes/__tests__/cors.test.ts
+++ b/apps/api/src/routes/__tests__/cors.test.ts
@@ -72,6 +72,16 @@ describe("CORS configuration", () => {
         };
     });
 
+    it("sets frame blocking headers consistently", async () => {
+        const app = await createTestApp();
+        const env = createTestEnv();
+
+        const res = await app.request("http://localhost/", {}, env as any);
+
+        expect(res.headers.get("x-frame-options")).toBe("DENY");
+        expect(res.headers.get("content-security-policy")).toContain("frame-ancestors 'none'");
+    });
+
     it("uses FRONTEND_URL as fallback when ALLOWED_ORIGINS is not set", async () => {
         const app = await createTestApp();
         const env = createTestEnv({

--- a/apps/api/src/routes/__tests__/security-headers.test.ts
+++ b/apps/api/src/routes/__tests__/security-headers.test.ts
@@ -1,0 +1,14 @@
+import { describe, expect, it } from "vitest";
+import { createTestApp, createTestEnv } from "../../test/helpers";
+
+describe("security headers", () => {
+    it("sets frame blocking headers consistently", async () => {
+        const app = await createTestApp();
+        const env = createTestEnv();
+
+        const res = await app.request("http://localhost/", {}, env as any);
+
+        expect(res.headers.get("x-frame-options")).toBe("DENY");
+        expect(res.headers.get("content-security-policy")).toContain("frame-ancestors 'none'");
+    });
+});


### PR DESCRIPTION
Fixes #681.\n\n- Explicitly sets X-Frame-Options to DENY alongside CSP frame-ancestors none.\n- Adds API coverage for the frame blocking header pair.\n\nLocal verification:\n- npm run test --workspace api -- src/routes/__tests__/cors.test.ts\n- git diff --check

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

このPRは、`secureHeaders` ミドルウェアに `xFrameOptions: \"DENY\"` を明示的に追加し、既存のCSP `frame-ancestors 'none'` との整合性を取ります。Honoのデフォルト（`SAMEORIGIN`）を上書きすることで、クリックジャッキング対策を強化しています。

- `apps/api/src/index.ts`: `xFrameOptions: \"DENY\"` を1行追加し、全ルートに適用されるセキュリティヘッダーを強化。
- `apps/api/src/routes/__tests__/cors.test.ts`: `X-Frame-Options` と `frame-ancestors` の両ヘッダーが正しく設定されることを検証するテストケースを追加。
</details>

<details open><summary><h3>Confidence Score: 5/5</h3></summary>

変更は最小限で1行の追加と対応するテスト1件のみ。既存のCSP設定と整合しており、副作用のリスクはほぼない。

`xFrameOptions: "DENY"` の明示的な指定はHonoのデフォルト（`SAMEORIGIN`）を上書きするシンプルな変更で、CSPの `frame-ancestors 'none'` と完全に整合している。テストも追加されており、動作を確認できる。

特に注意が必要なファイルはない。`cors.test.ts` へのテスト追加は軽微なスタイル上の懸念（ファイル配置）のみ。
</details>

<details open><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| apps/api/src/index.ts | `xFrameOptions: "DENY"` を明示的に追加し、CSP `frame-ancestors 'none'` との整合性を確保。変更は1行で問題なし。 |
| apps/api/src/routes/__tests__/cors.test.ts | フレームブロッキングヘッダーのペアを検証するテストケースを追加。ロジックは正確で `x-frame-options` および `frame-ancestors` の両方を検証している。 |

</details>

</details>

<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant Client
    participant Hono as Hono App
    participant SecureHeaders as secureHeaders Middleware
    participant Handler as Route Handler

    Client->>Hono: HTTP Request (any path)
    Hono->>SecureHeaders: apply middleware (*)
    SecureHeaders-->>SecureHeaders: Set X-Frame-Options: DENY
    SecureHeaders-->>SecureHeaders: Set CSP frame-ancestors 'none'
    SecureHeaders-->>SecureHeaders: Set Referrer-Policy: strict-origin-when-cross-origin
    SecureHeaders->>Handler: next()
    Handler-->>Client: Response with security headers
```

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 1 code review issue. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 1
apps/api/src/routes/__tests__/cors.test.ts:75-83
**テストファイルの配置**

フレームブロッキングヘッダーのテストが `cors.test.ts` に追加されています。`X-Frame-Options` や CSP の `frame-ancestors` はCORSとは独立したセキュリティヘッダーであるため、専用の `security-headers.test.ts` などに配置するほうがテストスイートの意図が明確になります。現状のファイルでも動作に問題はありませんが、ファイルが肥大化するにつれてテストの目的が分かりにくくなる可能性があります。

`````

</details>

<sub>Reviews (1): Last reviewed commit: ["fix: align frame blocking headers"](https://github.com/hiroki-org/openshelf/commit/397f984a04e6f9d7f0d122a514864c7d0d86571b) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=30814829)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->