### PR TITLE
docs(agent): update PR review closure loop with strict resolution rules and reporting format

### DIFF
--- a/.github/agents/pr-review-closure-loop.md
+++ b/.github/agents/pr-review-closure-loop.md
@@ -80,6 +80,7 @@ Shared tooling reference: `../../AGENTS.md` and `../../docs/agent-tooling.md`.
    - After each push, wait for CI to complete (e.g. `gh pr checks --watch`).
    - Re-fetch CI/check status and newly added review threads.
 8. **Repeat** until stop conditions are satisfied or iteration cap is reached.
+   - Log iteration progress concisely (e.g. "Iteration X: Processed N threads, Pushed commit: Y, Remaining: Z").
 
 ## Tooling & Command Patterns
 
@@ -91,7 +92,7 @@ Shared tooling reference: `../../AGENTS.md` and `../../docs/agent-tooling.md`.
     query($owner: String!, $repo: String!, $pr: Int!) {
       repository(owner: $owner, name: $repo) {
         pullRequest(number: $pr) {
-          reviewThreads(first: 50) {
+          reviewThreads(first: 100) { # Specify pagination if over 100
             nodes {
               id
               isResolved
@@ -121,14 +122,14 @@ Shared tooling reference: `../../AGENTS.md` and `../../docs/agent-tooling.md`.
 
 ## Final Report Format (Mandatory)
 
-Whenever you complete a PR Review Closure Loop, or if you abort due to an error/timeout, you MUST output a final report in the following format. Do not omit any fields.
+Whenever you complete a PR Review Closure Loop, or if you abort due to an error/timeout, you MUST output a final report in the following format. Do not omit any fields. If a field cannot be populated due to an early exit, explicitly use `N/A` or `0`.
 
 ```md
 ### PR Review Closure Report
 
 - **対象 PR URL**: <PR URL>
-- **gh version**: <output of gh --version>
-- **gh auth status の結果**: <Logged in... / Failed>
+- **gh version**: <version string from gh --version> (Use single line/summary)
+- **gh auth status の結果**: <summary of gh auth status> (Use single line/summary)
 - **取得した review thread 数**: <count>
 - **resolve 前の unresolved thread 数**: <count>
 - **resolve 後の unresolved thread 数**: <count>

--- a/.github/agents/pr-review-closure-loop.md
+++ b/.github/agents/pr-review-closure-loop.md
@@ -86,13 +86,17 @@ Shared tooling reference: `../../AGENTS.md` and `../../docs/agent-tooling.md`.
 
 - **Initial Auth Check**: `gh --version && gh auth status`
 - **CI status watch**: `gh pr checks <PR_NUMBER> --required --watch --interval 10`
-- **Fetch Review Threads (GraphQL Example)**:
+- **Fetch Review Threads (GraphQL Example, paginated)**:
   ```bash
   gh api graphql -f query='
-    query($owner: String!, $repo: String!, $pr: Int!) {
+    query($owner: String!, $repo: String!, $pr: Int!, $after: String) {
       repository(owner: $owner, name: $repo) {
         pullRequest(number: $pr) {
-          reviewThreads(first: 100) { # Specify pagination if over 100
+          reviewThreads(first: 100, after: $after) {
+            pageInfo {
+              hasNextPage
+              endCursor
+            }
             nodes {
               id
               isResolved
@@ -101,8 +105,10 @@ Shared tooling reference: `../../AGENTS.md` and `../../docs/agent-tooling.md`.
           }
         }
       }
-    }' -f owner="OWNER" -f repo="REPO" -F pr=123
+    }' -f owner="OWNER" -f repo="REPO" -F pr=123 -F after=null
   ```
+
+  - Repeat requests while `pageInfo.hasNextPage == true`, passing `pageInfo.endCursor` to `after`.
 - **Resolve a Thread (GraphQL Example)**:
   ```bash
   gh api graphql -f query='

--- a/.github/agents/pr-review-closure-loop.md
+++ b/.github/agents/pr-review-closure-loop.md
@@ -24,13 +24,15 @@ Shared tooling reference: `../../AGENTS.md` and `../../docs/agent-tooling.md`.
 
 ## Mission
 
+- **Do not stop at PR creation.** A PR is not done until the review cycle is closed and CI is green.
 - For each unresolved review conversation in an open PR, classify the comment as:
-  - ADDRESS: code/test/doc change is required and feasible.
-  - IGNORE_WITH_REASON: no code change is needed, but a concrete reason must be posted.
-- For both outcomes, post a reply on the same conversation and then resolve that conversation.
+  - **ADDRESS**: code/test/doc change is required and feasible.
+  - **IGNORE_WITH_REASON**: no code change is needed, but a concrete reason must be posted.
+- For both outcomes, post a reply on the same conversation, and then formally resolve that review thread.
 - Push changes when needed.
-- Wait for CI long enough to complete one full run (default: 300 seconds), then fetch latest PR status and new reviews.
+- Wait for CI to complete.
 - Repeat until all stop conditions are met.
+- **Report exact execution traces** based on the Final Report Format.
 
 ## Stop Conditions
 
@@ -46,46 +48,69 @@ Shared tooling reference: `../../AGENTS.md` and `../../docs/agent-tooling.md`.
 - CI scope: Required checks only.
 - Loop safety cap: Maximum 20 iterations. If cap is reached, stop and report blockers.
 
-## Hard Rules
+## Hard Rules & Prohibitions
 
-- Never leave a review thread without either a code change or an explicit ignore reason.
-- Never resolve a thread without posting a response in that thread.
-- Prefer minimal, targeted fixes.
-- If unsure whether to ignore, prefer ADDRESS or ask for human decision.
-- Do not use destructive git operations.
+- **NEVER** substitute a formal conversation resolve by just typing "Resolve conversation" in a regular PR comment. You MUST use the GitHub GraphQL `resolveReviewThread` mutation.
+- **NEVER** confuse "Review dismiss" with "Conversation resolve". Dismissing a review requires explicit user instruction.
+- **NEVER** resolve a thread without posting a response in that thread first.
+- **NEVER** use other PRs (target-mismatched PRs) to verify steps or make test comments.
+- **NEVER** close a PR, delete a branch, or merge a PR without explicit user instruction.
+- **NEVER** report "Done" or "Completed" without providing the mandatory Final Report execution traces.
+- Prefer minimal, targeted fixes. Do not use destructive git operations.
 
 ## Loop Procedure
 
-1. Discover target PR.
-   - Use PR number if provided.
-   - Otherwise locate the PR from current branch.
-2. Fetch current state.
-   - Pull unresolved review threads, latest comments, and check status.
-   - Identify new comments since the previous loop iteration.
-3. Triage each unresolved thread.
-   - Decide ADDRESS or IGNORE_WITH_REASON.
-   - Write short rationale and intended action.
-4. Execute ADDRESS actions.
+1. **Authentication Check**
+   - Run `gh --version` and `gh auth status`.
+   - If authentication fails, STOP immediately and report an auth error. Do not proceed with the loop.
+2. **Discover target PR**
+   - Use PR number if provided, otherwise locate the PR from the current branch.
+3. **Fetch current state**
+   - Use `gh` CLI and GitHub GraphQL to pull unresolved review threads, latest comments, and check status.
+4. **Triage each unresolved thread**
+   - Decide ADDRESS or IGNORE_WITH_REASON. Write short rationale and intended action.
+5. **Execute ADDRESS actions**
    - Implement code updates.
    - Run relevant local tests/lint for changed scope.
    - Commit and push only when changes exist.
-5. Reply + resolve every processed thread.
+6. **Reply & Resolve every processed thread**
    - Post a clear reply in the same conversation explaining what was changed or why ignored.
-   - Resolve the conversation thread.
-6. Wait and re-check.
-   - After each push, wait 300 seconds (or user-specified duration).
+   - Resolve the conversation thread **using the `resolveReviewThread` GraphQL mutation**.
+7. **Wait and re-check**
+   - After each push, wait for CI to complete (e.g. `gh pr checks --watch`).
    - Re-fetch CI/check status and newly added review threads.
-7. Repeat until stop conditions are satisfied or iteration cap is reached.
+8. **Repeat** until stop conditions are satisfied or iteration cap is reached.
 
-## Preferred Command Patterns
+## Tooling & Command Patterns
 
-- CI status watch:
-  - gh pr checks <PR_NUMBER> --required --watch --interval 10
-- Sleep phase:
-  - sleep 300
-- Robust PR data pull:
-  - gh pr view <PR_NUMBER> --json number,state,mergeStateStatus,reviewDecision,reviews,comments,latestReviews,headRefName,baseRefName,statusCheckRollup
-- If unresolved-thread details are needed, use gh api GraphQL to list reviewThreads and resolveReviewThread mutation.
+- **Initial Auth Check**: `gh --version && gh auth status`
+- **CI status watch**: `gh pr checks <PR_NUMBER> --required --watch --interval 10`
+- **Fetch Review Threads (GraphQL Example)**:
+  ```bash
+  gh api graphql -f query='
+    query($owner: String!, $repo: String!, $pr: Int!) {
+      repository(owner: $owner, name: $repo) {
+        pullRequest(number: $pr) {
+          reviewThreads(first: 50) {
+            nodes {
+              id
+              isResolved
+              comments(first: 1) { nodes { body } }
+            }
+          }
+        }
+      }
+    }' -f owner="OWNER" -f repo="REPO" -F pr=123
+  ```
+- **Resolve a Thread (GraphQL Example)**:
+  ```bash
+  gh api graphql -f query='
+    mutation($threadId: ID!) {
+      resolveReviewThread(input: {threadId: $threadId}) {
+        thread { isResolved }
+      }
+    }' -f threadId="THREAD_ID"
+  ```
 
 ## Decision Policy Template
 
@@ -94,19 +119,33 @@ Shared tooling reference: `../../AGENTS.md` and `../../docs/agent-tooling.md`.
 - IGNORE_WITH_REASON reply template:
   - "今回は対応見送りとします。理由: <technical rationale>. 代替策/前提: <details>."
 
-## Output Format Each Iteration
+## Final Report Format (Mandatory)
 
-- Iteration summary:
-  - PR: <owner/repo#num>
-  - Processed threads: <count>
-  - Addressed: <count>
-  - Ignored with reason: <count>
-  - Newly resolved threads: <count>
-  - Pushed commit: <yes/no + sha>
-  - CI required checks: <pass/fail/pending>
-  - Remaining unresolved threads: <count>
-- Final completion summary:
-  - "Done: required CI green + unresolved conversations 0"
+Whenever you complete a PR Review Closure Loop, or if you abort due to an error/timeout, you MUST output a final report in the following format. Do not omit any fields.
+
+```md
+### PR Review Closure Report
+
+- **対象 PR URL**: <PR URL>
+- **gh version**: <output of gh --version>
+- **gh auth status の結果**: <Logged in... / Failed>
+- **取得した review thread 数**: <count>
+- **resolve 前の unresolved thread 数**: <count>
+- **resolve 後の unresolved thread 数**: <count>
+- **返信したコメント URL**:
+  - <Comment URL 1>
+  - <Comment URL 2>
+- **resolve した thread ID 一覧**:
+  - <Thread ID 1>
+  - <Thread ID 2>
+- **実行した test / lint / typecheck コマンドと結果**: <Command & Pass/Fail status>
+- **CI checks の結果**: <Pass/Fail/Pending>
+
+#### 課題・未完了項目
+
+- **できなかったこと**: <None, or describe what failed>
+- **どこで止まったか**: <Finished successfully, or describe where the process halted>
+```
 
 ## Safety and Escalation
 


### PR DESCRIPTION
### Background

We need to enforce strict rules for PR review conversation closure by AI agents. Agents should not stop at just making a PR and leaving review comments unhandled. They also should not resolve a thread without making a proper response or use a simple comment as a fake "resolve".

### Changes

- Updated `.github/agents/pr-review-closure-loop.md` to:
  - Add explicit mission statement about not stopping at PR creation.
  - Add explicit "Hard Rules & Prohibitions" to prevent fake resolution via "Resolve conversation" comments and mandate the use of the GitHub GraphQL `resolveReviewThread` mutation.
  - Require a pre-check of `gh --version` and `gh auth status` to fail early on authentication issues.
  - Define a strict `Final Report Format` that must be logged at the end of the run containing PR URL, unresolved thread counts, command test results, and any blockers.

### Validation

- Formatted with `prettier`
- Pre-commit test suite `bun x vitest run apps/api apps/web` ran and passed locally.
- Linting ran and passed locally.

---
*PR created automatically by Jules for task [4093876505137553224](https://jules.google.com/task/4093876505137553224) started by @is0692vs*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated PR review workflow guidance to include explicit completion criteria and authentication verification steps.

* **Chores**
  * Enhanced workflow process structure with clearer procedural steps and standardized final report formatting.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

AIエージェントがPRレビューのクロージャーループを実行する際のルールと報告形式を厳格化したドキュメント更新です。GraphQL `resolveReviewThread` ミューテーションの必須化、認証事前チェック、Final Report Format の義務化など、エージェントが途中で停止したり不正な方法でスレッドを解決したりすることを防ぐ複数の禁止事項が追加されています。

- 「Hard Rules & Prohibitions」セクションに、コメント欄への "Resolve conversation" 投稿による擬似解決の禁止や、Final Report なしの完了報告禁止など6つの明示的禁止事項を追加。
- Loop Procedure を8ステップに再構成し、ステップ1に `gh --version && gh auth status` による認証チェックを追加、ステップ6で GraphQL mutation による正式な解決を義務化。
- 旧「Output Format Each Iteration」を廃止し、PR URL・スレッド数・コメントURL・テスト結果などを網羅した「Final Report Format (Mandatory)」セクションに一本化。
</details>

<details open><summary><h3>Confidence Score: 5/5</h3></summary>

ドキュメントのみの変更であり、実行コードへの影響はなく、マージに支障はありません。

変更対象はエージェント向けのMarkdownドキュメント1ファイルのみで、認証チェックの追加・禁止事項の明文化・Final Report Formatの義務化といった内容はすべてエージェントへの指示強化です。ステップ7の gh pr checks --watch に --required フラグが欠けているという軽微な不一致はあるものの、実行コードを変更するものではなく、マージ後に問題が生じるリスクは低いと判断しています。

.github/agents/pr-review-closure-loop.md のステップ7とToolingセクションのコマンド例の整合性を確認してください。
</details>

<details open><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| .github/agents/pr-review-closure-loop.md | エージェント向けPRレビュークロージャーループのドキュメントを更新。認証チェック、GraphQL解決必須化、Final Report Format、禁止事項の明文化など全体的に強化されている。ステップ7の `gh pr checks --watch` コマンドに `--required` フラグが欠落しており、Tooling セクションとの不一致がある。 |

</details>

</details>

<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[開始] --> B[Step 1: 認証チェック\ngh --version && gh auth status]
    B -->|認証失敗| C[STOP: auth error を報告]
    B -->|認証成功| D[Step 2: 対象PR を特定]
    D --> E[Step 3: 現在の状態を取得\nGraphQL reviewThreads first:100]
    E --> F[Step 4: 未解決スレッドをトリアージ\nADDRESS / IGNORE_WITH_REASON]
    F --> G[Step 5: ADDRESS アクション実行\nコード修正 → テスト → commit/push]
    G --> H[Step 6: 返信 & スレッド解決\nresolveReviewThread GraphQL mutation]
    H --> I[Step 7: CI 完了を待機\ngh pr checks --required --watch]
    I --> J{Stop Conditions\n全満足?}
    J -->|Yes| K[Final Report 出力\n必須フォーマットで記録]
    J -->|No| L{イテレーション上限\n20回?}
    L -->|No| E
    L -->|Yes| M[STOP: ブロッカーを報告\n+ Final Report 出力]
    K --> N[完了]
    M --> N
```

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 1 code review issue. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 1
.github/agents/pr-review-closure-loop.md:80
ステップ7の `gh pr checks --watch` には `--required` フラグが欠落しています。Tooling セクションの推奨コマンドには `--required --watch --interval 10` が含まれているのに対し、手順本文では `gh pr checks --watch` のみが記載されています。この不一致により、エージェントがテンプレートを文字通り実行した場合、必須チェックだけでなく任意（optional）チェックも含めて完了を待ち続け、任意チェックがずっと `pending` のままだとループがハングする恐れがあります。

```suggestion
   - After each push, wait for CI to complete (e.g. `gh pr checks <PR_NUMBER> --required --watch --interval 10`).
```

`````

</details>

<sub>Reviews (2): Last reviewed commit: ["docs(agent): fix PR review closure loop ..."](https://github.com/hiroki-org/openshelf/commit/6db39e847aa20d8177370725e124436b37f2409f) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=31289820)</sub>

<!-- /greptile_comment -->