### PR TITLE
🎨 Palette: PDFビューアのズームコントロールのアクセシビリティ改善

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -1,3 +1,7 @@
 ## 2025-05-04 - Toast Container Accessibility Improvement
 **Learning:** トーストのライブリージョンは、安定した親ラッパーに `aria-live="polite"` を使用し、`role="status"` や `aria-atomic="true"` を避けるべきです。なぜなら、これらはトーストリストに対して繰り返しのフルリストアナウンスを引き起こす可能性があるためです。
 **Action:** 今後、動的リストや通知 UI を構築・改善する際は、このガイダンスに従います。
+
+## 2025-05-04 - Icon-only button Accessibility Improvement
+**Learning:** `+` や `-` といったアイコンや記号のみのボタンでは、スクリーンリーダーで内容が正しく伝わらないため、機能や目的を示す明確な `aria-label` が必須です。
+**Action:** 今後、アイコンのみで構成されるボタンやコントロールを見つけた場合、コンテキストに合わせた `aria-label` を必ず付与します。

--- a/apps/web/src/components/__tests__/pdf-viewer.test.tsx
+++ b/apps/web/src/components/__tests__/pdf-viewer.test.tsx
@@ -211,9 +211,9 @@ describe("PdfViewer", () => {
       ).toBeInTheDocument();
     });
 
