### PR TITLE
🛡️ Sentinel: [HIGH] Fix Drizzle ORM Wildcard Injection in user search

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -1,0 +1,4 @@
+## 2025-05-07 - [Drizzle ORM Wildcard Injection in Search]
+**Vulnerability:** The Drizzle `like()` helper does not automatically escape literal wildcard characters (`%`, `_`). User input containing these characters used directly in a `like()` query can cause unexpected matches or lead to an algorithmic complexity DoS (Wildcard Injection).
+**Learning:** Found in `apps/api/src/routes/users.ts` user search where `like(users.name, \`%\${q}%\`)` was used without escaping `q`.
+**Prevention:** Construct the condition using the `sql` template literal with manual escaping, e.g., `sql\`\${column} LIKE \${\`%\${escapeLikeLiteral(input)}%\`} ESCAPE '\\\\'\``.

--- a/apps/api/src/routes/users.ts
+++ b/apps/api/src/routes/users.ts
@@ -1,11 +1,16 @@
 import { Hono, Context } from "hono";
 import { drizzle } from "drizzle-orm/d1";
-import { eq, like, or, and, ne, type InferSelectModel } from "drizzle-orm";
+import { eq, sql, or, and, ne, type InferSelectModel } from "drizzle-orm";
 import { users, enableForeignKeys, touchUpdatedAt } from "../db/schema";
 import type { Env, Variables } from "../types";
 import { authMiddleware } from "../middleware/auth";
 
 const usersRoute = new Hono<{ Bindings: Env; Variables: Variables }>();
