### PR TITLE
🛡️ Sentinel: [HIGH] CORSおよびCSRFミドルウェアでのワイルドカードオリジンマッチングの無効化

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -13,7 +13,7 @@
 **Learning:** Utilities that resolve or validate origins against a configurable list should explicitly reject wildcard patterns in sensitive flows such as OAuth redirects or CORS responses, ensuring wildcards only apply when strictly intended by the configuration.
 **Prevention:** Pass `{ allowWildcard: false }` to the `isAllowedOrigin` helper in all places where sensitive token delivery relies on frontend URLs.
 
-## 2024-05-09 - [Disable Wildcard Origin Matching in CORS/CSRF Middleware]
+## 2026-05-09 - [Disable Wildcard Origin Matching in CORS/CSRF Middleware]
 **Vulnerability:** CORS and CSRF middleware configurations in `apps/api/src/index.ts` permitted wildcard subdomains by default, enabling Open Redirect and CSRF bypass risks if wildcard patterns were loosely validated against client-provided origins.
 **Learning:** `isAllowedOrigin` defaults to allowing wildcard logic unless explicitly disabled.
 **Prevention:** Explicitly supply `{ allowWildcard: false }` to the `isAllowedOrigin` calls in both CORS and CSRF verifications to disable loose wildcard checks and adhere to strictly provided `ALLOWED_ORIGINS` when processing origins outside of isolated `frontend_origin` callbacks.

--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -12,3 +12,8 @@
 **Vulnerability:** A wildcard in the `ALLOWED_ORIGINS` configuration allows the CORS and OAuth flow to accept any client-provided origin, leading to a bypass in origin verification and an open redirect where tokens can be stolen.
 **Learning:** Utilities that resolve or validate origins against a configurable list should explicitly reject wildcard patterns in sensitive flows such as OAuth redirects or CORS responses, ensuring wildcards only apply when strictly intended by the configuration.
 **Prevention:** Pass `{ allowWildcard: false }` to the `isAllowedOrigin` helper in all places where sensitive token delivery relies on frontend URLs.
+
+## 2024-05-09 - [Disable Wildcard Origin Matching in CORS/CSRF Middleware]
+**Vulnerability:** CORS and CSRF middleware configurations in `apps/api/src/index.ts` permitted wildcard subdomains by default, enabling Open Redirect and CSRF bypass risks if wildcard patterns were loosely validated against client-provided origins.
+**Learning:** `isAllowedOrigin` defaults to allowing wildcard logic unless explicitly disabled.
+**Prevention:** Explicitly supply `{ allowWildcard: false }` to the `isAllowedOrigin` calls in both CORS and CSRF verifications to disable loose wildcard checks and adhere to strictly provided `ALLOWED_ORIGINS` when processing origins outside of isolated `frontend_origin` callbacks.

