### PR TITLE
Update hono to 4.12.18 to fix security vulnerabilities

### DIFF
--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -30,7 +30,7 @@
   },
   "dependencies": {
     "drizzle-orm": "^0.45.2",
-    "hono": "^4.12.16",
+    "hono": "^4.12.18",
     "p-map": "^4.0.0"
   }
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -21,6 +21,7 @@
         "@vitest/coverage-v8": "^4.1.5",
         "babel-plugin-react-compiler": "1.0.0",
         "eslint": "^10.3.0",
+        "jsdom": "^27.4.0",
         "postcss": "^8.5.12",
         "typescript": "^6.0.3",
         "vitest": "^4.1.5"
@@ -35,7 +36,7 @@
       "license": "MIT",
       "dependencies": {
         "drizzle-orm": "^0.45.2",
-        "hono": "^4.12.16",
+        "hono": "^4.12.18",
         "p-map": "^4.0.0"
       },
       "devDependencies": {
@@ -7741,9 +7742,9 @@
       }
     },
     "node_modules/hono": {
-      "version": "4.12.16",
-      "resolved": "https://registry.npmjs.org/hono/-/hono-4.12.16.tgz",
-      "integrity": "sha512-jN0ZewiNAWSe5khM3EyCmBb250+b40wWbwNILNfEvq84VREWwOIkuUsFONk/3i3nqkz7Oe1PcpM2mwQEK2L9Kg==",
+      "version": "4.12.18",
+      "resolved": "https://registry.npmjs.org/hono/-/hono-4.12.18.tgz",
+      "integrity": "sha512-RWzP96k/yv0PQfyXnWjs6zot20TqfpfsNXhOnev8d1InAxubW93L11/oNUc3tQqn2G0bSdAOBpX+2uDFHV7kdQ==",
       "license": "MIT",
       "engines": {
         "node": ">=16.9.0"


### PR DESCRIPTION
Update hono to 4.12.18 to fix security vulnerabilities

OSV Auto Fix #45

---
*PR created automatically by Jules for task [9553399342081941722](https://jules.google.com/task/9553399342081941722) started by @is0692vs*

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

hono を 4.12.16 → 4.12.18 にバージョンアップし、JWT の `exp`/`nbf`/`iat` クレームに対する不正な NumericDate 検証バイパス脆弱性（GHSA-hm8q-7f3q-5f36）を修正する、セキュリティパッチ専用の PR です。

- `apps/api/package.json` の hono 依存バージョンを `^4.12.16` → `^4.12.18` に更新し、`package-lock.json` の解決バージョンと integrity ハッシュも対応して更新しています。
- `package-lock.json` では hono の更新とともに `jsdom ^27.4.0` もルートの `devDependencies` に追加されていますが、ルート `package.json` の差分はこの PR に含まれていないため、事前の不整合が解消された可能性があります。
</details>

<details open><summary><h3>Confidence Score: 4/5</h3></summary>

hono のセキュリティパッチ適用は適切で、コードロジックの変更はありません。

依存関係の更新のみのシンプルな変更で、アプリコードへの影響はありません。`package-lock.json` に `jsdom` が追加されている点は hono の修正と無関係であり、意図した変更かどうか確認が必要です。

`package-lock.json` に `jsdom ^27.4.0` の追加が含まれており、この PR の目的（hono のセキュリティ修正）とは無関係な変更が混在しています。
</details>

<details open><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| apps/api/package.json | hono のバージョンを ^4.12.16 → ^4.12.18 に更新。JWT NumericDate クレーム検証バイパス脆弱性（GHSA-hm8q-7f3q-5f36）への対応。 |
| package-lock.json | hono の解決バージョンと integrity ハッシュを更新。さらに jsdom ^27.4.0 がルートの devDependencies として追加されているが、対応する package.json の差分はこの PR に含まれていない。 |

</details>

</details>

<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant Client
    participant HonoAPI as Hono API (apps/api)
    participant JWT as hono/utils/jwt

    Client->>HonoAPI: リクエスト (JWT付き)
    HonoAPI->>JWT: verify(token)
    Note over JWT: v4.12.16以前:<br/>falsy/非有限/非数値の<br/>exp・nbf・iatを黙って通過
    Note over JWT: v4.12.18以降:<br/>RFC 7519 に従い<br/>不正なクレームを拒否
    JWT-->>HonoAPI: 検証結果
    HonoAPI-->>Client: レスポンス
```

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 1 code review issue. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 1
package-lock.json:24
**jsdom の追加がルート package.json の差分に含まれていない**

`package-lock.json` ではルートの `devDependencies` に `jsdom: "^27.4.0"` が新たに追加されていますが、この PR の変更対象ファイルにルートの `package.json` は含まれていません。`package.json` にはすでに `jsdom` が存在しているため、ロックファイルとの不整合が以前から存在していた可能性があります。このアップデートは hono のセキュリティ修正とは無関係であるため、意図した変更かどうかを確認することを推奨します。

`````

</details>

<sub>Reviews (1): Last reviewed commit: ["Update hono to 4.12.18 to fix security v..."](https://github.com/hiroki-org/openshelf/commit/2ea72d685f1ec86223d942ad7d09c303c2796691) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=31421825)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->