+
+// Security: Escape wildcards to prevent Algorithmic Complexity DoS (Wildcard Injection)
+const escapeLikeLiteral = (str: string) => {
+  return str.replace(/[\\%_]/g, "\\$&");
+};
 
 // GET /api/users/me — current profile
 usersRoute.get("/me", authMiddleware, async (c) => {
@@ -65,13 +70,13 @@ usersRoute.put("/me", authMiddleware, updateMeHandler);
 
 // Simple in-memory cache for user search
 type UserSearchResult = Pick<
-    InferSelectModel<typeof users>,
-    "id" | "name" | "displayName" | "githubId" | "avatarUrl"
+  InferSelectModel<typeof users>,
+  "id" | "name" | "displayName" | "githubId" | "avatarUrl"
 >;
 
 type CachedSearchResult = {
-    data: UserSearchResult[];
-    timestamp: number;
+  data: UserSearchResult[];
+  timestamp: number;
 };
 const searchCache = new Map<string, CachedSearchResult>();
 const CACHE_TTL_MS = 60 * 1000; // 1 minute
@@ -128,7 +133,11 @@ usersRoute.get("/search", authMiddleware, async (c) => {
     .from(users)
     .where(
       and(
-        or(like(users.name, `%${q}%`), like(users.githubId, `%${q}%`)),
+        or(
+          sql`${users.name} LIKE ${`%${escapeLikeLiteral(q)}%`} ESCAPE '\\'`,
+          sql`${users.githubId} LIKE ${`%${escapeLikeLiteral(q)}%`} ESCAPE '\\'`,
+        ),
+
         ne(users.id, currentUserId),
       ),
     )


### PR DESCRIPTION
🚨 **Severity:** HIGH
💡 **Vulnerability:** ユーザー検索機能（`apps/api/src/routes/users.ts`）において、検索クエリにユーザーからの入力をそのままDrizzle ORMの `like()` ヘルパーに渡していました。`%` や `_` といったワイルドカード文字が適切にエスケープされないため、意図しない一致を発生させたり、アルゴリズムの複雑さを利用したDoS攻撃（Wildcard Injection）につながるリスクがありました。
🎯 **Impact:** 攻撃者が特定のワイルドカード文字を大量に送信することで、データベースの負荷が異常に高まり、サービス停止に陥る可能性があります。
🔧 **Fix:** `escapeLikeLiteral` ヘルパー関数を導入し、ユーザー入力から `%`, `_`, `\` を適切にエスケープするように修正しました。また、`like()` を `sql` タグに置き換え、明示的に `ESCAPE '\'` 句を付与しました。
✅ **Verification:** テストスイート（`bun x vitest run apps/api/` および `apps/web/`）を実行し、問題なくパスすることを確認しました。

---
*PR created automatically by Jules for task [1330020127434241869](https://jules.google.com/task/1330020127434241869) started by @is0692vs*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed a security vulnerability in the user search feature where special wildcard characters were not properly escaped, potentially enabling injection attacks and unexpected search results.

* **Documentation**
  * Added security guidance documenting wildcard injection risks and providing remediation patterns for SQL LIKE operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

ユーザー検索クエリ（`q`）をDrizzleの `like()` ヘルパーにそのまま渡していた箇所を修正し、`%`・`_`・`\` をエスケープする `escapeLikeLiteral` 関数と Drizzle の `sql` テンプレートタグに置き換えました。これにより、ワイルドカードインジェクションによる意図しないマッチとアルゴリズム的 DoS のリスクが排除されています。

- `escapeLikeLiteral` 関数は正規表現 `/[\\%_]/g` を使って3種の特殊文字を正しくエスケープしており、`ESCAPE '\\'` 句と組み合わせた SQLite の動作も正しい実装です。
- `like` のインポートを削除し `sql` に置き換え、型定義のインデント統一など軽微なスタイル修正も含まれています。
</details>


<details open><summary><h3>Confidence Score: 4/5</h3></summary>

ワイルドカードエスケープの修正自体は正しく実装されており、マージは概ね安全です。

エスケープロジック・バインドパラメータの使い方・ESCAPE 句はいずれも正しく、セキュリティ修正の意図を達成しています。ただし検索クエリに最大長の上限がなく、非常に長い入力に対する LIKE スキャンのコスト増大とキャッシュメモリ消費が残存しています。

apps/api/src/routes/users.ts — 検索クエリの最大長バリデーションの追加を検討してください。
</details>


<details open><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| apps/api/src/routes/users.ts | ユーザー検索のLIKEクエリにエスケープ処理を追加。`escapeLikeLiteral`関数とDrizzleの`sql`タグを使い、ワイルドカード文字（`%`/`_`/`\`）を安全に扱えるよう修正。インプット長の上限チェックが未実装のため、長大な文字列への対策が不完全。 |
| .jules/sentinel.md | Sentinelの学習ログとして脆弱性の概要と対策を記録したドキュメントのみの追加。コードへの影響なし。 |

</details>


</details>


<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant Client
    participant SearchRoute as GET /api/users/search
    participant Cache as In-Memory Cache
    participant DB as D1 (SQLite)

    Client->>SearchRoute: "q=ユーザー入力 (e.g. foo%_bar)"
    SearchRoute->>SearchRoute: "length < 2 → 空配列を返す"
    SearchRoute->>Cache: getCachedResults(q + currentUserId)
    alt キャッシュヒット
        Cache-->>SearchRoute: UserSearchResult[]
        SearchRoute-->>Client: "{ users: [...] }"
    else キャッシュミス
        SearchRoute->>SearchRoute: escapeLikeLiteral(q) → foo\%\_bar
        SearchRoute->>DB: "SELECT ... WHERE name LIKE '%foo\%\_bar%' ESCAPE '\' OR githubId LIKE ... AND id != currentUserId LIMIT 10"
        DB-->>SearchRoute: rows
        SearchRoute->>Cache: setCachedResults(key, rows)
        SearchRoute-->>Client: "{ users: [...] }"
    end
```

<!-- greptile_failed_comments -->
<details open><summary><h3>Comments Outside Diff (1)</h3></summary>

1. `apps/api/src/routes/users.ts`, line 113 ([link](https://github.com/hiroki-org/openshelf/blob/82e7764d130c0d5bb25ea76377bc36b9d51d92b7/apps/api/src/routes/users.ts#L113)) 

   <a href="#"><img alt="P2" src="https://greptile-static-assets.s3.amazonaws.com/badges/p2.svg?v=7" align="top"></a> 検索クエリ `q` に最小文字数（2文字）のチェックはありますが、**最大文字数の上限がありません**。ワイルドカードのエスケープにより複雑度の爆発は防げましたが、非常に長い文字列（例：数百〜数千文字）を渡された場合、LIKE スキャンのコストが増大し、またキャッシュエントリが大量のメモリを消費する可能性があります。

   

   <details><summary>Prompt To Fix With AI</summary>

   `````markdown
   This is a comment left during a code review.
   Path: apps/api/src/routes/users.ts
   Line: 113

   Comment:
   検索クエリ `q` に最小文字数（2文字）のチェックはありますが、**最大文字数の上限がありません**。ワイルドカードのエスケープにより複雑度の爆発は防げましたが、非常に長い文字列（例：数百〜数千文字）を渡された場合、LIKE スキャンのコストが増大し、またキャッシュエントリが大量のメモリを消費する可能性があります。

   

   How can I resolve this? If you propose a fix, please make it concise.
   `````
   </details>

</details>

<!-- /greptile_failed_comments -->

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 1 code review issue. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 1
apps/api/src/routes/users.ts:113
検索クエリ `q` に最小文字数（2文字）のチェックはありますが、**最大文字数の上限がありません**。ワイルドカードのエスケープにより複雑度の爆発は防げましたが、非常に長い文字列（例：数百〜数千文字）を渡された場合、LIKE スキャンのコストが増大し、またキャッシュエントリが大量のメモリを消費する可能性があります。

```suggestion
  if (!q || q.length < 2 || q.length > 100) return c.json({ users: [] });
```


`````

</details>

<sub>Reviews (1): Last reviewed commit: ["🛡️ Sentinel: \[CRITICAL/HIGH\] Fix Drizzl..."](https://github.com/hiroki-org/openshelf/commit/82e7764d130c0d5bb25ea76377bc36b9d51d92b7) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=31191693)</sub>

<!-- /greptile_comment -->