--- a/apps/api/src/index.ts
+++ b/apps/api/src/index.ts
@@ -42,7 +42,7 @@ app.use(
         const requestOrigin = normalizeOrigin(origin ?? undefined);
         const frontendOrigin = normalizeOrigin(c.env.FRONTEND_URL);
 
-        if (isAllowedOrigin(requestOrigin, frontendOrigin, allowedOrigins)) {
+        if (isAllowedOrigin(requestOrigin, frontendOrigin, allowedOrigins, { allowWildcard: false })) {
           return origin;
         }
       } catch (err) {
@@ -91,12 +91,14 @@ app.use("/api/*", async (c, next) => {
     const isAllowedOriginValue = isAllowedOrigin(
       requestOrigin,
       frontendOrigin,
-      allowedOrigins
+      allowedOrigins,
+      { allowWildcard: false }
     );
     const isAllowedReferer = isAllowedOrigin(
       refererOrigin,
       frontendOrigin,
-      allowedOrigins
+      allowedOrigins,
+      { allowWildcard: false }
     );
 
     if (isAllowedOriginValue || isAllowedReferer) return await next();


### PR DESCRIPTION
🛡️ Sentinel: [HIGH] CORS/CSRFミドルウェアでのワイルドカードオリジンマッチングの無効化

🚨 **Severity:** HIGH
💡 **Vulnerability:** `apps/api/src/index.ts` の CORS および CSRF ミドルウェアの設定において、`isAllowedOrigin` がデフォルトでワイルドカード（`*`）を使用したオリジンの評価を許可していました。これにより、万が一 `ALLOWED_ORIGINS` の設定に緩いワイルドカード（例: `https://*.example.com`）が含まれていた場合、クライアントから渡される意図しないサブドメインや細工されたオリジンを許可してしまい、オープンリダイレクトやCSRFのバイパスといったセキュリティリスクに繋がる可能性がありました。
🎯 **Impact:** 攻撃者が許可されていないオリジンからAPIに対して不正なクロスオリジンリクエストを送信したり、OAuthフロー等でのリダイレクト先を悪用するリスクがあります。
🔧 **Fix:** CORS および CSRF の検証部分で `isAllowedOrigin` を呼び出す際、オプションとして明示的に `{ allowWildcard: false }` を渡すように修正しました。これにより、設定された `ALLOWED_ORIGINS` とリクエストオリジンが厳格に比較されるようになります。また、Sentinelのジャーナルに今回の学習内容を記録しました。
✅ **Verification:** 
- `bun x vitest run apps/api/` を実行し、CORS および CSRF 関連のテストを含め、全てのテストが正常にパスすることを確認しました。
- `bun x vitest run apps/web/` を実行し、フロントエンドへの影響がないことを確認しました。

---
*PR created automatically by Jules for task [16819812405049412603](https://jules.google.com/task/16819812405049412603) started by @is0692vs*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated API CORS and CSRF middleware to disallow wildcard-based origin matching in request validation. Incoming requests now require exact origin matches instead of accepting wildcard patterns.

* **Documentation**
  * Added documentation describing API middleware origin validation policy updates.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Hiroki-org/OpenShelf/pull/708)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

CORSおよびCSRFミドルウェアの `isAllowedOrigin` 呼び出し（計3箇所）に `{ allowWildcard: false }` を明示的に渡すことで、`ALLOWED_ORIGINS` にワイルドカードパターン（例: `https://*.example.com`）が含まれる場合でも意図しないオリジンが許可されないよう修正します。認証ルート（`auth.ts`）では同オプションがすでに適用済みのため、今回の変更によってすべてのオリジン検証経路が一貫した設定になります。

- **CORS ミドルウェア**: `origin` コールバック内の `isAllowedOrigin` 呼び出しに `{ allowWildcard: false }` を追加
- **CSRF ミドルウェア**: Origin ヘッダーおよび Referer ヘッダーの2箇所の `isAllowedOrigin` 呼び出しに `{ allowWildcard: false }` を追加
- **センチネルジャーナル** (`.jules/sentinel.md`): 今回の修正内容と教訓を記録（ただし日付が \"2024-05-09\" となっており年の誤記あり）
</details>

<details open><summary><h3>Confidence Score: 4/5</h3></summary>

変更は安全にマージ可能です。修正はピンポイントで意図した箇所に適切に適用されており、既存の認証ルートの修正と一貫しています。

コードの修正内容は正確で、`isAllowedOrigin` の3つの呼び出しすべてに `{ allowWildcard: false }` が追加されています。`utils/origin.ts` の実装を確認したところ、このオプションはワイルドカードパターンを含む `ALLOWED_ORIGINS` エントリのマッチングを完全に無効化する動作をします。ジャーナルの日付誤記（2024-05-09）が1件あります。

`.jules/sentinel.md` のジャーナルエントリに日付の誤記があります。`apps/api/src/index.ts` は問題ありません。
</details>

<details open><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| apps/api/src/index.ts | CORSおよびCSRFミドルウェアの `isAllowedOrigin` 呼び出し（計3箇所）に `{ allowWildcard: false }` を追加し、`ALLOWED_ORIGINS` 内のワイルドカードパターンが誤マッチしないよう修正。変更はすべて意図した箇所に的確に適用されており、既存のauth routeとも整合している。 |
| .jules/sentinel.md | 今回のCORS/CSRF修正内容をセンチネルジャーナルに記録。記録内容は正確だが、エントリーの日付が "2024-05-09" となっており、実際の適用年と食い違っている。 |

</details>

</details>

<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[クロスオリジンリクエスト] --> B{メソッド確認 GET/HEAD/OPTIONS?}
    B -- Yes --> C[次のハンドラへ]
    B -- No --> D{Bearer トークンまたはテスト認証?}
    D -- Yes --> C
    D -- No --> E[isAllowedOrigin Originヘッダー allowWildcard: false]
    E --> F[isAllowedOrigin Refererヘッダー allowWildcard: false]
    F --> G{いずれかが許可済み?}
    G -- Yes --> C
    G -- No --> H[403 Forbidden]
```

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 1 code review issue. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 1
.jules/sentinel.md:16
センチネルジャーナルの日付が "2024-05-09" となっていますが、今回の変更が適用された実際の日付と一致していません。ジャーナルの整合性のため、正しい年に修正することをお勧めします。

```suggestion
## 2026-05-09 - [Disable Wildcard Origin Matching in CORS/CSRF Middleware]
```

`````

</details>

<sub>Reviews (1): Last reviewed commit: ["fix(api): CORS/CSRF ミドルウェアでワイルドカードによるオリジ..."](https://github.com/hiroki-org/openshelf/commit/435b7fa0c87f711144600a90e25f3f96093739e7) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=31446084)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->