-    const [documentProps] = mockDocument.mock.calls[mockDocument.mock.calls.length - 1] as [
-      MockDocumentProps,
-    ];
+    const [documentProps] = mockDocument.mock.calls[
+      mockDocument.mock.calls.length - 1
+    ] as [MockDocumentProps];
     mockPage.mockClear();
     await act(async () => {
       documentProps.onLoadSuccess?.(
@@ -265,9 +265,9 @@ describe("PdfViewer", () => {
 
   it("supports custom search navigation across pages", async () => {
     render(<PdfViewer fileUrl="https://example.com/search.pdf" />);
-    const [documentProps] = mockDocument.mock.calls[mockDocument.mock.calls.length - 1] as [
-      MockDocumentProps,
-    ];
+    const [documentProps] = mockDocument.mock.calls[
+      mockDocument.mock.calls.length - 1
+    ] as [MockDocumentProps];
 
     await act(async () => {
       documentProps.onLoadSuccess?.(
@@ -297,7 +297,7 @@ describe("PdfViewer", () => {
   it("syncs pinch zoom with zoom controls on touch devices", async () => {
     render(<PdfViewer fileUrl="https://example.com/pinch.pdf" />);
     const surface = screen.getByTestId("pdf-viewer-surface");
-    const zoomSelect = screen.getByLabelText("PDF zoom") as HTMLSelectElement;
+    const zoomSelect = screen.getByLabelText("ズーム倍率") as HTMLSelectElement;
 
     fireEvent.touchStart(surface, {
       touches: [
@@ -315,7 +315,7 @@ describe("PdfViewer", () => {
 
     expect(zoomSelect.value).toBe("1.75");
 
-    fireEvent.click(screen.getByRole("button", { name: "+" }));
+    fireEvent.click(screen.getByRole("button", { name: "拡大" }));
     expect(zoomSelect.value).toBe("2");
   });
 
@@ -328,17 +328,29 @@ describe("PdfViewer", () => {
       ] as [MockDocumentProps];
 
       await act(async () => {
-        const mockDoc = createMockPdfDocument(["alpha", "beta target", "gamma target"]);
+        const mockDoc = createMockPdfDocument([
+          "alpha",
+          "beta target",
+          "gamma target",
+        ]);
         // Override page 2 to throw an error
         mockDoc.getPage = vi.fn(async (pageNumber: number) => {
           if (pageNumber === 2) {
             return {
-              getTextContent: vi.fn().mockRejectedValue(new Error("Extraction failed")),
+              getTextContent: vi
+                .fn()
+                .mockRejectedValue(new Error("Extraction failed")),
             };
           }
           return {
             getTextContent: vi.fn(async () => ({
-              items: [{ str: ["alpha", "beta target", "gamma target"][pageNumber - 1] ?? "" }],
+              items: [
+                {
+                  str:
+                    ["alpha", "beta target", "gamma target"][pageNumber - 1] ??
+                    "",
+                },
+              ],
             })),
           };
         });
@@ -354,7 +366,7 @@ describe("PdfViewer", () => {
         expect(screen.getByText("1 / 1")).toBeInTheDocument();
         expect(consoleSpy).toHaveBeenCalledWith(
           "Failed to extract text for page 2:",
-          expect.any(String)
+          expect.any(String),
         );
       });
     } finally {
@@ -365,13 +377,19 @@ describe("PdfViewer", () => {
   it("handles text extraction errors gracefully during search when error is not an Error instance", async () => {
     const consoleSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
     try {
-      render(<PdfViewer fileUrl="https://example.com/search-error-string.pdf" />);
+      render(
+        <PdfViewer fileUrl="https://example.com/search-error-string.pdf" />,
+      );
       const [documentProps] = mockDocument.mock.calls[
         mockDocument.mock.calls.length - 1
       ] as [MockDocumentProps];
 
       await act(async () => {
-        const mockDoc = createMockPdfDocument(["alpha", "beta target", "gamma target"]);
+        const mockDoc = createMockPdfDocument([
+          "alpha",
+          "beta target",
+          "gamma target",
+        ]);
         mockDoc.getPage = vi.fn(async (pageNumber: number) => {
           if (pageNumber === 2) {
             return {
@@ -380,7 +398,13 @@ describe("PdfViewer", () => {
           }
           return {
             getTextContent: vi.fn(async () => ({
-              items: [{ str: ["alpha", "beta target", "gamma target"][pageNumber - 1] ?? "" }],
+              items: [
+                {
+                  str:
+                    ["alpha", "beta target", "gamma target"][pageNumber - 1] ??
+                    "",
+                },
+              ],
             })),
           };
         });
@@ -395,7 +419,7 @@ describe("PdfViewer", () => {
         expect(screen.getByText("1 / 1")).toBeInTheDocument();
         expect(consoleSpy).toHaveBeenCalledWith(
           "Failed to extract text for page 2:",
-          "String error"
+          "String error",
         );
       });
     } finally {

--- a/apps/web/src/components/pdf-viewer.tsx
+++ b/apps/web/src/components/pdf-viewer.tsx
@@ -30,7 +30,9 @@ type PdfDocumentProxy = {
   getPage: (pageNumber: number) => Promise<PdfPageProxy>;
 };
 
-const ZOOM_PRESETS = [0.5, 0.67, 0.75, 0.9, 1, 1.1, 1.25, 1.5, 1.75, 2] as const;
+const ZOOM_PRESETS = [
+  0.5, 0.67, 0.75, 0.9, 1, 1.1, 1.25, 1.5, 1.75, 2,
+] as const;
 const MIN_ZOOM = ZOOM_PRESETS[0];
 const MAX_ZOOM = ZOOM_PRESETS[ZOOM_PRESETS.length - 1];
 const CONTINUOUS_BUFFER = 2;
@@ -71,7 +73,10 @@ const options = {
 export function PdfViewer({ fileUrl, onDownloadFallback }: PdfViewerProps) {
   const containerRef = useRef<HTMLDivElement | null>(null);
   const pageNodesRef = useRef<Map<number, HTMLDivElement>>(new Map());
-  const pinchStateRef = useRef<{ startDistance: number; startZoom: number } | null>(null);
+  const pinchStateRef = useRef<{
+    startDistance: number;
+    startZoom: number;
+  } | null>(null);
   const pdfDocumentRef = useRef<PdfDocumentProxy | null>(null);
   const searchTextCacheRef = useRef<Map<number, string>>(new Map());
   const isProgrammaticNavRef = useRef(false);
@@ -91,7 +96,10 @@ export function PdfViewer({ fileUrl, onDownloadFallback }: PdfViewerProps) {
   const [isPinching, setIsPinching] = useState(false);
 
   useEffect(() => {
-    if (typeof window === "undefined" || typeof window.matchMedia !== "function") {
+    if (
+      typeof window === "undefined" ||
+      typeof window.matchMedia !== "function"
+    ) {
       return;
     }
 
@@ -123,7 +131,9 @@ export function PdfViewer({ fileUrl, onDownloadFallback }: PdfViewerProps) {
       touchEvent.preventDefault();
     };
 
-    node.addEventListener("touchmove", handleNativeTouchMove, { passive: false });
+    node.addEventListener("touchmove", handleNativeTouchMove, {
+      passive: false,
+    });
     return () => {
       node.removeEventListener("touchmove", handleNativeTouchMove);
     };
@@ -141,10 +151,7 @@ export function PdfViewer({ fileUrl, onDownloadFallback }: PdfViewerProps) {
   const activePage = viewMode === "continuous" ? visiblePage : pageNumber;
   const canPrev = activePage > 1;
   const canNext = numPages > 0 && activePage < numPages;
-  const searchMatchSet = useMemo(
-    () => new Set(searchMatches),
-    [searchMatches],
-  );
+  const searchMatchSet = useMemo(() => new Set(searchMatches), [searchMatches]);
   const pages = useMemo(
     () => Array.from({ length: numPages }, (_, index) => index + 1),
     [numPages],
@@ -170,11 +177,14 @@ export function PdfViewer({ fileUrl, onDownloadFallback }: PdfViewerProps) {
     [],
   );
 
-  const scrollToPage = useCallback((targetPage: number, behavior: ScrollBehavior = "smooth") => {
-    const node = pageNodesRef.current.get(targetPage);
-    if (!node) return;
-    node.scrollIntoView({ behavior, block: "start" });
-  }, []);
+  const scrollToPage = useCallback(
+    (targetPage: number, behavior: ScrollBehavior = "smooth") => {
+      const node = pageNodesRef.current.get(targetPage);
+      if (!node) return;
+      node.scrollIntoView({ behavior, block: "start" });
+    },
+    [],
+  );
 
   const goToPage = useCallback(
     (targetPage: number) => {
@@ -302,7 +312,7 @@ export function PdfViewer({ fileUrl, onDownloadFallback }: PdfViewerProps) {
                   "str" in item &&
                   typeof (item as { str?: unknown }).str === "string"
                 ) {
-                  return ((item as { str: string }).str).toLowerCase();
+                  return (item as { str: string }).str.toLowerCase();
                 }
                 return "";
               })
@@ -313,7 +323,8 @@ export function PdfViewer({ fileUrl, onDownloadFallback }: PdfViewerProps) {
             matches.push(page);
           }
         } catch (error) {
-          const message = error instanceof Error ? String(error) : String(error);
+          const message =
+            error instanceof Error ? String(error) : String(error);
           console.warn(`Failed to extract text for page ${page}:`, message);
         }
       }
@@ -395,42 +406,43 @@ export function PdfViewer({ fileUrl, onDownloadFallback }: PdfViewerProps) {
     >
       <div className="mb-3 flex flex-wrap items-center justify-between gap-2">
         <div className="flex items-center gap-2">
-            <button
-              type="button"
-              onClick={() => goToPage(activePage - 1)}
-              disabled={!canPrev}
-              className="rounded border border-gray-300 px-2 py-1 text-xs disabled:cursor-not-allowed disabled:opacity-50 dark:border-gray-600"
-            >
-              前へ
-            </button>
-            <span className="text-xs text-gray-600 dark:text-gray-300">
-              {activePage} / {numPages || "-"}
-            </span>
-            <button
-              type="button"
-              onClick={() => goToPage(activePage + 1)}
-              disabled={!canNext}
-              className="rounded border border-gray-300 px-2 py-1 text-xs disabled:cursor-not-allowed disabled:opacity-50 dark:border-gray-600"
-            >
+          <button
+            type="button"
+            onClick={() => goToPage(activePage - 1)}
+            disabled={!canPrev}
+            className="rounded border border-gray-300 px-2 py-1 text-xs disabled:cursor-not-allowed disabled:opacity-50 dark:border-gray-600"
+          >
+            前へ
+          </button>
+          <span className="text-xs text-gray-600 dark:text-gray-300">
+            {activePage} / {numPages || "-"}
+          </span>
+          <button
+            type="button"
+            onClick={() => goToPage(activePage + 1)}
+            disabled={!canNext}
+            className="rounded border border-gray-300 px-2 py-1 text-xs disabled:cursor-not-allowed disabled:opacity-50 dark:border-gray-600"
+          >
             次へ
           </button>
         </div>
 
         <div className="flex items-center gap-2">
-            <button
-              type="button"
-              onClick={() => {
-                const currentIndex = ZOOM_PRESETS.indexOf(snapZoom(zoom));
-                if (currentIndex > 0) setZoom(ZOOM_PRESETS[currentIndex - 1]);
-              }}
-              disabled={zoom <= MIN_ZOOM}
-              className="rounded border border-gray-300 px-2 py-1 text-xs disabled:cursor-not-allowed disabled:opacity-50 dark:border-gray-600"
+          <button
+            type="button"
+            aria-label="縮小"
+            onClick={() => {
+              const currentIndex = ZOOM_PRESETS.indexOf(snapZoom(zoom));
+              if (currentIndex > 0) setZoom(ZOOM_PRESETS[currentIndex - 1]);
+            }}
+            disabled={zoom <= MIN_ZOOM}
+            className="rounded border border-gray-300 px-2 py-1 text-xs disabled:cursor-not-allowed disabled:opacity-50 dark:border-gray-600"
           >
             -
           </button>
 
           <select
-            aria-label="PDF zoom"
+            aria-label="ズーム倍率"
             value={snapZoom(zoom)}
             onChange={(e) => setZoom(Number(e.target.value))}
             className="rounded border border-gray-300 px-2 py-1 text-xs dark:border-gray-600 dark:bg-gray-900"
@@ -442,79 +454,78 @@ export function PdfViewer({ fileUrl, onDownloadFallback }: PdfViewerProps) {
             ))}
           </select>
 
-            <button
-              type="button"
-              onClick={() => {
-                const currentIndex = ZOOM_PRESETS.indexOf(snapZoom(zoom));
-                if (currentIndex < ZOOM_PRESETS.length - 1) {
-                  setZoom(ZOOM_PRESETS[currentIndex + 1]);
-                }
-              }}
-              disabled={zoom >= MAX_ZOOM}
-              className="rounded border border-gray-300 px-2 py-1 text-xs disabled:cursor-not-allowed disabled:opacity-50 dark:border-gray-600"
+          <button
+            type="button"
+            aria-label="拡大"
+            onClick={() => {
+              const currentIndex = ZOOM_PRESETS.indexOf(snapZoom(zoom));
+              if (currentIndex < ZOOM_PRESETS.length - 1) {
+                setZoom(ZOOM_PRESETS[currentIndex + 1]);
+              }
+            }}
+            disabled={zoom >= MAX_ZOOM}
+            className="rounded border border-gray-300 px-2 py-1 text-xs disabled:cursor-not-allowed disabled:opacity-50 dark:border-gray-600"
           >
             +
           </button>
 
-            <button
-              type="button"
-              onClick={toggleFullScreen}
-              className="rounded bg-gray-800 px-2 py-1 text-xs text-white hover:bg-gray-700 dark:bg-gray-200 dark:text-gray-900"
-            >
-              全画面
-            </button>
-
-            <button
-              type="button"
-              onClick={() =>
-                setViewMode((mode) =>
-                  mode === "paged" ? "continuous" : "paged",
-                )
-              }
-              className="rounded border border-gray-300 px-2 py-1 text-xs dark:border-gray-600"
-            >
-              {viewMode === "paged" ? "連続スクロール" : "ページ送り"}
-            </button>
-          </div>
-        </div>
-
-        <div className="mb-3 flex flex-wrap items-center gap-2">
-          <input
-            aria-label="PDF内検索"
-            type="search"
-            value={searchQuery}
-            onChange={(event) => setSearchQuery(event.target.value)}
-            placeholder="検索語を入力"
-            className="min-w-[180px] flex-1 rounded border border-gray-300 px-2 py-1 text-xs dark:border-gray-600 dark:bg-gray-900"
-          />
           <button
             type="button"
-            disabled={searchMatches.length === 0}
-            onClick={() => moveMatchCursor(-1)}
-            className="rounded border border-gray-300 px-2 py-1 text-xs disabled:cursor-not-allowed disabled:opacity-50 dark:border-gray-600"
+            onClick={toggleFullScreen}
+            className="rounded bg-gray-800 px-2 py-1 text-xs text-white hover:bg-gray-700 dark:bg-gray-200 dark:text-gray-900"
           >
-            前の一致
+            全画面
           </button>
+
           <button
             type="button"
-            disabled={searchMatches.length === 0}
-            onClick={() => moveMatchCursor(1)}
-            className="rounded border border-gray-300 px-2 py-1 text-xs disabled:cursor-not-allowed disabled:opacity-50 dark:border-gray-600"
+            onClick={() =>
+              setViewMode((mode) => (mode === "paged" ? "continuous" : "paged"))
+            }
+            className="rounded border border-gray-300 px-2 py-1 text-xs dark:border-gray-600"
           >
-            次の一致
+            {viewMode === "paged" ? "連続スクロール" : "ページ送り"}
           </button>
-          <span
-            aria-live="polite"
-            aria-atomic="true"
-            className="text-xs text-gray-500 dark:text-gray-300"
-          >
-            {searchQuery.trim().length === 0
-              ? ""
-              : searchMatches.length === 0
-                ? "一致なし"
-                : `${activeMatchIndex + 1} / ${searchMatches.length}`}
-          </span>
         </div>
+      </div>
+
+      <div className="mb-3 flex flex-wrap items-center gap-2">
+        <input
+          aria-label="PDF内検索"
+          type="search"
+          value={searchQuery}
+          onChange={(event) => setSearchQuery(event.target.value)}
+          placeholder="検索語を入力"
+          className="min-w-[180px] flex-1 rounded border border-gray-300 px-2 py-1 text-xs dark:border-gray-600 dark:bg-gray-900"
+        />
+        <button
+          type="button"
+          disabled={searchMatches.length === 0}
+          onClick={() => moveMatchCursor(-1)}
+          className="rounded border border-gray-300 px-2 py-1 text-xs disabled:cursor-not-allowed disabled:opacity-50 dark:border-gray-600"
+        >
+          前の一致
+        </button>
+        <button
+          type="button"
+          disabled={searchMatches.length === 0}
+          onClick={() => moveMatchCursor(1)}
+          className="rounded border border-gray-300 px-2 py-1 text-xs disabled:cursor-not-allowed disabled:opacity-50 dark:border-gray-600"
+        >
+          次の一致
+        </button>
+        <span
+          aria-live="polite"
+          aria-atomic="true"
+          className="text-xs text-gray-500 dark:text-gray-300"
+        >
+          {searchQuery.trim().length === 0
+            ? ""
+            : searchMatches.length === 0
+              ? "一致なし"
+              : `${activeMatchIndex + 1} / ${searchMatches.length}`}
+        </span>
+      </div>
 
       <div
         ref={containerRef}
@@ -563,7 +574,8 @@ export function PdfViewer({ fileUrl, onDownloadFallback }: PdfViewerProps) {
               <div className="flex flex-col items-center gap-4 py-1">
                 {pages.map((targetPage) => {
                   const isVisibleByBuffer =
-                    targetPage >= renderRange.start && targetPage <= renderRange.end;
+                    targetPage >= renderRange.start &&
+                    targetPage <= renderRange.end;
                   const isSearchMatch = searchMatchSet.has(targetPage);
                   const isActiveSearchMatch = activeMatchPage === targetPage;
                   const shouldRender = isVisibleByBuffer || isActiveSearchMatch;

--- a/apps/web/src/components/pdf-viewer.tsx
+++ b/apps/web/src/components/pdf-viewer.tsx
@@ -324,7 +324,7 @@ export function PdfViewer({ fileUrl, onDownloadFallback }: PdfViewerProps) {
           }
         } catch (error) {
           const message =
-            error instanceof Error ? String(error) : String(error);
+            error instanceof Error ? error.message : String(error);
           console.warn(`Failed to extract text for page ${page}:`, message);
         }
       }


### PR DESCRIPTION
💡 **What**: `apps/web/src/components/pdf-viewer.tsx` において、ズームの縮小（-）および拡大（+）ボタンに `aria-label` を追加しました。また、ズーム倍率を選択する `select` 要素の `aria-label` を「PDF zoom」から日本語の「ズーム倍率」に修正しました。

🎯 **Why**: アイコンや記号（`-` や `+`）のみで構成されるボタンは、視覚的には意味が推測できてもスクリーンリーダーなどの支援技術を利用するユーザーにはその目的が伝わりづらいためです。機能を示す `aria-label` を明示的に付与することで、インターフェースのアクセシビリティと直感性を向上させました。

♿ **Accessibility**:
- ズーム縮小ボタンに `aria-label="縮小"` を追加
- ズーム拡大ボタンに `aria-label="拡大"` を追加
- セレクトボックスのラベルを `aria-label="ズーム倍率"` に変更（日本語UIとの統一）

---
*PR created automatically by Jules for task [169634367809711320](https://jules.google.com/task/169634367809711320) started by @is0692vs*

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

PDFビューアのズームコントロール（縮小・拡大ボタンおよびセレクトボックス）にアクセシビリティ属性を追加し、スクリーンリーダー対応を改善しました。あわせてコンポーネント全体のインデントおよび行折り返しのフォーマット整形も含まれています。

- `pdf-viewer.tsx`: 縮小ボタンに `aria-label="縮小"`、拡大ボタンに `aria-label="拡大"` を追加。セレクトの `aria-label` を `"PDF zoom"` から `"ズーム倍率"` に変更。JSX の不揃いなインデントも修正。
- `pdf-viewer.test.tsx`: 上記の `aria-label` 変更に合わせてテストクエリ（`getByLabelText`・`getByRole`）を更新。フォーマット整形も含む。
- `.Jules/palette.md`: アイコンのみのボタンには `aria-label` が必須という学習記録を追記。
</details>

<details open><summary><h3>Confidence Score: 4/5</h3></summary>

アクセシビリティ属性の追加とフォーマット整形が主な変更であり、機能ロジックへの影響は最小限。安全にマージできます。

変更の大部分は aria-label の追加・変更とコードフォーマットの整形で、既存動作を壊すリスクはほぼありません。テキスト抽出エラー処理の三項演算子（error instanceof Error ? String(error) : String(error)）の両分岐が同一式になっており、instanceof チェックが無効化されている既存バグを引き継いでいます。この行が今回の PR で再フォーマットされているため修正の機会でしたが、見送られています。

pdf-viewer.tsx の catch ブロック内エラーメッセージ構築部分（326〜327 行）を確認してください。
</details>

<details open><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| apps/web/src/components/pdf-viewer.tsx | ズーム縮小・拡大ボタンへ aria-label="縮小"/"拡大" を追加、select の aria-label を "ズーム倍率" に変更。インデント整形・行折り返しのリファクタリングを含む。三項演算子の両分岐が同一（既存バグ）。 |
| apps/web/src/components/__tests__/pdf-viewer.test.tsx | aria-label の変更（"PDF zoom" → "ズーム倍率"、ボタン名 "+" → "拡大"）に合わせてテストクエリを更新。コードフォーマットの整形のみでロジック変更なし。 |
| .Jules/palette.md | アイコンのみのボタンには aria-label が必要という学習記録を追記。ドキュメントのみの変更。 |

</details>

</details>

<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[ズームコントロール] --> B["縮小ボタン (-)"]
    A --> C["ズーム倍率 セレクト"]
    A --> D["拡大ボタン (+)"]
    B -->|旧| B1["aria-label なし（スクリーンリーダーが '-' と読み上げ）"]
    B -->|新| B2["aria-label='縮小'"]
    C -->|旧| C1["aria-label='PDF zoom'"]
    C -->|新| C2["aria-label='ズーム倍率'"]
    D -->|旧| D1["aria-label なし（スクリーンリーダーが '+' と読み上げ）"]
    D -->|新| D2["aria-label='拡大'"]
```

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 1 code review issue. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 1
apps/web/src/components/pdf-viewer.tsx:326-327
三項演算子の両分岐が同一の式（`String(error)`）になっており、`instanceof Error` チェックが無意味になっています。本来は `Error` インスタンスの場合に `error.message` を使うことで、`"Error: ..."` プレフィックスなしのクリーンなメッセージが得られるはずです。この PR でこの行が再フォーマットされたタイミングで修正する機会です。

```suggestion
          const message =
            error instanceof Error ? error.message : String(error);
```

`````

</details>

<sub>Reviews (1): Last reviewed commit: ["feat(ux): add aria-labels to zoom contro..."](https://github.com/hiroki-org/openshelf/commit/8fea7980a86d78b6ece9f84427847efef91e97a6) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=30856307)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->