### PR TITLE
🔒 Fix: Migrate JWT from LocalStorage to HttpOnly Cookie

### DIFF
--- a/apps/api/src/db/__tests__/schema.test.ts
+++ b/apps/api/src/db/__tests__/schema.test.ts
@@ -22,7 +22,12 @@ import {
 
 describe("db schema", () => {
   it("exports expected enums", () => {
-    expect(VALID_VENUE_TYPES).toEqual(["conference", "journal", "workshop", "other"]);
+    expect(VALID_VENUE_TYPES).toEqual([
+      "conference",
+      "journal",
+      "workshop",
+      "other",
+    ]);
     expect(VALID_CATEGORIES).toEqual([
       "thesis_bachelor",
       "thesis_master",

--- a/apps/api/src/db/schema.ts
+++ b/apps/api/src/db/schema.ts
@@ -1,337 +1,355 @@
 import {
-    sqliteTable,
-    text,
-    integer,
-    uniqueIndex,
-    primaryKey,
-    index,
+  sqliteTable,
+  text,
+  integer,
+  uniqueIndex,
+  primaryKey,
+  index,
 } from "drizzle-orm/sqlite-core";
 import { sql } from "drizzle-orm";
 import { drizzle } from "drizzle-orm/d1";
 
 // ─── helpers ────────────────────────────────────────────────────
 const id = () =>
-    text("id")
-        .primaryKey()
-        .$defaultFn(() => crypto.randomUUID());
+  text("id")
+    .primaryKey()
+    .$defaultFn(() => crypto.randomUUID());
 
 const createdAt = () =>
-    text("created_at")
-        .notNull()
-        .default(sql`(datetime('now'))`);
+  text("created_at")
+    .notNull()
+    .default(sql`(datetime('now'))`);
 
 // ─── users ──────────────────────────────────────────────────────
 export const users = sqliteTable(
-    "users",
-    {
-        id: id(),
-        githubId: text("github_id").notNull(),
-        name: text("name").notNull(),
-        displayName: text("display_name"),
-        avatarUrl: text("avatar_url"),
-        email: text("email"),
-        createdAt: createdAt(),
-        updatedAt: text("updated_at").notNull().default(sql`(datetime('now'))`),
-    },
-    (t) => [uniqueIndex("users_github_id_idx").on(t.githubId)],
+  "users",
+  {
+    id: id(),
+    githubId: text("github_id").notNull(),
+    name: text("name").notNull(),
+    displayName: text("display_name"),
+    avatarUrl: text("avatar_url"),
+    email: text("email"),
+    createdAt: createdAt(),
+    updatedAt: text("updated_at")
+      .notNull()
+      .default(sql`(datetime('now'))`),
+  },
+  (t) => [uniqueIndex("users_github_id_idx").on(t.githubId)],
 );
 
-export const VALID_VENUE_TYPES = ["conference", "journal", "workshop", "other"] as const;
-export type VenueType = typeof VALID_VENUE_TYPES[number];
+export const VALID_VENUE_TYPES = [
+  "conference",
+  "journal",
+  "workshop",
+  "other",
+] as const;
+export type VenueType = (typeof VALID_VENUE_TYPES)[number];
 
-export const VALID_CATEGORIES = ["thesis_bachelor", "thesis_master", "report", "presentation", "other"] as const;
-export type CategoryType = typeof VALID_CATEGORIES[number];
+export const VALID_CATEGORIES = [
+  "thesis_bachelor",
+  "thesis_master",
+  "report",
+  "presentation",
+  "other",
+] as const;
+export type CategoryType = (typeof VALID_CATEGORIES)[number];
 
 // ─── papers ─────────────────────────────────────────────────────
 export const papers = sqliteTable(
-    "papers",
-    {
-        id: id(),
-        title: text("title").notNull(),
-        abstract: text("abstract"),
-        description: text("description"),
-        descriptionUpdatedAt: text("description_updated_at"),
-        visibility: text("visibility", { enum: ["public", "org_only", "private"] })
-            .notNull()
-            .default("private"),
-        showViewCount: integer("show_view_count", { mode: "boolean" })
-            .notNull()
-            .default(false),
-        language: text("language"),
-        externalUrl: text("external_url"),
-        doi: text("doi"),
-        venue: text("venue"),
-        venueType: text("venue_type", {
-            enum: VALID_VENUE_TYPES,
-        }),
-        year: integer("year"),
-        category: text("category", {
-            enum: VALID_CATEGORIES,
-        }),
-        tags: text("tags"),
-        createdAt: createdAt(),
-        /** INSERT 時のみ自動設定．UPDATE 時は touchUpdatedAt() を使うこと */
-        updatedAt: text("updated_at")
-            .notNull()
-            .default(sql`(datetime('now'))`),
-    },
-    (t) => [
-        index("papers_visibility_idx").on(t.visibility),
-        index("papers_year_idx").on(t.year),
-    ],
+  "papers",
+  {
+    id: id(),
+    title: text("title").notNull(),
+    abstract: text("abstract"),
+    description: text("description"),
+    descriptionUpdatedAt: text("description_updated_at"),
+    visibility: text("visibility", { enum: ["public", "org_only", "private"] })
+      .notNull()
+      .default("private"),
+    showViewCount: integer("show_view_count", { mode: "boolean" })
+      .notNull()
+      .default(false),
+    language: text("language"),
+    externalUrl: text("external_url"),
+    doi: text("doi"),
+    venue: text("venue"),
+    venueType: text("venue_type", {
+      enum: VALID_VENUE_TYPES,
+    }),
+    year: integer("year"),
+    category: text("category", {
+      enum: VALID_CATEGORIES,
+    }),
+    tags: text("tags"),
+    createdAt: createdAt(),
+    /** INSERT 時のみ自動設定．UPDATE 時は touchUpdatedAt() を使うこと */
+    updatedAt: text("updated_at")
+      .notNull()
+      .default(sql`(datetime('now'))`),
+  },
+  (t) => [
+    index("papers_visibility_idx").on(t.visibility),
+    index("papers_year_idx").on(t.year),
+  ],
 );
 
 // ─── paper_views ────────────────────────────────────────────────
 export const paperViews = sqliteTable(
-    "paper_views",
-    {
-        id: id(),
-        paperId: text("paper_id")
-            .notNull()
-            .references(() => papers.id, { onDelete: "cascade" }),
-        viewedAt: text("viewed_at")
-            .notNull()
-            .default(sql`(datetime('now'))`),
-        viewerFingerprint: text("viewer_fingerprint").notNull(),
-        viewBucket: integer("view_bucket").notNull(),
-    },
-    (t) => [
-        index("paper_views_paper_id_viewed_at_idx").on(t.paperId, t.viewedAt),
-        uniqueIndex("paper_views_dedupe_idx").on(
-            t.paperId,
-            t.viewerFingerprint,
-            t.viewBucket,
-        ),
-    ],
+  "paper_views",
+  {
+    id: id(),
+    paperId: text("paper_id")
+      .notNull()
+      .references(() => papers.id, { onDelete: "cascade" }),
+    viewedAt: text("viewed_at")
+      .notNull()
+      .default(sql`(datetime('now'))`),
+    viewerFingerprint: text("viewer_fingerprint").notNull(),
+    viewBucket: integer("view_bucket").notNull(),
+  },
+  (t) => [
+    index("paper_views_paper_id_viewed_at_idx").on(t.paperId, t.viewedAt),
+    uniqueIndex("paper_views_dedupe_idx").on(
+      t.paperId,
+      t.viewerFingerprint,
+      t.viewBucket,
+    ),
+  ],
 );
 
 // ─── paper_stats_daily ───────────────────────────────────────────
 export const paperStatsDaily = sqliteTable(
-    "paper_stats_daily",
-    {
-        paperId: text("paper_id")
-            .notNull()
-            .references(() => papers.id, { onDelete: "cascade" }),
-        date: text("date").notNull(),
-        views: integer("views").notNull().default(0),
-        downloads: integer("downloads").notNull().default(0),
-        previews: integer("previews").notNull().default(0),
-    },
-    (t) => [
-        primaryKey({ columns: [t.paperId, t.date] }),
-        index("paper_stats_daily_date_idx").on(t.date),
-    ],
+  "paper_stats_daily",
+  {
+    paperId: text("paper_id")
+      .notNull()
+      .references(() => papers.id, { onDelete: "cascade" }),
+    date: text("date").notNull(),
+    views: integer("views").notNull().default(0),
+    downloads: integer("downloads").notNull().default(0),
+    previews: integer("previews").notNull().default(0),
+  },
+  (t) => [
+    primaryKey({ columns: [t.paperId, t.date] }),
+    index("paper_stats_daily_date_idx").on(t.date),
+  ],
 );
 
 // ─── paper_stats_total ───────────────────────────────────────────
-export const paperStatsTotal = sqliteTable(
-    "paper_stats_total",
-    {
-        paperId: text("paper_id")
-            .primaryKey()
-            .references(() => papers.id, { onDelete: "cascade" }),
-        totalViews: integer("total_views").notNull().default(0),
-        totalDownloads: integer("total_downloads").notNull().default(0),
-        totalPreviews: integer("total_previews").notNull().default(0),
-        lastUpdated: text("last_updated")
-            .notNull()
-            .default(sql`(datetime('now'))`),
-    },
-);
+export const paperStatsTotal = sqliteTable("paper_stats_total", {
+  paperId: text("paper_id")
+    .primaryKey()
+    .references(() => papers.id, { onDelete: "cascade" }),
+  totalViews: integer("total_views").notNull().default(0),
+  totalDownloads: integer("total_downloads").notNull().default(0),
+  totalPreviews: integer("total_previews").notNull().default(0),
+  lastUpdated: text("last_updated")
+    .notNull()
+    .default(sql`(datetime('now'))`),
+});
 
 // ─── paper_stats_dedup ───────────────────────────────────────────
 export const paperStatsDedup = sqliteTable(
-    "paper_stats_dedup",
-    {
-        paperId: text("paper_id")
-            .notNull()
-            .references(() => papers.id, { onDelete: "cascade" }),
-        event: text("event", { enum: ["view", "download", "preview"] }).notNull(),
-        date: text("date").notNull(),
-        sessionHash: text("session_hash").notNull(),
-        referrer: text("referrer"),
-        createdAt: createdAt(),
-    },
-    (t) => [
-        uniqueIndex("paper_stats_dedup_unique_idx").on(
-            t.paperId,
-            t.event,
-            t.date,
-            t.sessionHash,
-        ),
-        index("paper_stats_dedup_paper_date_idx").on(t.paperId, t.date),
-    ],
+  "paper_stats_dedup",
+  {
+    paperId: text("paper_id")
+      .notNull()
+      .references(() => papers.id, { onDelete: "cascade" }),
+    event: text("event", { enum: ["view", "download", "preview"] }).notNull(),
+    date: text("date").notNull(),
+    sessionHash: text("session_hash").notNull(),
+    referrer: text("referrer"),
+    createdAt: createdAt(),
+  },
+  (t) => [
+    uniqueIndex("paper_stats_dedup_unique_idx").on(
+      t.paperId,
+      t.event,
+      t.date,
+      t.sessionHash,
+    ),
+    index("paper_stats_dedup_paper_date_idx").on(t.paperId, t.date),
+  ],
 );
 
 // ─── paper_files ────────────────────────────────────────────────
 export const paperFiles = sqliteTable(
-    "paper_files",
-    {
-        id: id(),
-        paperId: text("paper_id")
-            .notNull()
-            .references(() => papers.id, { onDelete: "cascade" }),
-        r2Key: text("r2_key").notNull(),
-        fileType: text("file_type", {
-            enum: ["paper", "slides", "poster", "supplementary"],
-        }).notNull(),
-        filename: text("filename").notNull(),
-        sizeBytes: integer("size_bytes").notNull(),
-        mimeType: text("mime_type"),
-        createdAt: createdAt(),
-        updatedAt: text("updated_at").notNull().default(sql`(datetime('now'))`),
-    },
-    (t) => [index("paper_files_paper_id_idx").on(t.paperId)],
+  "paper_files",
+  {
+    id: id(),
+    paperId: text("paper_id")
+      .notNull()
+      .references(() => papers.id, { onDelete: "cascade" }),
+    r2Key: text("r2_key").notNull(),
+    fileType: text("file_type", {
+      enum: ["paper", "slides", "poster", "supplementary"],
+    }).notNull(),
+    filename: text("filename").notNull(),
+    sizeBytes: integer("size_bytes").notNull(),
+    mimeType: text("mime_type"),
+    createdAt: createdAt(),
+    updatedAt: text("updated_at")
+      .notNull()
+      .default(sql`(datetime('now'))`),
+  },
+  (t) => [index("paper_files_paper_id_idx").on(t.paperId)],
 );
 
 // ─── paper_authors ──────────────────────────────────────────────
 export const paperAuthors = sqliteTable(
-    "paper_authors",
-    {
-        paperId: text("paper_id")
-            .notNull()
-            .references(() => papers.id, { onDelete: "cascade" }),
-        userId: text("user_id")
-            .notNull()
-            .references(() => users.id, { onDelete: "cascade" }),
-        role: text("role", { enum: ["uploader", "coauthor"] }).notNull(),
-    },
-    (t) => [
-        primaryKey({ columns: [t.paperId, t.userId] }),
-        index("paper_authors_user_id_idx").on(t.userId),
-    ],
+  "paper_authors",
+  {
+    paperId: text("paper_id")
+      .notNull()
+      .references(() => papers.id, { onDelete: "cascade" }),
+    userId: text("user_id")
+      .notNull()
+      .references(() => users.id, { onDelete: "cascade" }),
+    role: text("role", { enum: ["uploader", "coauthor"] }).notNull(),
+  },
+  (t) => [
+    primaryKey({ columns: [t.paperId, t.userId] }),
+    index("paper_authors_user_id_idx").on(t.userId),
+  ],
 );
 
 // ─── orgs ───────────────────────────────────────────────────────
 export const orgs = sqliteTable(
-    "orgs",
-    {
-        id: id(),
-        slug: text("slug").notNull(),
-        name: text("name").notNull(),
-        description: text("description"),
-        createdAt: createdAt(),
-        updatedAt: text("updated_at").notNull().default(sql`(datetime('now'))`),
-    },
-    (t) => [uniqueIndex("orgs_slug_idx").on(t.slug)],
+  "orgs",
+  {
+    id: id(),
+    slug: text("slug").notNull(),
+    name: text("name").notNull(),
+    description: text("description"),
+    createdAt: createdAt(),
+    updatedAt: text("updated_at")
+      .notNull()
+      .default(sql`(datetime('now'))`),
+  },
+  (t) => [uniqueIndex("orgs_slug_idx").on(t.slug)],
 );
 
 // ─── org_members ────────────────────────────────────────────────
 export const orgMembers = sqliteTable(
-    "org_members",
-    {
-        orgId: text("org_id")
-            .notNull()
-            .references(() => orgs.id, { onDelete: "cascade" }),
-        userId: text("user_id")
-            .notNull()
-            .references(() => users.id, { onDelete: "cascade" }),
-        role: text("role", { enum: ["owner", "admin", "member"] })
-            .notNull()
-            .default("member"),
-    },
-    (t) => [primaryKey({ columns: [t.orgId, t.userId] })],
+  "org_members",
+  {
+    orgId: text("org_id")
+      .notNull()
+      .references(() => orgs.id, { onDelete: "cascade" }),
+    userId: text("user_id")
+      .notNull()
+      .references(() => users.id, { onDelete: "cascade" }),
+    role: text("role", { enum: ["owner", "admin", "member"] })
+      .notNull()
+      .default("member"),
+  },
+  (t) => [primaryKey({ columns: [t.orgId, t.userId] })],
 );
 
 // ─── paper_orgs ─────────────────────────────────────────────────
 export const paperOrgs = sqliteTable(
-    "paper_orgs",
-    {
-        paperId: text("paper_id")
-            .notNull()
-            .references(() => papers.id, { onDelete: "cascade" }),
-        orgId: text("org_id")
-            .notNull()
-            .references(() => orgs.id, { onDelete: "cascade" }),
-    },
-    (t) => [
-        primaryKey({ columns: [t.paperId, t.orgId] }),
-        index("paper_orgs_org_id_idx").on(t.orgId),
-    ],
+  "paper_orgs",
+  {
+    paperId: text("paper_id")
+      .notNull()
+      .references(() => papers.id, { onDelete: "cascade" }),
+    orgId: text("org_id")
+      .notNull()
+      .references(() => orgs.id, { onDelete: "cascade" }),
+  },
+  (t) => [
+    primaryKey({ columns: [t.paperId, t.orgId] }),
+    index("paper_orgs_org_id_idx").on(t.orgId),
+  ],
 );
 
 // ─── collections ────────────────────────────────────────────────
 export const collections = sqliteTable(
-    "collections",
-    {
-        id: id(),
-        ownerType: text("owner_type", { enum: ["user", "org"] }).notNull(),
-        ownerId: text("owner_id").notNull(),
-        orgSlug: text("org_slug"),
+  "collections",
+  {
+    id: id(),
+    ownerType: text("owner_type", { enum: ["user", "org"] }).notNull(),
+    ownerId: text("owner_id").notNull(),
+    orgSlug: text("org_slug"),
 
-        slug: text("slug").notNull(),
-        name: text("name").notNull(),
-        description: text("description"),
-        visibility: text("visibility", { enum: ["public", "org_only", "private"] })
-            .notNull()
-            .default("private"),
-        createdAt: createdAt(),
-        updatedAt: text("updated_at")
-            .notNull()
-            .default(sql`(datetime('now'))`),
-
-    },
-    (t) => [
-        uniqueIndex("collections_owner_slug_idx").on(t.ownerType, t.ownerId, t.slug),
-    ],
+    slug: text("slug").notNull(),
+    name: text("name").notNull(),
+    description: text("description"),
+    visibility: text("visibility", { enum: ["public", "org_only", "private"] })
+      .notNull()
+      .default("private"),
+    createdAt: createdAt(),
+    updatedAt: text("updated_at")
+      .notNull()
+      .default(sql`(datetime('now'))`),
+  },
+  (t) => [
+    uniqueIndex("collections_owner_slug_idx").on(
+      t.ownerType,
+      t.ownerId,
+      t.slug,
+    ),
+  ],
 );
 
 // ─── collection_papers ──────────────────────────────────────────
 export const collectionPapers = sqliteTable(
-    "collection_papers",
-    {
-        collectionId: text("collection_id")
-            .notNull()
-            .references(() => collections.id, { onDelete: "cascade" }),
-        paperId: text("paper_id")
-            .notNull()
-            .references(() => papers.id, { onDelete: "cascade" }),
-        sortOrder: integer("sort_order").notNull().default(0),
-        addedAt: text("added_at")
-            .notNull()
-            .default(sql`(datetime('now'))`),
-
-    },
-    (t) => [
-        primaryKey({ columns: [t.collectionId, t.paperId] }),
-        index("collection_papers_paper_id_idx").on(t.paperId),
-    ],
+  "collection_papers",
+  {
+    collectionId: text("collection_id")
+      .notNull()
+      .references(() => collections.id, { onDelete: "cascade" }),
+    paperId: text("paper_id")
+      .notNull()
+      .references(() => papers.id, { onDelete: "cascade" }),
+    sortOrder: integer("sort_order").notNull().default(0),
+    addedAt: text("added_at")
+      .notNull()
+      .default(sql`(datetime('now'))`),
+  },
+  (t) => [
+    primaryKey({ columns: [t.collectionId, t.paperId] }),
+    index("collection_papers_paper_id_idx").on(t.paperId),
+  ],
 );
 
 // ─── coauthor_invites ───────────────────────────────────────────
 export const coauthorInvites = sqliteTable(
-    "coauthor_invites",
-    {
-        id: id(),
-        paperId: text("paper_id")
-            .notNull()
-            .references(() => papers.id, { onDelete: "cascade" }),
-        inviterId: text("inviter_id")
-            .notNull()
-            .references(() => users.id, { onDelete: "cascade" }),
-        inviteeId: text("invitee_id").references(() => users.id, {
-            onDelete: "set null",
-        }),
-        inviteeEmail: text("invitee_email"),
-        token: text("token"),
-        status: text("status", { enum: ["pending", "accepted", "declined"] })
-            .notNull()
-            .default("pending"),
-        createdAt: createdAt(),
-        updatedAt: text("updated_at").notNull().default(sql`(datetime('now'))`),
-        respondedAt: text("responded_at"),
-    },
-    (t) => [
-        index("coauthor_invites_paper_id_idx").on(t.paperId),
-        index("coauthor_invites_invitee_id_idx").on(t.inviteeId),
-        uniqueIndex("coauthor_invites_token_idx").on(t.token),
-        uniqueIndex("coauthor_invites_paper_invitee_idx")
-            .on(t.paperId, t.inviteeId)
-            .where(sql`invitee_id IS NOT NULL`),
-        uniqueIndex("coauthor_invites_paper_email_idx")
-            .on(t.paperId, t.inviteeEmail)
-            .where(sql`invitee_email IS NOT NULL`),
-    ],
+  "coauthor_invites",
+  {
+    id: id(),
+    paperId: text("paper_id")
+      .notNull()
+      .references(() => papers.id, { onDelete: "cascade" }),
+    inviterId: text("inviter_id")
+      .notNull()
+      .references(() => users.id, { onDelete: "cascade" }),
+    inviteeId: text("invitee_id").references(() => users.id, {
+      onDelete: "set null",
+    }),
+    inviteeEmail: text("invitee_email"),
+    token: text("token"),
+    status: text("status", { enum: ["pending", "accepted", "declined"] })
+      .notNull()
+      .default("pending"),
+    createdAt: createdAt(),
+    updatedAt: text("updated_at")
+      .notNull()
+      .default(sql`(datetime('now'))`),
+    respondedAt: text("responded_at"),
+  },
+  (t) => [
+    index("coauthor_invites_paper_id_idx").on(t.paperId),
+    index("coauthor_invites_invitee_id_idx").on(t.inviteeId),
+    uniqueIndex("coauthor_invites_token_idx").on(t.token),
+    uniqueIndex("coauthor_invites_paper_invitee_idx")
+      .on(t.paperId, t.inviteeId)
+      .where(sql`invitee_id IS NOT NULL`),
+    uniqueIndex("coauthor_invites_paper_email_idx")
+      .on(t.paperId, t.inviteeEmail)
+      .where(sql`invitee_email IS NOT NULL`),
+  ],
 );
 
 // ─── helpers ────────────────────────────────────────────────────
@@ -343,7 +361,7 @@ export const coauthorInvites = sqliteTable(
  *   await db.update(papers).set({ title: "new", ...touchUpdatedAt() }).where(...)
  */
 export const touchUpdatedAt = () => ({
-    updatedAt: sql`(datetime('now'))`,
+  updatedAt: sql`(datetime('now'))`,
 });
 
 /**
@@ -355,5 +373,5 @@ export const touchUpdatedAt = () => ({
  *   await enableForeignKeys(db);
  */
 export const enableForeignKeys = async (db: ReturnType<typeof drizzle>) => {
-    await db.run(sql`PRAGMA foreign_keys = ON`);
+  await db.run(sql`PRAGMA foreign_keys = ON`);
 };

--- a/apps/api/src/index.ts
+++ b/apps/api/src/index.ts
@@ -91,12 +91,12 @@ app.use("/api/*", async (c, next) => {
     const isAllowedOriginValue = isAllowedOrigin(
       requestOrigin,
       frontendOrigin,
-      allowedOrigins
+      allowedOrigins,
     );
     const isAllowedReferer = isAllowedOrigin(
       refererOrigin,
       frontendOrigin,
-      allowedOrigins
+      allowedOrigins,
     );
 
     if (isAllowedOriginValue || isAllowedReferer) return await next();

--- a/apps/api/src/middleware/__tests__/auth.test.ts
+++ b/apps/api/src/middleware/__tests__/auth.test.ts
@@ -6,86 +6,117 @@ import type { Env, Variables } from "../../types";
 // Mock the verify function to avoid the "alg" option error with hono/jwt in tests, since the
 // original code uses verify<JwtPayload>(token, c.env.JWT_SECRET)
 vi.mock("hono/jwt", async (importOriginal) => {
-    const mod = await importOriginal<typeof import("hono/jwt")>();
-    return {
-        ...mod,
-        verify: vi.fn().mockImplementation(async (token, secret) => {
-            if (token === "invalid-token") {
-                throw new Error("Invalid token");
-            }
-            return {
-                sub: "user-123",
-                githubId: "github-123",
-                name: "Test User",
-                exp: Math.floor(Date.now() / 1000) + 60 * 60,
-            };
-        }),
-    };
+  const mod = await importOriginal<typeof import("hono/jwt")>();
+  return {
+    ...mod,
+    verify: vi.fn().mockImplementation(async (token, secret) => {
+      if (token === "invalid-token") {
+        throw new Error("Invalid token");
+      }
+      return {
+        sub: "user-123",
+        githubId: "github-123",
+        name: "Test User",
+        exp: Math.floor(Date.now() / 1000) + 60 * 60,
+      };
+    }),
+  };
 });
 
 describe("authMiddleware", () => {
-    const SECRET = "test-secret";
+  const SECRET = "test-secret";
 
-    const createApp = () => {
-        const app = new Hono<{ Bindings: Env, Variables: Variables }>();
-        app.use("*", async (c, next) => {
-            // Mock c.env for testing
-            c.env = {
-                JWT_SECRET: SECRET,
-                DB: undefined as any,
-                BUCKET: undefined as any,
-                GITHUB_CLIENT_ID: "",
-                GITHUB_CLIENT_SECRET: "",
-                FRONTEND_URL: "",
-            };
-            await next();
-        });
-        app.get("/protected", authMiddleware, (c) => c.json({ user: c.get("user") }));
-        return app;
-    };
-
-    it("should return 401 if Authorization header is missing", async () => {
-        const app = createApp();
-        const res = await app.request("/protected");
-        expect(res.status).toBe(401);
-        const json = await res.json();
-        expect(json).toEqual({ error: "Unauthorized" });
+  const createApp = () => {
+    const app = new Hono<{ Bindings: Env; Variables: Variables }>();
+    app.use("*", async (c, next) => {
+      // Mock c.env for testing
+      c.env = {
+        JWT_SECRET: SECRET,
+        DB: undefined as any,
+        BUCKET: undefined as any,
+        GITHUB_CLIENT_ID: "",
+        GITHUB_CLIENT_SECRET: "",
+        FRONTEND_URL: "",
+      };
+      await next();
     });
+    app.get("/protected", authMiddleware, (c) =>
+      c.json({ user: c.get("user") }),
+    );
+    return app;
+  };
 
-    it("should return 401 if Authorization header doesn't start with Bearer", async () => {
-        const app = createApp();
-        const res = await app.request("/protected", {
-            headers: {
-                "Authorization": "Basic something"
-            }
-        });
-        expect(res.status).toBe(401);
-        const json = await res.json();
-        expect(json).toEqual({ error: "Unauthorized" });
+  it("should return 401 if Authorization header and cookie are missing", async () => {
+    const app = createApp();
+    const res = await app.request("/protected");
+    expect(res.status).toBe(401);
+    const json = await res.json();
+    expect(json).toEqual({ error: "Unauthorized" });
+  });
+
+  it("should return 401 if Authorization header doesn't start with Bearer and cookie is missing", async () => {
+    const app = createApp();
+    const res = await app.request("/protected", {
+      headers: {
+        Authorization: "Basic something",
+      },
     });
+    expect(res.status).toBe(401);
+    const json = await res.json();
+    expect(json).toEqual({ error: "Unauthorized" });
+  });
 
-    it("should return 401 if token is invalid", async () => {
-        const app = createApp();
-        const res = await app.request("/protected", {
-            headers: {
-                "Authorization": "Bearer invalid-token"
-            }
-        });
-        expect(res.status).toBe(401);
-        const json = await res.json();
-        expect(json).toEqual({ error: "Invalid token" });
+  it("should return 401 if token is invalid", async () => {
+    const app = createApp();
+    const res = await app.request("/protected", {
+      headers: {
+        Authorization: "Bearer invalid-token",
+      },
     });
+    expect(res.status).toBe(401);
+    const json = await res.json();
+    expect(json).toEqual({ error: "Invalid token" });
+  });
 
-    it("should call next and set user if token is valid", async () => {
-        const app = createApp();
-
-        const res = await app.request("/protected", {
-            headers: {
-                "Authorization": `Bearer valid-token`
-            }
-        });
-        expect(res.status).toBe(200);
-        const json = await res.json();
-        expect(json).toEqual({ user: expect.objectContaining({ sub: "user-123", name: "Test User" }) });
+  it("should return 401 if cookie token is invalid", async () => {
+    const app = createApp();
+    const res = await app.request("/protected", {
+      headers: {
+        Cookie: "auth_token=invalid-token",
+      },
     });
+    expect(res.status).toBe(401);
+    const json = await res.json();
+    expect(json).toEqual({ error: "Invalid token" });
+  });
+
+  it("should call next and set user if Bearer token is valid", async () => {
+    const app = createApp();
+
+    const res = await app.request("/protected", {
+      headers: {
+        Authorization: `Bearer valid-token`,
+      },
+    });
+    expect(res.status).toBe(200);
+    const json = await res.json();
+    expect(json).toEqual({
+      user: expect.objectContaining({ sub: "user-123", name: "Test User" }),
+    });
+  });
+
+  it("should call next and set user if auth_token cookie is valid", async () => {
+    const app = createApp();
+
+    const res = await app.request("/protected", {
+      headers: {
+        Cookie: `auth_token=valid-token`,
+      },
+    });
+    expect(res.status).toBe(200);
+    const json = await res.json();
+    expect(json).toEqual({
+      user: expect.objectContaining({ sub: "user-123", name: "Test User" }),
+    });
+  });
 });

--- a/apps/api/src/middleware/auth.ts
+++ b/apps/api/src/middleware/auth.ts
@@ -1,25 +1,31 @@
 import { createMiddleware } from "hono/factory";
 import { verify } from "hono/jwt";
+import { getCookie } from "hono/cookie";
 import type { Env, JwtPayload, Variables } from "../types";
 
 export const authMiddleware = createMiddleware<{
-    Bindings: Env;
-    Variables: Variables;
+  Bindings: Env;
+  Variables: Variables;
 }>(async (c, next) => {
-    const authHeader = c.req.header("Authorization");
-    const token = authHeader?.startsWith("Bearer ") ? authHeader.slice(7) : null;
-    if (!token) {
-        return c.json({ error: "Unauthorized" }, 401);
-    }
-    try {
-        const payload = (await verify(
-            token,
-            c.env.JWT_SECRET,
-            "HS256",
-        )) as JwtPayload;
-        c.set("user", payload);
-        await next();
-    } catch {
-        return c.json({ error: "Invalid token" }, 401);
-    }
+  const authHeader = c.req.header("Authorization");
+  let token = authHeader?.startsWith("Bearer ") ? authHeader.slice(7) : null;
+
+  if (!token) {
+    token = getCookie(c, "auth_token") ?? null;
+  }
+
+  if (!token) {
+    return c.json({ error: "Unauthorized" }, 401);
+  }
+  try {
+    const payload = (await verify(
+      token,
+      c.env.JWT_SECRET,
+      "HS256",
+    )) as JwtPayload;
+    c.set("user", payload);
+    await next();
+  } catch {
+    return c.json({ error: "Invalid token" }, 401);
+  }
 });

--- a/apps/api/src/routes/__tests__/auth.test.ts
+++ b/apps/api/src/routes/__tests__/auth.test.ts
@@ -1,1011 +1,1124 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import {
-    createExpiredJWT,
-    createTestApp,
-    createTestEnv,
-    createTestJWT,
-    makeQuery,
+  createExpiredJWT,
+  createTestApp,
+  createTestEnv,
+  createTestJWT,
+  makeQuery,
 } from "../../test/helpers";
 
 let mockDb: any;
 const originalNodeEnv = process.env.NODE_ENV;
 
 type OAuthStateEntry = {
-    createdAt: string;
-    browserNonce: string;
+  createdAt: string;
+  browserNonce: string;
 };
 
-function createOAuthStateDb(initialStates: Record<string, OAuthStateEntry> = {}) {
-    const states = new Map<string, OAuthStateEntry>(Object.entries(initialStates));
+function createOAuthStateDb(
+  initialStates: Record<string, OAuthStateEntry> = {},
+) {
+  const states = new Map<string, OAuthStateEntry>(
+    Object.entries(initialStates),
+  );
 
-    const db = {
-        prepare: vi.fn((sql: string) => ({
-            run: async () => {
-                if (
-                    sql.startsWith(
-                        "DELETE FROM oauth_states WHERE created_at <= datetime('now', '-5 minutes')",
-                    )
-                ) {
-                    const now = Date.now();
-                    for (const [state, row] of states.entries()) {
-                        const createdAt = new Date(`${row.createdAt}Z`);
-                        if (now - createdAt.getTime() > 5 * 60 * 1000) {
-                            states.delete(state);
-                        }
-                    }
-                }
-                return {};
-            },
-            bind: (...args: unknown[]) => {
-                if (
-                    sql.startsWith(
-                        "INSERT INTO oauth_states (state, browser_nonce) VALUES (?, ?)",
-                    )
-                ) {
-                    return {
-                        run: async () => {
-                            const state = String(args[0] ?? "");
-                            const browserNonce = String(args[1] ?? "");
-                            const createdAt = new Date().toISOString().replace("T", " ").slice(0, 19);
-                            states.set(state, { createdAt, browserNonce });
-                            return {};
-                        },
-                    };
-                }
-
-                if (
-                    sql.startsWith(
-                        "DELETE FROM oauth_states WHERE state = ? AND browser_nonce = ? RETURNING created_at",
-                    )
-                ) {
-                    return {
-                        first: async <T>() => {
-                            const state = String(args[0] ?? "");
-                            const browserNonce = String(args[1] ?? "");
-                            const stateRow = states.get(state);
-                            if (!stateRow || stateRow.browserNonce !== browserNonce) return null;
-                            states.delete(state);
-                            return { created_at: stateRow.createdAt } as T;
-                        },
-                    };
-                }
-
-                return {
-                    run: async () => ({}),
-                    first: async () => null,
-                };
+  const db = {
+    prepare: vi.fn((sql: string) => ({
+      run: async () => {
+        if (
+          sql.startsWith(
+            "DELETE FROM oauth_states WHERE created_at <= datetime('now', '-5 minutes')",
+          )
+        ) {
+          const now = Date.now();
+          for (const [state, row] of states.entries()) {
+            const createdAt = new Date(`${row.createdAt}Z`);
+            if (now - createdAt.getTime() > 5 * 60 * 1000) {
+              states.delete(state);
             }
-        }))
-    };
+          }
+        }
+        return {};
+      },
+      bind: (...args: unknown[]) => {
+        if (
+          sql.startsWith(
+            "INSERT INTO oauth_states (state, browser_nonce) VALUES (?, ?)",
+          )
+        ) {
+          return {
+            run: async () => {
+              const state = String(args[0] ?? "");
+              const browserNonce = String(args[1] ?? "");
+              const createdAt = new Date()
+                .toISOString()
+                .replace("T", " ")
+                .slice(0, 19);
+              states.set(state, { createdAt, browserNonce });
+              return {};
+            },
+          };
+        }
 
-    return { db, states };
+        if (
+          sql.startsWith(
+            "DELETE FROM oauth_states WHERE state = ? AND browser_nonce = ? RETURNING created_at",
+          )
+        ) {
+          return {
+            first: async <T>() => {
+              const state = String(args[0] ?? "");
+              const browserNonce = String(args[1] ?? "");
+              const stateRow = states.get(state);
+              if (!stateRow || stateRow.browserNonce !== browserNonce)
+                return null;
+              states.delete(state);
+              return { created_at: stateRow.createdAt } as T;
+            },
+          };
+        }
+
+        return {
+          run: async () => ({}),
+          first: async () => null,
+        };
+      },
+    })),
+  };
+
+  return { db, states };
 }
 
 vi.mock("drizzle-orm/d1", () => ({
-    drizzle: vi.fn(() => mockDb)
+  drizzle: vi.fn(() => mockDb),
 }));
 
 describe("auth routes", () => {
-    beforeEach(() => {
-        process.env.NODE_ENV = "test";
-        vi.restoreAllMocks();
-        vi.resetModules();
-        mockDb = {
-            run: vi.fn(async () => undefined),
-            select: vi.fn(() => makeQuery()),
-            insert: vi.fn(() => ({
-                values: vi.fn(() => ({
-                    onConflictDoUpdate: vi.fn(async () => undefined),
-                }))
-            })),
-        };
+  beforeEach(() => {
+    process.env.NODE_ENV = "test";
+    vi.restoreAllMocks();
+    vi.resetModules();
+    mockDb = {
+      run: vi.fn(async () => undefined),
+      select: vi.fn(() => makeQuery()),
+      insert: vi.fn(() => ({
+        values: vi.fn(() => ({
+          onConflictDoUpdate: vi.fn(async () => undefined),
+        })),
+      })),
+    };
+  });
+
+  afterEach(() => {
+    process.env.NODE_ENV = originalNodeEnv;
+  });
+
+  it("GET /api/auth/github uses request Origin over frontend_origin query when both are present", async () => {
+    const app = await createTestApp();
+    const oauthStateDb = createOAuthStateDb();
+    const env = createTestEnv({
+      DB: oauthStateDb.db as any,
+      ALLOWED_ORIGINS:
+        "https://frontend.example.com,https://staging.example.com",
     });
 
-    afterEach(() => {
-        process.env.NODE_ENV = originalNodeEnv;
+    const res = await app.request(
+      "http://localhost/api/auth/github?frontend_origin=https%3A%2F%2Ffrontend.example.com",
+      {
+        headers: {
+          Origin: "https://frontend.example.com",
+        },
+      },
+      env as any,
+    );
+
+    expect(res.status).toBe(302);
+    const location = res.headers.get("location") ?? "";
+    expect(location).toContain("https://github.com/login/oauth/authorize?");
+    expect(location).toContain("client_id=test-client-id");
+    expect(location).toContain(
+      "redirect_uri=http%3A%2F%2Flocalhost%2Fapi%2Fauth%2Fgithub%2Fcallback",
+    );
+
+    const state = new URL(location).searchParams.get("state");
+    expect(state).toBeTruthy();
+    expect(state ? oauthStateDb.states.has(state) : false).toBe(true);
+    const setCookie = res.headers.get("set-cookie") ?? "";
+    expect(setCookie).toContain("oauth_flow_nonce=");
+    expect(setCookie).toContain(
+      "oauth_flow_origin=https%3A%2F%2Ffrontend.example.com",
+    );
+    expect(setCookie).toContain("HttpOnly");
+    expect(
+      state ? oauthStateDb.states.get(state)?.browserNonce : null,
+    ).toBeTruthy();
+  });
+
+  it("GET /api/auth/github falls back to query origin when request Origin is missing", async () => {
+    const app = await createTestApp();
+    const oauthStateDb = createOAuthStateDb();
+    const env = createTestEnv({
+      DB: oauthStateDb.db as any,
+      ALLOWED_ORIGINS: "https://frontend.example.com,http://localhost:3000",
     });
 
-    it("GET /api/auth/github uses request Origin over frontend_origin query when both are present", async () => {
-        const app = await createTestApp();
-        const oauthStateDb = createOAuthStateDb();
-        const env = createTestEnv({
-            DB: oauthStateDb.db as any,
-            ALLOWED_ORIGINS: "https://frontend.example.com,https://staging.example.com",
-        });
+    const res = await app.request(
+      "http://localhost/api/auth/github?frontend_origin=http%3A%2F%2Flocalhost%3A3000",
+      {},
+      env as any,
+    );
 
-        const res = await app.request(
-            "http://localhost/api/auth/github?frontend_origin=https%3A%2F%2Ffrontend.example.com",
-            {
-                headers: {
-                    Origin: "https://frontend.example.com",
-                },
-            },
-            env as any,
-        );
+    expect(res.status).toBe(302);
+    const setCookie = res.headers.get("set-cookie") ?? "";
+    expect(setCookie).toContain(
+      "oauth_flow_origin=http%3A%2F%2Flocalhost%3A3000",
+    );
+  });
 
-        expect(res.status).toBe(302);
-        const location = res.headers.get("location") ?? "";
-        expect(location).toContain("https://github.com/login/oauth/authorize?");
-        expect(location).toContain("client_id=test-client-id");
-        expect(location).toContain("redirect_uri=http%3A%2F%2Flocalhost%2Fapi%2Fauth%2Fgithub%2Fcallback");
+  it("GET /api/auth/github/callback returns 400 when state does not exist in D1", async () => {
+    const app = await createTestApp();
+    const oauthStateDb = createOAuthStateDb();
+    const env = createTestEnv({ DB: oauthStateDb.db as any });
 
-        const state = new URL(location).searchParams.get("state");
-        expect(state).toBeTruthy();
-        expect(state ? oauthStateDb.states.has(state) : false).toBe(true);
-        const setCookie = res.headers.get("set-cookie") ?? "";
-        expect(setCookie).toContain("oauth_flow_nonce=");
-        expect(setCookie).toContain("oauth_flow_origin=https%3A%2F%2Ffrontend.example.com");
-        expect(setCookie).toContain("HttpOnly");
-        expect(state ? oauthStateDb.states.get(state)?.browserNonce : null).toBeTruthy();
+    const res = await app.request(
+      "http://localhost/api/auth/github/callback?code=code123&state=missing-state",
+      {
+        headers: {
+          Cookie: "oauth_flow_nonce=nonce-1",
+        },
+      },
+      env as any,
+    );
+
+    expect(res.status).toBe(400);
+    await expect(res.json()).resolves.toEqual({
+      error: "Invalid or expired state",
+    });
+  });
+
+  it("GET /api/auth/github/callback returns 400 when state parameter is missing", async () => {
+    const app = await createTestApp();
+    const env = createTestEnv({ DB: createOAuthStateDb().db as any });
+
+    const res = await app.request(
+      "http://localhost/api/auth/github/callback?code=code123",
+      {
+        headers: {
+          Cookie: "oauth_flow_nonce=nonce-1",
+        },
+      },
+      env as any,
+    );
+
+    expect(res.status).toBe(400);
+    await expect(res.json()).resolves.toEqual({
+      error: "Missing state parameter",
+    });
+  });
+
+  it("GET /api/auth/github/callback returns 400 when OAuth flow cookie is missing", async () => {
+    const nowState = new Date().toISOString().replace("T", " ").slice(0, 19);
+    const oauthStateDb = createOAuthStateDb({
+      "cookie-state": {
+        createdAt: nowState,
+        browserNonce: "cookie-nonce",
+      },
+    });
+    const app = await createTestApp();
+    const env = createTestEnv({ DB: oauthStateDb.db as any });
+
+    const res = await app.request(
+      "http://localhost/api/auth/github/callback?code=code123&state=cookie-state",
+      {},
+      env as any,
+    );
+
+    expect(res.status).toBe(400);
+    await expect(res.json()).resolves.toEqual({
+      error: "Missing OAuth flow cookie",
+    });
+    expect(oauthStateDb.states.has("cookie-state")).toBe(true);
+  });
+
+  it("GET /api/auth/github/callback returns 400 when state is expired", async () => {
+    const expiredAt = new Date(Date.now() - 6 * 60 * 1000)
+      .toISOString()
+      .replace("T", " ")
+      .slice(0, 19);
+    const oauthStateDb = createOAuthStateDb({
+      "expired-state": {
+        createdAt: expiredAt,
+        browserNonce: "expired-nonce",
+      },
+    });
+    const app = await createTestApp();
+    const env = createTestEnv({ DB: oauthStateDb.db as any });
+
+    const res = await app.request(
+      "http://localhost/api/auth/github/callback?code=code123&state=expired-state",
+      {
+        headers: {
+          Cookie: "oauth_flow_nonce=expired-nonce",
+        },
+      },
+      env as any,
+    );
+
+    expect(res.status).toBe(400);
+    await expect(res.json()).resolves.toEqual({ error: "State expired" });
+    expect(oauthStateDb.states.has("expired-state")).toBe(false);
+  });
+
+  it("GET /api/auth/github/callback returns 400 when code is missing", async () => {
+    const nowState = new Date().toISOString().replace("T", " ").slice(0, 19);
+    const oauthStateDb = createOAuthStateDb({
+      "good-state": {
+        createdAt: nowState,
+        browserNonce: "good-nonce",
+      },
+    });
+    const app = await createTestApp();
+    const env = createTestEnv({ DB: oauthStateDb.db as any });
+
+    const res = await app.request(
+      "http://localhost/api/auth/github/callback?state=good-state",
+      {
+        headers: {
+          Cookie: "oauth_flow_nonce=good-nonce",
+        },
+      },
+      env as any,
+    );
+
+    expect(res.status).toBe(400);
+    await expect(res.json()).resolves.toEqual({
+      error: "Missing code parameter",
+    });
+  });
+
+  it("GET /api/auth/github/callback returns frontend redirect with JWT for valid state", async () => {
+    mockDb.select = vi
+      .fn()
+      .mockImplementationOnce(() => makeQuery({ getResult: { id: "user-1" } }));
+
+    const nowState = new Date().toISOString().replace("T", " ").slice(0, 19);
+    const oauthStateDb = createOAuthStateDb({
+      "good-state": {
+        createdAt: nowState,
+        browserNonce: "good-nonce",
+      },
     });
 
-    it("GET /api/auth/github falls back to query origin when request Origin is missing", async () => {
-        const app = await createTestApp();
-        const oauthStateDb = createOAuthStateDb();
-        const env = createTestEnv({
-            DB: oauthStateDb.db as any,
-            ALLOWED_ORIGINS: "https://frontend.example.com,http://localhost:3000",
-        });
+    vi.stubGlobal(
+      "fetch",
+      vi
+        .fn()
+        .mockResolvedValueOnce({
+          ok: true,
+          json: async () => ({ access_token: "gh-token" }),
+        })
+        .mockResolvedValueOnce({
+          ok: true,
+          json: async () => ({
+            id: 123,
+            login: "octocat",
+            name: "Octo Cat",
+            avatar_url: "http://avatar",
+            email: "octo@example.com",
+          }),
+        }),
+    );
 
-        const res = await app.request(
-            "http://localhost/api/auth/github?frontend_origin=http%3A%2F%2Flocalhost%3A3000",
-            {},
-            env as any,
-        );
+    const app = await createTestApp();
+    const env = createTestEnv({ DB: oauthStateDb.db as any });
 
-        expect(res.status).toBe(302);
-        const setCookie = res.headers.get("set-cookie") ?? "";
-        expect(setCookie).toContain("oauth_flow_origin=http%3A%2F%2Flocalhost%3A3000");
+    const res = await app.request(
+      "http://localhost/api/auth/github/callback?code=code123&state=good-state",
+      {
+        headers: {
+          Cookie: "oauth_flow_nonce=good-nonce",
+        },
+      },
+      env as any,
+    );
+
+    expect(res.status).toBe(302);
+    const location = res.headers.get("location") ?? "";
+    expect(location).toContain("http://localhost:3000/auth/callback");
+    expect(location).not.toContain("#token=");
+    expect(oauthStateDb.states.has("good-state")).toBe(false);
+
+    const cookies = res.headers.get("set-cookie") || "";
+    expect(cookies).toContain("auth_token=");
+    expect(cookies).toContain("HttpOnly");
+    expect(cookies).toContain("SameSite=Lax");
+  });
+
+  it("GET /api/auth/github/callback returns the origin captured from the login request", async () => {
+    mockDb.select = vi
+      .fn()
+      .mockImplementationOnce(() => makeQuery({ getResult: { id: "user-1" } }));
+
+    const nowState = new Date().toISOString().replace("T", " ").slice(0, 19);
+    const oauthStateDb = createOAuthStateDb({
+      "good-state": {
+        createdAt: nowState,
+        browserNonce: "good-nonce",
+      },
     });
 
-    it("GET /api/auth/github/callback returns 400 when state does not exist in D1", async () => {
-        const app = await createTestApp();
-        const oauthStateDb = createOAuthStateDb();
-        const env = createTestEnv({ DB: oauthStateDb.db as any });
+    vi.stubGlobal(
+      "fetch",
+      vi
+        .fn()
+        .mockResolvedValueOnce({
+          ok: true,
+          json: async () => ({ access_token: "gh-token" }),
+        })
+        .mockResolvedValueOnce({
+          ok: true,
+          json: async () => ({
+            id: 123,
+            login: "octocat",
+            name: "Octo Cat",
+            avatar_url: "http://avatar",
+            email: "octo@example.com",
+          }),
+        }),
+    );
 
-        const res = await app.request(
-            "http://localhost/api/auth/github/callback?code=code123&state=missing-state",
-            {
-                headers: {
-                    Cookie: "oauth_flow_nonce=nonce-1",
-                },
-            },
-            env as any
-        );
-
-        expect(res.status).toBe(400);
-        await expect(res.json()).resolves.toEqual({ error: "Invalid or expired state" });
+    const app = await createTestApp();
+    const env = createTestEnv({
+      DB: oauthStateDb.db as any,
+      FRONTEND_URL: "https://frontend.example.com",
+      ALLOWED_ORIGINS:
+        "https://frontend.example.com,https://staging.example.com",
     });
 
-    it("GET /api/auth/github/callback returns 400 when state parameter is missing", async () => {
-        const app = await createTestApp();
-        const env = createTestEnv({ DB: createOAuthStateDb().db as any });
+    const res = await app.request(
+      "http://localhost/api/auth/github/callback?code=code123&state=good-state",
+      {
+        headers: {
+          Cookie:
+            "oauth_flow_nonce=good-nonce; oauth_flow_origin=https://staging.example.com",
+        },
+      },
+      env as any,
+    );
 
-        const res = await app.request(
-            "http://localhost/api/auth/github/callback?code=code123",
-            {
-                headers: {
-                    Cookie: "oauth_flow_nonce=nonce-1",
-                },
-            },
-            env as any,
-        );
+    expect(res.status).toBe(302);
+    const location = res.headers.get("location") ?? "";
+    expect(location).toContain("https://staging.example.com/auth/callback");
+    expect(location).not.toContain("#token=");
 
-        expect(res.status).toBe(400);
-        await expect(res.json()).resolves.toEqual({ error: "Missing state parameter" });
+    const cookies = res.headers.get("set-cookie") || "";
+    expect(cookies).toContain("auth_token=");
+  });
+
+  it("GET /api/auth/github/callback falls back to FRONTEND_URL when oauth_flow_origin is not allowlisted", async () => {
+    mockDb.select = vi
+      .fn()
+      .mockImplementationOnce(() => makeQuery({ getResult: { id: "user-1" } }));
+
+    const nowState = new Date().toISOString().replace("T", " ").slice(0, 19);
+    const oauthStateDb = createOAuthStateDb({
+      "good-state": {
+        createdAt: nowState,
+        browserNonce: "good-nonce",
+      },
     });
 
-    it("GET /api/auth/github/callback returns 400 when OAuth flow cookie is missing", async () => {
-        const nowState = new Date().toISOString().replace("T", " ").slice(0, 19);
-        const oauthStateDb = createOAuthStateDb({
-            "cookie-state": {
-                createdAt: nowState,
-                browserNonce: "cookie-nonce",
-            },
-        });
-        const app = await createTestApp();
-        const env = createTestEnv({ DB: oauthStateDb.db as any });
+    vi.stubGlobal(
+      "fetch",
+      vi
+        .fn()
+        .mockResolvedValueOnce({
+          ok: true,
+          json: async () => ({ access_token: "gh-token" }),
+        })
+        .mockResolvedValueOnce({
+          ok: true,
+          json: async () => ({
+            id: 123,
+            login: "octocat",
+            name: "Octo Cat",
+            avatar_url: "http://avatar",
+            email: "octo@example.com",
+          }),
+        }),
+    );
 
-        const res = await app.request(
-            "http://localhost/api/auth/github/callback?code=code123&state=cookie-state",
-            {},
-            env as any
-        );
-
-        expect(res.status).toBe(400);
-        await expect(res.json()).resolves.toEqual({ error: "Missing OAuth flow cookie" });
-        expect(oauthStateDb.states.has("cookie-state")).toBe(true);
+    const app = await createTestApp();
+    const env = createTestEnv({
+      DB: oauthStateDb.db as any,
+      FRONTEND_URL: "https://frontend.example.com",
+      ALLOWED_ORIGINS: "https://frontend.example.com",
     });
 
-    it("GET /api/auth/github/callback returns 400 when state is expired", async () => {
-        const expiredAt = new Date(Date.now() - 6 * 60 * 1000)
-            .toISOString()
-            .replace("T", " ")
-            .slice(0, 19);
-        const oauthStateDb = createOAuthStateDb({
-            "expired-state": {
-                createdAt: expiredAt,
-                browserNonce: "expired-nonce",
-            },
-        });
-        const app = await createTestApp();
-        const env = createTestEnv({ DB: oauthStateDb.db as any });
+    const res = await app.request(
+      "http://localhost/api/auth/github/callback?code=code123&state=good-state",
+      {
+        headers: {
+          Cookie:
+            "oauth_flow_nonce=good-nonce; oauth_flow_origin=https://attacker.example.com",
+        },
+      },
+      env as any,
+    );
 
-        const res = await app.request(
-            "http://localhost/api/auth/github/callback?code=code123&state=expired-state",
-            {
-                headers: {
-                    Cookie: "oauth_flow_nonce=expired-nonce",
-                },
-            },
-            env as any
-        );
+    expect(res.status).toBe(302);
+    const location = res.headers.get("location") ?? "";
+    expect(location).toContain("https://frontend.example.com/auth/callback");
+    expect(location).not.toContain("#token=");
+  });
 
-        expect(res.status).toBe(400);
-        await expect(res.json()).resolves.toEqual({ error: "State expired" });
-        expect(oauthStateDb.states.has("expired-state")).toBe(false);
+  it("GET /api/auth/github/callback returns 502 when OAuth token exchange fails", async () => {
+    const nowState = new Date().toISOString().replace("T", " ").slice(0, 19);
+    const oauthStateDb = createOAuthStateDb({
+      "good-state": {
+        createdAt: nowState,
+        browserNonce: "good-nonce",
+      },
+    });
+    vi.stubGlobal(
+      "fetch",
+      vi.fn().mockResolvedValue({
+        ok: false,
+        text: async () => "bad token exchange",
+      }),
+    );
+
+    const app = await createTestApp();
+    const env = createTestEnv({ DB: oauthStateDb.db as any });
+
+    const res = await app.request(
+      "http://localhost/api/auth/github/callback?code=code123&state=good-state",
+      {
+        headers: {
+          Cookie: "oauth_flow_nonce=good-nonce",
+        },
+      },
+      env as any,
+    );
+
+    expect(res.status).toBe(502);
+    await expect(res.json()).resolves.toEqual({
+      error: "Failed to exchange OAuth code",
+      details: "bad token exchange",
+    });
+  });
+
+  it("GET /api/auth/github/callback returns 400 when GitHub does not return an access token", async () => {
+    const nowState = new Date().toISOString().replace("T", " ").slice(0, 19);
+    const oauthStateDb = createOAuthStateDb({
+      "good-state": {
+        createdAt: nowState,
+        browserNonce: "good-nonce",
+      },
+    });
+    vi.stubGlobal(
+      "fetch",
+      vi.fn().mockResolvedValue({
+        ok: true,
+        json: async () => ({ token_type: "bearer" }),
+      }),
+    );
+
+    const app = await createTestApp();
+    const env = createTestEnv({ DB: oauthStateDb.db as any });
+
+    const res = await app.request(
+      "http://localhost/api/auth/github/callback?code=code123&state=good-state",
+      {
+        headers: {
+          Cookie: "oauth_flow_nonce=good-nonce",
+        },
+      },
+      env as any,
+    );
+
+    expect(res.status).toBe(400);
+    await expect(res.json()).resolves.toEqual({
+      error: "Failed to get access token",
+    });
+  });
+
+  it("GET /api/auth/github/callback returns 502 when fetching the GitHub user fails", async () => {
+    const nowState = new Date().toISOString().replace("T", " ").slice(0, 19);
+    const oauthStateDb = createOAuthStateDb({
+      "good-state": {
+        createdAt: nowState,
+        browserNonce: "good-nonce",
+      },
+    });
+    vi.stubGlobal(
+      "fetch",
+      vi
+        .fn()
+        .mockResolvedValueOnce({
+          ok: true,
+          json: async () => ({ access_token: "gh-token" }),
+        })
+        .mockResolvedValueOnce({
+          ok: false,
+          text: async () => "bad user payload",
+        }),
+    );
+
+    const app = await createTestApp();
+    const env = createTestEnv({ DB: oauthStateDb.db as any });
+
+    const res = await app.request(
+      "http://localhost/api/auth/github/callback?code=code123&state=good-state",
+      {
+        headers: {
+          Cookie: "oauth_flow_nonce=good-nonce",
+        },
+      },
+      env as any,
+    );
+
+    expect(res.status).toBe(502);
+    await expect(res.json()).resolves.toEqual({
+      error: "Failed to fetch GitHub user",
+      details: "bad user payload",
+    });
+  });
+
+  it("GET /api/auth/github/callback returns 502 for invalid GitHub user payloads", async () => {
+    const nowState = new Date().toISOString().replace("T", " ").slice(0, 19);
+    const oauthStateDb = createOAuthStateDb({
+      "good-state": {
+        createdAt: nowState,
+        browserNonce: "good-nonce",
+      },
+    });
+    vi.stubGlobal(
+      "fetch",
+      vi
+        .fn()
+        .mockResolvedValueOnce({
+          ok: true,
+          json: async () => ({ access_token: "gh-token" }),
+        })
+        .mockResolvedValueOnce({
+          ok: true,
+          json: async () => ({ id: "abc", login: 123 }),
+        }),
+    );
+
+    const app = await createTestApp();
+    const env = createTestEnv({ DB: oauthStateDb.db as any });
+
+    const res = await app.request(
+      "http://localhost/api/auth/github/callback?code=code123&state=good-state",
+      {
+        headers: {
+          Cookie: "oauth_flow_nonce=good-nonce",
+        },
+      },
+      env as any,
+    );
+
+    expect(res.status).toBe(502);
+    await expect(res.json()).resolves.toEqual({
+      error: "Invalid GitHub user payload",
+    });
+  });
+
+  it("GET /api/auth/github/callback returns 500 when FRONTEND_URL is missing", async () => {
+    mockDb.select = vi
+      .fn()
+      .mockImplementationOnce(() => makeQuery({ getResult: { id: "user-1" } }));
+
+    const nowState = new Date().toISOString().replace("T", " ").slice(0, 19);
+    const oauthStateDb = createOAuthStateDb({
+      "good-state": {
+        createdAt: nowState,
+        browserNonce: "good-nonce",
+      },
     });
 
-    it("GET /api/auth/github/callback returns 400 when code is missing", async () => {
-        const nowState = new Date().toISOString().replace("T", " ").slice(0, 19);
-        const oauthStateDb = createOAuthStateDb({
-            "good-state": {
-                createdAt: nowState,
-                browserNonce: "good-nonce",
-            },
-        });
-        const app = await createTestApp();
-        const env = createTestEnv({ DB: oauthStateDb.db as any });
+    vi.stubGlobal(
+      "fetch",
+      vi
+        .fn()
+        .mockResolvedValueOnce({
+          ok: true,
+          json: async () => ({ access_token: "gh-token" }),
+        })
+        .mockResolvedValueOnce({
+          ok: true,
+          json: async () => ({ id: 123, login: "octocat", name: "Octo Cat" }),
+        }),
+    );
 
-        const res = await app.request(
-            "http://localhost/api/auth/github/callback?state=good-state",
-            {
-                headers: {
-                    Cookie: "oauth_flow_nonce=good-nonce",
-                },
-            },
-            env as any,
-        );
-
-        expect(res.status).toBe(400);
-        await expect(res.json()).resolves.toEqual({ error: "Missing code parameter" });
+    const app = await createTestApp();
+    const env = createTestEnv({
+      DB: oauthStateDb.db as any,
+      FRONTEND_URL: "",
     });
 
-    it("GET /api/auth/github/callback returns frontend redirect with JWT for valid state", async () => {
-        mockDb.select = vi
-            .fn()
-            .mockImplementationOnce(() => makeQuery({ getResult: { id: "user-1" } }));
+    const res = await app.request(
+      "http://localhost/api/auth/github/callback?code=code123&state=good-state",
+      {
+        headers: {
+          Cookie: "oauth_flow_nonce=good-nonce",
+        },
+      },
+      env as any,
+    );
 
-        const nowState = new Date().toISOString().replace("T", " ").slice(0, 19);
-        const oauthStateDb = createOAuthStateDb({
-            "good-state": {
-                createdAt: nowState,
-                browserNonce: "good-nonce",
-            },
-        });
+    expect(res.status).toBe(500);
+    await expect(res.json()).resolves.toEqual({
+      error: "Server configuration error",
+    });
+  });
 
-        vi.stubGlobal(
-            "fetch",
-            vi
-                .fn()
-                .mockResolvedValueOnce({
-                    ok: true,
-                    json: async () => ({ access_token: "gh-token" })
-                })
-                .mockResolvedValueOnce({
-                    ok: true,
-                    json: async () => ({ id: 123, login: "octocat", name: "Octo Cat", avatar_url: "http://avatar", email: "octo@example.com" })
-                })
-        );
+  it("GET /api/auth/github/callback rejects replayed state on second use", async () => {
+    mockDb.select = vi
+      .fn()
+      .mockImplementationOnce(() => makeQuery({ getResult: { id: "user-1" } }));
 
-        const app = await createTestApp();
-        const env = createTestEnv({ DB: oauthStateDb.db as any });
+    vi.stubGlobal(
+      "fetch",
+      vi
+        .fn()
+        .mockResolvedValueOnce({
+          ok: true,
+          json: async () => ({ access_token: "gh-token" }),
+        })
+        .mockResolvedValueOnce({
+          ok: true,
+          json: async () => ({
+            id: 123,
+            login: "octocat",
+            name: "Octo Cat",
+            avatar_url: "http://avatar",
+            email: "octo@example.com",
+          }),
+        }),
+    );
 
-        const res = await app.request(
-            "http://localhost/api/auth/github/callback?code=code123&state=good-state",
-            {
-                headers: {
-                    Cookie: "oauth_flow_nonce=good-nonce",
-                },
-            },
-            env as any
-        );
+    const nowState = new Date().toISOString().replace("T", " ").slice(0, 19);
+    const oauthStateDb = createOAuthStateDb({
+      "replay-state": {
+        createdAt: nowState,
+        browserNonce: "replay-nonce",
+      },
+    });
+    const app = await createTestApp();
+    const env = createTestEnv({ DB: oauthStateDb.db as any });
 
-        expect(res.status).toBe(302);
-        const location = res.headers.get("location") ?? "";
-        expect(location).toContain("http://localhost:3000/auth/callback#token=");
-        expect(oauthStateDb.states.has("good-state")).toBe(false);
+    const firstRes = await app.request(
+      "http://localhost/api/auth/github/callback?code=code123&state=replay-state",
+      {
+        headers: {
+          Cookie: "oauth_flow_nonce=replay-nonce",
+        },
+      },
+      env as any,
+    );
+    expect(firstRes.status).toBe(302);
+
+    const secondRes = await app.request(
+      "http://localhost/api/auth/github/callback?code=code123&state=replay-state",
+      {
+        headers: {
+          Cookie: "oauth_flow_nonce=replay-nonce",
+        },
+      },
+      env as any,
+    );
+
+    expect(secondRes.status).toBe(400);
+    await expect(secondRes.json()).resolves.toEqual({
+      error: "Invalid or expired state",
+    });
+  });
+
+  it("GET /api/auth/me returns 200 for valid Bearer token", async () => {
+    const token = await createTestJWT({
+      sub: "user-1",
+      githubId: "123",
+      name: "Tester",
+    });
+    mockDb.select = vi.fn(() =>
+      makeQuery({ getResult: { id: "user-1", name: "Tester" } }),
+    );
+
+    const app = await createTestApp();
+    const env = createTestEnv();
+
+    const res = await app.request(
+      "http://localhost/api/auth/me",
+      {
+        headers: {
+          Authorization: `Bearer ${token}`,
+        },
+      },
+      env as any,
+    );
+
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as any;
+    expect(body.user.id).toBe("user-1");
+  });
+
+  it("GET /api/auth/me returns 404 when the user does not exist", async () => {
+    const token = await createTestJWT({
+      sub: "user-1",
+      githubId: "123",
+      name: "Tester",
+    });
+    mockDb.select = vi.fn(() => makeQuery({ getResult: null }));
+
+    const app = await createTestApp();
+    const env = createTestEnv();
+
+    const res = await app.request(
+      "http://localhost/api/auth/me",
+      {
+        headers: {
+          Authorization: `Bearer ${token}`,
+        },
+      },
+      env as any,
+    );
+
+    expect(res.status).toBe(404);
+    await expect(res.json()).resolves.toEqual({ error: "User not found" });
+  });
+
+  it("GET /api/auth/me returns 401 when token is missing", async () => {
+    const app = await createTestApp();
+    const env = createTestEnv();
+
+    const res = await app.request(
+      "http://localhost/api/auth/me",
+      {},
+      env as any,
+    );
+    expect(res.status).toBe(401);
+  });
+
+  it("GET /api/auth/me returns 401 when token is invalid", async () => {
+    const app = await createTestApp();
+    const env = createTestEnv();
+
+    const res = await app.request(
+      "http://localhost/api/auth/me",
+      {
+        headers: {
+          Authorization: "Bearer invalid-token",
+        },
+      },
+      env as any,
+    );
+
+    expect(res.status).toBe(401);
+  });
+
+  it("GET /api/auth/me returns 401 when token is expired", async () => {
+    const token = await createExpiredJWT({
+      sub: "user-1",
+      githubId: "123",
+      name: "Tester",
+    });
+    const app = await createTestApp();
+    const env = createTestEnv();
+
+    const res = await app.request(
+      "http://localhost/api/auth/me",
+      {
+        headers: {
+          Authorization: `Bearer ${token}`,
+        },
+      },
+      env as any,
+    );
+
+    expect(res.status).toBe(401);
+  });
+
+  it("POST /api/auth/logout returns ok", async () => {
+    const app = await createTestApp();
+    const env = createTestEnv();
+
+    const res = await app.request(
+      "http://localhost/api/auth/logout",
+      {
+        method: "POST",
+        headers: {
+          Origin: "http://localhost:3000",
+        },
+      },
+      env as any,
+    );
+
+    expect(res.status).toBe(200);
+    await expect(res.json()).resolves.toEqual({ ok: true });
+  });
+
+  it("POST /api/test-auth/test-token returns 404 when test auth is disabled", async () => {
+    const app = await createTestApp();
+    const env = createTestEnv();
+
+    const res = await app.request(
+      "http://localhost/api/test-auth/test-token",
+      {
+        method: "POST",
+        headers: {
+          Origin: "http://localhost:3000",
+        },
+      },
+      env as any,
+    );
+
+    expect(res.status).toBe(404);
+    await expect(res.json()).resolves.toEqual({ error: "Not Found" });
+  });
+
+  it("POST /api/test-auth/test-token validates the shared secret and request body", async () => {
+    const app = await createTestApp();
+    const env = createTestEnv({
+      ENABLE_TEST_AUTH: "true",
+      TEST_AUTH_SECRET: "shared-secret",
     });
 
-    it("GET /api/auth/github/callback returns the origin captured from the login request", async () => {
-        mockDb.select = vi
-            .fn()
-            .mockImplementationOnce(() => makeQuery({ getResult: { id: "user-1" } }));
+    const unauthorized = await app.request(
+      "http://localhost/api/test-auth/test-token",
+      {
+        method: "POST",
+        headers: {
+          "Content-Type": "application/json",
+          Origin: "http://localhost:3000",
+        },
+        body: JSON.stringify({
+          sub: "user-1",
+          githubId: "123",
+          name: "Tester",
+        }),
+      },
+      env as any,
+    );
+    expect(unauthorized.status).toBe(401);
 
-        const nowState = new Date().toISOString().replace("T", " ").slice(0, 19);
-        const oauthStateDb = createOAuthStateDb({
-            "good-state": {
-                createdAt: nowState,
-                browserNonce: "good-nonce",
-            },
-        });
-
-        vi.stubGlobal(
-            "fetch",
-            vi
-                .fn()
-                .mockResolvedValueOnce({
-                    ok: true,
-                    json: async () => ({ access_token: "gh-token" }),
-                })
-                .mockResolvedValueOnce({
-                    ok: true,
-                    json: async () => ({
-                        id: 123,
-                        login: "octocat",
-                        name: "Octo Cat",
-                        avatar_url: "http://avatar",
-                        email: "octo@example.com",
-                    }),
-                }),
-        );
-
-        const app = await createTestApp();
-        const env = createTestEnv({
-            DB: oauthStateDb.db as any,
-            FRONTEND_URL: "https://frontend.example.com",
-            ALLOWED_ORIGINS: "https://frontend.example.com,https://staging.example.com",
-        });
-
-        const res = await app.request(
-            "http://localhost/api/auth/github/callback?code=code123&state=good-state",
-            {
-                headers: {
-                    Cookie: "oauth_flow_nonce=good-nonce; oauth_flow_origin=https://staging.example.com",
-                },
-            },
-            env as any,
-        );
-
-        expect(res.status).toBe(302);
-        const location = res.headers.get("location") ?? "";
-        expect(location).toContain("https://staging.example.com/auth/callback#token=");
+    const invalidJson = await app.request(
+      "http://localhost/api/test-auth/test-token",
+      {
+        method: "POST",
+        headers: {
+          "Content-Type": "application/json",
+          "x-test-auth-secret": "shared-secret",
+          Origin: "http://localhost:3000",
+        },
+        body: "{",
+      },
+      env as any,
+    );
+    expect(invalidJson.status).toBe(400);
+    await expect(invalidJson.json()).resolves.toEqual({
+      error: "Invalid JSON",
     });
 
-    it("GET /api/auth/github/callback falls back to FRONTEND_URL when oauth_flow_origin is not allowlisted", async () => {
-        mockDb.select = vi
-            .fn()
-            .mockImplementationOnce(() => makeQuery({ getResult: { id: "user-1" } }));
+    const invalidBody = await app.request(
+      "http://localhost/api/test-auth/test-token",
+      {
+        method: "POST",
+        headers: {
+          "Content-Type": "application/json",
+          "x-test-auth-secret": "shared-secret",
+          Origin: "http://localhost:3000",
+        },
+        body: JSON.stringify({ sub: "user-1" }),
+      },
+      env as any,
+    );
+    expect(invalidBody.status).toBe(400);
+    await expect(invalidBody.json()).resolves.toEqual({
+      error: "Invalid request body",
+    });
+  });
 
-        const nowState = new Date().toISOString().replace("T", " " ).slice(0, 19);
-        const oauthStateDb = createOAuthStateDb({
-            "good-state": {
-                createdAt: nowState,
-                browserNonce: "good-nonce",
-            },
-        });
+  it("POST /api/test-auth/test-token upserts the user and returns a signed JWT", async () => {
+    mockDb.select = vi.fn(() =>
+      makeQuery({ getResult: { id: "persisted-user" } }),
+    );
 
-        vi.stubGlobal(
-            "fetch",
-            vi
-                .fn()
-                .mockResolvedValueOnce({
-                    ok: true,
-                    json: async () => ({ access_token: "gh-token" }),
-                })
-                .mockResolvedValueOnce({
-                    ok: true,
-                    json: async () => ({
-                        id: 123,
-                        login: "octocat",
-                        name: "Octo Cat",
-                        avatar_url: "http://avatar",
-                        email: "octo@example.com",
-                    }),
-                }),
-        );
-
-        const app = await createTestApp();
-        const env = createTestEnv({
-            DB: oauthStateDb.db as any,
-            FRONTEND_URL: "https://frontend.example.com",
-            ALLOWED_ORIGINS: "https://frontend.example.com",
-        });
-
-        const res = await app.request(
-            "http://localhost/api/auth/github/callback?code=code123&state=good-state",
-            {
-                headers: {
-                    Cookie: "oauth_flow_nonce=good-nonce; oauth_flow_origin=https://attacker.example.com",
-                },
-            },
-            env as any,
-        );
-
-        expect(res.status).toBe(302);
-        const location = res.headers.get("location") ?? "";
-        expect(location).toContain("https://frontend.example.com/auth/callback#token=");
+    const app = await createTestApp();
+    const env = createTestEnv({
+      ENABLE_TEST_AUTH: "true",
+      TEST_AUTH_SECRET: "shared-secret",
     });
 
-    it("GET /api/auth/github/callback returns 502 when OAuth token exchange fails", async () => {
-        const nowState = new Date().toISOString().replace("T", " ").slice(0, 19);
-        const oauthStateDb = createOAuthStateDb({
-            "good-state": {
-                createdAt: nowState,
-                browserNonce: "good-nonce",
-            },
-        });
-        vi.stubGlobal(
-            "fetch",
-            vi.fn().mockResolvedValue({
-                ok: false,
-                text: async () => "bad token exchange",
-            }),
-        );
+    const res = await app.request(
+      "http://localhost/api/test-auth/test-token",
+      {
+        method: "POST",
+        headers: {
+          "Content-Type": "application/json",
+          "x-test-auth-secret": "shared-secret",
+        },
+        body: JSON.stringify({
+          sub: "user-1",
+          githubId: "123",
+          name: "Tester",
+        }),
+      },
+      env as any,
+    );
 
-        const app = await createTestApp();
-        const env = createTestEnv({ DB: oauthStateDb.db as any });
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as { token: string };
+    expect(body.token).toMatch(/\./);
+  });
 
-        const res = await app.request(
-            "http://localhost/api/auth/github/callback?code=code123&state=good-state",
-            {
-                headers: {
-                    Cookie: "oauth_flow_nonce=good-nonce",
-                },
-            },
-            env as any,
-        );
+  it("POST /api/test-auth/test-token returns 500 if user persistence fails", async () => {
+    mockDb.select = vi.fn(() => makeQuery({ getResult: null }));
 
-        expect(res.status).toBe(502);
-        await expect(res.json()).resolves.toEqual({
-            error: "Failed to exchange OAuth code",
-            details: "bad token exchange",
-        });
+    const app = await createTestApp();
+    const env = createTestEnv({
+      ENABLE_TEST_AUTH: "true",
+      TEST_AUTH_SECRET: "shared-secret",
     });
 
-    it("GET /api/auth/github/callback returns 400 when GitHub does not return an access token", async () => {
-        const nowState = new Date().toISOString().replace("T", " ").slice(0, 19);
-        const oauthStateDb = createOAuthStateDb({
-            "good-state": {
-                createdAt: nowState,
-                browserNonce: "good-nonce",
-            },
-        });
-        vi.stubGlobal(
-            "fetch",
-            vi.fn().mockResolvedValue({
-                ok: true,
-                json: async () => ({ token_type: "bearer" }),
-            }),
-        );
+    const res = await app.request(
+      "http://localhost/api/test-auth/test-token",
+      {
+        method: "POST",
+        headers: {
+          "Content-Type": "application/json",
+          "x-test-auth-secret": "shared-secret",
+        },
+        body: JSON.stringify({ sub: "u1", githubId: "g1", name: "N" }),
+      },
+      env as any,
+    );
+    expect(res.status).toBe(500);
+  });
 
-        const app = await createTestApp();
-        const env = createTestEnv({ DB: oauthStateDb.db as any });
-
-        const res = await app.request(
-            "http://localhost/api/auth/github/callback?code=code123&state=good-state",
-            {
-                headers: {
-                    Cookie: "oauth_flow_nonce=good-nonce",
-                },
-            },
-            env as any,
-        );
-
-        expect(res.status).toBe(400);
-        await expect(res.json()).resolves.toEqual({ error: "Failed to get access token" });
+  it("GET /api/auth/github/callback uses login as name if GitHub name is missing", async () => {
+    mockDb.select = vi.fn(() => makeQuery({ getResult: { id: "user-1" } }));
+    const nowState = new Date().toISOString().replace("T", " ").slice(0, 19);
+    const oauthStateDb = createOAuthStateDb({
+      s1: { createdAt: nowState, browserNonce: "n1" },
     });
 
-    it("GET /api/auth/github/callback returns 502 when fetching the GitHub user fails", async () => {
-        const nowState = new Date().toISOString().replace("T", " ").slice(0, 19);
-        const oauthStateDb = createOAuthStateDb({
-            "good-state": {
-                createdAt: nowState,
-                browserNonce: "good-nonce",
-            },
-        });
-        vi.stubGlobal(
-            "fetch",
-            vi
-                .fn()
-                .mockResolvedValueOnce({
-                    ok: true,
-                    json: async () => ({ access_token: "gh-token" }),
-                })
-                .mockResolvedValueOnce({
-                    ok: false,
-                    text: async () => "bad user payload",
-                }),
-        );
+    vi.stubGlobal(
+      "fetch",
+      vi
+        .fn()
+        .mockResolvedValueOnce({
+          ok: true,
+          json: async () => ({ access_token: "t" }),
+        })
+        .mockResolvedValueOnce({
+          ok: true,
+          json: async () => ({ id: 1, login: "userlogin", name: "" }),
+        }),
+    );
 
-        const app = await createTestApp();
-        const env = createTestEnv({ DB: oauthStateDb.db as any });
+    const app = await createTestApp();
+    const env = createTestEnv({ DB: oauthStateDb.db as any });
+    const res = await app.request(
+      "http://localhost/api/auth/github/callback?code=c&state=s1",
+      {
+        headers: { Cookie: "oauth_flow_nonce=n1" },
+      },
+      env as any,
+    );
+    expect(res.status).toBe(302);
+  });
 
-        const res = await app.request(
-            "http://localhost/api/auth/github/callback?code=code123&state=good-state",
-            {
-                headers: {
-                    Cookie: "oauth_flow_nonce=good-nonce",
-                },
-            },
-            env as any,
-        );
+  it("POST /api/test-auth/test-org returns 404 or 401 based on configuration", async () => {
+    const app = await createTestApp();
+    const res404 = await app.request(
+      "http://localhost/api/test-auth/test-org",
+      {
+        method: "POST",
+        headers: { Origin: "http://localhost:3000" },
+      },
+      createTestEnv({ ENABLE_TEST_AUTH: "false" }) as any,
+    );
+    expect(res404.status).toBe(404);
 
-        expect(res.status).toBe(502);
-        await expect(res.json()).resolves.toEqual({
-            error: "Failed to fetch GitHub user",
-            details: "bad user payload",
-        });
+    const res401 = await app.request(
+      "http://localhost/api/test-auth/test-org",
+      {
+        method: "POST",
+        headers: {
+          Origin: "http://localhost:3000",
+          "x-test-auth-secret": "wrong",
+        },
+      },
+      createTestEnv({
+        ENABLE_TEST_AUTH: "true",
+        TEST_AUTH_SECRET: "secret",
+      }) as any,
+    );
+    expect(res401.status).toBe(401);
+  });
+
+  it("POST /api/test-auth/test-org validates auth and creates membership records", async () => {
+    const app = await createTestApp();
+    const env = createTestEnv({
+      ENABLE_TEST_AUTH: "true",
+      TEST_AUTH_SECRET: "shared-secret",
     });
 
-    it("GET /api/auth/github/callback returns 502 for invalid GitHub user payloads", async () => {
-        const nowState = new Date().toISOString().replace("T", " ").slice(0, 19);
-        const oauthStateDb = createOAuthStateDb({
-            "good-state": {
-                createdAt: nowState,
-                browserNonce: "good-nonce",
-            },
-        });
-        vi.stubGlobal(
-            "fetch",
-            vi
-                .fn()
-                .mockResolvedValueOnce({
-                    ok: true,
-                    json: async () => ({ access_token: "gh-token" }),
-                })
-                .mockResolvedValueOnce({
-                    ok: true,
-                    json: async () => ({ id: "abc", login: 123 }),
-                }),
-        );
+    const invalidJson = await app.request(
+      "http://localhost/api/test-auth/test-org",
+      {
+        method: "POST",
+        headers: {
+          "Content-Type": "application/json",
+          "x-test-auth-secret": "shared-secret",
+        },
+        body: "{",
+      },
+      env as any,
+    );
+    expect(invalidJson.status).toBe(400);
 
-        const app = await createTestApp();
-        const env = createTestEnv({ DB: oauthStateDb.db as any });
-
-        const res = await app.request(
-            "http://localhost/api/auth/github/callback?code=code123&state=good-state",
-            {
-                headers: {
-                    Cookie: "oauth_flow_nonce=good-nonce",
-                },
-            },
-            env as any,
-        );
-
-        expect(res.status).toBe(502);
-        await expect(res.json()).resolves.toEqual({ error: "Invalid GitHub user payload" });
+    const invalidBody = await app.request(
+      "http://localhost/api/test-auth/test-org",
+      {
+        method: "POST",
+        headers: {
+          "Content-Type": "application/json",
+          "x-test-auth-secret": "shared-secret",
+        },
+        body: JSON.stringify({ userId: "user-1" }),
+      },
+      env as any,
+    );
+    expect(invalidBody.status).toBe(400);
+    await expect(invalidBody.json()).resolves.toEqual({
+      error: "userId and orgId are required",
     });
 
-    it("GET /api/auth/github/callback returns 500 when FRONTEND_URL is missing", async () => {
-        mockDb.select = vi
-            .fn()
-            .mockImplementationOnce(() => makeQuery({ getResult: { id: "user-1" } }));
+    const onConflictDoNothing = vi.fn(async () => undefined);
+    mockDb.insert = vi.fn(() => ({
+      values: vi.fn(() => ({
+        onConflictDoNothing,
+      })),
+    }));
 
-        const nowState = new Date().toISOString().replace("T", " ").slice(0, 19);
-        const oauthStateDb = createOAuthStateDb({
-            "good-state": {
-                createdAt: nowState,
-                browserNonce: "good-nonce",
-            },
-        });
-
-        vi.stubGlobal(
-            "fetch",
-            vi
-                .fn()
-                .mockResolvedValueOnce({
-                    ok: true,
-                    json: async () => ({ access_token: "gh-token" }),
-                })
-                .mockResolvedValueOnce({
-                    ok: true,
-                    json: async () => ({ id: 123, login: "octocat", name: "Octo Cat" }),
-                }),
-        );
-
-        const app = await createTestApp();
-        const env = createTestEnv({
-            DB: oauthStateDb.db as any,
-            FRONTEND_URL: "",
-        });
-
-        const res = await app.request(
-            "http://localhost/api/auth/github/callback?code=code123&state=good-state",
-            {
-                headers: {
-                    Cookie: "oauth_flow_nonce=good-nonce",
-                },
-            },
-            env as any,
-        );
-
-        expect(res.status).toBe(500);
-        await expect(res.json()).resolves.toEqual({ error: "Server configuration error" });
-    });
-
-    it("GET /api/auth/github/callback rejects replayed state on second use", async () => {
-        mockDb.select = vi
-            .fn()
-            .mockImplementationOnce(() => makeQuery({ getResult: { id: "user-1" } }));
-
-        vi.stubGlobal(
-            "fetch",
-            vi
-                .fn()
-                .mockResolvedValueOnce({
-                    ok: true,
-                    json: async () => ({ access_token: "gh-token" })
-                })
-                .mockResolvedValueOnce({
-                    ok: true,
-                    json: async () => ({ id: 123, login: "octocat", name: "Octo Cat", avatar_url: "http://avatar", email: "octo@example.com" })
-                })
-        );
-
-        const nowState = new Date().toISOString().replace("T", " ").slice(0, 19);
-        const oauthStateDb = createOAuthStateDb({
-            "replay-state": {
-                createdAt: nowState,
-                browserNonce: "replay-nonce",
-            },
-        });
-        const app = await createTestApp();
-        const env = createTestEnv({ DB: oauthStateDb.db as any });
-
-        const firstRes = await app.request(
-            "http://localhost/api/auth/github/callback?code=code123&state=replay-state",
-            {
-                headers: {
-                    Cookie: "oauth_flow_nonce=replay-nonce",
-                },
-            },
-            env as any
-        );
-        expect(firstRes.status).toBe(302);
-
-        const secondRes = await app.request(
-            "http://localhost/api/auth/github/callback?code=code123&state=replay-state",
-            {
-                headers: {
-                    Cookie: "oauth_flow_nonce=replay-nonce",
-                },
-            },
-            env as any
-        );
-
-        expect(secondRes.status).toBe(400);
-        await expect(secondRes.json()).resolves.toEqual({ error: "Invalid or expired state" });
-    });
-
-    it("GET /api/auth/me returns 200 for valid Bearer token", async () => {
-        const token = await createTestJWT({ sub: "user-1", githubId: "123", name: "Tester" });
-        mockDb.select = vi.fn(() => makeQuery({ getResult: { id: "user-1", name: "Tester" } }));
-
-        const app = await createTestApp();
-        const env = createTestEnv();
-
-        const res = await app.request(
-            "http://localhost/api/auth/me",
-            {
-                headers: {
-                    Authorization: `Bearer ${token}`
-                }
-            },
-            env as any
-        );
-
-        expect(res.status).toBe(200);
-        const body = (await res.json()) as any;
-        expect(body.user.id).toBe("user-1");
-    });
-
-    it("GET /api/auth/me returns 404 when the user does not exist", async () => {
-        const token = await createTestJWT({ sub: "user-1", githubId: "123", name: "Tester" });
-        mockDb.select = vi.fn(() => makeQuery({ getResult: null }));
-
-        const app = await createTestApp();
-        const env = createTestEnv();
-
-        const res = await app.request(
-            "http://localhost/api/auth/me",
-            {
-                headers: {
-                    Authorization: `Bearer ${token}`,
-                },
-            },
-            env as any,
-        );
-
-        expect(res.status).toBe(404);
-        await expect(res.json()).resolves.toEqual({ error: "User not found" });
-    });
-
-    it("GET /api/auth/me returns 401 when token is missing", async () => {
-        const app = await createTestApp();
-        const env = createTestEnv();
-
-        const res = await app.request("http://localhost/api/auth/me", {}, env as any);
-        expect(res.status).toBe(401);
-    });
-
-    it("GET /api/auth/me returns 401 when token is invalid", async () => {
-        const app = await createTestApp();
-        const env = createTestEnv();
-
-        const res = await app.request(
-            "http://localhost/api/auth/me",
-            {
-                headers: {
-                    Authorization: "Bearer invalid-token"
-                }
-            },
-            env as any
-        );
-
-        expect(res.status).toBe(401);
-    });
-
-    it("GET /api/auth/me returns 401 when token is expired", async () => {
-        const token = await createExpiredJWT({ sub: "user-1", githubId: "123", name: "Tester" });
-        const app = await createTestApp();
-        const env = createTestEnv();
-
-        const res = await app.request(
-            "http://localhost/api/auth/me",
-            {
-                headers: {
-                    Authorization: `Bearer ${token}`
-                }
-            },
-            env as any
-        );
-
-        expect(res.status).toBe(401);
-    });
-
-    it("POST /api/auth/logout returns ok", async () => {
-        const app = await createTestApp();
-        const env = createTestEnv();
-
-        const res = await app.request(
-            "http://localhost/api/auth/logout",
-            {
-                method: "POST",
-                headers: {
-                    Origin: "http://localhost:3000",
-                },
-            },
-            env as any,
-        );
-
-        expect(res.status).toBe(200);
-        await expect(res.json()).resolves.toEqual({ ok: true });
-    });
-
-    it("POST /api/test-auth/test-token returns 404 when test auth is disabled", async () => {
-        const app = await createTestApp();
-        const env = createTestEnv();
-
-        const res = await app.request(
-            "http://localhost/api/test-auth/test-token",
-            {
-                method: "POST",
-                headers: {
-                    Origin: "http://localhost:3000",
-                },
-            },
-            env as any,
-        );
-
-        expect(res.status).toBe(404);
-        await expect(res.json()).resolves.toEqual({ error: "Not Found" });
-    });
-
-    it("POST /api/test-auth/test-token validates the shared secret and request body", async () => {
-        const app = await createTestApp();
-        const env = createTestEnv({
-            ENABLE_TEST_AUTH: "true",
-            TEST_AUTH_SECRET: "shared-secret",
-        });
-
-        const unauthorized = await app.request(
-            "http://localhost/api/test-auth/test-token",
-            {
-                method: "POST",
-                headers: {
-                    "Content-Type": "application/json",
-                    Origin: "http://localhost:3000",
-                },
-                body: JSON.stringify({ sub: "user-1", githubId: "123", name: "Tester" }),
-            },
-            env as any,
-        );
-        expect(unauthorized.status).toBe(401);
-
-        const invalidJson = await app.request(
-            "http://localhost/api/test-auth/test-token",
-            {
-                method: "POST",
-                headers: {
-                    "Content-Type": "application/json",
-                    "x-test-auth-secret": "shared-secret",
-                    Origin: "http://localhost:3000",
-                },
-                body: "{",
-            },
-            env as any,
-        );
-        expect(invalidJson.status).toBe(400);
-        await expect(invalidJson.json()).resolves.toEqual({ error: "Invalid JSON" });
-
-        const invalidBody = await app.request(
-            "http://localhost/api/test-auth/test-token",
-            {
-                method: "POST",
-                headers: {
-                    "Content-Type": "application/json",
-                    "x-test-auth-secret": "shared-secret",
-                    Origin: "http://localhost:3000",
-                },
-                body: JSON.stringify({ sub: "user-1" }),
-            },
-            env as any,
-        );
-        expect(invalidBody.status).toBe(400);
-        await expect(invalidBody.json()).resolves.toEqual({ error: "Invalid request body" });
-    });
-
-    it("POST /api/test-auth/test-token upserts the user and returns a signed JWT", async () => {
-        mockDb.select = vi.fn(() => makeQuery({ getResult: { id: "persisted-user" } }));
-
-        const app = await createTestApp();
-        const env = createTestEnv({
-            ENABLE_TEST_AUTH: "true",
-            TEST_AUTH_SECRET: "shared-secret",
-        });
-
-        const res = await app.request(
-            "http://localhost/api/test-auth/test-token",
-            {
-                method: "POST",
-                headers: {
-                    "Content-Type": "application/json",
-                    "x-test-auth-secret": "shared-secret",
-                },
-                body: JSON.stringify({
-                    sub: "user-1",
-                    githubId: "123",
-                    name: "Tester",
-                }),
-            },
-            env as any,
-        );
-
-        expect(res.status).toBe(200);
-        const body = (await res.json()) as { token: string };
-        expect(body.token).toMatch(/\./);
-        });
-
-        it("POST /api/test-auth/test-token returns 500 if user persistence fails", async () => {
-        mockDb.select = vi.fn(() => makeQuery({ getResult: null }));
-
-        const app = await createTestApp();
-        const env = createTestEnv({
-            ENABLE_TEST_AUTH: "true",
-            TEST_AUTH_SECRET: "shared-secret",
-        });
-
-        const res = await app.request(
-            "http://localhost/api/test-auth/test-token",
-            {
-                method: "POST",
-                headers: {
-                    "Content-Type": "application/json",
-                    "x-test-auth-secret": "shared-secret",
-                },
-                body: JSON.stringify({ sub: "u1", githubId: "g1", name: "N" }),
-            },
-            env as any
-        );
-        expect(res.status).toBe(500);
-        });
-
-        it("GET /api/auth/github/callback uses login as name if GitHub name is missing", async () => {
-        mockDb.select = vi.fn(() => makeQuery({ getResult: { id: "user-1" } }));
-        const nowState = new Date().toISOString().replace("T", " ").slice(0, 19);
-        const oauthStateDb = createOAuthStateDb({ "s1": { createdAt: nowState, browserNonce: "n1" } });
-
-        vi.stubGlobal("fetch", vi.fn()
-            .mockResolvedValueOnce({ ok: true, json: async () => ({ access_token: "t" }) })
-            .mockResolvedValueOnce({ ok: true, json: async () => ({ id: 1, login: "userlogin", name: "" }) })
-        );
-
-        const app = await createTestApp();
-        const env = createTestEnv({ DB: oauthStateDb.db as any });
-        const res = await app.request("http://localhost/api/auth/github/callback?code=c&state=s1", {
-            headers: { Cookie: "oauth_flow_nonce=n1" }
-        }, env as any);
-        expect(res.status).toBe(302);
-        });
-
-        it("POST /api/test-auth/test-org returns 404 or 401 based on configuration", async () => {
-        const app = await createTestApp();
-        const res404 = await app.request("http://localhost/api/test-auth/test-org", {
-            method: "POST",
-            headers: { Origin: "http://localhost:3000" }
-        }, createTestEnv({ ENABLE_TEST_AUTH: "false" }) as any);
-        expect(res404.status).toBe(404);
-
-        const res401 = await app.request("http://localhost/api/test-auth/test-org", {
-            method: "POST",
-            headers: {
-                Origin: "http://localhost:3000",
-                "x-test-auth-secret": "wrong"
-            }
-        }, createTestEnv({ ENABLE_TEST_AUTH: "true", TEST_AUTH_SECRET: "secret" }) as any);
-        expect(res401.status).toBe(401);
-    });
-
-    it("POST /api/test-auth/test-org validates auth and creates membership records", async () => {
-        const app = await createTestApp();
-        const env = createTestEnv({
-            ENABLE_TEST_AUTH: "true",
-            TEST_AUTH_SECRET: "shared-secret",
-        });
-
-        const invalidJson = await app.request(
-            "http://localhost/api/test-auth/test-org",
-            {
-                method: "POST",
-                headers: {
-                    "Content-Type": "application/json",
-                    "x-test-auth-secret": "shared-secret",
-                },
-                body: "{",
-            },
-            env as any,
-        );
-        expect(invalidJson.status).toBe(400);
-
-        const invalidBody = await app.request(
-            "http://localhost/api/test-auth/test-org",
-            {
-                method: "POST",
-                headers: {
-                    "Content-Type": "application/json",
-                    "x-test-auth-secret": "shared-secret",
-                },
-                body: JSON.stringify({ userId: "user-1" }),
-            },
-            env as any,
-        );
-        expect(invalidBody.status).toBe(400);
-        await expect(invalidBody.json()).resolves.toEqual({
-            error: "userId and orgId are required",
-        });
-
-        const onConflictDoNothing = vi.fn(async () => undefined);
-        mockDb.insert = vi.fn(() => ({
-            values: vi.fn(() => ({
-                onConflictDoNothing,
-            })),
-        }));
-
-        const ok = await app.request(
-            "http://localhost/api/test-auth/test-org",
-            {
-                method: "POST",
-                headers: {
-                    "Content-Type": "application/json",
-                    "x-test-auth-secret": "shared-secret",
-                },
-                body: JSON.stringify({ userId: "user-1", orgId: "org-1" }),
-            },
-            env as any,
-        );
-        expect(ok.status).toBe(200);
-        await expect(ok.json()).resolves.toEqual({ ok: true });
-        expect(onConflictDoNothing).toHaveBeenCalled();
-    });
+    const ok = await app.request(
+      "http://localhost/api/test-auth/test-org",
+      {
+        method: "POST",
+        headers: {
+          "Content-Type": "application/json",
+          "x-test-auth-secret": "shared-secret",
+        },
+        body: JSON.stringify({ userId: "user-1", orgId: "org-1" }),
+      },
+      env as any,
+    );
+    expect(ok.status).toBe(200);
+    await expect(ok.json()).resolves.toEqual({ ok: true });
+    expect(onConflictDoNothing).toHaveBeenCalled();
+  });
 });

--- a/apps/api/src/routes/__tests__/badge.test.ts
+++ b/apps/api/src/routes/__tests__/badge.test.ts
@@ -1,308 +1,319 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import {
-    createMockDb as createSharedMockDb,
-    createTestApp,
-    createTestEnv,
-    queueSelectResponses as queueSharedSelectResponses,
+  createMockDb as createSharedMockDb,
+  createTestApp,
+  createTestEnv,
+  queueSelectResponses as queueSharedSelectResponses,
 } from "../../test/helpers";
 
 let mockDb: any;
 
 vi.mock("drizzle-orm/d1", () => ({
-    drizzle: vi.fn(() => mockDb),
+  drizzle: vi.fn(() => mockDb),
 }));
 
 function createMockDb(overrides: Record<string, any> = {}) {
-    return createSharedMockDb(overrides);
+  return createSharedMockDb(overrides);
 }
 
 function queueSelectResponses(
-    responses: Array<{ getResult?: unknown; allResult?: unknown[] }>,
+  responses: Array<{ getResult?: unknown; allResult?: unknown[] }>,
 ) {
-    queueSharedSelectResponses(mockDb, responses);
+  queueSharedSelectResponses(mockDb, responses);
 }
 
 describe("badge routes", () => {
-    beforeEach(() => {
-        vi.restoreAllMocks();
-        vi.resetModules();
-        mockDb = createMockDb();
+  beforeEach(() => {
+    vi.restoreAllMocks();
+    vi.resetModules();
+    mockDb = createMockDb();
+  });
+
+  it("GET /badge/:paperId returns SVG badge for public papers", async () => {
+    queueSelectResponses([
+      {
+        getResult: {
+          id: "paper-1",
+          title: "Graph Neural Search in Mixed Languages",
+          year: 2026,
+          visibility: "public",
+        },
+      },
+    ]);
+
+    const app = await createTestApp();
+    const env = createTestEnv();
+    const res = await app.request(
+      "http://localhost/badge/paper-1",
+      {},
+      env as any,
+    );
+
+    expect(res.status).toBe(200);
+    expect(res.headers.get("content-type")).toContain("image/svg+xml");
+    expect(res.headers.get("cache-control")).toBe(
+      "public, max-age=86400, stale-while-revalidate=3600",
+    );
+    expect(res.headers.get("etag")).toBeTruthy();
+    const body = await res.text();
+    expect(body).toContain("<svg");
+    expect(body).toContain("📄 OpenShelf");
+    expect(body).toContain("(2026)");
+  });
+
+  it("GET /badge/:paperId?style=compact returns compact message", async () => {
+    queueSelectResponses([
+      {
+        getResult: {
+          id: "paper-1",
+          title: "Any title",
+          year: null,
+          visibility: "public",
+        },
+      },
+    ]);
+
+    const app = await createTestApp();
+    const env = createTestEnv();
+    const res = await app.request(
+      "http://localhost/badge/paper-1?style=compact&label=Repo&color=ff69b4",
+      {},
+      env as any,
+    );
+
+    expect(res.status).toBe(200);
+    const body = await res.text();
+    expect(body).toContain("📄 Repo");
+    expect(body).toContain(">Paper<");
+    expect(body).toContain("#ff69b4");
+  });
+
+  it("GET /badge/:paperId returns escaped SVG for XSS-like title", async () => {
+    queueSelectResponses([
+      {
+        getResult: {
+          id: "paper-1",
+          title: "<script>alert(1)</script> & bad",
+          year: 2025,
+          visibility: "public",
+        },
+      },
+    ]);
+
+    const app = await createTestApp();
+    const env = createTestEnv();
+    const res = await app.request(
+      "http://localhost/badge/paper-1",
+      {},
+      env as any,
+    );
+
+    expect(res.status).toBe(200);
+    const body = await res.text();
+    expect(body).not.toContain("<script>");
+    expect(body).toContain("&lt;script&gt;alert(1)&lt;/script&gt;");
+    expect(body).toContain("&amp; bad");
+  });
+
+  it("GET /badge/:paperId returns 404 not-found SVG for private/not found papers", async () => {
+    queueSelectResponses([
+      {
+        getResult: {
+          id: "paper-2",
+          title: "Private",
+          year: 2026,
+          visibility: "private",
+        },
+      },
+      {
+        getResult: null,
+      },
+    ]);
+
+    const app = await createTestApp();
+    const env = createTestEnv();
+
+    const privateRes = await app.request(
+      "http://localhost/badge/paper-2",
+      {},
+      env as any,
+    );
+    expect(privateRes.status).toBe(404);
+    expect(privateRes.headers.get("content-type")).toContain("image/svg+xml");
+    expect(await privateRes.text()).toContain("not found");
+
+    const missingRes = await app.request(
+      "http://localhost/badge/missing-id",
+      {},
+      env as any,
+    );
+    expect(missingRes.status).toBe(404);
+    expect(await missingRes.text()).toContain("not found");
+  });
+
+  it("GET /badge/api/:paperId returns shields endpoint JSON", async () => {
+    queueSelectResponses([
+      {
+        getResult: {
+          id: "paper-1",
+          title: "OpenShelf Dynamic Badge",
+          year: 2024,
+          visibility: "public",
+        },
+      },
+      {
+        getResult: {
+          id: "paper-private",
+          title: "Private",
+          year: null,
+          visibility: "private",
+        },
+      },
+    ]);
+
+    const app = await createTestApp();
+    const env = createTestEnv();
+
+    const okRes = await app.request(
+      "http://localhost/badge/api/paper-1?label=OpenShelf&color=blue",
+      {},
+      env as any,
+    );
+    expect(okRes.status).toBe(200);
+    await expect(okRes.json()).resolves.toMatchObject({
+      schemaVersion: 1,
+      label: "📄 OpenShelf",
+      color: "blue",
     });
 
-    it("GET /badge/:paperId returns SVG badge for public papers", async () => {
-        queueSelectResponses([
-            {
-                getResult: {
-                    id: "paper-1",
-                    title: "Graph Neural Search in Mixed Languages",
-                    year: 2026,
-                    visibility: "public",
-                },
-            },
-        ]);
-
-        const app = await createTestApp();
-        const env = createTestEnv();
-        const res = await app.request(
-            "http://localhost/badge/paper-1",
-            {},
-            env as any,
-        );
-
-        expect(res.status).toBe(200);
-        expect(res.headers.get("content-type")).toContain("image/svg+xml");
-        expect(res.headers.get("cache-control")).toBe(
-            "public, max-age=86400, stale-while-revalidate=3600",
-        );
-        expect(res.headers.get("etag")).toBeTruthy();
-        const body = await res.text();
-        expect(body).toContain("<svg");
-        expect(body).toContain("📄 OpenShelf");
-        expect(body).toContain("(2026)");
+    const privateRes = await app.request(
+      "http://localhost/badge/api/paper-private",
+      {},
+      env as any,
+    );
+    expect(privateRes.status).toBe(404);
+    await expect(privateRes.json()).resolves.toMatchObject({
+      schemaVersion: 1,
+      label: "📄 OpenShelf",
+      message: "not found",
+      color: "9f9f9f",
     });
+  });
 
-    it("GET /badge/:paperId?style=compact returns compact message", async () => {
-        queueSelectResponses([
-            {
-                getResult: {
-                    id: "paper-1",
-                    title: "Any title",
-                    year: null,
-                    visibility: "public",
-                },
-            },
-        ]);
+  it("returns 304 for weak If-None-Match values", async () => {
+    queueSelectResponses([
+      {
+        getResult: {
+          id: "paper-1",
+          title: "ETag paper",
+          year: 2023,
+          visibility: "public",
+        },
+      },
+      {
+        getResult: {
+          id: "paper-1",
+          title: "ETag paper",
+          year: 2023,
+          visibility: "public",
+        },
+      },
+    ]);
 
-        const app = await createTestApp();
-        const env = createTestEnv();
-        const res = await app.request(
-            "http://localhost/badge/paper-1?style=compact&label=Repo&color=ff69b4",
-            {},
-            env as any,
-        );
+    const app = await createTestApp();
+    const env = createTestEnv();
+    const first = await app.request(
+      "http://localhost/badge/paper-1",
+      {},
+      env as any,
+    );
+    const etag = first.headers.get("etag");
+    expect(etag).toBeTruthy();
 
-        expect(res.status).toBe(200);
-        const body = await res.text();
-        expect(body).toContain("📄 Repo");
-        expect(body).toContain(">Paper<");
-        expect(body).toContain("#ff69b4");
-    });
+    const second = await app.request(
+      "http://localhost/badge/paper-1",
+      { headers: { "If-None-Match": `W/${etag}` } },
+      env as any,
+    );
+    expect(second.status).toBe(304);
+    expect(second.headers.get("etag")).toBe(etag);
+  });
 
-    it("GET /badge/:paperId returns escaped SVG for XSS-like title", async () => {
-        queueSelectResponses([
-            {
-                getResult: {
-                    id: "paper-1",
-                    title: "<script>alert(1)</script> & bad",
-                    year: 2025,
-                    visibility: "public",
-                },
-            },
-        ]);
+  it("returns 304 when If-None-Match includes multiple values", async () => {
+    queueSelectResponses([
+      {
+        getResult: {
+          id: "paper-1",
+          title: "ETag paper",
+          year: 2023,
+          visibility: "public",
+        },
+      },
+      {
+        getResult: {
+          id: "paper-1",
+          title: "ETag paper",
+          year: 2023,
+          visibility: "public",
+        },
+      },
+    ]);
 
-        const app = await createTestApp();
-        const env = createTestEnv();
-        const res = await app.request(
-            "http://localhost/badge/paper-1",
-            {},
-            env as any,
-        );
+    const app = await createTestApp();
+    const env = createTestEnv();
+    const first = await app.request(
+      "http://localhost/badge/paper-1",
+      {},
+      env as any,
+    );
+    const etag = first.headers.get("etag");
+    expect(etag).toBeTruthy();
 
-        expect(res.status).toBe(200);
-        const body = await res.text();
-        expect(body).not.toContain("<script>");
-        expect(body).toContain("&lt;script&gt;alert(1)&lt;/script&gt;");
-        expect(body).toContain("&amp; bad");
-    });
+    const second = await app.request(
+      "http://localhost/badge/paper-1",
+      { headers: { "If-None-Match": `"other", ${etag}` } },
+      env as any,
+    );
+    expect(second.status).toBe(304);
+    expect(second.headers.get("etag")).toBe(etag);
+  });
+  it("returns 304 when If-None-Match matches ETag", async () => {
+    queueSelectResponses([
+      {
+        getResult: {
+          id: "paper-1",
+          title: "ETag paper",
+          year: 2023,
+          visibility: "public",
+        },
+      },
+      {
+        getResult: {
+          id: "paper-1",
+          title: "ETag paper",
+          year: 2023,
+          visibility: "public",
+        },
+      },
+    ]);
 
-    it("GET /badge/:paperId returns 404 not-found SVG for private/not found papers", async () => {
-        queueSelectResponses([
-            {
-                getResult: {
-                    id: "paper-2",
-                    title: "Private",
-                    year: 2026,
-                    visibility: "private",
-                },
-            },
-            {
-                getResult: null,
-            },
-        ]);
+    const app = await createTestApp();
+    const env = createTestEnv();
+    const first = await app.request(
+      "http://localhost/badge/paper-1",
+      {},
+      env as any,
+    );
+    const etag = first.headers.get("etag");
+    expect(etag).toBeTruthy();
 
-        const app = await createTestApp();
-        const env = createTestEnv();
-
-        const privateRes = await app.request(
-            "http://localhost/badge/paper-2",
-            {},
-            env as any,
-        );
-        expect(privateRes.status).toBe(404);
-        expect(privateRes.headers.get("content-type")).toContain("image/svg+xml");
-        expect(await privateRes.text()).toContain("not found");
-
-        const missingRes = await app.request(
-            "http://localhost/badge/missing-id",
-            {},
-            env as any,
-        );
-        expect(missingRes.status).toBe(404);
-        expect(await missingRes.text()).toContain("not found");
-    });
-
-    it("GET /badge/api/:paperId returns shields endpoint JSON", async () => {
-        queueSelectResponses([
-            {
-                getResult: {
-                    id: "paper-1",
-                    title: "OpenShelf Dynamic Badge",
-                    year: 2024,
-                    visibility: "public",
-                },
-            },
-            {
-                getResult: {
-                    id: "paper-private",
-                    title: "Private",
-                    year: null,
-                    visibility: "private",
-                },
-            },
-        ]);
-
-        const app = await createTestApp();
-        const env = createTestEnv();
-
-        const okRes = await app.request(
-            "http://localhost/badge/api/paper-1?label=OpenShelf&color=blue",
-            {},
-            env as any,
-        );
-        expect(okRes.status).toBe(200);
-        await expect(okRes.json()).resolves.toMatchObject({
-            schemaVersion: 1,
-            label: "📄 OpenShelf",
-            color: "blue",
-        });
-
-        const privateRes = await app.request(
-            "http://localhost/badge/api/paper-private",
-            {},
-            env as any,
-        );
-        expect(privateRes.status).toBe(404);
-        await expect(privateRes.json()).resolves.toMatchObject({
-            schemaVersion: 1,
-            label: "📄 OpenShelf",
-            message: "not found",
-            color: "9f9f9f",
-        });
-    });
-
-
-    it("returns 304 for weak If-None-Match values", async () => {
-        queueSelectResponses([
-            {
-                getResult: {
-                    id: "paper-1",
-                    title: "ETag paper",
-                    year: 2023,
-                    visibility: "public",
-                },
-            },
-            {
-                getResult: {
-                    id: "paper-1",
-                    title: "ETag paper",
-                    year: 2023,
-                    visibility: "public",
-                },
-            },
-        ]);
-
-        const app = await createTestApp();
-        const env = createTestEnv();
-        const first = await app.request("http://localhost/badge/paper-1", {}, env as any);
-        const etag = first.headers.get("etag");
-        expect(etag).toBeTruthy();
-
-        const second = await app.request(
-            "http://localhost/badge/paper-1",
-            { headers: { "If-None-Match": `W/${etag}` } },
-            env as any,
-        );
-        expect(second.status).toBe(304);
-        expect(second.headers.get("etag")).toBe(etag);
-    });
-
-    it("returns 304 when If-None-Match includes multiple values", async () => {
-        queueSelectResponses([
-            {
-                getResult: {
-                    id: "paper-1",
-                    title: "ETag paper",
-                    year: 2023,
-                    visibility: "public",
-                },
-            },
-            {
-                getResult: {
-                    id: "paper-1",
-                    title: "ETag paper",
-                    year: 2023,
-                    visibility: "public",
-                },
-            },
-        ]);
-
-        const app = await createTestApp();
-        const env = createTestEnv();
-        const first = await app.request("http://localhost/badge/paper-1", {}, env as any);
-        const etag = first.headers.get("etag");
-        expect(etag).toBeTruthy();
-
-        const second = await app.request(
-            "http://localhost/badge/paper-1",
-            { headers: { "If-None-Match": `"other", ${etag}` } },
-            env as any,
-        );
-        expect(second.status).toBe(304);
-        expect(second.headers.get("etag")).toBe(etag);
-    });
-    it("returns 304 when If-None-Match matches ETag", async () => {
-        queueSelectResponses([
-            {
-                getResult: {
-                    id: "paper-1",
-                    title: "ETag paper",
-                    year: 2023,
-                    visibility: "public",
-                },
-            },
-            {
-                getResult: {
-                    id: "paper-1",
-                    title: "ETag paper",
-                    year: 2023,
-                    visibility: "public",
-                },
-            },
-        ]);
-
-        const app = await createTestApp();
-        const env = createTestEnv();
-        const first = await app.request("http://localhost/badge/paper-1", {}, env as any);
-        const etag = first.headers.get("etag");
-        expect(etag).toBeTruthy();
-
-        const second = await app.request(
-            "http://localhost/badge/paper-1",
-            { headers: { "If-None-Match": etag! } },
-            env as any,
-        );
-        expect(second.status).toBe(304);
-        expect(second.headers.get("etag")).toBe(etag);
-        expect(await second.text()).toBe("");
-    });
+    const second = await app.request(
+      "http://localhost/badge/paper-1",
+      { headers: { "If-None-Match": etag! } },
+      env as any,
+    );
+    expect(second.status).toBe(304);
+    expect(second.headers.get("etag")).toBe(etag);
+    expect(await second.text()).toBe("");
+  });
 });

--- a/apps/api/src/routes/__tests__/collections.test.ts
+++ b/apps/api/src/routes/__tests__/collections.test.ts
@@ -1,1510 +1,1946 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import {
-    createTestApp,
-    createMockDb as createSharedMockDb,
-    createTestEnv,
-    createTestJWT,
-    makeQuery,
-    queueSelectResponses as queueSharedSelectResponses,
+  createTestApp,
+  createMockDb as createSharedMockDb,
+  createTestEnv,
+  createTestJWT,
+  makeQuery,
+  queueSelectResponses as queueSharedSelectResponses,
 } from "../../test/helpers";
 
 let mockDb: any;
 
 vi.mock("drizzle-orm/d1", () => ({
-    drizzle: vi.fn(() => mockDb),
+  drizzle: vi.fn(() => mockDb),
 }));
 
 function createMockDb() {
-    return createSharedMockDb();
+  return createSharedMockDb();
 }
 
 function queueSelectResponses(
-    responses: Array<{ getResult?: unknown; allResult?: unknown[] }>,
+  responses: Array<{ getResult?: unknown; allResult?: unknown[] }>,
 ) {
-    queueSharedSelectResponses(mockDb, responses);
+  queueSharedSelectResponses(mockDb, responses);
 }
 
 describe("collections routes", () => {
-    beforeEach(() => {
-        vi.restoreAllMocks();
-        vi.resetModules();
-        mockDb = createMockDb();
+  beforeEach(() => {
+    vi.restoreAllMocks();
+    vi.resetModules();
+    mockDb = createMockDb();
+  });
+
+  it("POST /api/collections requires auth", async () => {
+    const app = await createTestApp();
+    const env = createTestEnv();
+
+    const res = await app.request(
+      "http://localhost/api/collections",
+      {
+        method: "POST",
+        headers: {
+          "Content-Type": "application/json",
+          Origin: "http://localhost:3000",
+        },
+        body: JSON.stringify({
+          owner_type: "user",
+          name: "My Collection",
+          slug: "my-collection",
+        }),
+      },
+      env as any,
+    );
+
+    expect(res.status).toBe(401);
+  });
+
+  it("POST /api/collections ignores general db insert errors", async () => {
+    const err = new Error("General insert error");
+    mockDb.insert = vi.fn().mockReturnValue({
+      values: vi.fn().mockRejectedValue(err),
     });
+    const app = await createTestApp();
+    const env = createTestEnv();
+    const res = await app.request(
+      "http://localhost/api/collections",
+      {
+        method: "POST",
+        headers: {
+          Authorization: `Bearer ${await createTestJWT({ sub: "user-1" })}`,
+        },
+        body: JSON.stringify({ name: "C1", slug: "col-1", owner_type: "user" }),
+      },
+      env,
+    );
+    expect(res.status).toBe(500);
+  });
 
-    it("POST /api/collections requires auth", async () => {
-        const app = await createTestApp();
-        const env = createTestEnv();
-
-        const res = await app.request(
-            "http://localhost/api/collections",
-            {
-                method: "POST",
-                headers: {
-                    "Content-Type": "application/json",
-                    Origin: "http://localhost:3000",
-                },
-                body: JSON.stringify({ owner_type: "user", name: "My Collection", slug: "my-collection" }),
-            },
-            env as any,
-        );
-
-        expect(res.status).toBe(401);
+  it("POST /api/collections returns 409 if slug already in use", async () => {
+    const err = new Error("UNIQUE constraint failed: collections.slug");
+    mockDb.insert = vi.fn().mockReturnValue({
+      values: vi.fn().mockRejectedValue(err),
     });
+    const app = await createTestApp();
+    const env = createTestEnv();
+    const res = await app.request(
+      "http://localhost/api/collections",
+      {
+        method: "POST",
+        headers: {
+          Authorization: `Bearer ${await createTestJWT({ sub: "user-1" })}`,
+        },
+        body: JSON.stringify({ name: "C1", slug: "col-1", owner_type: "user" }),
+      },
+      env,
+    );
+    expect(res.status).toBe(409);
+    expect(await res.json()).toEqual({ error: "slug already in use" });
+  });
 
+  it("GET /api/collections/:id ignores invalid authorization headers", async () => {
+    queueSelectResponses([{ getResult: { id: "c1", visibility: "public" } }]);
+    const app = await createTestApp();
+    const env = createTestEnv();
+    const res = await app.request(
+      "http://localhost/api/collections/c1",
+      {
+        method: "GET",
+        headers: { Authorization: "Bearer INVALID_TOKEN_HERE" },
+      },
+      env,
+    );
+    expect(res.status).toBe(200);
+  });
 
+  it("POST /api/collections returns 400 when name is invalid", async () => {
+    const app = await createTestApp();
+    const env = createTestEnv();
+    const res = await app.request(
+      "http://localhost/api/collections",
+      {
+        method: "POST",
+        headers: {
+          Authorization: `Bearer ${await createTestJWT({ sub: "user-1" })}`,
+        },
+        body: JSON.stringify({ name: "", slug: "col-1", owner_type: "user" }),
+      },
+      env,
+    );
+    expect(res.status).toBe(400);
+    expect(await res.json()).toHaveProperty("error");
+  });
 
-    it("POST /api/collections ignores general db insert errors", async () => {
-        const err = new Error("General insert error");
-        mockDb.insert = vi.fn().mockReturnValue({
-            values: vi.fn().mockRejectedValue(err)
-        });
-        const app = await createTestApp();
-        const env = createTestEnv();
-        const res = await app.request("http://localhost/api/collections", {
-            method: "POST",
-            headers: { Authorization: `Bearer ${await createTestJWT({ sub: "user-1" })}` },
-            body: JSON.stringify({ name: "C1", slug: "col-1", owner_type: "user" }),
-        }, env);
-        expect(res.status).toBe(500);
+  it("POST /api/collections returns 400 when slug is invalid", async () => {
+    const app = await createTestApp();
+    const env = createTestEnv();
+    const res = await app.request(
+      "http://localhost/api/collections",
+      {
+        method: "POST",
+        headers: {
+          Authorization: `Bearer ${await createTestJWT({ sub: "user-1" })}`,
+        },
+        body: JSON.stringify({
+          name: "C1",
+          slug: "invalid slug!",
+          owner_type: "user",
+        }),
+      },
+      env,
+    );
+    expect(res.status).toBe(400);
+    expect(await res.json()).toHaveProperty("error");
+  });
+
+  it("POST /api/collections returns 400 when description is invalid", async () => {
+    const app = await createTestApp();
+    const env = createTestEnv();
+    const res = await app.request(
+      "http://localhost/api/collections",
+      {
+        method: "POST",
+        headers: {
+          Authorization: `Bearer ${await createTestJWT({ sub: "user-1" })}`,
+        },
+        body: JSON.stringify({
+          name: "C1",
+          slug: "col-1",
+          owner_type: "user",
+          description: "a".repeat(1001),
+        }),
+      },
+      env,
+    );
+    expect(res.status).toBe(400);
+    expect(await res.json()).toHaveProperty("error");
+  });
+
+  it("GET /api/collections/:id returns 404 when collection is private org collection and user is not admin", async () => {
+    queueSelectResponses([
+      {
+        getResult: {
+          id: "c1",
+          ownerType: "org",
+          ownerId: "org1",
+          visibility: "private",
+        },
+      },
+      { getResult: { role: "member" } },
+    ]);
+    const app = await createTestApp();
+    const env = createTestEnv();
+    const res = await app.request(
+      "http://localhost/api/collections/c1",
+      {
+        method: "GET",
+        headers: {
+          Authorization: `Bearer ${await createTestJWT({ sub: "user-1" })}`,
+        },
+      },
+      env,
+    );
+    expect(res.status).toBe(404);
+    expect(await res.json()).toEqual({ error: "Collection not found" });
+  });
+
+  it("GET /api/collections/:id returns collection when collection is org_only org collection and user is member", async () => {
+    queueSelectResponses([
+      {
+        getResult: {
+          id: "c1",
+          ownerType: "org",
+          ownerId: "org1",
+          visibility: "org_only",
+        },
+      },
+      { getResult: { role: "member" } },
+    ]);
+    const app = await createTestApp();
+    const env = createTestEnv();
+    const res = await app.request(
+      "http://localhost/api/collections/c1",
+      {
+        method: "GET",
+        headers: {
+          Authorization: `Bearer ${await createTestJWT({ sub: "user-1" })}`,
+        },
+      },
+      env,
+    );
+    expect(res.status).toBe(200);
+  });
+
+  it("GET /api/collections/:id returns 404 when collection is org_only org collection and user is not member", async () => {
+    queueSelectResponses([
+      {
+        getResult: {
+          id: "c1",
+          ownerType: "org",
+          ownerId: "org1",
+          visibility: "org_only",
+        },
+      },
+      { getResult: null },
+    ]);
+    const app = await createTestApp();
+    const env = createTestEnv();
+    const res = await app.request(
+      "http://localhost/api/collections/c1",
+      {
+        method: "GET",
+        headers: {
+          Authorization: `Bearer ${await createTestJWT({ sub: "user-1" })}`,
+        },
+      },
+      env,
+    );
+    expect(res.status).toBe(404);
+    expect(await res.json()).toEqual({ error: "Collection not found" });
+  });
+
+  it("POST /api/collections returns 404 if owner org not found by slug", async () => {
+    queueSelectResponses([{ getResult: null }]);
+    const app = await createTestApp();
+    const env = createTestEnv();
+    const res = await app.request(
+      "http://localhost/api/collections",
+      {
+        method: "POST",
+        headers: {
+          Authorization: `Bearer ${await createTestJWT({ sub: "user-1" })}`,
+        },
+        body: JSON.stringify({
+          name: "C1",
+          slug: "col-1",
+          owner_type: "org",
+          org_slug: "nonexistent",
+        }),
+      },
+      env,
+    );
+    expect(res.status).toBe(404);
+  });
+
+  it("POST /api/collections handles org finding by owner_id", async () => {
+    queueSelectResponses([
+      { getResult: { id: "org1", slug: "org-slug" } },
+      { getResult: { role: "admin" } },
+      { getResult: { id: "c1" } },
+    ]);
+    mockDb.insert = vi
+      .fn()
+      .mockReturnValue({ values: vi.fn().mockResolvedValue({}) });
+    const app = await createTestApp();
+    const env = createTestEnv();
+    const res = await app.request(
+      "http://localhost/api/collections",
+      {
+        method: "POST",
+        headers: {
+          Authorization: `Bearer ${await createTestJWT({ sub: "user-1" })}`,
+        },
+        body: JSON.stringify({
+          name: "C1",
+          slug: "org-col-1",
+          owner_type: "org",
+          owner_id: "org1",
+        }),
+      },
+      env,
+    );
+    expect(res.status).toBe(201);
+  });
+
+  it("POST /api/collections returns 400 for invalid visibility", async () => {
+    const app = await createTestApp();
+    const env = createTestEnv();
+    const res = await app.request(
+      "http://localhost/api/collections",
+      {
+        method: "POST",
+        headers: {
+          Authorization: `Bearer ${await createTestJWT({ sub: "user-1" })}`,
+        },
+        body: JSON.stringify({
+          name: "C1",
+          slug: "col-1",
+          owner_type: "user",
+          visibility: 123,
+        }),
+      },
+      env,
+    );
+    expect(res.status).toBe(400);
+    expect(await res.json()).toEqual({ error: "Invalid visibility" });
+  });
+
+  it("POST /api/collections returns 400 for invalid owner_type", async () => {
+    const app = await createTestApp();
+    const env = createTestEnv();
+    const res = await app.request(
+      "http://localhost/api/collections",
+      {
+        method: "POST",
+        headers: {
+          Authorization: `Bearer ${await createTestJWT({ sub: "user-1" })}`,
+        },
+        body: JSON.stringify({
+          name: "C1",
+          slug: "col-1",
+          owner_type: "invalid-type",
+        }),
+      },
+      env,
+    );
+    expect(res.status).toBe(400);
+    expect(await res.json()).toEqual({
+      error: "owner_type must be 'user' or 'org'",
     });
+  });
+  it("POST /api/collections returns 400 for invalid JSON body", async () => {
+    const token = await createTestJWT({ sub: "user-1" });
+    const app = await createTestApp();
+    const env = createTestEnv();
 
-    it("POST /api/collections returns 409 if slug already in use", async () => {
-        const err = new Error("UNIQUE constraint failed: collections.slug");
-        mockDb.insert = vi.fn().mockReturnValue({
-            values: vi.fn().mockRejectedValue(err)
-        });
-        const app = await createTestApp();
-        const env = createTestEnv();
-        const res = await app.request("http://localhost/api/collections", {
-            method: "POST",
-            headers: { Authorization: `Bearer ${await createTestJWT({ sub: "user-1" })}` },
-            body: JSON.stringify({ name: "C1", slug: "col-1", owner_type: "user" }),
-        }, env);
-        expect(res.status).toBe(409);
-        expect(await res.json()).toEqual({ error: "slug already in use" });
+    const res = await app.request(
+      "http://localhost/api/collections",
+      {
+        method: "POST",
+        headers: {
+          Authorization: `Bearer ${token}`,
+          "Content-Type": "application/json",
+        },
+        body: "invalid json {",
+      },
+      env as any,
+    );
+
+    expect(res.status).toBe(400);
+    expect(((await res.json()) as any).error).toBe("Invalid JSON body");
+  });
+  it("GET /api/collections/:id returns 404 when not found", async () => {
+    mockDb.select = vi.fn(() => makeQuery({ getResult: null }));
+
+    const app = await createTestApp();
+    const env = createTestEnv();
+
+    const res = await app.request(
+      "http://localhost/api/collections/not-found",
+      {},
+      env as any,
+    );
+
+    expect(res.status).toBe(404);
+  });
+
+  it("GET /api/users/:id/collections filters out non-public collections when unauthenticated", async () => {
+    queueSelectResponses([
+      {
+        allResult: [
+          {
+            id: "c1",
+            visibility: "private",
+            ownerType: "user",
+            ownerId: "user2",
+          },
+          {
+            id: "c2",
+            visibility: "public",
+            ownerType: "user",
+            ownerId: "user2",
+          },
+        ],
+      },
+    ]);
+    const app = await createTestApp();
+    const env = createTestEnv();
+    const res = await app.request(
+      "http://localhost/api/users/user2/collections",
+      {
+        method: "GET",
+      },
+      env,
+    );
+    expect(res.status).toBe(200);
+    expect(await res.json()).toEqual({
+      collections: [
+        { id: "c2", visibility: "public", ownerType: "user", ownerId: "user2" },
+      ],
     });
-
-    it("GET /api/collections/:id ignores invalid authorization headers", async () => {
-        queueSelectResponses([
-            { getResult: { id: "c1", visibility: "public" } }
-        ]);
-        const app = await createTestApp();
-        const env = createTestEnv();
-        const res = await app.request("http://localhost/api/collections/c1", {
-            method: "GET",
-            headers: { Authorization: "Bearer INVALID_TOKEN_HERE" },
-        }, env);
-        expect(res.status).toBe(200);
-    });
-
-    it("POST /api/collections returns 400 when name is invalid", async () => {
-        const app = await createTestApp();
-        const env = createTestEnv();
-        const res = await app.request("http://localhost/api/collections", {
-            method: "POST",
-            headers: { Authorization: `Bearer ${await createTestJWT({ sub: "user-1" })}` },
-            body: JSON.stringify({ name: "", slug: "col-1", owner_type: "user" }),
-        }, env);
-        expect(res.status).toBe(400);
-        expect(await res.json()).toHaveProperty("error");
-    });
-
-    it("POST /api/collections returns 400 when slug is invalid", async () => {
-        const app = await createTestApp();
-        const env = createTestEnv();
-        const res = await app.request("http://localhost/api/collections", {
-            method: "POST",
-            headers: { Authorization: `Bearer ${await createTestJWT({ sub: "user-1" })}` },
-            body: JSON.stringify({ name: "C1", slug: "invalid slug!", owner_type: "user" }),
-        }, env);
-        expect(res.status).toBe(400);
-        expect(await res.json()).toHaveProperty("error");
-    });
-
-    it("POST /api/collections returns 400 when description is invalid", async () => {
-        const app = await createTestApp();
-        const env = createTestEnv();
-        const res = await app.request("http://localhost/api/collections", {
-            method: "POST",
-            headers: { Authorization: `Bearer ${await createTestJWT({ sub: "user-1" })}` },
-            body: JSON.stringify({ name: "C1", slug: "col-1", owner_type: "user", description: "a".repeat(1001) }),
-        }, env);
-        expect(res.status).toBe(400);
-        expect(await res.json()).toHaveProperty("error");
-    });
-
-    it("GET /api/collections/:id returns 404 when collection is private org collection and user is not admin", async () => {
-        queueSelectResponses([
-            { getResult: { id: "c1", ownerType: "org", ownerId: "org1", visibility: "private" } },
-            { getResult: { role: "member" } },
-        ]);
-        const app = await createTestApp();
-        const env = createTestEnv();
-        const res = await app.request("http://localhost/api/collections/c1", {
-            method: "GET",
-            headers: { Authorization: `Bearer ${await createTestJWT({ sub: "user-1" })}` },
-        }, env);
-        expect(res.status).toBe(404);
-        expect(await res.json()).toEqual({ error: "Collection not found" });
-    });
-
-    it("GET /api/collections/:id returns collection when collection is org_only org collection and user is member", async () => {
-        queueSelectResponses([
-            { getResult: { id: "c1", ownerType: "org", ownerId: "org1", visibility: "org_only" } },
-            { getResult: { role: "member" } },
-        ]);
-        const app = await createTestApp();
-        const env = createTestEnv();
-        const res = await app.request("http://localhost/api/collections/c1", {
-            method: "GET",
-            headers: { Authorization: `Bearer ${await createTestJWT({ sub: "user-1" })}` },
-        }, env);
-        expect(res.status).toBe(200);
-    });
-
-    it("GET /api/collections/:id returns 404 when collection is org_only org collection and user is not member", async () => {
-        queueSelectResponses([
-            { getResult: { id: "c1", ownerType: "org", ownerId: "org1", visibility: "org_only" } },
-            { getResult: null },
-        ]);
-        const app = await createTestApp();
-        const env = createTestEnv();
-        const res = await app.request("http://localhost/api/collections/c1", {
-            method: "GET",
-            headers: { Authorization: `Bearer ${await createTestJWT({ sub: "user-1" })}` },
-        }, env);
-        expect(res.status).toBe(404);
-        expect(await res.json()).toEqual({ error: "Collection not found" });
-    });
-
-    it("POST /api/collections returns 404 if owner org not found by slug", async () => {
-        queueSelectResponses([
-            { getResult: null }
-        ]);
-        const app = await createTestApp();
-        const env = createTestEnv();
-        const res = await app.request("http://localhost/api/collections", {
-            method: "POST",
-            headers: { Authorization: `Bearer ${await createTestJWT({ sub: "user-1" })}` },
-            body: JSON.stringify({ name: "C1", slug: "col-1", owner_type: "org", org_slug: "nonexistent" }),
-        }, env);
-        expect(res.status).toBe(404);
-    });
-
-    it("POST /api/collections handles org finding by owner_id", async () => {
-        queueSelectResponses([
-            { getResult: { id: "org1", slug: "org-slug" } },
-            { getResult: { role: "admin" } },
-            { getResult: { id: "c1" } },
-        ]);
-        mockDb.insert = vi.fn().mockReturnValue({ values: vi.fn().mockResolvedValue({}) });
-        const app = await createTestApp();
-        const env = createTestEnv();
-        const res = await app.request("http://localhost/api/collections", {
-            method: "POST",
-            headers: { Authorization: `Bearer ${await createTestJWT({ sub: "user-1" })}` },
-            body: JSON.stringify({ name: "C1", slug: "org-col-1", owner_type: "org", owner_id: "org1" }),
-        }, env);
-        expect(res.status).toBe(201);
-    });
-
-    it("POST /api/collections returns 400 for invalid visibility", async () => {
-        const app = await createTestApp();
-        const env = createTestEnv();
-        const res = await app.request("http://localhost/api/collections", {
-            method: "POST",
-            headers: { Authorization: `Bearer ${await createTestJWT({ sub: "user-1" })}` },
-            body: JSON.stringify({ name: "C1", slug: "col-1", owner_type: "user", visibility: 123 }),
-        }, env);
-        expect(res.status).toBe(400);
-        expect(await res.json()).toEqual({ error: "Invalid visibility" });
-    });
-
-    it("POST /api/collections returns 400 for invalid owner_type", async () => {
-        const app = await createTestApp();
-        const env = createTestEnv();
-        const res = await app.request("http://localhost/api/collections", {
-            method: "POST",
-            headers: { Authorization: `Bearer ${await createTestJWT({ sub: "user-1" })}` },
-            body: JSON.stringify({ name: "C1", slug: "col-1", owner_type: "invalid-type" }),
-        }, env);
-        expect(res.status).toBe(400);
-        expect(await res.json()).toEqual({ error: "owner_type must be 'user' or 'org'" });
-    });
-    it("POST /api/collections returns 400 for invalid JSON body", async () => {
-        const token = await createTestJWT({ sub: "user-1" });
-        const app = await createTestApp();
-        const env = createTestEnv();
-
-        const res = await app.request(
-            "http://localhost/api/collections",
-            {
-                method: "POST",
-                headers: {
-                    Authorization: `Bearer ${token}`,
-                    "Content-Type": "application/json",
-                },
-                body: "invalid json {",
-            },
-            env as any,
-        );
-
-        expect(res.status).toBe(400);
-        expect(((await res.json()) as any).error).toBe("Invalid JSON body");
-    });
-    it("GET /api/collections/:id returns 404 when not found", async () => {
-        mockDb.select = vi.fn(() => makeQuery({ getResult: null }));
-
-        const app = await createTestApp();
-        const env = createTestEnv();
-
-        const res = await app.request("http://localhost/api/collections/not-found", {}, env as any);
-
-        expect(res.status).toBe(404);
-    });
-
-
-    it("GET /api/users/:id/collections filters out non-public collections when unauthenticated", async () => {
-        queueSelectResponses([
-            { allResult: [{ id: "c1", visibility: "private", ownerType: "user", ownerId: "user2" }, { id: "c2", visibility: "public", ownerType: "user", ownerId: "user2" }] },
-        ]);
-        const app = await createTestApp();
-        const env = createTestEnv();
-        const res = await app.request("http://localhost/api/users/user2/collections", {
-            method: "GET",
-        }, env);
-        expect(res.status).toBe(200);
-        expect(await res.json()).toEqual({ collections: [{ id: "c2", visibility: "public", ownerType: "user", ownerId: "user2" }] });
-    });
-    it("GET /api/users/:id/collections returns list", async () => {
-        mockDb.select = vi.fn(() =>
-            makeQuery({
-                allResult: [
-                    {
-                        id: "col-1",
-                        ownerType: "user",
-                        ownerId: "user-1",
-                        slug: "favorites",
-                        name: "Favorites",
-                        description: null,
-                        visibility: "public",
-                    },
-                ],
-            }),
-        );
-
-        const app = await createTestApp();
-        const env = createTestEnv();
-
-        const res = await app.request("http://localhost/api/users/user-1/collections", {}, env as any);
-
-        expect(res.status).toBe(200);
-        const body = (await res.json()) as any;
-        expect(body.collections).toHaveLength(1);
-        expect(body.collections[0].slug).toBe("favorites");
-    });
-
-    it("POST /api/collections creates a user collection", async () => {
-        const token = await createTestJWT({ sub: "user-1" });
-        const createdCollection = {
+  });
+  it("GET /api/users/:id/collections returns list", async () => {
+    mockDb.select = vi.fn(() =>
+      makeQuery({
+        allResult: [
+          {
             id: "col-1",
             ownerType: "user",
             ownerId: "user-1",
             slug: "favorites",
             name: "Favorites",
-            description: "Picked papers",
-            visibility: "private",
-        };
-        queueSelectResponses([{ getResult: createdCollection }]);
-
-        const insertValues = vi.fn(async () => undefined);
-        mockDb.insert = vi.fn(() => ({ values: insertValues }));
-
-        const app = await createTestApp();
-        const env = createTestEnv();
-
-        const res = await app.request(
-            "http://localhost/api/collections",
-            {
-                method: "POST",
-                headers: {
-                    Authorization: `Bearer ${token}`,
-                    "Content-Type": "application/json",
-                },
-                body: JSON.stringify({
-                    owner_type: "user",
-                    name: "Favorites",
-                    slug: "favorites",
-                    description: " Picked papers ",
-                }),
-            },
-            env as any,
-        );
-
-        expect(res.status).toBe(201);
-        expect(insertValues).toHaveBeenCalledWith(
-            expect.objectContaining({
-                ownerType: "user",
-                ownerId: "user-1",
-                slug: "favorites",
-                name: "Favorites",
-                description: "Picked papers",
-                visibility: "private",
-            }),
-        );
-    });
-
-    it("POST /api/collections returns 403 when requester cannot manage org collections", async () => {
-        const token = await createTestJWT({ sub: "user-1" });
-        queueSelectResponses([
-            { getResult: { id: "org-1", slug: "lab" } },
-            { getResult: { orgId: "org-1", userId: "user-1", role: "member" } },
-        ]);
-
-        const app = await createTestApp();
-        const env = createTestEnv();
-
-        const res = await app.request(
-            "http://localhost/api/collections",
-            {
-                method: "POST",
-                headers: {
-                    Authorization: `Bearer ${token}`,
-                    "Content-Type": "application/json",
-                },
-                body: JSON.stringify({
-                    owner_type: "org",
-                    org_slug: "lab",
-                    name: "Lab picks",
-                    slug: "lab-picks",
-                    visibility: "org_only",
-                }),
-            },
-            env as any,
-        );
-
-        expect(res.status).toBe(403);
-        expect((await res.json()) as any).toEqual({
-            error: "Forbidden: admin access required",
-        });
-    });
-
-    it("GET /api/collections/:id hides private collections from anonymous users", async () => {
-        queueSelectResponses([
-            {
-                getResult: {
-                    id: "col-1",
-                    ownerType: "user",
-                    ownerId: "user-1",
-                    visibility: "private",
-                },
-            },
-        ]);
-
-        const app = await createTestApp();
-        const env = createTestEnv();
-
-        const res = await app.request("http://localhost/api/collections/col-1", {}, env as any);
-
-        expect(res.status).toBe(404);
-    });
-
-    it("GET /api/collections/:id returns a private collection to its owner", async () => {
-        const token = await createTestJWT({ sub: "user-1" });
-        queueSelectResponses([
-            {
-                getResult: {
-                    id: "col-1",
-                    ownerType: "user",
-                    ownerId: "user-1",
-                    visibility: "private",
-                },
-            },
-        ]);
-
-        const app = await createTestApp();
-        const env = createTestEnv();
-
-        const res = await app.request(
-            "http://localhost/api/collections/col-1",
-            {
-                headers: { Authorization: `Bearer ${token}` },
-            },
-            env as any,
-        );
-
-        expect(res.status).toBe(200);
-        expect(((await res.json()) as any).collection.id).toBe("col-1");
-    });
-
-
-    it("PATCH /api/collections/:id returns 404 when collection not found", async () => {
-        queueSelectResponses([
-            { getResult: null }
-        ]);
-        const app = await createTestApp();
-        const env = createTestEnv();
-        const res = await app.request("http://localhost/api/collections/c1", {
-            method: "PATCH",
-            headers: { Authorization: `Bearer ${await createTestJWT({ sub: "user-1" })}` },
-            body: JSON.stringify({ name: "C2", slug: "col-2", description: "desc", visibility: "public" }),
-        }, env);
-        expect(res.status).toBe(404);
-        expect(await res.json()).toEqual({ error: "Collection not found" });
-    });
-
-    it("PATCH /api/collections/:id returns 403 when forbidden", async () => {
-        queueSelectResponses([
-            { getResult: { id: "c1", ownerType: "user", ownerId: "user2" } },
-        ]);
-        const app = await createTestApp();
-        const env = createTestEnv();
-        const res = await app.request("http://localhost/api/collections/c1", {
-            method: "PATCH",
-            headers: { Authorization: `Bearer ${await createTestJWT({ sub: "user-1" })}` },
-            body: JSON.stringify({ name: "C2", slug: "col-2", description: "desc", visibility: "public" }),
-        }, env);
-        expect(res.status).toBe(403);
-        expect(await res.json()).toEqual({ error: "Forbidden" });
-    });
-
-    it("PATCH /api/collections/:id handles invalid JSON body", async () => {
-        queueSelectResponses([
-            { getResult: { id: "c1", ownerType: "user", ownerId: "user-1" } },
-        ]);
-        const app = await createTestApp();
-        const env = createTestEnv();
-        const res = await app.request("http://localhost/api/collections/c1", {
-            method: "PATCH",
-            headers: { Authorization: `Bearer ${await createTestJWT({ sub: "user-1" })}` },
-            body: "{invalid-json}",
-        }, env);
-        expect(res.status).toBe(400);
-        expect(await res.json()).toEqual({ error: "Invalid JSON body" });
-    });
-
-    it("PATCH /api/collections/:id returns 400 for invalid visibility", async () => {
-        queueSelectResponses([
-            { getResult: { id: "c1", ownerType: "user", ownerId: "user-1" } },
-        ]);
-        const app = await createTestApp();
-        const env = createTestEnv();
-        const res = await app.request("http://localhost/api/collections/c1", {
-            method: "PATCH",
-            headers: { Authorization: `Bearer ${await createTestJWT({ sub: "user-1" })}` },
-            body: JSON.stringify({ visibility: 123 }),
-        }, env);
-        expect(res.status).toBe(400);
-        expect(await res.json()).toEqual({ error: "Invalid visibility" });
-    });
-
-    it("PATCH /api/collections/:id ignores general db update errors", async () => {
-        queueSelectResponses([
-            { getResult: { id: "c1", ownerType: "user", ownerId: "user-1" } },
-        ]);
-        const err = new Error("General update error");
-        mockDb.update = vi.fn().mockReturnValue({
-            set: vi.fn().mockReturnValue({
-                where: vi.fn().mockRejectedValue(err)
-            })
-        });
-        const app = await createTestApp();
-        const env = createTestEnv();
-        const res = await app.request("http://localhost/api/collections/c1", {
-            method: "PATCH",
-            headers: { Authorization: `Bearer ${await createTestJWT({ sub: "user-1" })}` },
-            body: JSON.stringify({ name: "C2", slug: "col-2", description: "desc", visibility: "public" }),
-        }, env);
-        expect(res.status).toBe(500);
-    });
-
-    it("PATCH /api/collections/:id returns 409 if slug already in use", async () => {
-        queueSelectResponses([
-            { getResult: { id: "c1", ownerType: "user", ownerId: "user-1" } },
-        ]);
-        const err = new Error("UNIQUE constraint failed: collections.slug");
-        mockDb.update = vi.fn().mockReturnValue({
-            set: vi.fn().mockReturnValue({
-                where: vi.fn().mockRejectedValue(err)
-            })
-        });
-        const app = await createTestApp();
-        const env = createTestEnv();
-        const res = await app.request("http://localhost/api/collections/c1", {
-            method: "PATCH",
-            headers: { Authorization: `Bearer ${await createTestJWT({ sub: "user-1" })}` },
-            body: JSON.stringify({ name: "C2", slug: "col-2", description: "desc", visibility: "public" }),
-        }, env);
-        expect(res.status).toBe(409);
-        expect(await res.json()).toEqual({ error: "slug already in use" });
-    });
-
-    it("PATCH /api/collections/:id returns 400 when name is invalid", async () => {
-        queueSelectResponses([
-            { getResult: { id: "c1", ownerType: "user", ownerId: "user-1" } }, // get collection
-        ]);
-        const app = await createTestApp();
-        const env = createTestEnv();
-        const res = await app.request("http://localhost/api/collections/c1", {
-            method: "PATCH",
-            headers: { Authorization: `Bearer ${await createTestJWT({ sub: "user-1" })}` },
-            body: JSON.stringify({ name: "" }),
-        }, env);
-        expect(res.status).toBe(400);
-        expect(await res.json()).toHaveProperty("error");
-    });
-
-    it("PATCH /api/collections/:id returns 400 when slug is invalid", async () => {
-        queueSelectResponses([
-            { getResult: { id: "c1", ownerType: "user", ownerId: "user-1" } }, // get collection
-        ]);
-        const app = await createTestApp();
-        const env = createTestEnv();
-        const res = await app.request("http://localhost/api/collections/c1", {
-            method: "PATCH",
-            headers: { Authorization: `Bearer ${await createTestJWT({ sub: "user-1" })}` },
-            body: JSON.stringify({ slug: "invalid slug!" }),
-        }, env);
-        expect(res.status).toBe(400);
-        expect(await res.json()).toHaveProperty("error");
-    });
-
-    it("PATCH /api/collections/:id returns 400 when description is invalid", async () => {
-        queueSelectResponses([
-            { getResult: { id: "c1", ownerType: "user", ownerId: "user-1" } }, // get collection
-        ]);
-        const app = await createTestApp();
-        const env = createTestEnv();
-        const res = await app.request("http://localhost/api/collections/c1", {
-            method: "PATCH",
-            headers: { Authorization: `Bearer ${await createTestJWT({ sub: "user-1" })}` },
-            body: JSON.stringify({ description: "a".repeat(1001) }),
-        }, env);
-        expect(res.status).toBe(400);
-        expect(await res.json()).toHaveProperty("error");
-    });
-
-    it("DELETE /api/collections/:id returns 404 when collection not found", async () => {
-        queueSelectResponses([
-            { getResult: null }
-        ]);
-        const app = await createTestApp();
-        const env = createTestEnv();
-        const res = await app.request("http://localhost/api/collections/c1", {
-            method: "DELETE",
-            headers: { Authorization: `Bearer ${await createTestJWT({ sub: "user-1" })}` },
-        }, env);
-        expect(res.status).toBe(404);
-        expect(await res.json()).toEqual({ error: "Collection not found" });
-    });
-
-    it("DELETE /api/collections/:id returns 403 when forbidden", async () => {
-        queueSelectResponses([
-            { getResult: { id: "c1", ownerType: "user", ownerId: "user2" } },
-        ]);
-        const app = await createTestApp();
-        const env = createTestEnv();
-        const res = await app.request("http://localhost/api/collections/c1", {
-            method: "DELETE",
-            headers: { Authorization: `Bearer ${await createTestJWT({ sub: "user-1" })}` },
-        }, env);
-        expect(res.status).toBe(403);
-        expect(await res.json()).toEqual({ error: "Forbidden" });
-    });
-
-    it("PATCH /api/collections/:id returns 403 when user cannot manage org collection", async () => {
-        queueSelectResponses([
-            { getResult: { id: "c1", ownerType: "org", ownerId: "org1" } },
-            { getResult: null },
-        ]);
-        const app = await createTestApp();
-        const env = createTestEnv();
-        const res = await app.request("http://localhost/api/collections/c1", {
-            method: "PATCH",
-            headers: { Authorization: `Bearer ${await createTestJWT({ sub: "user-1" })}` },
-            body: JSON.stringify({ name: "C2" }),
-        }, env);
-        expect(res.status).toBe(403);
-        expect(await res.json()).toEqual({ error: "Forbidden" });
-    });
-
-    it("PATCH /api/collections/:id allows org admin to update collection", async () => {
-        queueSelectResponses([
-            { getResult: { id: "c1", ownerType: "org", ownerId: "org1" } },
-            { getResult: { role: "admin" } },
-            { getResult: { id: "c1", name: "C2" } }
-        ]);
-        const app = await createTestApp();
-        const env = createTestEnv();
-        const res = await app.request("http://localhost/api/collections/c1", {
-            method: "PATCH",
-            headers: { Authorization: `Bearer ${await createTestJWT({ sub: "user-1" })}` },
-            body: JSON.stringify({ name: "C2", slug: "col-2", description: "desc2", visibility: "public" }),
-        }, env);
-        expect(res.status).toBe(200);
-    });
-    it("PATCH /api/collections/:id updates collection details for the owner", async () => {
-        const token = await createTestJWT({ sub: "user-1" });
-        const existingCollection = {
-            id: "col-1",
-            ownerType: "user",
-            ownerId: "user-1",
-            name: "Old",
-            slug: "old",
             description: null,
-            visibility: "private",
-        };
-        const updatedCollection = {
-            ...existingCollection,
-            name: "Renamed",
-            slug: "renamed",
             visibility: "public",
-        };
-        queueSelectResponses([
-            { getResult: existingCollection },
-            { getResult: updatedCollection },
-        ]);
+          },
+        ],
+      }),
+    );
 
-        const setValues = vi.fn(() => ({ where: vi.fn(async () => undefined) }));
-        mockDb.update = vi.fn(() => ({ set: setValues }));
+    const app = await createTestApp();
+    const env = createTestEnv();
 
-        const app = await createTestApp();
-        const env = createTestEnv();
+    const res = await app.request(
+      "http://localhost/api/users/user-1/collections",
+      {},
+      env as any,
+    );
 
-        const res = await app.request(
-            "http://localhost/api/collections/col-1",
-            {
-                method: "PATCH",
-                headers: {
-                    Authorization: `Bearer ${token}`,
-                    "Content-Type": "application/json",
-                },
-                body: JSON.stringify({
-                    name: " Renamed ",
-                    slug: "RENAMED",
-                    visibility: "public",
-                }),
-            },
-            env as any,
-        );
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as any;
+    expect(body.collections).toHaveLength(1);
+    expect(body.collections[0].slug).toBe("favorites");
+  });
 
-        expect(res.status).toBe(200);
-        expect(setValues).toHaveBeenCalledWith(
-            expect.objectContaining({
-                name: "Renamed",
-                slug: "renamed",
-                visibility: "public",
-            }),
-        );
-        expect(((await res.json()) as any).collection.slug).toBe("renamed");
+  it("POST /api/collections creates a user collection", async () => {
+    const token = await createTestJWT({ sub: "user-1" });
+    const createdCollection = {
+      id: "col-1",
+      ownerType: "user",
+      ownerId: "user-1",
+      slug: "favorites",
+      name: "Favorites",
+      description: "Picked papers",
+      visibility: "private",
+    };
+    queueSelectResponses([{ getResult: createdCollection }]);
+
+    const insertValues = vi.fn(async () => undefined);
+    mockDb.insert = vi.fn(() => ({ values: insertValues }));
+
+    const app = await createTestApp();
+    const env = createTestEnv();
+
+    const res = await app.request(
+      "http://localhost/api/collections",
+      {
+        method: "POST",
+        headers: {
+          Authorization: `Bearer ${token}`,
+          "Content-Type": "application/json",
+        },
+        body: JSON.stringify({
+          owner_type: "user",
+          name: "Favorites",
+          slug: "favorites",
+          description: " Picked papers ",
+        }),
+      },
+      env as any,
+    );
+
+    expect(res.status).toBe(201);
+    expect(insertValues).toHaveBeenCalledWith(
+      expect.objectContaining({
+        ownerType: "user",
+        ownerId: "user-1",
+        slug: "favorites",
+        name: "Favorites",
+        description: "Picked papers",
+        visibility: "private",
+      }),
+    );
+  });
+
+  it("POST /api/collections returns 403 when requester cannot manage org collections", async () => {
+    const token = await createTestJWT({ sub: "user-1" });
+    queueSelectResponses([
+      { getResult: { id: "org-1", slug: "lab" } },
+      { getResult: { orgId: "org-1", userId: "user-1", role: "member" } },
+    ]);
+
+    const app = await createTestApp();
+    const env = createTestEnv();
+
+    const res = await app.request(
+      "http://localhost/api/collections",
+      {
+        method: "POST",
+        headers: {
+          Authorization: `Bearer ${token}`,
+          "Content-Type": "application/json",
+        },
+        body: JSON.stringify({
+          owner_type: "org",
+          org_slug: "lab",
+          name: "Lab picks",
+          slug: "lab-picks",
+          visibility: "org_only",
+        }),
+      },
+      env as any,
+    );
+
+    expect(res.status).toBe(403);
+    expect((await res.json()) as any).toEqual({
+      error: "Forbidden: admin access required",
     });
+  });
 
-    it("PATCH /api/collections/:id rejects requests without updatable fields", async () => {
-        const token = await createTestJWT({ sub: "user-1" });
-        queueSelectResponses([
-            {
-                getResult: {
-                    id: "col-1",
-                    ownerType: "user",
-                    ownerId: "user-1",
-                    visibility: "private",
-                },
-            },
-        ]);
+  it("GET /api/collections/:id hides private collections from anonymous users", async () => {
+    queueSelectResponses([
+      {
+        getResult: {
+          id: "col-1",
+          ownerType: "user",
+          ownerId: "user-1",
+          visibility: "private",
+        },
+      },
+    ]);
 
-        const app = await createTestApp();
-        const env = createTestEnv();
+    const app = await createTestApp();
+    const env = createTestEnv();
 
-        const res = await app.request(
-            "http://localhost/api/collections/col-1",
-            {
-                method: "PATCH",
-                headers: {
-                    Authorization: `Bearer ${token}`,
-                    "Content-Type": "application/json",
-                },
-                body: JSON.stringify({}),
-            },
-            env as any,
-        );
+    const res = await app.request(
+      "http://localhost/api/collections/col-1",
+      {},
+      env as any,
+    );
 
-        expect(res.status).toBe(400);
-        expect(((await res.json()) as any).error).toBe("No fields to update");
+    expect(res.status).toBe(404);
+  });
+
+  it("GET /api/collections/:id returns a private collection to its owner", async () => {
+    const token = await createTestJWT({ sub: "user-1" });
+    queueSelectResponses([
+      {
+        getResult: {
+          id: "col-1",
+          ownerType: "user",
+          ownerId: "user-1",
+          visibility: "private",
+        },
+      },
+    ]);
+
+    const app = await createTestApp();
+    const env = createTestEnv();
+
+    const res = await app.request(
+      "http://localhost/api/collections/col-1",
+      {
+        headers: { Authorization: `Bearer ${token}` },
+      },
+      env as any,
+    );
+
+    expect(res.status).toBe(200);
+    expect(((await res.json()) as any).collection.id).toBe("col-1");
+  });
+
+  it("PATCH /api/collections/:id returns 404 when collection not found", async () => {
+    queueSelectResponses([{ getResult: null }]);
+    const app = await createTestApp();
+    const env = createTestEnv();
+    const res = await app.request(
+      "http://localhost/api/collections/c1",
+      {
+        method: "PATCH",
+        headers: {
+          Authorization: `Bearer ${await createTestJWT({ sub: "user-1" })}`,
+        },
+        body: JSON.stringify({
+          name: "C2",
+          slug: "col-2",
+          description: "desc",
+          visibility: "public",
+        }),
+      },
+      env,
+    );
+    expect(res.status).toBe(404);
+    expect(await res.json()).toEqual({ error: "Collection not found" });
+  });
+
+  it("PATCH /api/collections/:id returns 403 when forbidden", async () => {
+    queueSelectResponses([
+      { getResult: { id: "c1", ownerType: "user", ownerId: "user2" } },
+    ]);
+    const app = await createTestApp();
+    const env = createTestEnv();
+    const res = await app.request(
+      "http://localhost/api/collections/c1",
+      {
+        method: "PATCH",
+        headers: {
+          Authorization: `Bearer ${await createTestJWT({ sub: "user-1" })}`,
+        },
+        body: JSON.stringify({
+          name: "C2",
+          slug: "col-2",
+          description: "desc",
+          visibility: "public",
+        }),
+      },
+      env,
+    );
+    expect(res.status).toBe(403);
+    expect(await res.json()).toEqual({ error: "Forbidden" });
+  });
+
+  it("PATCH /api/collections/:id handles invalid JSON body", async () => {
+    queueSelectResponses([
+      { getResult: { id: "c1", ownerType: "user", ownerId: "user-1" } },
+    ]);
+    const app = await createTestApp();
+    const env = createTestEnv();
+    const res = await app.request(
+      "http://localhost/api/collections/c1",
+      {
+        method: "PATCH",
+        headers: {
+          Authorization: `Bearer ${await createTestJWT({ sub: "user-1" })}`,
+        },
+        body: "{invalid-json}",
+      },
+      env,
+    );
+    expect(res.status).toBe(400);
+    expect(await res.json()).toEqual({ error: "Invalid JSON body" });
+  });
+
+  it("PATCH /api/collections/:id returns 400 for invalid visibility", async () => {
+    queueSelectResponses([
+      { getResult: { id: "c1", ownerType: "user", ownerId: "user-1" } },
+    ]);
+    const app = await createTestApp();
+    const env = createTestEnv();
+    const res = await app.request(
+      "http://localhost/api/collections/c1",
+      {
+        method: "PATCH",
+        headers: {
+          Authorization: `Bearer ${await createTestJWT({ sub: "user-1" })}`,
+        },
+        body: JSON.stringify({ visibility: 123 }),
+      },
+      env,
+    );
+    expect(res.status).toBe(400);
+    expect(await res.json()).toEqual({ error: "Invalid visibility" });
+  });
+
+  it("PATCH /api/collections/:id ignores general db update errors", async () => {
+    queueSelectResponses([
+      { getResult: { id: "c1", ownerType: "user", ownerId: "user-1" } },
+    ]);
+    const err = new Error("General update error");
+    mockDb.update = vi.fn().mockReturnValue({
+      set: vi.fn().mockReturnValue({
+        where: vi.fn().mockRejectedValue(err),
+      }),
     });
+    const app = await createTestApp();
+    const env = createTestEnv();
+    const res = await app.request(
+      "http://localhost/api/collections/c1",
+      {
+        method: "PATCH",
+        headers: {
+          Authorization: `Bearer ${await createTestJWT({ sub: "user-1" })}`,
+        },
+        body: JSON.stringify({
+          name: "C2",
+          slug: "col-2",
+          description: "desc",
+          visibility: "public",
+        }),
+      },
+      env,
+    );
+    expect(res.status).toBe(500);
+  });
 
-    it("DELETE /api/collections/:id deletes a collection for the owner", async () => {
-        const token = await createTestJWT({ sub: "user-1" });
-        queueSelectResponses([
-            {
-                getResult: {
-                    id: "col-1",
-                    ownerType: "user",
-                    ownerId: "user-1",
-                    visibility: "private",
-                },
-            },
-        ]);
-
-        const deleteWhere = vi.fn(async () => ({ meta: { changes: 1 } }));
-        mockDb.delete = vi.fn(() => ({ where: deleteWhere }));
-
-        const app = await createTestApp();
-        const env = createTestEnv();
-
-        const res = await app.request(
-            "http://localhost/api/collections/col-1",
-            {
-                method: "DELETE",
-                headers: { Authorization: `Bearer ${token}` },
-            },
-            env as any,
-        );
-
-        expect(res.status).toBe(200);
-        await expect(res.json()).resolves.toEqual({ ok: true });
-        expect(deleteWhere).toHaveBeenCalled();
+  it("PATCH /api/collections/:id returns 409 if slug already in use", async () => {
+    queueSelectResponses([
+      { getResult: { id: "c1", ownerType: "user", ownerId: "user-1" } },
+    ]);
+    const err = new Error("UNIQUE constraint failed: collections.slug");
+    mockDb.update = vi.fn().mockReturnValue({
+      set: vi.fn().mockReturnValue({
+        where: vi.fn().mockRejectedValue(err),
+      }),
     });
+    const app = await createTestApp();
+    const env = createTestEnv();
+    const res = await app.request(
+      "http://localhost/api/collections/c1",
+      {
+        method: "PATCH",
+        headers: {
+          Authorization: `Bearer ${await createTestJWT({ sub: "user-1" })}`,
+        },
+        body: JSON.stringify({
+          name: "C2",
+          slug: "col-2",
+          description: "desc",
+          visibility: "public",
+        }),
+      },
+      env,
+    );
+    expect(res.status).toBe(409);
+    expect(await res.json()).toEqual({ error: "slug already in use" });
+  });
 
+  it("PATCH /api/collections/:id returns 400 when name is invalid", async () => {
+    queueSelectResponses([
+      { getResult: { id: "c1", ownerType: "user", ownerId: "user-1" } }, // get collection
+    ]);
+    const app = await createTestApp();
+    const env = createTestEnv();
+    const res = await app.request(
+      "http://localhost/api/collections/c1",
+      {
+        method: "PATCH",
+        headers: {
+          Authorization: `Bearer ${await createTestJWT({ sub: "user-1" })}`,
+        },
+        body: JSON.stringify({ name: "" }),
+      },
+      env,
+    );
+    expect(res.status).toBe(400);
+    expect(await res.json()).toHaveProperty("error");
+  });
 
-    it("GET /api/orgs/:slug/collections returns empty array when org not found", async () => {
-        queueSelectResponses([
-            { getResult: null },
-        ]);
-        const app = await createTestApp();
-        const env = createTestEnv();
-        const res = await app.request("http://localhost/api/orgs/nonexistent/collections", {
-            method: "GET",
-        }, env);
-        expect(res.status).toBe(200);
-        expect(await res.json()).toEqual({ collections: [] });
-    });
-    it("GET /api/orgs/:slug/collections returns admin-visible collections", async () => {
-        const token = await createTestJWT({ sub: "user-1" });
-        queueSelectResponses([
-            { getResult: { id: "org-1", slug: "lab" } },
-            {
-                allResult: [
-                    { id: "c1", visibility: "public", ownerType: "org", ownerId: "org-1" },
-                    { id: "c2", visibility: "org_only", ownerType: "org", ownerId: "org-1" },
-                    { id: "c3", visibility: "private", ownerType: "org", ownerId: "org-1" },
-                ],
-            },
-            { getResult: { orgId: "org-1", userId: "user-1", role: "admin" } },
-        ]);
+  it("PATCH /api/collections/:id returns 400 when slug is invalid", async () => {
+    queueSelectResponses([
+      { getResult: { id: "c1", ownerType: "user", ownerId: "user-1" } }, // get collection
+    ]);
+    const app = await createTestApp();
+    const env = createTestEnv();
+    const res = await app.request(
+      "http://localhost/api/collections/c1",
+      {
+        method: "PATCH",
+        headers: {
+          Authorization: `Bearer ${await createTestJWT({ sub: "user-1" })}`,
+        },
+        body: JSON.stringify({ slug: "invalid slug!" }),
+      },
+      env,
+    );
+    expect(res.status).toBe(400);
+    expect(await res.json()).toHaveProperty("error");
+  });
 
-        const app = await createTestApp();
-        const env = createTestEnv();
+  it("PATCH /api/collections/:id returns 400 when description is invalid", async () => {
+    queueSelectResponses([
+      { getResult: { id: "c1", ownerType: "user", ownerId: "user-1" } }, // get collection
+    ]);
+    const app = await createTestApp();
+    const env = createTestEnv();
+    const res = await app.request(
+      "http://localhost/api/collections/c1",
+      {
+        method: "PATCH",
+        headers: {
+          Authorization: `Bearer ${await createTestJWT({ sub: "user-1" })}`,
+        },
+        body: JSON.stringify({ description: "a".repeat(1001) }),
+      },
+      env,
+    );
+    expect(res.status).toBe(400);
+    expect(await res.json()).toHaveProperty("error");
+  });
 
-        const res = await app.request(
-            "http://localhost/api/orgs/lab/collections",
-            {
-                headers: { Authorization: `Bearer ${token}` },
-            },
-            env as any,
-        );
+  it("DELETE /api/collections/:id returns 404 when collection not found", async () => {
+    queueSelectResponses([{ getResult: null }]);
+    const app = await createTestApp();
+    const env = createTestEnv();
+    const res = await app.request(
+      "http://localhost/api/collections/c1",
+      {
+        method: "DELETE",
+        headers: {
+          Authorization: `Bearer ${await createTestJWT({ sub: "user-1" })}`,
+        },
+      },
+      env,
+    );
+    expect(res.status).toBe(404);
+    expect(await res.json()).toEqual({ error: "Collection not found" });
+  });
 
-        expect(res.status).toBe(200);
-        expect(((await res.json()) as any).collections).toHaveLength(3);
-    });
+  it("DELETE /api/collections/:id returns 403 when forbidden", async () => {
+    queueSelectResponses([
+      { getResult: { id: "c1", ownerType: "user", ownerId: "user2" } },
+    ]);
+    const app = await createTestApp();
+    const env = createTestEnv();
+    const res = await app.request(
+      "http://localhost/api/collections/c1",
+      {
+        method: "DELETE",
+        headers: {
+          Authorization: `Bearer ${await createTestJWT({ sub: "user-1" })}`,
+        },
+      },
+      env,
+    );
+    expect(res.status).toBe(403);
+    expect(await res.json()).toEqual({ error: "Forbidden" });
+  });
 
-    it("GET /api/orgs/:slug/collections hides private org collections from non-admin members", async () => {
-        const token = await createTestJWT({ sub: "user-1" });
-        queueSelectResponses([
-            { getResult: { id: "org-1", slug: "lab" } },
-            {
-                allResult: [
-                    { id: "c1", visibility: "public", ownerType: "org", ownerId: "org-1" },
-                    { id: "c2", visibility: "org_only", ownerType: "org", ownerId: "org-1" },
-                    { id: "c3", visibility: "private", ownerType: "org", ownerId: "org-1" },
-                ],
-            },
-            { getResult: { orgId: "org-1", userId: "user-1", role: "member" } },
-        ]);
+  it("PATCH /api/collections/:id returns 403 when user cannot manage org collection", async () => {
+    queueSelectResponses([
+      { getResult: { id: "c1", ownerType: "org", ownerId: "org1" } },
+      { getResult: null },
+    ]);
+    const app = await createTestApp();
+    const env = createTestEnv();
+    const res = await app.request(
+      "http://localhost/api/collections/c1",
+      {
+        method: "PATCH",
+        headers: {
+          Authorization: `Bearer ${await createTestJWT({ sub: "user-1" })}`,
+        },
+        body: JSON.stringify({ name: "C2" }),
+      },
+      env,
+    );
+    expect(res.status).toBe(403);
+    expect(await res.json()).toEqual({ error: "Forbidden" });
+  });
 
-        const app = await createTestApp();
-        const env = createTestEnv();
+  it("PATCH /api/collections/:id allows org admin to update collection", async () => {
+    queueSelectResponses([
+      { getResult: { id: "c1", ownerType: "org", ownerId: "org1" } },
+      { getResult: { role: "admin" } },
+      { getResult: { id: "c1", name: "C2" } },
+    ]);
+    const app = await createTestApp();
+    const env = createTestEnv();
+    const res = await app.request(
+      "http://localhost/api/collections/c1",
+      {
+        method: "PATCH",
+        headers: {
+          Authorization: `Bearer ${await createTestJWT({ sub: "user-1" })}`,
+        },
+        body: JSON.stringify({
+          name: "C2",
+          slug: "col-2",
+          description: "desc2",
+          visibility: "public",
+        }),
+      },
+      env,
+    );
+    expect(res.status).toBe(200);
+  });
+  it("PATCH /api/collections/:id updates collection details for the owner", async () => {
+    const token = await createTestJWT({ sub: "user-1" });
+    const existingCollection = {
+      id: "col-1",
+      ownerType: "user",
+      ownerId: "user-1",
+      name: "Old",
+      slug: "old",
+      description: null,
+      visibility: "private",
+    };
+    const updatedCollection = {
+      ...existingCollection,
+      name: "Renamed",
+      slug: "renamed",
+      visibility: "public",
+    };
+    queueSelectResponses([
+      { getResult: existingCollection },
+      { getResult: updatedCollection },
+    ]);
 
-        const res = await app.request(
-            "http://localhost/api/orgs/lab/collections",
-            {
-                headers: { Authorization: `Bearer ${token}` },
-            },
-            env as any,
-        );
+    const setValues = vi.fn(() => ({ where: vi.fn(async () => undefined) }));
+    mockDb.update = vi.fn(() => ({ set: setValues }));
 
-        expect(res.status).toBe(200);
-        expect(((await res.json()) as any).collections.map((row: any) => row.id)).toEqual([
-            "c1",
-            "c2",
-        ]);
-    });
+    const app = await createTestApp();
+    const env = createTestEnv();
 
-    it("POST /api/collections/:id/papers rejects invalid JSON", async () => {
-        const token = await createTestJWT({ sub: "user-1" });
-        queueSelectResponses([
-            {
-                getResult: {
-                    id: "col-1",
-                    ownerType: "user",
-                    ownerId: "user-1",
-                    visibility: "private",
-                },
-            },
-        ]);
+    const res = await app.request(
+      "http://localhost/api/collections/col-1",
+      {
+        method: "PATCH",
+        headers: {
+          Authorization: `Bearer ${token}`,
+          "Content-Type": "application/json",
+        },
+        body: JSON.stringify({
+          name: " Renamed ",
+          slug: "RENAMED",
+          visibility: "public",
+        }),
+      },
+      env as any,
+    );
 
-        const app = await createTestApp();
-        const env = createTestEnv();
+    expect(res.status).toBe(200);
+    expect(setValues).toHaveBeenCalledWith(
+      expect.objectContaining({
+        name: "Renamed",
+        slug: "renamed",
+        visibility: "public",
+      }),
+    );
+    expect(((await res.json()) as any).collection.slug).toBe("renamed");
+  });
 
-        const res = await app.request(
-            "http://localhost/api/collections/col-1/papers",
-            {
-                method: "POST",
-                headers: {
-                    Authorization: `Bearer ${token}`,
-                    "Content-Type": "application/json",
-                },
-                body: "invalid-json",
-            },
-            env as any,
-        );
+  it("PATCH /api/collections/:id rejects requests without updatable fields", async () => {
+    const token = await createTestJWT({ sub: "user-1" });
+    queueSelectResponses([
+      {
+        getResult: {
+          id: "col-1",
+          ownerType: "user",
+          ownerId: "user-1",
+          visibility: "private",
+        },
+      },
+    ]);
 
-        expect(res.status).toBe(400);
-        await expect(res.json()).resolves.toEqual({ error: "Invalid JSON body" });
-    });
+    const app = await createTestApp();
+    const env = createTestEnv();
 
+    const res = await app.request(
+      "http://localhost/api/collections/col-1",
+      {
+        method: "PATCH",
+        headers: {
+          Authorization: `Bearer ${token}`,
+          "Content-Type": "application/json",
+        },
+        body: JSON.stringify({}),
+      },
+      env as any,
+    );
 
-    it("POST /api/collections/:id/papers returns 404 when collection not found", async () => {
-        queueSelectResponses([
-            { getResult: null }
-        ]);
-        const app = await createTestApp();
-        const env = createTestEnv();
-        const res = await app.request("http://localhost/api/collections/c1/papers", {
-            method: "POST",
-            headers: { Authorization: `Bearer ${await createTestJWT({ sub: "user-1" })}` },
-            body: JSON.stringify({ paper_id: "p1" }),
-        }, env);
-        expect(res.status).toBe(404);
-        expect(await res.json()).toEqual({ error: "Collection not found" });
-    });
+    expect(res.status).toBe(400);
+    expect(((await res.json()) as any).error).toBe("No fields to update");
+  });
 
-    it("POST /api/collections/:id/papers returns 403 when forbidden", async () => {
-        queueSelectResponses([
-            { getResult: { id: "c1", ownerType: "user", ownerId: "user2" } }
-        ]);
-        const app = await createTestApp();
-        const env = createTestEnv();
-        const res = await app.request("http://localhost/api/collections/c1/papers", {
-            method: "POST",
-            headers: { Authorization: `Bearer ${await createTestJWT({ sub: "user-1" })}` },
-            body: JSON.stringify({ paper_id: "p1" }),
-        }, env);
-        expect(res.status).toBe(403);
-        expect(await res.json()).toEqual({ error: "Forbidden" });
-    });
+  it("DELETE /api/collections/:id deletes a collection for the owner", async () => {
+    const token = await createTestJWT({ sub: "user-1" });
+    queueSelectResponses([
+      {
+        getResult: {
+          id: "col-1",
+          ownerType: "user",
+          ownerId: "user-1",
+          visibility: "private",
+        },
+      },
+    ]);
 
-    it("POST /api/collections/:id/papers returns 404 when paper not found", async () => {
-        queueSelectResponses([
-            { getResult: { id: "c1", ownerType: "user", ownerId: "user-1" } },
-            { getResult: null }
-        ]);
-        const app = await createTestApp();
-        const env = createTestEnv();
-        const res = await app.request("http://localhost/api/collections/c1/papers", {
-            method: "POST",
-            headers: { Authorization: `Bearer ${await createTestJWT({ sub: "user-1" })}` },
-            body: JSON.stringify({ paper_id: "p1" }),
-        }, env);
-        expect(res.status).toBe(404);
-        expect(await res.json()).toEqual({ error: "Paper not found" });
-    });
+    const deleteWhere = vi.fn(async () => ({ meta: { changes: 1 } }));
+    mockDb.delete = vi.fn(() => ({ where: deleteWhere }));
 
-    it("POST /api/collections/:id/papers ignores general db insert errors", async () => {
-        queueSelectResponses([
-            { getResult: { id: "c1", ownerType: "user", ownerId: "user-1" } },
-            { getResult: { id: "p1" } },
-            { getResult: null },
-            { getResult: { c: 0 } },
-            { getResult: null },
-        ]);
-        const err = new Error("General insert paper error");
-        mockDb.insert = vi.fn().mockReturnValue({
-            values: vi.fn().mockRejectedValue(err)
-        });
-        const app = await createTestApp();
-        const env = createTestEnv();
-        const res = await app.request("http://localhost/api/collections/c1/papers", {
-            method: "POST",
-            headers: { Authorization: `Bearer ${await createTestJWT({ sub: "user-1" })}` },
-            body: JSON.stringify({ paper_id: "p1" }),
-        }, env);
-        expect(res.status).toBe(500);
-    });
+    const app = await createTestApp();
+    const env = createTestEnv();
 
-    it("DELETE /api/collections/:id/papers/:paperId returns 404 when collection not found", async () => {
-        queueSelectResponses([
-            { getResult: null }
-        ]);
-        const app = await createTestApp();
-        const env = createTestEnv();
-        const res = await app.request("http://localhost/api/collections/c1/papers/p1", {
-            method: "DELETE",
-            headers: { Authorization: `Bearer ${await createTestJWT({ sub: "user-1" })}` },
-        }, env);
-        expect(res.status).toBe(404);
-        expect(await res.json()).toEqual({ error: "Collection not found" });
-    });
+    const res = await app.request(
+      "http://localhost/api/collections/col-1",
+      {
+        method: "DELETE",
+        headers: { Authorization: `Bearer ${token}` },
+      },
+      env as any,
+    );
 
-    it("DELETE /api/collections/:id/papers/:paperId returns 403 when forbidden", async () => {
-        queueSelectResponses([
-            { getResult: { id: "c1", ownerType: "user", ownerId: "user2" } }
-        ]);
-        const app = await createTestApp();
-        const env = createTestEnv();
-        const res = await app.request("http://localhost/api/collections/c1/papers/p1", {
-            method: "DELETE",
-            headers: { Authorization: `Bearer ${await createTestJWT({ sub: "user-1" })}` },
-        }, env);
-        expect(res.status).toBe(403);
-        expect(await res.json()).toEqual({ error: "Forbidden" });
-    });
+    expect(res.status).toBe(200);
+    await expect(res.json()).resolves.toEqual({ ok: true });
+    expect(deleteWhere).toHaveBeenCalled();
+  });
 
-    it("DELETE /api/collections/:id/papers/:paperId returns 404 when paper is not in collection", async () => {
-        queueSelectResponses([
-            { getResult: { id: "c1", ownerType: "user", ownerId: "user-1" } },
-        ]);
-        mockDb.delete = vi.fn().mockReturnValue({
-            where: vi.fn().mockResolvedValue({ meta: { changes: 0 } })
-        });
-        const app = await createTestApp();
-        const env = createTestEnv();
-        const res = await app.request("http://localhost/api/collections/c1/papers/p1", {
-            method: "DELETE",
-            headers: { Authorization: `Bearer ${await createTestJWT({ sub: "user-1" })}` },
-        }, env);
-        expect(res.status).toBe(404);
-        expect(await res.json()).toEqual({ error: "Paper not in collection" });
-    });
-
-    it("PATCH /api/collections/:id/papers returns 404 when collection not found", async () => {
-        queueSelectResponses([
-            { getResult: null }
-        ]);
-        const app = await createTestApp();
-        const env = createTestEnv();
-        const res = await app.request("http://localhost/api/collections/c1/papers", {
-            method: "PATCH",
-            headers: { Authorization: `Bearer ${await createTestJWT({ sub: "user-1" })}` },
-            body: JSON.stringify({ paper_ids: ["p1"] }),
-        }, env);
-        expect(res.status).toBe(404);
-        expect(await res.json()).toEqual({ error: "Collection not found" });
-    });
-
-    it("PATCH /api/collections/:id/papers returns 403 when forbidden", async () => {
-        queueSelectResponses([
-            { getResult: { id: "c1", ownerType: "user", ownerId: "user2" } }
-        ]);
-        const app = await createTestApp();
-        const env = createTestEnv();
-        const res = await app.request("http://localhost/api/collections/c1/papers", {
-            method: "PATCH",
-            headers: { Authorization: `Bearer ${await createTestJWT({ sub: "user-1" })}` },
-            body: JSON.stringify({ paper_ids: ["p1"] }),
-        }, env);
-        expect(res.status).toBe(403);
-        expect(await res.json()).toEqual({ error: "Forbidden" });
-    });
-
-    it("PATCH /api/collections/:id/papers returns 400 when paper not in collection", async () => {
-        queueSelectResponses([
-            { getResult: { id: "c1", ownerType: "user", ownerId: "user-1" } },
-            { allResult: [{ paperId: "p1" }] }
-        ]);
-        const app = await createTestApp();
-        const env = createTestEnv();
-        const res = await app.request("http://localhost/api/collections/c1/papers", {
-            method: "PATCH",
-            headers: { Authorization: `Bearer ${await createTestJWT({ sub: "user-1" })}` },
-            body: JSON.stringify({ paper_ids: ["p2"] }),
-        }, env);
-        expect(res.status).toBe(400);
-        expect(await res.json()).toEqual({ error: "paper_ids contains paper not in collection" });
-    });
-
-    it("PATCH /api/collections/:id/papers updates sort order successfully via batch", async () => {
-        queueSelectResponses([
-            { getResult: { id: "c1", ownerType: "user", ownerId: "user-1" } },
-            { allResult: [{ paperId: "p1" }, { paperId: "p2" }] }
-        ]);
-        mockDb.batch = vi.fn().mockResolvedValue([]);
-        mockDb.update = vi.fn().mockImplementation(() => ({ set: vi.fn().mockImplementation(() => ({ where: vi.fn().mockImplementation(() => ("UPDATE_STATEMENT")) })) }));
-        const app = await createTestApp();
-        const env = createTestEnv();
-        const res = await app.request("http://localhost/api/collections/c1/papers", {
-            method: "PATCH",
-            headers: { Authorization: `Bearer ${await createTestJWT({ sub: "user-1" })}` },
-            body: JSON.stringify({ paper_ids: ["p2", "p1"] }),
-        }, env);
-        expect(res.status).toBe(200);
-        expect(await res.json()).toEqual({ ok: true });
-        expect(mockDb.batch).toHaveBeenCalled();
-    });
-
-    it("GET /api/collections/:id/papers returns only user authored papers when some are restricted", async () => {
-        queueSelectResponses([
-            { getResult: { id: "c1", visibility: "public", ownerType: "user", ownerId: "u1" } },
-            { allResult: [{ id: "p1", visibility: "private" }, { id: "p2", visibility: "public" }] },
-            { allResult: [{ paperId: "p1" }] },
-        ]);
-        const app = await createTestApp();
-        const env = createTestEnv();
-        const res = await app.request("http://localhost/api/collections/c1/papers", {
-            method: "GET",
-            headers: { Authorization: `Bearer ${await createTestJWT({ sub: "user-1" })}` },
-        }, env);
-        expect(res.status).toBe(200);
-        const data = (await res.json()) as { papers: Array<{ id: string }> };
-        expect(data.papers.length).toBe(2);
-        const ids = data.papers.map((p) => p.id);
-        expect(ids).toContain("p1");
-        expect(ids).toContain("p2");
-    });
-
-    it("GET /api/collections/:id/papers handles org_only visibility papers via membership", async () => {
-        queueSelectResponses([
-            { getResult: { id: "c1", visibility: "public", ownerType: "user", ownerId: "u1" } },
-            { allResult: [{ id: "p1", visibility: "org_only" }] },
-            { allResult: [] },
-            { allResult: [{ paperId: "p1" }] },
-        ]);
-        const app = await createTestApp();
-        const env = createTestEnv();
-        const res = await app.request("http://localhost/api/collections/c1/papers", {
-            method: "GET",
-            headers: { Authorization: `Bearer ${await createTestJWT({ sub: "user-1" })}` },
-        }, env);
-        expect(res.status).toBe(200);
-        const data = (await res.json()) as { papers: Array<{ id: string }> };
-        expect(data.papers.length).toBe(1);
-        expect(data.papers[0].id).toBe("p1");
-    });
-
-    it("GET /api/collections/:id/papers filters out private papers for authenticated users who don't have access", async () => {
-        queueSelectResponses([
-            { getResult: { id: "c1", visibility: "public", ownerType: "user", ownerId: "u1" } },
-            { allResult: [{ id: "p1", visibility: "private" }, { id: "p2", visibility: "public" }] },
-            { allResult: [] },
-        ]);
-        const app = await createTestApp();
-        const env = createTestEnv();
-        const res = await app.request("http://localhost/api/collections/c1/papers", {
-            method: "GET",
-            headers: { Authorization: `Bearer ${await createTestJWT({ sub: "user-1" })}` },
-        }, env);
-        expect(res.status).toBe(200);
-        const data = (await res.json()) as { papers: Array<{ id: string }> };
-        expect(data.papers.length).toBe(1);
-        expect(data.papers[0].id).toBe("p2");
-    });
-
-    it("PATCH /api/collections/:id/papers rejects paper_ids with empty strings or non-strings", async () => {
-        queueSelectResponses([
-            { getResult: { id: "c1", ownerType: "user", ownerId: "user-1" } },
-        ]);
-        const app = await createTestApp();
-        const env = createTestEnv();
-        const res = await app.request("http://localhost/api/collections/c1/papers", {
-            method: "PATCH",
-            headers: { Authorization: `Bearer ${await createTestJWT({ sub: "user-1" })}` },
-            body: JSON.stringify({ paper_ids: ["p1", "  ", 123] }),
-        }, env);
-        expect(res.status).toBe(400);
-        expect(await res.json()).toEqual({ error: "paper_ids must be an array of valid strings" });
-    });
-    it("POST /api/collections/:id/papers adds a visible paper with the next sort order", async () => {
-        const token = await createTestJWT({ sub: "user-1" });
-        const collection = {
-            id: "col-1",
-            ownerType: "user",
-            ownerId: "user-1",
+  it("GET /api/orgs/:slug/collections returns empty array when org not found", async () => {
+    queueSelectResponses([{ getResult: null }]);
+    const app = await createTestApp();
+    const env = createTestEnv();
+    const res = await app.request(
+      "http://localhost/api/orgs/nonexistent/collections",
+      {
+        method: "GET",
+      },
+      env,
+    );
+    expect(res.status).toBe(200);
+    expect(await res.json()).toEqual({ collections: [] });
+  });
+  it("GET /api/orgs/:slug/collections returns admin-visible collections", async () => {
+    const token = await createTestJWT({ sub: "user-1" });
+    queueSelectResponses([
+      { getResult: { id: "org-1", slug: "lab" } },
+      {
+        allResult: [
+          {
+            id: "c1",
+            visibility: "public",
+            ownerType: "org",
+            ownerId: "org-1",
+          },
+          {
+            id: "c2",
+            visibility: "org_only",
+            ownerType: "org",
+            ownerId: "org-1",
+          },
+          {
+            id: "c3",
             visibility: "private",
-        };
-        queueSelectResponses([
-            { getResult: collection },
-            { getResult: { id: "paper-1", visibility: "private" } },
-            { getResult: { paperId: "paper-1" } },
-            { getResult: { maxOrder: 2 } },
-        ]);
+            ownerType: "org",
+            ownerId: "org-1",
+          },
+        ],
+      },
+      { getResult: { orgId: "org-1", userId: "user-1", role: "admin" } },
+    ]);
 
-        const insertValues = vi.fn(async () => undefined);
-        mockDb.insert = vi.fn(() => ({ values: insertValues }));
+    const app = await createTestApp();
+    const env = createTestEnv();
 
-        const app = await createTestApp();
-        const env = createTestEnv();
+    const res = await app.request(
+      "http://localhost/api/orgs/lab/collections",
+      {
+        headers: { Authorization: `Bearer ${token}` },
+      },
+      env as any,
+    );
 
-        const res = await app.request(
-            "http://localhost/api/collections/col-1/papers",
-            {
-                method: "POST",
-                headers: {
-                    Authorization: `Bearer ${token}`,
-                    "Content-Type": "application/json",
-                },
-                body: JSON.stringify({ paper_id: "paper-1" }),
-            },
-            env as any,
-        );
+    expect(res.status).toBe(200);
+    expect(((await res.json()) as any).collections).toHaveLength(3);
+  });
 
-        expect(res.status).toBe(201);
-        expect(insertValues).toHaveBeenCalledWith({
-            collectionId: "col-1",
-            paperId: "paper-1",
+  it("GET /api/orgs/:slug/collections hides private org collections from non-admin members", async () => {
+    const token = await createTestJWT({ sub: "user-1" });
+    queueSelectResponses([
+      { getResult: { id: "org-1", slug: "lab" } },
+      {
+        allResult: [
+          {
+            id: "c1",
+            visibility: "public",
+            ownerType: "org",
+            ownerId: "org-1",
+          },
+          {
+            id: "c2",
+            visibility: "org_only",
+            ownerType: "org",
+            ownerId: "org-1",
+          },
+          {
+            id: "c3",
+            visibility: "private",
+            ownerType: "org",
+            ownerId: "org-1",
+          },
+        ],
+      },
+      { getResult: { orgId: "org-1", userId: "user-1", role: "member" } },
+    ]);
+
+    const app = await createTestApp();
+    const env = createTestEnv();
+
+    const res = await app.request(
+      "http://localhost/api/orgs/lab/collections",
+      {
+        headers: { Authorization: `Bearer ${token}` },
+      },
+      env as any,
+    );
+
+    expect(res.status).toBe(200);
+    expect(
+      ((await res.json()) as any).collections.map((row: any) => row.id),
+    ).toEqual(["c1", "c2"]);
+  });
+
+  it("POST /api/collections/:id/papers rejects invalid JSON", async () => {
+    const token = await createTestJWT({ sub: "user-1" });
+    queueSelectResponses([
+      {
+        getResult: {
+          id: "col-1",
+          ownerType: "user",
+          ownerId: "user-1",
+          visibility: "private",
+        },
+      },
+    ]);
+
+    const app = await createTestApp();
+    const env = createTestEnv();
+
+    const res = await app.request(
+      "http://localhost/api/collections/col-1/papers",
+      {
+        method: "POST",
+        headers: {
+          Authorization: `Bearer ${token}`,
+          "Content-Type": "application/json",
+        },
+        body: "invalid-json",
+      },
+      env as any,
+    );
+
+    expect(res.status).toBe(400);
+    await expect(res.json()).resolves.toEqual({ error: "Invalid JSON body" });
+  });
+
+  it("POST /api/collections/:id/papers returns 404 when collection not found", async () => {
+    queueSelectResponses([{ getResult: null }]);
+    const app = await createTestApp();
+    const env = createTestEnv();
+    const res = await app.request(
+      "http://localhost/api/collections/c1/papers",
+      {
+        method: "POST",
+        headers: {
+          Authorization: `Bearer ${await createTestJWT({ sub: "user-1" })}`,
+        },
+        body: JSON.stringify({ paper_id: "p1" }),
+      },
+      env,
+    );
+    expect(res.status).toBe(404);
+    expect(await res.json()).toEqual({ error: "Collection not found" });
+  });
+
+  it("POST /api/collections/:id/papers returns 403 when forbidden", async () => {
+    queueSelectResponses([
+      { getResult: { id: "c1", ownerType: "user", ownerId: "user2" } },
+    ]);
+    const app = await createTestApp();
+    const env = createTestEnv();
+    const res = await app.request(
+      "http://localhost/api/collections/c1/papers",
+      {
+        method: "POST",
+        headers: {
+          Authorization: `Bearer ${await createTestJWT({ sub: "user-1" })}`,
+        },
+        body: JSON.stringify({ paper_id: "p1" }),
+      },
+      env,
+    );
+    expect(res.status).toBe(403);
+    expect(await res.json()).toEqual({ error: "Forbidden" });
+  });
+
+  it("POST /api/collections/:id/papers returns 404 when paper not found", async () => {
+    queueSelectResponses([
+      { getResult: { id: "c1", ownerType: "user", ownerId: "user-1" } },
+      { getResult: null },
+    ]);
+    const app = await createTestApp();
+    const env = createTestEnv();
+    const res = await app.request(
+      "http://localhost/api/collections/c1/papers",
+      {
+        method: "POST",
+        headers: {
+          Authorization: `Bearer ${await createTestJWT({ sub: "user-1" })}`,
+        },
+        body: JSON.stringify({ paper_id: "p1" }),
+      },
+      env,
+    );
+    expect(res.status).toBe(404);
+    expect(await res.json()).toEqual({ error: "Paper not found" });
+  });
+
+  it("POST /api/collections/:id/papers ignores general db insert errors", async () => {
+    queueSelectResponses([
+      { getResult: { id: "c1", ownerType: "user", ownerId: "user-1" } },
+      { getResult: { id: "p1" } },
+      { getResult: null },
+      { getResult: { c: 0 } },
+      { getResult: null },
+    ]);
+    const err = new Error("General insert paper error");
+    mockDb.insert = vi.fn().mockReturnValue({
+      values: vi.fn().mockRejectedValue(err),
+    });
+    const app = await createTestApp();
+    const env = createTestEnv();
+    const res = await app.request(
+      "http://localhost/api/collections/c1/papers",
+      {
+        method: "POST",
+        headers: {
+          Authorization: `Bearer ${await createTestJWT({ sub: "user-1" })}`,
+        },
+        body: JSON.stringify({ paper_id: "p1" }),
+      },
+      env,
+    );
+    expect(res.status).toBe(500);
+  });
+
+  it("DELETE /api/collections/:id/papers/:paperId returns 404 when collection not found", async () => {
+    queueSelectResponses([{ getResult: null }]);
+    const app = await createTestApp();
+    const env = createTestEnv();
+    const res = await app.request(
+      "http://localhost/api/collections/c1/papers/p1",
+      {
+        method: "DELETE",
+        headers: {
+          Authorization: `Bearer ${await createTestJWT({ sub: "user-1" })}`,
+        },
+      },
+      env,
+    );
+    expect(res.status).toBe(404);
+    expect(await res.json()).toEqual({ error: "Collection not found" });
+  });
+
+  it("DELETE /api/collections/:id/papers/:paperId returns 403 when forbidden", async () => {
+    queueSelectResponses([
+      { getResult: { id: "c1", ownerType: "user", ownerId: "user2" } },
+    ]);
+    const app = await createTestApp();
+    const env = createTestEnv();
+    const res = await app.request(
+      "http://localhost/api/collections/c1/papers/p1",
+      {
+        method: "DELETE",
+        headers: {
+          Authorization: `Bearer ${await createTestJWT({ sub: "user-1" })}`,
+        },
+      },
+      env,
+    );
+    expect(res.status).toBe(403);
+    expect(await res.json()).toEqual({ error: "Forbidden" });
+  });
+
+  it("DELETE /api/collections/:id/papers/:paperId returns 404 when paper is not in collection", async () => {
+    queueSelectResponses([
+      { getResult: { id: "c1", ownerType: "user", ownerId: "user-1" } },
+    ]);
+    mockDb.delete = vi.fn().mockReturnValue({
+      where: vi.fn().mockResolvedValue({ meta: { changes: 0 } }),
+    });
+    const app = await createTestApp();
+    const env = createTestEnv();
+    const res = await app.request(
+      "http://localhost/api/collections/c1/papers/p1",
+      {
+        method: "DELETE",
+        headers: {
+          Authorization: `Bearer ${await createTestJWT({ sub: "user-1" })}`,
+        },
+      },
+      env,
+    );
+    expect(res.status).toBe(404);
+    expect(await res.json()).toEqual({ error: "Paper not in collection" });
+  });
+
+  it("PATCH /api/collections/:id/papers returns 404 when collection not found", async () => {
+    queueSelectResponses([{ getResult: null }]);
+    const app = await createTestApp();
+    const env = createTestEnv();
+    const res = await app.request(
+      "http://localhost/api/collections/c1/papers",
+      {
+        method: "PATCH",
+        headers: {
+          Authorization: `Bearer ${await createTestJWT({ sub: "user-1" })}`,
+        },
+        body: JSON.stringify({ paper_ids: ["p1"] }),
+      },
+      env,
+    );
+    expect(res.status).toBe(404);
+    expect(await res.json()).toEqual({ error: "Collection not found" });
+  });
+
+  it("PATCH /api/collections/:id/papers returns 403 when forbidden", async () => {
+    queueSelectResponses([
+      { getResult: { id: "c1", ownerType: "user", ownerId: "user2" } },
+    ]);
+    const app = await createTestApp();
+    const env = createTestEnv();
+    const res = await app.request(
+      "http://localhost/api/collections/c1/papers",
+      {
+        method: "PATCH",
+        headers: {
+          Authorization: `Bearer ${await createTestJWT({ sub: "user-1" })}`,
+        },
+        body: JSON.stringify({ paper_ids: ["p1"] }),
+      },
+      env,
+    );
+    expect(res.status).toBe(403);
+    expect(await res.json()).toEqual({ error: "Forbidden" });
+  });
+
+  it("PATCH /api/collections/:id/papers returns 400 when paper not in collection", async () => {
+    queueSelectResponses([
+      { getResult: { id: "c1", ownerType: "user", ownerId: "user-1" } },
+      { allResult: [{ paperId: "p1" }] },
+    ]);
+    const app = await createTestApp();
+    const env = createTestEnv();
+    const res = await app.request(
+      "http://localhost/api/collections/c1/papers",
+      {
+        method: "PATCH",
+        headers: {
+          Authorization: `Bearer ${await createTestJWT({ sub: "user-1" })}`,
+        },
+        body: JSON.stringify({ paper_ids: ["p2"] }),
+      },
+      env,
+    );
+    expect(res.status).toBe(400);
+    expect(await res.json()).toEqual({
+      error: "paper_ids contains paper not in collection",
+    });
+  });
+
+  it("PATCH /api/collections/:id/papers updates sort order successfully via batch", async () => {
+    queueSelectResponses([
+      { getResult: { id: "c1", ownerType: "user", ownerId: "user-1" } },
+      { allResult: [{ paperId: "p1" }, { paperId: "p2" }] },
+    ]);
+    mockDb.batch = vi.fn().mockResolvedValue([]);
+    mockDb.update = vi
+      .fn()
+      .mockImplementation(() => ({
+        set: vi
+          .fn()
+          .mockImplementation(() => ({
+            where: vi.fn().mockImplementation(() => "UPDATE_STATEMENT"),
+          })),
+      }));
+    const app = await createTestApp();
+    const env = createTestEnv();
+    const res = await app.request(
+      "http://localhost/api/collections/c1/papers",
+      {
+        method: "PATCH",
+        headers: {
+          Authorization: `Bearer ${await createTestJWT({ sub: "user-1" })}`,
+        },
+        body: JSON.stringify({ paper_ids: ["p2", "p1"] }),
+      },
+      env,
+    );
+    expect(res.status).toBe(200);
+    expect(await res.json()).toEqual({ ok: true });
+    expect(mockDb.batch).toHaveBeenCalled();
+  });
+
+  it("GET /api/collections/:id/papers returns only user authored papers when some are restricted", async () => {
+    queueSelectResponses([
+      {
+        getResult: {
+          id: "c1",
+          visibility: "public",
+          ownerType: "user",
+          ownerId: "u1",
+        },
+      },
+      {
+        allResult: [
+          { id: "p1", visibility: "private" },
+          { id: "p2", visibility: "public" },
+        ],
+      },
+      { allResult: [{ paperId: "p1" }] },
+    ]);
+    const app = await createTestApp();
+    const env = createTestEnv();
+    const res = await app.request(
+      "http://localhost/api/collections/c1/papers",
+      {
+        method: "GET",
+        headers: {
+          Authorization: `Bearer ${await createTestJWT({ sub: "user-1" })}`,
+        },
+      },
+      env,
+    );
+    expect(res.status).toBe(200);
+    const data = (await res.json()) as { papers: Array<{ id: string }> };
+    expect(data.papers.length).toBe(2);
+    const ids = data.papers.map((p) => p.id);
+    expect(ids).toContain("p1");
+    expect(ids).toContain("p2");
+  });
+
+  it("GET /api/collections/:id/papers handles org_only visibility papers via membership", async () => {
+    queueSelectResponses([
+      {
+        getResult: {
+          id: "c1",
+          visibility: "public",
+          ownerType: "user",
+          ownerId: "u1",
+        },
+      },
+      { allResult: [{ id: "p1", visibility: "org_only" }] },
+      { allResult: [] },
+      { allResult: [{ paperId: "p1" }] },
+    ]);
+    const app = await createTestApp();
+    const env = createTestEnv();
+    const res = await app.request(
+      "http://localhost/api/collections/c1/papers",
+      {
+        method: "GET",
+        headers: {
+          Authorization: `Bearer ${await createTestJWT({ sub: "user-1" })}`,
+        },
+      },
+      env,
+    );
+    expect(res.status).toBe(200);
+    const data = (await res.json()) as { papers: Array<{ id: string }> };
+    expect(data.papers.length).toBe(1);
+    expect(data.papers[0].id).toBe("p1");
+  });
+
+  it("GET /api/collections/:id/papers filters out private papers for authenticated users who don't have access", async () => {
+    queueSelectResponses([
+      {
+        getResult: {
+          id: "c1",
+          visibility: "public",
+          ownerType: "user",
+          ownerId: "u1",
+        },
+      },
+      {
+        allResult: [
+          { id: "p1", visibility: "private" },
+          { id: "p2", visibility: "public" },
+        ],
+      },
+      { allResult: [] },
+    ]);
+    const app = await createTestApp();
+    const env = createTestEnv();
+    const res = await app.request(
+      "http://localhost/api/collections/c1/papers",
+      {
+        method: "GET",
+        headers: {
+          Authorization: `Bearer ${await createTestJWT({ sub: "user-1" })}`,
+        },
+      },
+      env,
+    );
+    expect(res.status).toBe(200);
+    const data = (await res.json()) as { papers: Array<{ id: string }> };
+    expect(data.papers.length).toBe(1);
+    expect(data.papers[0].id).toBe("p2");
+  });
+
+  it("PATCH /api/collections/:id/papers rejects paper_ids with empty strings or non-strings", async () => {
+    queueSelectResponses([
+      { getResult: { id: "c1", ownerType: "user", ownerId: "user-1" } },
+    ]);
+    const app = await createTestApp();
+    const env = createTestEnv();
+    const res = await app.request(
+      "http://localhost/api/collections/c1/papers",
+      {
+        method: "PATCH",
+        headers: {
+          Authorization: `Bearer ${await createTestJWT({ sub: "user-1" })}`,
+        },
+        body: JSON.stringify({ paper_ids: ["p1", "  ", 123] }),
+      },
+      env,
+    );
+    expect(res.status).toBe(400);
+    expect(await res.json()).toEqual({
+      error: "paper_ids must be an array of valid strings",
+    });
+  });
+  it("POST /api/collections/:id/papers adds a visible paper with the next sort order", async () => {
+    const token = await createTestJWT({ sub: "user-1" });
+    const collection = {
+      id: "col-1",
+      ownerType: "user",
+      ownerId: "user-1",
+      visibility: "private",
+    };
+    queueSelectResponses([
+      { getResult: collection },
+      { getResult: { id: "paper-1", visibility: "private" } },
+      { getResult: { paperId: "paper-1" } },
+      { getResult: { maxOrder: 2 } },
+    ]);
+
+    const insertValues = vi.fn(async () => undefined);
+    mockDb.insert = vi.fn(() => ({ values: insertValues }));
+
+    const app = await createTestApp();
+    const env = createTestEnv();
+
+    const res = await app.request(
+      "http://localhost/api/collections/col-1/papers",
+      {
+        method: "POST",
+        headers: {
+          Authorization: `Bearer ${token}`,
+          "Content-Type": "application/json",
+        },
+        body: JSON.stringify({ paper_id: "paper-1" }),
+      },
+      env as any,
+    );
+
+    expect(res.status).toBe(201);
+    expect(insertValues).toHaveBeenCalledWith({
+      collectionId: "col-1",
+      paperId: "paper-1",
+      sortOrder: 3,
+    });
+  });
+
+  it("POST /api/collections/:id/papers adds a paper the manager can view via org membership", async () => {
+    const token = await createTestJWT({ sub: "user-1" });
+    const collection = {
+      id: "col-1",
+      ownerType: "user",
+      ownerId: "user-1",
+      visibility: "private",
+    };
+    queueSelectResponses([
+      { getResult: collection }, // Collection query
+      { getResult: { id: "paper-1", visibility: "org_only" } }, // Paper query
+      { getResult: null }, // isPaperAuthor returns false
+      { getResult: { id: "user-1" } }, // isMemberOfPaperOrg returns true
+      { getResult: { maxOrder: 2 } }, // maxOrder query
+    ]);
+
+    const insertValues = vi.fn(async () => undefined);
+    mockDb.insert = vi.fn(() => ({ values: insertValues }));
+
+    const app = await createTestApp();
+    const env = createTestEnv();
+
+    const res = await app.request(
+      "http://localhost/api/collections/col-1/papers",
+      {
+        method: "POST",
+        headers: {
+          Authorization: `Bearer ${token}`,
+          "Content-Type": "application/json",
+        },
+        body: JSON.stringify({ paper_id: "paper-1" }),
+      },
+      env as any,
+    );
+
+    expect(res.status).toBe(201);
+    expect(insertValues).toHaveBeenCalledWith({
+      collectionId: "col-1",
+      paperId: "paper-1",
+      sortOrder: 3,
+    });
+  });
+
+  it("POST /api/collections/:id/papers adds a public paper without specific membership", async () => {
+    const token = await createTestJWT({ sub: "user-1" });
+    const collection = {
+      id: "col-1",
+      ownerType: "user",
+      ownerId: "user-1",
+      visibility: "private",
+    };
+    queueSelectResponses([
+      { getResult: collection }, // Collection query
+      { getResult: { id: "paper-1", visibility: "public" } }, // Paper query
+      { getResult: { maxOrder: 2 } }, // maxOrder query
+    ]);
+
+    const insertValues = vi.fn(async () => undefined);
+    mockDb.insert = vi.fn(() => ({ values: insertValues }));
+
+    const app = await createTestApp();
+    const env = createTestEnv();
+
+    const res = await app.request(
+      "http://localhost/api/collections/col-1/papers",
+      {
+        method: "POST",
+        headers: {
+          Authorization: `Bearer ${token}`,
+          "Content-Type": "application/json",
+        },
+        body: JSON.stringify({ paper_id: "paper-1" }),
+      },
+      env as any,
+    );
+
+    expect(res.status).toBe(201);
+    expect(insertValues).toHaveBeenCalledWith({
+      collectionId: "col-1",
+      paperId: "paper-1",
+      sortOrder: 3,
+    });
+  });
+
+  it("POST /api/collections/:id/papers rejects papers the manager cannot view", async () => {
+    const token = await createTestJWT({ sub: "user-1" });
+    queueSelectResponses([
+      {
+        getResult: {
+          id: "col-1",
+          ownerType: "user",
+          ownerId: "user-1",
+          visibility: "private",
+        },
+      },
+      { getResult: { id: "paper-1", visibility: "private" } },
+      { getResult: null },
+    ]);
+
+    const app = await createTestApp();
+    const env = createTestEnv();
+
+    const res = await app.request(
+      "http://localhost/api/collections/col-1/papers",
+      {
+        method: "POST",
+        headers: {
+          Authorization: `Bearer ${token}`,
+          "Content-Type": "application/json",
+        },
+        body: JSON.stringify({ paper_id: "paper-1" }),
+      },
+      env as any,
+    );
+
+    expect(res.status).toBe(404);
+    expect(((await res.json()) as any).error).toBe("Paper not found");
+  });
+
+  it("PATCH /api/collections/:id/papers rejects invalid JSON body", async () => {
+    const token = await createTestJWT({ sub: "user-1" });
+    queueSelectResponses([
+      {
+        getResult: {
+          id: "col-1",
+          ownerType: "user",
+          ownerId: "user-1",
+          visibility: "private",
+        },
+      },
+    ]);
+
+    const app = await createTestApp();
+    const env = createTestEnv();
+
+    const res = await app.request(
+      "http://localhost/api/collections/col-1/papers",
+      {
+        method: "PATCH",
+        headers: {
+          Authorization: `Bearer ${token}`,
+          "Content-Type": "application/json",
+        },
+        body: "invalid-json",
+      },
+      env as any,
+    );
+
+    expect(res.status).toBe(400);
+    await expect(res.json()).resolves.toEqual({ error: "Invalid JSON body" });
+  });
+
+  it("PATCH /api/collections/:id/papers rejects duplicate paper IDs", async () => {
+    const token = await createTestJWT({ sub: "user-1" });
+    queueSelectResponses([
+      {
+        getResult: {
+          id: "col-1",
+          ownerType: "user",
+          ownerId: "user-1",
+          visibility: "private",
+        },
+      },
+      {
+        allResult: [{ paperId: "paper-1" }, { paperId: "paper-2" }],
+      },
+    ]);
+
+    const app = await createTestApp();
+    const env = createTestEnv();
+
+    const res = await app.request(
+      "http://localhost/api/collections/col-1/papers",
+      {
+        method: "PATCH",
+        headers: {
+          Authorization: `Bearer ${token}`,
+          "Content-Type": "application/json",
+        },
+        body: JSON.stringify({ paper_ids: ["paper-1", "paper-1"] }),
+      },
+      env as any,
+    );
+
+    expect(res.status).toBe(400);
+    expect(((await res.json()) as any).error).toBe(
+      "paper_ids must not contain duplicates",
+    );
+  });
+
+  it("PATCH /api/collections/:id/papers requires every existing paper to be included", async () => {
+    const token = await createTestJWT({ sub: "user-1" });
+    queueSelectResponses([
+      {
+        getResult: {
+          id: "col-1",
+          ownerType: "user",
+          ownerId: "user-1",
+          visibility: "private",
+        },
+      },
+      {
+        allResult: [{ paperId: "paper-1" }, { paperId: "paper-2" }],
+      },
+    ]);
+
+    const app = await createTestApp();
+    const env = createTestEnv();
+
+    const res = await app.request(
+      "http://localhost/api/collections/col-1/papers",
+      {
+        method: "PATCH",
+        headers: {
+          Authorization: `Bearer ${token}`,
+          "Content-Type": "application/json",
+        },
+        body: JSON.stringify({ paper_ids: ["paper-1"] }),
+      },
+      env as any,
+    );
+
+    expect(res.status).toBe(400);
+    expect(((await res.json()) as any).error).toBe(
+      "paper_ids must include all papers in collection",
+    );
+  });
+
+  it("DELETE /api/collections/:id/papers/:paperId returns 404 when the paper is not in the collection", async () => {
+    const token = await createTestJWT({ sub: "user-1" });
+    queueSelectResponses([
+      {
+        getResult: {
+          id: "col-1",
+          ownerType: "user",
+          ownerId: "user-1",
+          visibility: "private",
+        },
+      },
+    ]);
+
+    mockDb.delete = vi.fn(() => ({
+      where: vi.fn(async () => ({ meta: { changes: 0 } })),
+    }));
+
+    const app = await createTestApp();
+    const env = createTestEnv();
+
+    const res = await app.request(
+      "http://localhost/api/collections/col-1/papers/paper-1",
+      {
+        method: "DELETE",
+        headers: { Authorization: `Bearer ${token}` },
+      },
+      env as any,
+    );
+
+    expect(res.status).toBe(404);
+    expect(((await res.json()) as any).error).toBe("Paper not in collection");
+  });
+
+  it("GET /api/collections/:id/papers filters restricted papers by authorship and org access", async () => {
+    const token = await createTestJWT({ sub: "user-1" });
+    queueSelectResponses([
+      {
+        getResult: {
+          id: "col-1",
+          ownerType: "org",
+          ownerId: "org-1",
+          visibility: "public",
+        },
+      },
+      {
+        allResult: [
+          {
+            id: "paper-public",
+            title: "Public",
+            visibility: "public",
+            sortOrder: 0,
+          },
+          {
+            id: "paper-authored",
+            title: "Mine",
+            visibility: "private",
+            sortOrder: 1,
+          },
+          {
+            id: "paper-org",
+            title: "Org only",
+            visibility: "org_only",
+            sortOrder: 2,
+          },
+          {
+            id: "paper-hidden",
+            title: "Hidden",
+            visibility: "private",
             sortOrder: 3,
-        });
-    });
+          },
+        ],
+      },
+      { allResult: [{ paperId: "paper-authored" }] },
+      { allResult: [{ paperId: "paper-org" }] },
+    ]);
 
+    const app = await createTestApp();
+    const env = createTestEnv();
 
+    const res = await app.request(
+      "http://localhost/api/collections/col-1/papers",
+      {
+        headers: { Authorization: `Bearer ${token}` },
+      },
+      env as any,
+    );
 
-    it("POST /api/collections/:id/papers adds a paper the manager can view via org membership", async () => {
-        const token = await createTestJWT({ sub: "user-1" });
-        const collection = {
-            id: "col-1",
-            ownerType: "user",
-            ownerId: "user-1",
-            visibility: "private",
-        };
-        queueSelectResponses([
-            { getResult: collection }, // Collection query
-            { getResult: { id: "paper-1", visibility: "org_only" } }, // Paper query
-            { getResult: null }, // isPaperAuthor returns false
-            { getResult: { id: "user-1" } }, // isMemberOfPaperOrg returns true
-            { getResult: { maxOrder: 2 } }, // maxOrder query
-        ]);
+    expect(res.status).toBe(200);
+    expect(
+      ((await res.json()) as any).papers.map((paper: any) => paper.id),
+    ).toEqual(["paper-public", "paper-authored", "paper-org"]);
+  });
 
-        const insertValues = vi.fn(async () => undefined);
-        mockDb.insert = vi.fn(() => ({ values: insertValues }));
+  it("POST /api/collections/:id/papers returns 409 when paper is already in collection", async () => {
+    const token = await createTestJWT({ sub: "user-1" });
+    const collection = {
+      id: "col-1",
+      ownerType: "user",
+      ownerId: "user-1",
+      visibility: "private",
+    };
+    queueSelectResponses([
+      { getResult: collection }, // Collection query
+      { getResult: { id: "paper-1", visibility: "public" } }, // Paper query
+      { getResult: { maxOrder: 2 } }, // maxOrder query
+    ]);
 
-        const app = await createTestApp();
-        const env = createTestEnv();
+    mockDb.insert = vi.fn(() => ({
+      values: vi
+        .fn()
+        .mockRejectedValue(
+          new Error(
+            "UNIQUE constraint failed: collection_papers.collection_id, collection_papers.paper_id",
+          ),
+        ),
+    }));
 
-        const res = await app.request(
-            "http://localhost/api/collections/col-1/papers",
-            {
-                method: "POST",
-                headers: {
-                    Authorization: `Bearer ${token}`,
-                    "Content-Type": "application/json",
-                },
-                body: JSON.stringify({ paper_id: "paper-1" }),
-            },
-            env as any,
-        );
+    const app = await createTestApp();
+    const env = createTestEnv();
 
-        expect(res.status).toBe(201);
-        expect(insertValues).toHaveBeenCalledWith({
-            collectionId: "col-1",
-            paperId: "paper-1",
-            sortOrder: 3,
-        });
-    });
+    const res = await app.request(
+      "http://localhost/api/collections/col-1/papers",
+      {
+        method: "POST",
+        headers: {
+          Authorization: `Bearer ${token}`,
+          "Content-Type": "application/json",
+        },
+        body: JSON.stringify({ paper_id: "paper-1" }),
+      },
+      env as any,
+    );
 
-    it("POST /api/collections/:id/papers adds a public paper without specific membership", async () => {
-        const token = await createTestJWT({ sub: "user-1" });
-        const collection = {
-            id: "col-1",
-            ownerType: "user",
-            ownerId: "user-1",
-            visibility: "private",
-        };
-        queueSelectResponses([
-            { getResult: collection }, // Collection query
-            { getResult: { id: "paper-1", visibility: "public" } }, // Paper query
-            { getResult: { maxOrder: 2 } }, // maxOrder query
-        ]);
-
-        const insertValues = vi.fn(async () => undefined);
-        mockDb.insert = vi.fn(() => ({ values: insertValues }));
-
-        const app = await createTestApp();
-        const env = createTestEnv();
-
-        const res = await app.request(
-            "http://localhost/api/collections/col-1/papers",
-            {
-                method: "POST",
-                headers: {
-                    Authorization: `Bearer ${token}`,
-                    "Content-Type": "application/json",
-                },
-                body: JSON.stringify({ paper_id: "paper-1" }),
-            },
-            env as any,
-        );
-
-        expect(res.status).toBe(201);
-        expect(insertValues).toHaveBeenCalledWith({
-            collectionId: "col-1",
-            paperId: "paper-1",
-            sortOrder: 3,
-        });
-    });
-
-    it("POST /api/collections/:id/papers rejects papers the manager cannot view", async () => {
-        const token = await createTestJWT({ sub: "user-1" });
-        queueSelectResponses([
-            {
-                getResult: {
-                    id: "col-1",
-                    ownerType: "user",
-                    ownerId: "user-1",
-                    visibility: "private",
-                },
-            },
-            { getResult: { id: "paper-1", visibility: "private" } },
-            { getResult: null },
-        ]);
-
-        const app = await createTestApp();
-        const env = createTestEnv();
-
-        const res = await app.request(
-            "http://localhost/api/collections/col-1/papers",
-            {
-                method: "POST",
-                headers: {
-                    Authorization: `Bearer ${token}`,
-                    "Content-Type": "application/json",
-                },
-                body: JSON.stringify({ paper_id: "paper-1" }),
-            },
-            env as any,
-        );
-
-        expect(res.status).toBe(404);
-        expect(((await res.json()) as any).error).toBe("Paper not found");
-    });
-
-
-    it("PATCH /api/collections/:id/papers rejects invalid JSON body", async () => {
-        const token = await createTestJWT({ sub: "user-1" });
-        queueSelectResponses([
-            {
-                getResult: {
-                    id: "col-1",
-                    ownerType: "user",
-                    ownerId: "user-1",
-                    visibility: "private",
-                },
-            },
-        ]);
-
-        const app = await createTestApp();
-        const env = createTestEnv();
-
-        const res = await app.request(
-            "http://localhost/api/collections/col-1/papers",
-            {
-                method: "PATCH",
-                headers: {
-                    Authorization: `Bearer ${token}`,
-                    "Content-Type": "application/json",
-                },
-                body: "invalid-json",
-            },
-            env as any,
-        );
-
-        expect(res.status).toBe(400);
-        await expect(res.json()).resolves.toEqual({ error: "Invalid JSON body" });
-    });
-
-    it("PATCH /api/collections/:id/papers rejects duplicate paper IDs", async () => {
-        const token = await createTestJWT({ sub: "user-1" });
-        queueSelectResponses([
-            {
-                getResult: {
-                    id: "col-1",
-                    ownerType: "user",
-                    ownerId: "user-1",
-                    visibility: "private",
-                },
-            },
-            {
-                allResult: [{ paperId: "paper-1" }, { paperId: "paper-2" }],
-            },
-        ]);
-
-        const app = await createTestApp();
-        const env = createTestEnv();
-
-        const res = await app.request(
-            "http://localhost/api/collections/col-1/papers",
-            {
-                method: "PATCH",
-                headers: {
-                    Authorization: `Bearer ${token}`,
-                    "Content-Type": "application/json",
-                },
-                body: JSON.stringify({ paper_ids: ["paper-1", "paper-1"] }),
-            },
-            env as any,
-        );
-
-        expect(res.status).toBe(400);
-        expect(((await res.json()) as any).error).toBe(
-            "paper_ids must not contain duplicates",
-        );
-    });
-
-    it("PATCH /api/collections/:id/papers requires every existing paper to be included", async () => {
-        const token = await createTestJWT({ sub: "user-1" });
-        queueSelectResponses([
-            {
-                getResult: {
-                    id: "col-1",
-                    ownerType: "user",
-                    ownerId: "user-1",
-                    visibility: "private",
-                },
-            },
-            {
-                allResult: [{ paperId: "paper-1" }, { paperId: "paper-2" }],
-            },
-        ]);
-
-        const app = await createTestApp();
-        const env = createTestEnv();
-
-        const res = await app.request(
-            "http://localhost/api/collections/col-1/papers",
-            {
-                method: "PATCH",
-                headers: {
-                    Authorization: `Bearer ${token}`,
-                    "Content-Type": "application/json",
-                },
-                body: JSON.stringify({ paper_ids: ["paper-1"] }),
-            },
-            env as any,
-        );
-
-        expect(res.status).toBe(400);
-        expect(((await res.json()) as any).error).toBe(
-            "paper_ids must include all papers in collection",
-        );
-    });
-
-    it("DELETE /api/collections/:id/papers/:paperId returns 404 when the paper is not in the collection", async () => {
-        const token = await createTestJWT({ sub: "user-1" });
-        queueSelectResponses([
-            {
-                getResult: {
-                    id: "col-1",
-                    ownerType: "user",
-                    ownerId: "user-1",
-                    visibility: "private",
-                },
-            },
-        ]);
-
-        mockDb.delete = vi.fn(() => ({
-            where: vi.fn(async () => ({ meta: { changes: 0 } })),
-        }));
-
-        const app = await createTestApp();
-        const env = createTestEnv();
-
-        const res = await app.request(
-            "http://localhost/api/collections/col-1/papers/paper-1",
-            {
-                method: "DELETE",
-                headers: { Authorization: `Bearer ${token}` },
-            },
-            env as any,
-        );
-
-        expect(res.status).toBe(404);
-        expect(((await res.json()) as any).error).toBe("Paper not in collection");
-    });
-
-    it("GET /api/collections/:id/papers filters restricted papers by authorship and org access", async () => {
-        const token = await createTestJWT({ sub: "user-1" });
-        queueSelectResponses([
-            {
-                getResult: {
-                    id: "col-1",
-                    ownerType: "org",
-                    ownerId: "org-1",
-                    visibility: "public",
-                },
-            },
-            {
-                allResult: [
-                    { id: "paper-public", title: "Public", visibility: "public", sortOrder: 0 },
-                    { id: "paper-authored", title: "Mine", visibility: "private", sortOrder: 1 },
-                    { id: "paper-org", title: "Org only", visibility: "org_only", sortOrder: 2 },
-                    { id: "paper-hidden", title: "Hidden", visibility: "private", sortOrder: 3 },
-                ],
-            },
-            { allResult: [{ paperId: "paper-authored" }] },
-            { allResult: [{ paperId: "paper-org" }] },
-        ]);
-
-        const app = await createTestApp();
-        const env = createTestEnv();
-
-        const res = await app.request(
-            "http://localhost/api/collections/col-1/papers",
-            {
-                headers: { Authorization: `Bearer ${token}` },
-            },
-            env as any,
-        );
-
-        expect(res.status).toBe(200);
-        expect(((await res.json()) as any).papers.map((paper: any) => paper.id)).toEqual([
-            "paper-public",
-            "paper-authored",
-            "paper-org",
-        ]);
-    });
-
-    it("POST /api/collections/:id/papers returns 409 when paper is already in collection", async () => {
-        const token = await createTestJWT({ sub: "user-1" });
-        const collection = {
-            id: "col-1",
-            ownerType: "user",
-            ownerId: "user-1",
-            visibility: "private",
-        };
-        queueSelectResponses([
-            { getResult: collection }, // Collection query
-            { getResult: { id: "paper-1", visibility: "public" } }, // Paper query
-            { getResult: { maxOrder: 2 } }, // maxOrder query
-        ]);
-
-        mockDb.insert = vi.fn(() => ({
-            values: vi.fn().mockRejectedValue(new Error("UNIQUE constraint failed: collection_papers.collection_id, collection_papers.paper_id")),
-        }));
-
-        const app = await createTestApp();
-        const env = createTestEnv();
-
-        const res = await app.request(
-            "http://localhost/api/collections/col-1/papers",
-            {
-                method: "POST",
-                headers: {
-                    Authorization: `Bearer ${token}`,
-                    "Content-Type": "application/json",
-                },
-                body: JSON.stringify({ paper_id: "paper-1" }),
-            },
-            env as any,
-        );
-
-        expect(res.status).toBe(409);
-        expect(((await res.json()) as any).error).toBe("Paper already added");
-    });
+    expect(res.status).toBe(409);
+    expect(((await res.json()) as any).error).toBe("Paper already added");
+  });
 });

--- a/apps/api/src/routes/__tests__/cors.test.ts
+++ b/apps/api/src/routes/__tests__/cors.test.ts
@@ -4,206 +4,246 @@ import { createTestApp, createTestEnv, makeQuery } from "../../test/helpers";
 let mockDb: any;
 
 vi.mock("drizzle-orm/d1", () => ({
-    drizzle: vi.fn(() => mockDb)
+  drizzle: vi.fn(() => mockDb),
 }));
 
 // test-auth router is loaded via createTestApp() and imports db/schema;
 // we mock schema here so dynamic import paths resolve consistently in this suite.
 vi.mock("../../db/schema", () => ({
-    users: { id: "id", githubId: "github_id" },
-    orgs: { id: "id" },
-    orgMembers: { orgId: "org_id" },
-    papers: {
-        id: "id",
-        title: "title",
-        abstract: "abstract",
-        category: "category",
-        tags: "tags",
-        createdAt: "created_at",
-        updatedAt: "updated_at",
-        visibility: "visibility",
-    },
-    paperAuthors: {
-        paperId: "paper_id",
-        role: "role",
-        name: "name",
-        displayName: "display_name",
-        userId: "user_id",
-    },
-    paperFiles: {
-        paperId: "paper_id",
-        id: "id",
-        filename: "filename",
-        sizeBytes: "size_bytes",
-        mimeType: "mime_type",
-        fileType: "file_type",
-        createdAt: "created_at",
-    },
-    paperOrgs: { paperId: "paper_id", orgId: "org_id" },
-    collections: {
-        id: "id",
-        ownerType: "owner_type",
-        ownerId: "owner_id",
-        orgSlug: "org_slug",
-        slug: "slug",
-        name: "name",
-        visibility: "visibility",
-        updatedAt: "updated_at",
-    },
-    collectionPapers: {
-        collectionId: "collection_id",
-        paperId: "paper_id",
-        sortOrder: "sort_order",
-    },
-    enableForeignKeys: vi.fn(() => Promise.resolve()),
-    touchUpdatedAt: vi.fn(() => ({})),
+  users: { id: "id", githubId: "github_id" },
+  orgs: { id: "id" },
+  orgMembers: { orgId: "org_id" },
+  papers: {
+    id: "id",
+    title: "title",
+    abstract: "abstract",
+    category: "category",
+    tags: "tags",
+    createdAt: "created_at",
+    updatedAt: "updated_at",
+    visibility: "visibility",
+  },
+  paperAuthors: {
+    paperId: "paper_id",
+    role: "role",
+    name: "name",
+    displayName: "display_name",
+    userId: "user_id",
+  },
+  paperFiles: {
+    paperId: "paper_id",
+    id: "id",
+    filename: "filename",
+    sizeBytes: "size_bytes",
+    mimeType: "mime_type",
+    fileType: "file_type",
+    createdAt: "created_at",
+  },
+  paperOrgs: { paperId: "paper_id", orgId: "org_id" },
+  collections: {
+    id: "id",
+    ownerType: "owner_type",
+    ownerId: "owner_id",
+    orgSlug: "org_slug",
+    slug: "slug",
+    name: "name",
+    visibility: "visibility",
+    updatedAt: "updated_at",
+  },
+  collectionPapers: {
+    collectionId: "collection_id",
+    paperId: "paper_id",
+    sortOrder: "sort_order",
+  },
+  enableForeignKeys: vi.fn(() => Promise.resolve()),
+  touchUpdatedAt: vi.fn(() => ({})),
 }));
 
 describe("CORS configuration", () => {
-    beforeEach(() => {
-        vi.restoreAllMocks();
-        vi.resetModules();
-        mockDb = {
-            run: vi.fn(async () => undefined),
-            select: vi.fn(() => makeQuery()),
-            insert: vi.fn(() => ({
-                values: vi.fn(() => ({ onConflictDoUpdate: vi.fn(async () => undefined) }))
-            }))
-        };
+  beforeEach(() => {
+    vi.restoreAllMocks();
+    vi.resetModules();
+    mockDb = {
+      run: vi.fn(async () => undefined),
+      select: vi.fn(() => makeQuery()),
+      insert: vi.fn(() => ({
+        values: vi.fn(() => ({
+          onConflictDoUpdate: vi.fn(async () => undefined),
+        })),
+      })),
+    };
+  });
+
+  it("uses FRONTEND_URL as fallback when ALLOWED_ORIGINS is not set", async () => {
+    const app = await createTestApp();
+    const env = createTestEnv({
+      DB: {
+        prepare: vi.fn(() => ({
+          run: vi.fn(),
+          bind: vi.fn(() => ({ run: vi.fn(), first: vi.fn(() => null) })),
+        })),
+      },
+      FRONTEND_URL: "https://frontend.example.com",
+      ALLOWED_ORIGINS: undefined,
     });
 
-    it("uses FRONTEND_URL as fallback when ALLOWED_ORIGINS is not set", async () => {
-        const app = await createTestApp();
-        const env = createTestEnv({
-            DB: { prepare: vi.fn(() => ({ run: vi.fn(), bind: vi.fn(() => ({ run: vi.fn(), first: vi.fn(() => null) })) })) },
-            FRONTEND_URL: "https://frontend.example.com",
-            ALLOWED_ORIGINS: undefined
-        });
+    const res = await app.request(
+      "http://localhost/api/auth/github",
+      {
+        headers: {
+          Origin: "https://frontend.example.com",
+        },
+      },
+      env as any,
+    );
 
-        const res = await app.request(
-            "http://localhost/api/auth/github",
-            {
-                headers: {
-                    Origin: "https://frontend.example.com"
-                }
-            },
-            env as any
-        );
+    expect(res.headers.get("access-control-allow-origin")).toBe(
+      "https://frontend.example.com",
+    );
+  });
 
-        expect(res.headers.get("access-control-allow-origin")).toBe("https://frontend.example.com");
+  it("allows only origins listed in ALLOWED_ORIGINS", async () => {
+    const app = await createTestApp();
+    const env = createTestEnv({
+      DB: {
+        prepare: vi.fn(() => ({
+          run: vi.fn(),
+          bind: vi.fn(() => ({ run: vi.fn(), first: vi.fn(() => null) })),
+        })),
+      },
+      FRONTEND_URL: "https://frontend.example.com",
+      ALLOWED_ORIGINS: "https://frontend.example.com,http://localhost:3000",
     });
 
-    it("allows only origins listed in ALLOWED_ORIGINS", async () => {
-        const app = await createTestApp();
-        const env = createTestEnv({
-            DB: { prepare: vi.fn(() => ({ run: vi.fn(), bind: vi.fn(() => ({ run: vi.fn(), first: vi.fn(() => null) })) })) },
-            FRONTEND_URL: "https://frontend.example.com",
-            ALLOWED_ORIGINS: "https://frontend.example.com,http://localhost:3000"
-        });
+    const allowedRes = await app.request(
+      "http://localhost/api/auth/github",
+      {
+        headers: {
+          Origin: "http://localhost:3000",
+        },
+      },
+      env as any,
+    );
 
-        const allowedRes = await app.request(
-            "http://localhost/api/auth/github",
-            {
-                headers: {
-                    Origin: "http://localhost:3000"
-                }
-            },
-            env as any
-        );
+    expect(allowedRes.headers.get("access-control-allow-origin")).toBe(
+      "http://localhost:3000",
+    );
+  });
 
-        expect(allowedRes.headers.get("access-control-allow-origin")).toBe("http://localhost:3000");
+  it("blocks origins not listed in ALLOWED_ORIGINS", async () => {
+    const app = await createTestApp();
+    const env = createTestEnv({
+      DB: {
+        prepare: vi.fn(() => ({
+          run: vi.fn(),
+          bind: vi.fn(() => ({ run: vi.fn(), first: vi.fn(() => null) })),
+        })),
+      },
+      FRONTEND_URL: "https://frontend.example.com",
+      ALLOWED_ORIGINS: "https://frontend.example.com,http://localhost:3000",
     });
 
-    it("blocks origins not listed in ALLOWED_ORIGINS", async () => {
-        const app = await createTestApp();
-        const env = createTestEnv({
-            DB: { prepare: vi.fn(() => ({ run: vi.fn(), bind: vi.fn(() => ({ run: vi.fn(), first: vi.fn(() => null) })) })) },
-            FRONTEND_URL: "https://frontend.example.com",
-            ALLOWED_ORIGINS: "https://frontend.example.com,http://localhost:3000"
-        });
+    const blockedRes = await app.request(
+      "http://localhost/api/auth/github",
+      {
+        headers: {
+          Origin: "https://evil.example.com",
+        },
+      },
+      env as any,
+    );
 
-        const blockedRes = await app.request(
-            "http://localhost/api/auth/github",
-            {
-                headers: {
-                    Origin: "https://evil.example.com"
-                }
-            },
-            env as any
-        );
-
-        expect(blockedRes.headers.get("access-control-allow-origin")).toBeNull();
-    });
-    it("handles OPTIONS preflight with FRONTEND_URL fallback", async () => {
-        const app = await createTestApp();
-        const env = createTestEnv({
-            DB: { prepare: vi.fn(() => ({ run: vi.fn(), bind: vi.fn(() => ({ run: vi.fn(), first: vi.fn(() => null) })) })) },
-            FRONTEND_URL: "https://frontend.example.com",
-            ALLOWED_ORIGINS: undefined
-        });
-
-        const res = await app.request(
-            "http://localhost/api/auth/github",
-            {
-                method: "OPTIONS",
-                headers: {
-                    Origin: "https://frontend.example.com",
-                    "Access-Control-Request-Method": "POST"
-                }
-            },
-            env as any
-        );
-
-        expect(res.headers.get("access-control-allow-origin")).toBe("https://frontend.example.com");
-        expect(res.headers.get("access-control-allow-methods")).toContain("POST");
-        expect(res.headers.get("access-control-allow-headers")).toBeTruthy();
+    expect(blockedRes.headers.get("access-control-allow-origin")).toBeNull();
+  });
+  it("handles OPTIONS preflight with FRONTEND_URL fallback", async () => {
+    const app = await createTestApp();
+    const env = createTestEnv({
+      DB: {
+        prepare: vi.fn(() => ({
+          run: vi.fn(),
+          bind: vi.fn(() => ({ run: vi.fn(), first: vi.fn(() => null) })),
+        })),
+      },
+      FRONTEND_URL: "https://frontend.example.com",
+      ALLOWED_ORIGINS: undefined,
     });
 
-    it("handles OPTIONS preflight for allowed origins in ALLOWED_ORIGINS", async () => {
-        const app = await createTestApp();
-        const env = createTestEnv({
-            DB: { prepare: vi.fn(() => ({ run: vi.fn(), bind: vi.fn(() => ({ run: vi.fn(), first: vi.fn(() => null) })) })) },
-            FRONTEND_URL: "https://frontend.example.com",
-            ALLOWED_ORIGINS: "https://frontend.example.com,http://localhost:3000"
-        });
+    const res = await app.request(
+      "http://localhost/api/auth/github",
+      {
+        method: "OPTIONS",
+        headers: {
+          Origin: "https://frontend.example.com",
+          "Access-Control-Request-Method": "POST",
+        },
+      },
+      env as any,
+    );
 
-        const res = await app.request(
-            "http://localhost/api/auth/github",
-            {
-                method: "OPTIONS",
-                headers: {
-                    Origin: "http://localhost:3000",
-                    "Access-Control-Request-Method": "POST"
-                }
-            },
-            env as any
-        );
+    expect(res.headers.get("access-control-allow-origin")).toBe(
+      "https://frontend.example.com",
+    );
+    expect(res.headers.get("access-control-allow-methods")).toContain("POST");
+    expect(res.headers.get("access-control-allow-headers")).toBeTruthy();
+  });
 
-        expect(res.headers.get("access-control-allow-origin")).toBe("http://localhost:3000");
-        expect(res.headers.get("access-control-allow-methods")).toContain("POST");
-        expect(res.headers.get("access-control-allow-headers")).toBeTruthy();
+  it("handles OPTIONS preflight for allowed origins in ALLOWED_ORIGINS", async () => {
+    const app = await createTestApp();
+    const env = createTestEnv({
+      DB: {
+        prepare: vi.fn(() => ({
+          run: vi.fn(),
+          bind: vi.fn(() => ({ run: vi.fn(), first: vi.fn(() => null) })),
+        })),
+      },
+      FRONTEND_URL: "https://frontend.example.com",
+      ALLOWED_ORIGINS: "https://frontend.example.com,http://localhost:3000",
     });
 
-    it("blocks OPTIONS preflight for origins not listed in ALLOWED_ORIGINS", async () => {
-        const app = await createTestApp();
-        const env = createTestEnv({
-            DB: { prepare: vi.fn(() => ({ run: vi.fn(), bind: vi.fn(() => ({ run: vi.fn(), first: vi.fn(() => null) })) })) },
-            FRONTEND_URL: "https://frontend.example.com",
-            ALLOWED_ORIGINS: "https://frontend.example.com,http://localhost:3000"
-        });
+    const res = await app.request(
+      "http://localhost/api/auth/github",
+      {
+        method: "OPTIONS",
+        headers: {
+          Origin: "http://localhost:3000",
+          "Access-Control-Request-Method": "POST",
+        },
+      },
+      env as any,
+    );
 
-        const res = await app.request(
-            "http://localhost/api/auth/github",
-            {
-                method: "OPTIONS",
-                headers: {
-                    Origin: "https://evil.example.com",
-                    "Access-Control-Request-Method": "POST"
-                }
-            },
-            env as any
-        );
+    expect(res.headers.get("access-control-allow-origin")).toBe(
+      "http://localhost:3000",
+    );
+    expect(res.headers.get("access-control-allow-methods")).toContain("POST");
+    expect(res.headers.get("access-control-allow-headers")).toBeTruthy();
+  });
 
-        expect(res.headers.get("access-control-allow-origin")).toBeNull();
+  it("blocks OPTIONS preflight for origins not listed in ALLOWED_ORIGINS", async () => {
+    const app = await createTestApp();
+    const env = createTestEnv({
+      DB: {
+        prepare: vi.fn(() => ({
+          run: vi.fn(),
+          bind: vi.fn(() => ({ run: vi.fn(), first: vi.fn(() => null) })),
+        })),
+      },
+      FRONTEND_URL: "https://frontend.example.com",
+      ALLOWED_ORIGINS: "https://frontend.example.com,http://localhost:3000",
     });
+
+    const res = await app.request(
+      "http://localhost/api/auth/github",
+      {
+        method: "OPTIONS",
+        headers: {
+          Origin: "https://evil.example.com",
+          "Access-Control-Request-Method": "POST",
+        },
+      },
+      env as any,
+    );
+
+    expect(res.headers.get("access-control-allow-origin")).toBeNull();
+  });
 });

--- a/apps/api/src/routes/__tests__/csrf-catch.test.ts
+++ b/apps/api/src/routes/__tests__/csrf-catch.test.ts
@@ -2,67 +2,81 @@ import { describe, expect, it, vi, beforeEach } from "vitest";
 import { createTestEnv } from "../../test/helpers";
 
 describe("CSRF configuration catch blocks", () => {
-    beforeEach(() => {
-        vi.resetModules();
+  beforeEach(() => {
+    vi.resetModules();
+  });
+
+  it("logs sanitized Error object when CSRF check throws an Error", async () => {
+    const originalConsoleError = console.error;
+    const consoleErrorMock = vi.fn();
+    console.error = consoleErrorMock;
+
+    vi.doMock("../../utils/origin", async (importOriginal) => {
+      const actual = await importOriginal<any>();
+      return {
+        ...actual,
+        isAllowedOrigin: (
+          _origin: any,
+          _frontendOrigin: any,
+          _allowedOrigins: any,
+          _options: any,
+        ) => {
+          throw new Error("CSRF mocked error");
+        },
+      };
     });
 
-    it("logs sanitized Error object when CSRF check throws an Error", async () => {
-        const originalConsoleError = console.error;
-        const consoleErrorMock = vi.fn();
-        console.error = consoleErrorMock;
+    const { default: mockApp } = await import("../../index");
+    const env = createTestEnv({});
 
-        vi.doMock("../../utils/origin", async (importOriginal) => {
-            const actual = await importOriginal<any>();
-            return {
-                ...actual,
-                isAllowedOrigin: (_origin: any, _frontendOrigin: any, _allowedOrigins: any, _options: any) => {
-                    throw new Error("CSRF mocked error");
-                }
-            };
-        });
+    await mockApp.request(
+      "http://localhost/api/auth/logout",
+      { method: "POST" },
+      env as any,
+    );
 
-        const { default: mockApp } = await import("../../index");
-        const env = createTestEnv({});
+    expect(consoleErrorMock).toHaveBeenCalledWith(
+      "CSRF check error: Error: CSRF mocked error",
+    );
 
-        await mockApp.request(
-            "http://localhost/api/auth/logout",
-            { method: "POST" },
-            env as any
-        );
+    console.error = originalConsoleError;
+    vi.doUnmock("../../utils/origin");
+  });
 
-        expect(consoleErrorMock).toHaveBeenCalledWith("CSRF check error: Error: CSRF mocked error");
+  it("logs sanitized string when CSRF check throws a non-Error", async () => {
+    const originalConsoleError = console.error;
+    const consoleErrorMock = vi.fn();
+    console.error = consoleErrorMock;
 
-        console.error = originalConsoleError;
-        vi.doUnmock("../../utils/origin");
+    vi.doMock("../../utils/origin", async (importOriginal) => {
+      const actual = await importOriginal<any>();
+      return {
+        ...actual,
+        isAllowedOrigin: (
+          _origin: any,
+          _frontendOrigin: any,
+          _allowedOrigins: any,
+          _options: any,
+        ) => {
+          throw "CSRF mocked string error";
+        },
+      };
     });
 
-    it("logs sanitized string when CSRF check throws a non-Error", async () => {
-        const originalConsoleError = console.error;
-        const consoleErrorMock = vi.fn();
-        console.error = consoleErrorMock;
+    const { default: mockApp } = await import("../../index");
+    const env = createTestEnv({});
 
-        vi.doMock("../../utils/origin", async (importOriginal) => {
-            const actual = await importOriginal<any>();
-            return {
-                ...actual,
-                isAllowedOrigin: (_origin: any, _frontendOrigin: any, _allowedOrigins: any, _options: any) => {
-                    throw "CSRF mocked string error";
-                }
-            };
-        });
+    await mockApp.request(
+      "http://localhost/api/auth/logout",
+      { method: "POST" },
+      env as any,
+    );
 
-        const { default: mockApp } = await import("../../index");
-        const env = createTestEnv({});
+    expect(consoleErrorMock).toHaveBeenCalledWith(
+      "CSRF check error: non-Error exception during CSRF check",
+    );
 
-        await mockApp.request(
-            "http://localhost/api/auth/logout",
-            { method: "POST" },
-            env as any
-        );
-
-        expect(consoleErrorMock).toHaveBeenCalledWith("CSRF check error: non-Error exception during CSRF check");
-
-        console.error = originalConsoleError;
-        vi.doUnmock("../../utils/origin");
-    });
+    console.error = originalConsoleError;
+    vi.doUnmock("../../utils/origin");
+  });
 });

--- a/apps/api/src/routes/__tests__/feed.test.ts
+++ b/apps/api/src/routes/__tests__/feed.test.ts
@@ -4,692 +4,754 @@ import { createTestApp, createTestEnv, makeQuery } from "../../test/helpers";
 let mockDb: any;
 
 vi.mock("drizzle-orm/d1", () => ({
-    drizzle: vi.fn(() => mockDb),
+  drizzle: vi.fn(() => mockDb),
 }));
 
 describe("feed routes", () => {
-    beforeEach(() => {
-        vi.restoreAllMocks();
-        vi.resetModules();
-        mockDb = {
-            select: vi.fn(() => makeQuery()),
-        };
-    });
+  beforeEach(() => {
+    vi.restoreAllMocks();
+    vi.resetModules();
+    mockDb = {
+      select: vi.fn(() => makeQuery()),
+    };
+  });
 
-    it("GET /feed/orgs/:slug/atom.xml returns atom xml for public org papers", async () => {
-        mockDb.select = vi
-            .fn()
-            .mockImplementationOnce(() => makeQuery({
-                getResult: {
-                    id: "org-1",
-                    slug: "lab",
-                    name: "Lab",
-                    description: null,
-                    createdAt: "2026-01-01 00:00:00",
-                    updatedAt: "2026-01-02 00:00:00",
-                },
-            }))
-            .mockImplementationOnce(() => makeQuery({
-                allResult: [
-                    {
-                        id: "paper-1",
-                        title: "Public Paper",
-                        abstract: "Abstract text",
-                        category: "report",
-                        createdAt: "2026-01-03 00:00:00",
-                        updatedAt: "2026-01-04 00:00:00",
-                    },
-                ],
-            }))
-            .mockImplementationOnce(() => makeQuery({
-                allResult: [
-                    {
-                        paperId: "paper-1",
-                        role: "uploader",
-                        name: "Alice",
-                        displayName: "Alice A.",
-                    },
-                ],
-            }))
-            .mockImplementationOnce(() => makeQuery({
-                allResult: [
-                    {
-                        paperId: "paper-1",
-                        id: "file-1",
-                        filename: "paper.pdf",
-                        sizeBytes: 1234,
-                        mimeType: "application/pdf",
-                    },
-                ],
-            }));
+  it("GET /feed/orgs/:slug/atom.xml returns atom xml for public org papers", async () => {
+    mockDb.select = vi
+      .fn()
+      .mockImplementationOnce(() =>
+        makeQuery({
+          getResult: {
+            id: "org-1",
+            slug: "lab",
+            name: "Lab",
+            description: null,
+            createdAt: "2026-01-01 00:00:00",
+            updatedAt: "2026-01-02 00:00:00",
+          },
+        }),
+      )
+      .mockImplementationOnce(() =>
+        makeQuery({
+          allResult: [
+            {
+              id: "paper-1",
+              title: "Public Paper",
+              abstract: "Abstract text",
+              category: "report",
+              createdAt: "2026-01-03 00:00:00",
+              updatedAt: "2026-01-04 00:00:00",
+            },
+          ],
+        }),
+      )
+      .mockImplementationOnce(() =>
+        makeQuery({
+          allResult: [
+            {
+              paperId: "paper-1",
+              role: "uploader",
+              name: "Alice",
+              displayName: "Alice A.",
+            },
+          ],
+        }),
+      )
+      .mockImplementationOnce(() =>
+        makeQuery({
+          allResult: [
+            {
+              paperId: "paper-1",
+              id: "file-1",
+              filename: "paper.pdf",
+              sizeBytes: 1234,
+              mimeType: "application/pdf",
+            },
+          ],
+        }),
+      );
 
-        const app = await createTestApp();
-        const env = createTestEnv();
+    const app = await createTestApp();
+    const env = createTestEnv();
 
-        const res = await app.request("http://localhost/feed/orgs/lab/atom.xml", {}, env as any);
+    const res = await app.request(
+      "http://localhost/feed/orgs/lab/atom.xml",
+      {},
+      env as any,
+    );
 
-        expect(res.status).toBe(200);
-        expect(res.headers.get("content-type")).toContain("application/atom+xml");
-        const text = await res.text();
-        expect(text).toContain("<feed xmlns=\"http://www.w3.org/2005/Atom\">");
-        expect(text).toContain("<title>Lab - OpenShelf</title>");
-        expect(text).toContain("<entry>");
-        expect(text).toContain("Public Paper");
-        expect(text).toContain("rel=\"enclosure\"");
-        expect(text).toContain("/api/papers/paper-1/files/file-1/stream");
-        expect(text).toContain('length="1234"');
-    });
+    expect(res.status).toBe(200);
+    expect(res.headers.get("content-type")).toContain("application/atom+xml");
+    const text = await res.text();
+    expect(text).toContain('<feed xmlns="http://www.w3.org/2005/Atom">');
+    expect(text).toContain("<title>Lab - OpenShelf</title>");
+    expect(text).toContain("<entry>");
+    expect(text).toContain("Public Paper");
+    expect(text).toContain('rel="enclosure"');
+    expect(text).toContain("/api/papers/paper-1/files/file-1/stream");
+    expect(text).toContain('length="1234"');
+  });
 
-    it("GET /feed/orgs/:slug/atom.xml returns 404 when org is missing", async () => {
-        mockDb.select = vi.fn(() => makeQuery({ getResult: null }));
+  it("GET /feed/orgs/:slug/atom.xml returns 404 when org is missing", async () => {
+    mockDb.select = vi.fn(() => makeQuery({ getResult: null }));
 
-        const app = await createTestApp();
-        const env = createTestEnv();
+    const app = await createTestApp();
+    const env = createTestEnv();
 
-        const res = await app.request("http://localhost/feed/orgs/missing/atom.xml", {}, env as any);
+    const res = await app.request(
+      "http://localhost/feed/orgs/missing/atom.xml",
+      {},
+      env as any,
+    );
 
-        expect(res.status).toBe(404);
-    });
+    expect(res.status).toBe(404);
+  });
 
-    it("GET /feed/orgs/:slug/atom.xml returns valid xml for empty org feeds", async () => {
-        mockDb.select = vi
-            .fn()
-            .mockImplementationOnce(() => makeQuery({
-                getResult: {
-                    id: "org-1",
-                    slug: "lab",
-                    name: "Lab",
-                    description: null,
-                    createdAt: "2026-01-01 00:00:00",
-                    updatedAt: "2026-01-02 00:00:00",
-                },
-            }))
-            .mockImplementationOnce(() => makeQuery({ allResult: [] }));
+  it("GET /feed/orgs/:slug/atom.xml returns valid xml for empty org feeds", async () => {
+    mockDb.select = vi
+      .fn()
+      .mockImplementationOnce(() =>
+        makeQuery({
+          getResult: {
+            id: "org-1",
+            slug: "lab",
+            name: "Lab",
+            description: null,
+            createdAt: "2026-01-01 00:00:00",
+            updatedAt: "2026-01-02 00:00:00",
+          },
+        }),
+      )
+      .mockImplementationOnce(() => makeQuery({ allResult: [] }));
 
-        const app = await createTestApp();
-        const env = createTestEnv();
+    const app = await createTestApp();
+    const env = createTestEnv();
 
-        const res = await app.request("http://localhost/feed/orgs/lab/atom.xml", {}, env as any);
+    const res = await app.request(
+      "http://localhost/feed/orgs/lab/atom.xml",
+      {},
+      env as any,
+    );
 
-        expect(res.status).toBe(200);
-        const text = await res.text();
-        expect(text).toContain("<feed xmlns=\"http://www.w3.org/2005/Atom\">");
-        expect(text).toContain("<title>Lab - OpenShelf</title>");
-    });
+    expect(res.status).toBe(200);
+    const text = await res.text();
+    expect(text).toContain('<feed xmlns="http://www.w3.org/2005/Atom">');
+    expect(text).toContain("<title>Lab - OpenShelf</title>");
+  });
 
-    it("GET /feed/orgs/:slug/atom.xml returns 400 for invalid slug", async () => {
-        const app = await createTestApp();
-        const env = createTestEnv();
+  it("GET /feed/orgs/:slug/atom.xml returns 400 for invalid slug", async () => {
+    const app = await createTestApp();
+    const env = createTestEnv();
 
-        const res = await app.request("http://localhost/feed/orgs/Invalid_Slug/atom.xml", {}, env as any);
+    const res = await app.request(
+      "http://localhost/feed/orgs/Invalid_Slug/atom.xml",
+      {},
+      env as any,
+    );
 
-        expect(res.status).toBe(400);
-        await expect(res.json()).resolves.toEqual({ error: "invalid slug" });
-    });
+    expect(res.status).toBe(400);
+    await expect(res.json()).resolves.toEqual({ error: "invalid slug" });
+  });
 
-    it("GET /feed/orgs/:slug/atom.xml filters papers by tag", async () => {
-        mockDb.select = vi
-            .fn()
-            .mockImplementationOnce(() =>
-                makeQuery({
-                    getResult: {
-                        id: "org-1",
-                        slug: "lab",
-                        name: "Lab",
-                        description: null,
-                        createdAt: "2026-01-01 00:00:00",
-                        updatedAt: "2026-01-02 00:00:00",
-                    },
-                }),
-            )
-            .mockImplementationOnce(() =>
-                makeQuery({
-                    allResult: [
-                        {
-                            id: "paper-1",
-                            title: "Tagged Paper",
-                            abstract: "AI abstract",
-                            category: "report",
-                            tags: JSON.stringify(["AI", "ML"]),
-                            createdAt: "2026-01-03 00:00:00",
-                            updatedAt: "2026-01-04 00:00:00",
-                        },
-                        {
-                            id: "paper-2",
-                            title: "Other Paper",
-                            abstract: "NLP abstract",
-                            category: "report",
-                            tags: JSON.stringify(["NLP"]),
-                            createdAt: "2026-01-05 00:00:00",
-                            updatedAt: "2026-01-06 00:00:00",
-                        },
-                    ],
-                }),
-            )
-            .mockImplementationOnce(() =>
-                makeQuery({
-                    allResult: [
-                        {
-                            paperId: "paper-1",
-                            role: "uploader",
-                            name: "Alice",
-                            displayName: "Alice A.",
-                        },
-                    ],
-                }),
-            )
-            .mockImplementationOnce(() =>
-                makeQuery({
-                    allResult: [
-                        {
-                            paperId: "paper-1",
-                            id: "file-1",
-                            filename: "paper.pdf",
-                            sizeBytes: 1234,
-                            mimeType: "application/pdf",
-                        },
-                    ],
-                }),
-            );
+  it("GET /feed/orgs/:slug/atom.xml filters papers by tag", async () => {
+    mockDb.select = vi
+      .fn()
+      .mockImplementationOnce(() =>
+        makeQuery({
+          getResult: {
+            id: "org-1",
+            slug: "lab",
+            name: "Lab",
+            description: null,
+            createdAt: "2026-01-01 00:00:00",
+            updatedAt: "2026-01-02 00:00:00",
+          },
+        }),
+      )
+      .mockImplementationOnce(() =>
+        makeQuery({
+          allResult: [
+            {
+              id: "paper-1",
+              title: "Tagged Paper",
+              abstract: "AI abstract",
+              category: "report",
+              tags: JSON.stringify(["AI", "ML"]),
+              createdAt: "2026-01-03 00:00:00",
+              updatedAt: "2026-01-04 00:00:00",
+            },
+            {
+              id: "paper-2",
+              title: "Other Paper",
+              abstract: "NLP abstract",
+              category: "report",
+              tags: JSON.stringify(["NLP"]),
+              createdAt: "2026-01-05 00:00:00",
+              updatedAt: "2026-01-06 00:00:00",
+            },
+          ],
+        }),
+      )
+      .mockImplementationOnce(() =>
+        makeQuery({
+          allResult: [
+            {
+              paperId: "paper-1",
+              role: "uploader",
+              name: "Alice",
+              displayName: "Alice A.",
+            },
+          ],
+        }),
+      )
+      .mockImplementationOnce(() =>
+        makeQuery({
+          allResult: [
+            {
+              paperId: "paper-1",
+              id: "file-1",
+              filename: "paper.pdf",
+              sizeBytes: 1234,
+              mimeType: "application/pdf",
+            },
+          ],
+        }),
+      );
 
-        const app = await createTestApp();
-        const env = createTestEnv();
+    const app = await createTestApp();
+    const env = createTestEnv();
 
-        const res = await app.request("http://localhost/feed/org/lab?tag=AI", {}, env as any);
+    const res = await app.request(
+      "http://localhost/feed/org/lab?tag=AI",
+      {},
+      env as any,
+    );
 
-        expect(res.status).toBe(200);
-        const text = await res.text();
-        expect(text).toContain("Tagged Paper");
-        expect(text).not.toContain("Other Paper");
-    });
+    expect(res.status).toBe(200);
+    const text = await res.text();
+    expect(text).toContain("Tagged Paper");
+    expect(text).not.toContain("Other Paper");
+  });
 
-    it("GET /feed/users/:id/atom.xml returns atom xml for public user papers", async () => {
-        mockDb.select = vi
-            .fn()
-            .mockImplementationOnce(() => makeQuery({
-                getResult: {
-                    id: "user-1",
-                    name: "Alice",
-                    displayName: "Alice A.",
-                    githubId: "alice",
-                    updatedAt: "2026-01-02 00:00:00",
-                },
-            }))
-            .mockImplementationOnce(() => makeQuery({
-                allResult: [
-                    {
-                        id: "paper-1",
-                        title: "User Paper",
-                        abstract: null,
-                        category: null,
-                        createdAt: "2026-01-03 00:00:00",
-                        updatedAt: "2026-01-04 00:00:00",
-                    },
-                ],
-            }))
-            .mockImplementationOnce(() => makeQuery({
-                allResult: [
-                    {
-                        paperId: "paper-1",
-                        role: "uploader",
-                        name: "Alice",
-                        displayName: "Alice A.",
-                    },
-                ],
-            }))
-            .mockImplementationOnce(() => makeQuery({ allResult: [] }));
+  it("GET /feed/users/:id/atom.xml returns atom xml for public user papers", async () => {
+    mockDb.select = vi
+      .fn()
+      .mockImplementationOnce(() =>
+        makeQuery({
+          getResult: {
+            id: "user-1",
+            name: "Alice",
+            displayName: "Alice A.",
+            githubId: "alice",
+            updatedAt: "2026-01-02 00:00:00",
+          },
+        }),
+      )
+      .mockImplementationOnce(() =>
+        makeQuery({
+          allResult: [
+            {
+              id: "paper-1",
+              title: "User Paper",
+              abstract: null,
+              category: null,
+              createdAt: "2026-01-03 00:00:00",
+              updatedAt: "2026-01-04 00:00:00",
+            },
+          ],
+        }),
+      )
+      .mockImplementationOnce(() =>
+        makeQuery({
+          allResult: [
+            {
+              paperId: "paper-1",
+              role: "uploader",
+              name: "Alice",
+              displayName: "Alice A.",
+            },
+          ],
+        }),
+      )
+      .mockImplementationOnce(() => makeQuery({ allResult: [] }));
 
-        const app = await createTestApp();
-        const env = createTestEnv();
+    const app = await createTestApp();
+    const env = createTestEnv();
 
-        const res = await app.request("http://localhost/feed/users/user-1/atom.xml", {}, env as any);
+    const res = await app.request(
+      "http://localhost/feed/users/user-1/atom.xml",
+      {},
+      env as any,
+    );
 
-        expect(res.status).toBe(200);
-        const text = await res.text();
-        expect(text).toContain("<title>Alice A. - OpenShelf</title>");
-        expect(text).toContain("User Paper");
-    });
+    expect(res.status).toBe(200);
+    const text = await res.text();
+    expect(text).toContain("<title>Alice A. - OpenShelf</title>");
+    expect(text).toContain("User Paper");
+  });
 
-    it("GET /feed/users/:id/atom.xml de-duplicates repeated paper rows", async () => {
-        mockDb.select = vi
-            .fn()
-            .mockImplementationOnce(() => makeQuery({
-                getResult: {
-                    id: "user-1",
-                    name: "Alice",
-                    displayName: "Alice A.",
-                    githubId: "alice",
-                    updatedAt: "2026-01-02 00:00:00",
-                },
-            }))
-            .mockImplementationOnce(() => makeQuery({
-                allResult: [
-                    {
-                        id: "paper-1",
-                        title: "User Paper",
-                        abstract: null,
-                        category: null,
-                        createdAt: "2026-01-03 00:00:00",
-                        updatedAt: "2026-01-04 00:00:00",
-                    },
-                    {
-                        id: "paper-1",
-                        title: "User Paper",
-                        abstract: null,
-                        category: null,
-                        createdAt: "2026-01-03 00:00:00",
-                        updatedAt: "2026-01-04 00:00:00",
-                    },
-                ],
-            }))
-            .mockImplementationOnce(() => makeQuery({
-                allResult: [
-                    {
-                        paperId: "paper-1",
-                        role: "uploader",
-                        name: "Alice",
-                        displayName: "Alice A.",
-                    },
-                ],
-            }))
-            .mockImplementationOnce(() => makeQuery({ allResult: [] }));
+  it("GET /feed/users/:id/atom.xml de-duplicates repeated paper rows", async () => {
+    mockDb.select = vi
+      .fn()
+      .mockImplementationOnce(() =>
+        makeQuery({
+          getResult: {
+            id: "user-1",
+            name: "Alice",
+            displayName: "Alice A.",
+            githubId: "alice",
+            updatedAt: "2026-01-02 00:00:00",
+          },
+        }),
+      )
+      .mockImplementationOnce(() =>
+        makeQuery({
+          allResult: [
+            {
+              id: "paper-1",
+              title: "User Paper",
+              abstract: null,
+              category: null,
+              createdAt: "2026-01-03 00:00:00",
+              updatedAt: "2026-01-04 00:00:00",
+            },
+            {
+              id: "paper-1",
+              title: "User Paper",
+              abstract: null,
+              category: null,
+              createdAt: "2026-01-03 00:00:00",
+              updatedAt: "2026-01-04 00:00:00",
+            },
+          ],
+        }),
+      )
+      .mockImplementationOnce(() =>
+        makeQuery({
+          allResult: [
+            {
+              paperId: "paper-1",
+              role: "uploader",
+              name: "Alice",
+              displayName: "Alice A.",
+            },
+          ],
+        }),
+      )
+      .mockImplementationOnce(() => makeQuery({ allResult: [] }));
 
-        const app = await createTestApp();
-        const env = createTestEnv();
+    const app = await createTestApp();
+    const env = createTestEnv();
 
-        const res = await app.request("http://localhost/feed/users/user-1/atom.xml", {}, env as any);
+    const res = await app.request(
+      "http://localhost/feed/users/user-1/atom.xml",
+      {},
+      env as any,
+    );
 
-        expect(res.status).toBe(200);
-        const text = await res.text();
-        expect(text.match(/<entry>/g)).toHaveLength(1);
-    });
+    expect(res.status).toBe(200);
+    const text = await res.text();
+    expect(text.match(/<entry>/g)).toHaveLength(1);
+  });
 
-    it("GET /feed/users/:id/atom.xml filters papers by tag", async () => {
-        mockDb.select = vi
-            .fn()
-            .mockImplementationOnce(() =>
-                makeQuery({
-                    getResult: {
-                        id: "user-1",
-                        name: "Alice",
-                        displayName: "Alice A.",
-                        githubId: "alice",
-                        updatedAt: "2026-01-02 00:00:00",
-                    },
-                }),
-            )
-            .mockImplementationOnce(() =>
-                makeQuery({
-                    allResult: [
-                        {
-                            id: "paper-1",
-                            title: "Tagged Paper",
-                            abstract: "AI abstract",
-                            category: "report",
-                            tags: JSON.stringify(["AI", "ML"]),
-                            createdAt: "2026-01-03 00:00:00",
-                            updatedAt: "2026-01-04 00:00:00",
-                        },
-                        {
-                            id: "paper-2",
-                            title: "Other Paper",
-                            abstract: "NLP abstract",
-                            category: "report",
-                            tags: JSON.stringify(["NLP"]),
-                            createdAt: "2026-01-05 00:00:00",
-                            updatedAt: "2026-01-06 00:00:00",
-                        },
-                    ],
-                }),
-            )
-            .mockImplementationOnce(() =>
-                makeQuery({
-                    allResult: [
-                        {
-                            paperId: "paper-1",
-                            role: "uploader",
-                            name: "Alice",
-                            displayName: "Alice A.",
-                        },
-                    ],
-                }),
-            )
-            .mockImplementationOnce(() =>
-                makeQuery({
-                    allResult: [
-                        {
-                            paperId: "paper-1",
-                            id: "file-1",
-                            filename: "paper.pdf",
-                            sizeBytes: 1234,
-                            mimeType: "application/pdf",
-                        },
-                    ],
-                }),
-            );
+  it("GET /feed/users/:id/atom.xml filters papers by tag", async () => {
+    mockDb.select = vi
+      .fn()
+      .mockImplementationOnce(() =>
+        makeQuery({
+          getResult: {
+            id: "user-1",
+            name: "Alice",
+            displayName: "Alice A.",
+            githubId: "alice",
+            updatedAt: "2026-01-02 00:00:00",
+          },
+        }),
+      )
+      .mockImplementationOnce(() =>
+        makeQuery({
+          allResult: [
+            {
+              id: "paper-1",
+              title: "Tagged Paper",
+              abstract: "AI abstract",
+              category: "report",
+              tags: JSON.stringify(["AI", "ML"]),
+              createdAt: "2026-01-03 00:00:00",
+              updatedAt: "2026-01-04 00:00:00",
+            },
+            {
+              id: "paper-2",
+              title: "Other Paper",
+              abstract: "NLP abstract",
+              category: "report",
+              tags: JSON.stringify(["NLP"]),
+              createdAt: "2026-01-05 00:00:00",
+              updatedAt: "2026-01-06 00:00:00",
+            },
+          ],
+        }),
+      )
+      .mockImplementationOnce(() =>
+        makeQuery({
+          allResult: [
+            {
+              paperId: "paper-1",
+              role: "uploader",
+              name: "Alice",
+              displayName: "Alice A.",
+            },
+          ],
+        }),
+      )
+      .mockImplementationOnce(() =>
+        makeQuery({
+          allResult: [
+            {
+              paperId: "paper-1",
+              id: "file-1",
+              filename: "paper.pdf",
+              sizeBytes: 1234,
+              mimeType: "application/pdf",
+            },
+          ],
+        }),
+      );
 
-        const app = await createTestApp();
-        const env = createTestEnv();
+    const app = await createTestApp();
+    const env = createTestEnv();
 
-        const res = await app.request("http://localhost/feed/users/user-1/atom.xml?tag=AI", {}, env as any);
+    const res = await app.request(
+      "http://localhost/feed/users/user-1/atom.xml?tag=AI",
+      {},
+      env as any,
+    );
 
-        expect(res.status).toBe(200);
-        const text = await res.text();
-        expect(text).toContain("Tagged Paper");
-        expect(text).not.toContain("Other Paper");
-    });
+    expect(res.status).toBe(200);
+    const text = await res.text();
+    expect(text).toContain("Tagged Paper");
+    expect(text).not.toContain("Other Paper");
+  });
 
-    it("GET /feed/orgs/:slug/collections/:cSlug/atom.xml returns atom xml for public collection papers", async () => {
-        mockDb.select = vi
-            .fn()
-            .mockImplementationOnce(() => makeQuery({
-                getResult: {
-                    id: "org-1",
-                    slug: "lab",
-                    name: "Lab",
-                    description: null,
-                    createdAt: "2026-01-01 00:00:00",
-                    updatedAt: "2026-01-02 00:00:00",
-                },
-            }))
-            .mockImplementationOnce(() => makeQuery({
-                getResult: {
-                    id: "col-1",
-                    ownerType: "org",
-                    ownerId: "org-1",
-                    orgSlug: "lab",
-                    slug: "featured",
-                    name: "Featured",
-                    description: null,
-                    visibility: "public",
-                    createdAt: "2026-01-01 00:00:00",
-                    updatedAt: "2026-01-02 00:00:00",
-                },
-            }))
-            .mockImplementationOnce(() => makeQuery({
-                allResult: [
-                    {
-                        id: "paper-1",
-                        title: "Collection Paper",
-                        abstract: "Collection abstract",
-                        category: "report",
-                        createdAt: "2026-01-03 00:00:00",
-                        updatedAt: "2026-01-04 00:00:00",
-                    },
-                ],
-            }))
-            .mockImplementationOnce(() => makeQuery({
-                allResult: [
-                    {
-                        paperId: "paper-1",
-                        role: "uploader",
-                        name: "Alice",
-                        displayName: "Alice A.",
-                    },
-                ],
-            }))
-            .mockImplementationOnce(() => makeQuery({ allResult: [] }));
+  it("GET /feed/orgs/:slug/collections/:cSlug/atom.xml returns atom xml for public collection papers", async () => {
+    mockDb.select = vi
+      .fn()
+      .mockImplementationOnce(() =>
+        makeQuery({
+          getResult: {
+            id: "org-1",
+            slug: "lab",
+            name: "Lab",
+            description: null,
+            createdAt: "2026-01-01 00:00:00",
+            updatedAt: "2026-01-02 00:00:00",
+          },
+        }),
+      )
+      .mockImplementationOnce(() =>
+        makeQuery({
+          getResult: {
+            id: "col-1",
+            ownerType: "org",
+            ownerId: "org-1",
+            orgSlug: "lab",
+            slug: "featured",
+            name: "Featured",
+            description: null,
+            visibility: "public",
+            createdAt: "2026-01-01 00:00:00",
+            updatedAt: "2026-01-02 00:00:00",
+          },
+        }),
+      )
+      .mockImplementationOnce(() =>
+        makeQuery({
+          allResult: [
+            {
+              id: "paper-1",
+              title: "Collection Paper",
+              abstract: "Collection abstract",
+              category: "report",
+              createdAt: "2026-01-03 00:00:00",
+              updatedAt: "2026-01-04 00:00:00",
+            },
+          ],
+        }),
+      )
+      .mockImplementationOnce(() =>
+        makeQuery({
+          allResult: [
+            {
+              paperId: "paper-1",
+              role: "uploader",
+              name: "Alice",
+              displayName: "Alice A.",
+            },
+          ],
+        }),
+      )
+      .mockImplementationOnce(() => makeQuery({ allResult: [] }));
 
-        const app = await createTestApp();
-        const env = createTestEnv();
+    const app = await createTestApp();
+    const env = createTestEnv();
 
-        const res = await app.request(
-            "http://localhost/feed/orgs/lab/collections/featured/atom.xml",
-            {},
-            env as any,
-        );
+    const res = await app.request(
+      "http://localhost/feed/orgs/lab/collections/featured/atom.xml",
+      {},
+      env as any,
+    );
 
-        expect(res.status).toBe(200);
-        const text = await res.text();
-        expect(text).toContain("<title>Featured - Lab - OpenShelf</title>");
-        expect(text).toContain("Collection Paper");
-    });
+    expect(res.status).toBe(200);
+    const text = await res.text();
+    expect(text).toContain("<title>Featured - Lab - OpenShelf</title>");
+    expect(text).toContain("Collection Paper");
+  });
 
-    it("GET /feed/users/:id/collections/:cSlug/atom.xml returns atom xml for public collection papers", async () => {
-        mockDb.select = vi
-            .fn()
-            .mockImplementationOnce(() =>
-                makeQuery({
-                    getResult: {
-                        id: "user-1",
-                        name: "Alice",
-                        displayName: "Alice A.",
-                        githubId: "alice",
-                        updatedAt: "2026-01-02 00:00:00",
-                    },
-                }),
-            )
-            .mockImplementationOnce(() =>
-                makeQuery({
-                    getResult: {
-                        id: "col-1",
-                        ownerType: "user",
-                        ownerId: "user-1",
-                        orgSlug: null,
-                        slug: "featured",
-                        name: "Favorites",
-                        description: null,
-                        visibility: "public",
-                        createdAt: "2026-01-01 00:00:00",
-                        updatedAt: "2026-01-02 00:00:00",
-                    },
-                }),
-            )
-            .mockImplementationOnce(() =>
-                makeQuery({
-                    allResult: [
-                        {
-                            id: "paper-1",
-                            title: "Collection Paper",
-                            abstract: "Collection abstract",
-                            category: "report",
-                            createdAt: "2026-01-03 00:00:00",
-                            updatedAt: "2026-01-04 00:00:00",
-                        },
-                    ],
-                }),
-            )
-            .mockImplementationOnce(() =>
-                makeQuery({
-                    allResult: [
-                        {
-                            paperId: "paper-1",
-                            role: "uploader",
-                            name: "Alice",
-                            displayName: "Alice A.",
-                        },
-                    ],
-                }),
-            )
-            .mockImplementationOnce(() => makeQuery({ allResult: [] }));
+  it("GET /feed/users/:id/collections/:cSlug/atom.xml returns atom xml for public collection papers", async () => {
+    mockDb.select = vi
+      .fn()
+      .mockImplementationOnce(() =>
+        makeQuery({
+          getResult: {
+            id: "user-1",
+            name: "Alice",
+            displayName: "Alice A.",
+            githubId: "alice",
+            updatedAt: "2026-01-02 00:00:00",
+          },
+        }),
+      )
+      .mockImplementationOnce(() =>
+        makeQuery({
+          getResult: {
+            id: "col-1",
+            ownerType: "user",
+            ownerId: "user-1",
+            orgSlug: null,
+            slug: "featured",
+            name: "Favorites",
+            description: null,
+            visibility: "public",
+            createdAt: "2026-01-01 00:00:00",
+            updatedAt: "2026-01-02 00:00:00",
+          },
+        }),
+      )
+      .mockImplementationOnce(() =>
+        makeQuery({
+          allResult: [
+            {
+              id: "paper-1",
+              title: "Collection Paper",
+              abstract: "Collection abstract",
+              category: "report",
+              createdAt: "2026-01-03 00:00:00",
+              updatedAt: "2026-01-04 00:00:00",
+            },
+          ],
+        }),
+      )
+      .mockImplementationOnce(() =>
+        makeQuery({
+          allResult: [
+            {
+              paperId: "paper-1",
+              role: "uploader",
+              name: "Alice",
+              displayName: "Alice A.",
+            },
+          ],
+        }),
+      )
+      .mockImplementationOnce(() => makeQuery({ allResult: [] }));
 
-        const app = await createTestApp();
-        const env = createTestEnv();
+    const app = await createTestApp();
+    const env = createTestEnv();
 
-        const res = await app.request(
-            "http://localhost/feed/users/user-1/collections/featured/atom.xml",
-            {},
-            env as any,
-        );
+    const res = await app.request(
+      "http://localhost/feed/users/user-1/collections/featured/atom.xml",
+      {},
+      env as any,
+    );
 
-        expect(res.status).toBe(200);
-        const text = await res.text();
-        expect(text).toContain("<title>Favorites - Alice A. - OpenShelf</title>");
-        expect(text).toContain("Collection Paper");
-    });
+    expect(res.status).toBe(200);
+    const text = await res.text();
+    expect(text).toContain("<title>Favorites - Alice A. - OpenShelf</title>");
+    expect(text).toContain("Collection Paper");
+  });
 
-    it("GET /feed/org/:slug/collection/:collectionSlug returns atom xml for public collection papers", async () => {
-        mockDb.select = vi
-            .fn()
-            .mockImplementationOnce(() =>
-                makeQuery({
-                    getResult: {
-                        id: "org-1",
-                        slug: "lab",
-                        name: "Lab",
-                        description: null,
-                        createdAt: "2026-01-01 00:00:00",
-                        updatedAt: "2026-01-02 00:00:00",
-                    },
-                }),
-            )
-            .mockImplementationOnce(() =>
-                makeQuery({
-                    getResult: {
-                        id: "col-1",
-                        ownerType: "org",
-                        ownerId: "org-1",
-                        orgSlug: "lab",
-                        slug: "featured",
-                        name: "Featured",
-                        description: null,
-                        visibility: "public",
-                        createdAt: "2026-01-01 00:00:00",
-                        updatedAt: "2026-01-02 00:00:00",
-                    },
-                }),
-            )
-            .mockImplementationOnce(() =>
-                makeQuery({
-                    allResult: [
-                        {
-                            id: "paper-1",
-                            title: "Collection Paper",
-                            abstract: "Collection abstract",
-                            category: "report",
-                            createdAt: "2026-01-03 00:00:00",
-                            updatedAt: "2026-01-04 00:00:00",
-                        },
-                    ],
-                }),
-            )
-            .mockImplementationOnce(() =>
-                makeQuery({
-                    allResult: [
-                        {
-                            paperId: "paper-1",
-                            role: "uploader",
-                            name: "Alice",
-                            displayName: "Alice A.",
-                        },
-                    ],
-                }),
-            )
-            .mockImplementationOnce(() => makeQuery({ allResult: [] }));
+  it("GET /feed/org/:slug/collection/:collectionSlug returns atom xml for public collection papers", async () => {
+    mockDb.select = vi
+      .fn()
+      .mockImplementationOnce(() =>
+        makeQuery({
+          getResult: {
+            id: "org-1",
+            slug: "lab",
+            name: "Lab",
+            description: null,
+            createdAt: "2026-01-01 00:00:00",
+            updatedAt: "2026-01-02 00:00:00",
+          },
+        }),
+      )
+      .mockImplementationOnce(() =>
+        makeQuery({
+          getResult: {
+            id: "col-1",
+            ownerType: "org",
+            ownerId: "org-1",
+            orgSlug: "lab",
+            slug: "featured",
+            name: "Featured",
+            description: null,
+            visibility: "public",
+            createdAt: "2026-01-01 00:00:00",
+            updatedAt: "2026-01-02 00:00:00",
+          },
+        }),
+      )
+      .mockImplementationOnce(() =>
+        makeQuery({
+          allResult: [
+            {
+              id: "paper-1",
+              title: "Collection Paper",
+              abstract: "Collection abstract",
+              category: "report",
+              createdAt: "2026-01-03 00:00:00",
+              updatedAt: "2026-01-04 00:00:00",
+            },
+          ],
+        }),
+      )
+      .mockImplementationOnce(() =>
+        makeQuery({
+          allResult: [
+            {
+              paperId: "paper-1",
+              role: "uploader",
+              name: "Alice",
+              displayName: "Alice A.",
+            },
+          ],
+        }),
+      )
+      .mockImplementationOnce(() => makeQuery({ allResult: [] }));
 
-        const app = await createTestApp();
-        const env = createTestEnv();
+    const app = await createTestApp();
+    const env = createTestEnv();
 
-        const res = await app.request(
-            "http://localhost/feed/org/lab/collection/featured",
-            {},
-            env as any,
-        );
+    const res = await app.request(
+      "http://localhost/feed/org/lab/collection/featured",
+      {},
+      env as any,
+    );
 
-        expect(res.status).toBe(200);
-        const text = await res.text();
-        expect(text).toContain("<title>Featured - Lab - OpenShelf</title>");
-        expect(text).toContain("Collection Paper");
-    });
+    expect(res.status).toBe(200);
+    const text = await res.text();
+    expect(text).toContain("<title>Featured - Lab - OpenShelf</title>");
+    expect(text).toContain("Collection Paper");
+  });
 
-    it("GET /feed/user/:id/collection/:collectionSlug returns atom xml for public collection papers", async () => {
-        mockDb.select = vi
-            .fn()
-            .mockImplementationOnce(() =>
-                makeQuery({
-                    getResult: {
-                        id: "user-1",
-                        name: "Alice",
-                        displayName: "Alice A.",
-                        githubId: "alice",
-                        updatedAt: "2026-01-02 00:00:00",
-                    },
-                }),
-            )
-            .mockImplementationOnce(() =>
-                makeQuery({
-                    getResult: {
-                        id: "col-1",
-                        ownerType: "user",
-                        ownerId: "user-1",
-                        orgSlug: null,
-                        slug: "featured",
-                        name: "Favorites",
-                        description: null,
-                        visibility: "public",
-                        createdAt: "2026-01-01 00:00:00",
-                        updatedAt: "2026-01-02 00:00:00",
-                    },
-                }),
-            )
-            .mockImplementationOnce(() =>
-                makeQuery({
-                    allResult: [
-                        {
-                            id: "paper-1",
-                            title: "Collection Paper",
-                            abstract: "Collection abstract",
-                            category: "report",
-                            createdAt: "2026-01-03 00:00:00",
-                            updatedAt: "2026-01-04 00:00:00",
-                        },
-                    ],
-                }),
-            )
-            .mockImplementationOnce(() =>
-                makeQuery({
-                    allResult: [
-                        {
-                            paperId: "paper-1",
-                            role: "uploader",
-                            name: "Alice",
-                            displayName: "Alice A.",
-                        },
-                    ],
-                }),
-            )
-            .mockImplementationOnce(() => makeQuery({ allResult: [] }));
+  it("GET /feed/user/:id/collection/:collectionSlug returns atom xml for public collection papers", async () => {
+    mockDb.select = vi
+      .fn()
+      .mockImplementationOnce(() =>
+        makeQuery({
+          getResult: {
+            id: "user-1",
+            name: "Alice",
+            displayName: "Alice A.",
+            githubId: "alice",
+            updatedAt: "2026-01-02 00:00:00",
+          },
+        }),
+      )
+      .mockImplementationOnce(() =>
+        makeQuery({
+          getResult: {
+            id: "col-1",
+            ownerType: "user",
+            ownerId: "user-1",
+            orgSlug: null,
+            slug: "featured",
+            name: "Favorites",
+            description: null,
+            visibility: "public",
+            createdAt: "2026-01-01 00:00:00",
+            updatedAt: "2026-01-02 00:00:00",
+          },
+        }),
+      )
+      .mockImplementationOnce(() =>
+        makeQuery({
+          allResult: [
+            {
+              id: "paper-1",
+              title: "Collection Paper",
+              abstract: "Collection abstract",
+              category: "report",
+              createdAt: "2026-01-03 00:00:00",
+              updatedAt: "2026-01-04 00:00:00",
+            },
+          ],
+        }),
+      )
+      .mockImplementationOnce(() =>
+        makeQuery({
+          allResult: [
+            {
+              paperId: "paper-1",
+              role: "uploader",
+              name: "Alice",
+              displayName: "Alice A.",
+            },
+          ],
+        }),
+      )
+      .mockImplementationOnce(() => makeQuery({ allResult: [] }));
 
-        const app = await createTestApp();
-        const env = createTestEnv();
+    const app = await createTestApp();
+    const env = createTestEnv();
 
-        const res = await app.request(
-            "http://localhost/feed/user/user-1/collection/featured",
-            {},
-            env as any,
-        );
+    const res = await app.request(
+      "http://localhost/feed/user/user-1/collection/featured",
+      {},
+      env as any,
+    );
 
-        expect(res.status).toBe(200);
-        const text = await res.text();
-        expect(text).toContain("<title>Favorites - Alice A. - OpenShelf</title>");
-        expect(text).toContain("Collection Paper");
-    });
+    expect(res.status).toBe(200);
+    const text = await res.text();
+    expect(text).toContain("<title>Favorites - Alice A. - OpenShelf</title>");
+    expect(text).toContain("Collection Paper");
+  });
 
-    it("GET /feed/orgs/:slug/collections/:cSlug/atom.xml returns 400 for invalid slug", async () => {
-        const app = await createTestApp();
-        const env = createTestEnv();
+  it("GET /feed/orgs/:slug/collections/:cSlug/atom.xml returns 400 for invalid slug", async () => {
+    const app = await createTestApp();
+    const env = createTestEnv();
 
-        const res = await app.request(
-            "http://localhost/feed/orgs/lab/collections/Invalid_Slug/atom.xml",
-            {},
-            env as any,
-        );
+    const res = await app.request(
+      "http://localhost/feed/orgs/lab/collections/Invalid_Slug/atom.xml",
+      {},
+      env as any,
+    );
 
-        expect(res.status).toBe(400);
-        await expect(res.json()).resolves.toEqual({ error: "invalid slug" });
-    });
+    expect(res.status).toBe(400);
+    await expect(res.json()).resolves.toEqual({ error: "invalid slug" });
+  });
 
-    it("GET /feed/users/:id/collections/:cSlug/atom.xml returns 400 for invalid slug", async () => {
-        const app = await createTestApp();
-        const env = createTestEnv();
+  it("GET /feed/users/:id/collections/:cSlug/atom.xml returns 400 for invalid slug", async () => {
+    const app = await createTestApp();
+    const env = createTestEnv();
 
-        const res = await app.request(
-            "http://localhost/feed/users/user-1/collections/Invalid_Slug/atom.xml",
-            {},
-            env as any,
-        );
+    const res = await app.request(
+      "http://localhost/feed/users/user-1/collections/Invalid_Slug/atom.xml",
+      {},
+      env as any,
+    );
 
-        expect(res.status).toBe(400);
-        await expect(res.json()).resolves.toEqual({ error: "invalid slug" });
-    });
+    expect(res.status).toBe(400);
+    await expect(res.json()).resolves.toEqual({ error: "invalid slug" });
+  });
 });

--- a/apps/api/src/routes/__tests__/invites.test.ts
+++ b/apps/api/src/routes/__tests__/invites.test.ts
@@ -1,191 +1,260 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import {
-    createTestApp,
-    createTestEnv,
-    createTestJWT,
-    makeQuery,
+  createTestApp,
+  createTestEnv,
+  createTestJWT,
+  makeQuery,
 } from "../../test/helpers";
 
 let mockDb: any;
 
 vi.mock("drizzle-orm/d1", () => ({
-    drizzle: vi.fn(() => mockDb)
+  drizzle: vi.fn(() => mockDb),
 }));
 
 describe("invites routes", () => {
-    beforeEach(() => {
-        vi.restoreAllMocks();
-        vi.resetModules();
-        mockDb = {
-            run: vi.fn(async () => undefined),
-            select: vi.fn(() => makeQuery()),
-            insert: vi.fn(() => ({ values: vi.fn(async () => undefined) })),
-            update: vi.fn(() => ({ set: vi.fn(() => ({ where: vi.fn(async () => undefined) })) })),
-            batch: vi.fn(async () => undefined)
-        };
+  beforeEach(() => {
+    vi.restoreAllMocks();
+    vi.resetModules();
+    mockDb = {
+      run: vi.fn(async () => undefined),
+      select: vi.fn(() => makeQuery()),
+      insert: vi.fn(() => ({ values: vi.fn(async () => undefined) })),
+      update: vi.fn(() => ({
+        set: vi.fn(() => ({ where: vi.fn(async () => undefined) })),
+      })),
+      batch: vi.fn(async () => undefined),
+    };
+  });
+
+  it("POST /api/papers/:id/invites sends coauthor invite", async () => {
+    const token = await createTestJWT({
+      sub: "user-1",
+      githubId: "123",
+      name: "Uploader",
+    });
+    mockDb.select = vi
+      .fn()
+      .mockImplementationOnce(() =>
+        makeQuery({
+          getResult: { paperId: "paper-1", userId: "user-1", role: "uploader" },
+        }),
+      )
+      .mockImplementationOnce(() => makeQuery({ getResult: null }))
+      .mockImplementationOnce(() => makeQuery({ getResult: { id: "user-2" } }));
+
+    const app = await createTestApp();
+    const env = createTestEnv();
+
+    const res = await app.request(
+      "http://localhost/api/papers/paper-1/invites",
+      {
+        method: "POST",
+        headers: {
+          Authorization: `Bearer ${token}`,
+          "Content-Type": "application/json",
+        },
+        body: JSON.stringify({ inviteeId: "user-2" }),
+      },
+      env as any,
+    );
+
+    expect(res.status).toBe(201);
+  });
+
+  it("GET /api/invites/received returns invites", async () => {
+    const token = await createTestJWT({
+      sub: "user-2",
+      githubId: "456",
+      name: "Invitee",
+    });
+    mockDb.select = vi.fn(() =>
+      makeQuery({
+        allResult: [
+          {
+            id: "inv-1",
+            paperId: "paper-1",
+            paperTitle: "Paper",
+            status: "pending",
+          },
+        ],
+      }),
+    );
+
+    const app = await createTestApp();
+    const env = createTestEnv();
+
+    const res = await app.request(
+      "http://localhost/api/invites/received",
+      {
+        headers: { Authorization: `Bearer ${token}` },
+      },
+      env as any,
+    );
+
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as any;
+    expect(body.invites).toHaveLength(1);
+  });
+
+  it("PUT /api/invites/:id accepts invite", async () => {
+    const token = await createTestJWT({
+      sub: "user-2",
+      githubId: "456",
+      name: "Invitee",
+    });
+    mockDb.select = vi.fn(() =>
+      makeQuery({
+        getResult: {
+          id: "inv-1",
+          inviteeId: "user-2",
+          paperId: "paper-1",
+          status: "pending",
+        },
+      }),
+    );
+
+    const app = await createTestApp();
+    const env = createTestEnv();
+
+    const res = await app.request(
+      "http://localhost/api/invites/inv-1",
+      {
+        method: "PUT",
+        headers: {
+          Authorization: `Bearer ${token}`,
+          "Content-Type": "application/json",
+        },
+        body: JSON.stringify({ action: "accept" }),
+      },
+      env as any,
+    );
+
+    expect(res.status).toBe(200);
+  });
+
+  it("PUT /api/invites/:id declines invite", async () => {
+    const token = await createTestJWT({
+      sub: "user-2",
+      githubId: "456",
+      name: "Invitee",
+    });
+    mockDb.select = vi.fn(() =>
+      makeQuery({
+        getResult: {
+          id: "inv-1",
+          inviteeId: "user-2",
+          paperId: "paper-1",
+          status: "pending",
+        },
+      }),
+    );
+
+    const app = await createTestApp();
+    const env = createTestEnv();
+
+    const res = await app.request(
+      "http://localhost/api/invites/inv-1",
+      {
+        method: "PUT",
+        headers: {
+          Authorization: `Bearer ${token}`,
+          "Content-Type": "application/json",
+        },
+        body: JSON.stringify({ action: "decline" }),
+      },
+      env as any,
+    );
+
+    expect(res.status).toBe(200);
+  });
+
+  it("PUT /api/invites/:id returns 400 for invalid JSON", async () => {
+    const token = await createTestJWT({
+      sub: "user-2",
+      githubId: "456",
+      name: "Invitee",
     });
 
-    it("POST /api/papers/:id/invites sends coauthor invite", async () => {
-        const token = await createTestJWT({ sub: "user-1", githubId: "123", name: "Uploader" });
-        mockDb.select = vi
-            .fn()
-            .mockImplementationOnce(() => makeQuery({ getResult: { paperId: "paper-1", userId: "user-1", role: "uploader" } }))
-            .mockImplementationOnce(() => makeQuery({ getResult: null }))
-            .mockImplementationOnce(() => makeQuery({ getResult: { id: "user-2" } }));
+    const app = await createTestApp();
+    const env = createTestEnv();
 
-        const app = await createTestApp();
-        const env = createTestEnv();
+    const res = await app.request(
+      "http://localhost/api/invites/inv-1",
+      {
+        method: "PUT",
+        headers: {
+          Authorization: `Bearer ${token}`,
+          "Content-Type": "application/json",
+        },
+        body: "{ invalid }",
+      },
+      env as any,
+    );
 
-        const res = await app.request(
-            "http://localhost/api/papers/paper-1/invites",
-            {
-                method: "POST",
-                headers: {
-                    Authorization: `Bearer ${token}`,
-                    "Content-Type": "application/json"
-                },
-                body: JSON.stringify({ inviteeId: "user-2" })
-            },
-            env as any
-        );
+    expect(res.status).toBe(400);
+    const body = (await res.json()) as any;
+    expect(body).toEqual({ error: "Invalid JSON body" });
+  });
 
-        expect(res.status).toBe(201);
+  it("POST /api/papers/:id/invites returns 400 when inviting self", async () => {
+    const token = await createTestJWT({
+      sub: "user-1",
+      githubId: "123",
+      name: "Uploader",
     });
+    mockDb.select = vi
+      .fn()
+      .mockImplementationOnce(() =>
+        makeQuery({
+          getResult: { paperId: "paper-1", userId: "user-1", role: "uploader" },
+        }),
+      );
 
-    it("GET /api/invites/received returns invites", async () => {
-        const token = await createTestJWT({ sub: "user-2", githubId: "456", name: "Invitee" });
-        mockDb.select = vi.fn(() => makeQuery({ allResult: [{ id: "inv-1", paperId: "paper-1", paperTitle: "Paper", status: "pending" }] }));
+    const app = await createTestApp();
+    const env = createTestEnv();
 
-        const app = await createTestApp();
-        const env = createTestEnv();
+    const res = await app.request(
+      "http://localhost/api/papers/paper-1/invites",
+      {
+        method: "POST",
+        headers: {
+          Authorization: `Bearer ${token}`,
+          "Content-Type": "application/json",
+        },
+        body: JSON.stringify({ inviteeId: "user-1" }),
+      },
+      env as any,
+    );
 
-        const res = await app.request(
-            "http://localhost/api/invites/received",
-            {
-                headers: { Authorization: `Bearer ${token}` }
-            },
-            env as any
-        );
+    expect(res.status).toBe(400);
+  });
 
-        expect(res.status).toBe(200);
-        const body = (await res.json()) as any;
-        expect(body.invites).toHaveLength(1);
+  it("PUT /api/invites/:id returns 400 for invalid JSON body", async () => {
+    const token = await createTestJWT({
+      sub: "user-1",
+      githubId: "123",
+      name: "Uploader",
     });
+    const app = await createTestApp();
+    const env = createTestEnv();
 
-    it("PUT /api/invites/:id accepts invite", async () => {
-        const token = await createTestJWT({ sub: "user-2", githubId: "456", name: "Invitee" });
-        mockDb.select = vi.fn(() => makeQuery({ getResult: { id: "inv-1", inviteeId: "user-2", paperId: "paper-1", status: "pending" } }));
+    // Malformed JSON should fail before invite lookup or authorization.
+    const res = await app.request(
+      "http://localhost/api/invites/inv-1",
+      {
+        method: "PUT",
+        headers: {
+          Authorization: `Bearer ${token}`,
+          "Content-Type": "application/json",
+        },
+        body: "{",
+      },
+      env as any,
+    );
 
-        const app = await createTestApp();
-        const env = createTestEnv();
-
-        const res = await app.request(
-            "http://localhost/api/invites/inv-1",
-            {
-                method: "PUT",
-                headers: {
-                    Authorization: `Bearer ${token}`,
-                    "Content-Type": "application/json"
-                },
-                body: JSON.stringify({ action: "accept" })
-            },
-            env as any
-        );
-
-        expect(res.status).toBe(200);
-    });
-
-    it("PUT /api/invites/:id declines invite", async () => {
-        const token = await createTestJWT({ sub: "user-2", githubId: "456", name: "Invitee" });
-        mockDb.select = vi.fn(() => makeQuery({ getResult: { id: "inv-1", inviteeId: "user-2", paperId: "paper-1", status: "pending" } }));
-
-        const app = await createTestApp();
-        const env = createTestEnv();
-
-        const res = await app.request(
-            "http://localhost/api/invites/inv-1",
-            {
-                method: "PUT",
-                headers: {
-                    Authorization: `Bearer ${token}`,
-                    "Content-Type": "application/json"
-                },
-                body: JSON.stringify({ action: "decline" })
-            },
-            env as any
-        );
-
-        expect(res.status).toBe(200);
-    });
-
-    it("PUT /api/invites/:id returns 400 for invalid JSON", async () => {
-        const token = await createTestJWT({ sub: "user-2", githubId: "456", name: "Invitee" });
-
-        const app = await createTestApp();
-        const env = createTestEnv();
-
-        const res = await app.request(
-            "http://localhost/api/invites/inv-1",
-            {
-                method: "PUT",
-                headers: {
-                    Authorization: `Bearer ${token}`,
-                    "Content-Type": "application/json"
-                },
-                body: "{ invalid }"
-            },
-            env as any
-        );
-
-        expect(res.status).toBe(400);
-        const body = await res.json() as any;
-        expect(body).toEqual({ error: "Invalid JSON body" });
-    });
-
-    it("POST /api/papers/:id/invites returns 400 when inviting self", async () => {
-        const token = await createTestJWT({ sub: "user-1", githubId: "123", name: "Uploader" });
-        mockDb.select = vi.fn().mockImplementationOnce(() => makeQuery({ getResult: { paperId: "paper-1", userId: "user-1", role: "uploader" } }));
-
-        const app = await createTestApp();
-        const env = createTestEnv();
-
-        const res = await app.request(
-            "http://localhost/api/papers/paper-1/invites",
-            {
-                method: "POST",
-                headers: {
-                    Authorization: `Bearer ${token}`,
-                    "Content-Type": "application/json"
-                },
-                body: JSON.stringify({ inviteeId: "user-1" })
-            },
-            env as any
-        );
-
-        expect(res.status).toBe(400);
-    });
-
-    it("PUT /api/invites/:id returns 400 for invalid JSON body", async () => {
-        const token = await createTestJWT({ sub: "user-1", githubId: "123", name: "Uploader" });
-        const app = await createTestApp();
-        const env = createTestEnv();
-
-        // Malformed JSON should fail before invite lookup or authorization.
-        const res = await app.request(
-            "http://localhost/api/invites/inv-1",
-            {
-                method: "PUT",
-                headers: {
-                    Authorization: `Bearer ${token}`,
-                    "Content-Type": "application/json"
-                },
-                body: "{"
-            },
-            env as any
-        );
-
-        expect(res.status).toBe(400);
-        await expect(res.json()).resolves.toEqual({ error: "Invalid JSON body" });
-        expect(mockDb.select).not.toHaveBeenCalled();
-    });
+    expect(res.status).toBe(400);
+    await expect(res.json()).resolves.toEqual({ error: "Invalid JSON body" });
+    expect(mockDb.select).not.toHaveBeenCalled();
+  });
 });

--- a/apps/api/src/routes/__tests__/orgs.test.ts
+++ b/apps/api/src/routes/__tests__/orgs.test.ts
@@ -1,1860 +1,2209 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import {
-    createTestApp,
-    createMockDb as createSharedMockDb,
-    createTestEnv,
-    createTestJWT,
-    makeQuery,
-    queueSelectResponses as queueSharedSelectResponses,
+  createTestApp,
+  createMockDb as createSharedMockDb,
+  createTestEnv,
+  createTestJWT,
+  makeQuery,
+  queueSelectResponses as queueSharedSelectResponses,
 } from "../../test/helpers";
 
 let mockDb: any;
 
 vi.mock("drizzle-orm/d1", () => ({
-    drizzle: vi.fn(() => mockDb),
+  drizzle: vi.fn(() => mockDb),
 }));
 
 function createMockDb(overrides: Record<string, any> = {}) {
-    return createSharedMockDb(overrides);
+  return createSharedMockDb(overrides);
 }
 
 function queueSelectResponses(
-    responses: Array<{ getResult?: unknown; allResult?: unknown[] }>,
+  responses: Array<{ getResult?: unknown; allResult?: unknown[] }>,
 ) {
-    queueSharedSelectResponses(mockDb, responses);
+  queueSharedSelectResponses(mockDb, responses);
 }
 
 describe("orgs routes", () => {
-    beforeEach(() => {
-        vi.restoreAllMocks();
-        vi.resetModules();
-        mockDb = createMockDb();
+  beforeEach(() => {
+    vi.restoreAllMocks();
+    vi.resetModules();
+    mockDb = createMockDb();
+  });
+
+  // ─── POST /api/orgs ────────────────────────────────────────
+  describe("POST /api/orgs", () => {
+    it("returns 400 for invalid description", async () => {
+      const token = await createTestJWT({
+        sub: "user-1",
+        githubId: "123",
+        name: "Tester",
+      });
+      const app = await createTestApp();
+      const env = createTestEnv();
+
+      const res = await app.request(
+        "http://localhost/api/orgs",
+        {
+          method: "POST",
+          headers: {
+            Authorization: `Bearer ${token}`,
+            "Content-Type": "application/json",
+          },
+          body: JSON.stringify({ name: "Lab", slug: "lab", description: 123 }),
+        },
+        env as any,
+      );
+
+      expect(res.status).toBe(400);
+      await expect(res.json()).resolves.toEqual({
+        error: "description must be a string",
+      });
     });
 
-    // ─── POST /api/orgs ────────────────────────────────────────
-    describe("POST /api/orgs", () => {
-        it("returns 400 for invalid description", async () => {
-            const token = await createTestJWT({ sub: "user-1", githubId: "123", name: "Tester" });
-            const app = await createTestApp();
-            const env = createTestEnv();
+    it("throws generic error during insert if not UNIQUE constraint", async () => {
+      const token = await createTestJWT({
+        sub: "user-1",
+        githubId: "123",
+        name: "Tester",
+      });
 
-            const res = await app.request(
-                "http://localhost/api/orgs",
-                {
-                    method: "POST",
-                    headers: {
-                        Authorization: `Bearer ${token}`,
-                        "Content-Type": "application/json",
-                    },
-                    body: JSON.stringify({ name: "Lab", slug: "lab", description: 123 }),
-                },
-                env as any,
-            );
+      mockDb.select = vi.fn(() => makeQuery({ getResult: null }));
 
-            expect(res.status).toBe(400);
-            await expect(res.json()).resolves.toEqual({ error: "description must be a string" });
-        });
+      mockDb.insert = vi.fn().mockImplementationOnce(() => ({
+        values: vi.fn(async () => {
+          throw new Error("Some other DB error");
+        }),
+      }));
 
-        it("throws generic error during insert if not UNIQUE constraint", async () => {
-            const token = await createTestJWT({ sub: "user-1", githubId: "123", name: "Tester" });
+      const app = await createTestApp();
+      const env = createTestEnv();
 
-            mockDb.select = vi.fn(() => makeQuery({ getResult: null }));
-
-            mockDb.insert = vi.fn()
-                .mockImplementationOnce(() => ({
-                    values: vi.fn(async () => {
-                        throw new Error("Some other DB error");
-                    })
-                }));
-
-            const app = await createTestApp();
-            const env = createTestEnv();
-
-
-            const res = await app.request(
-                    "http://localhost/api/orgs",
-                    {
-                        method: "POST",
-                        headers: {
-                            Authorization: `Bearer ${token}`,
-                            "Content-Type": "application/json",
-                        },
-                        body: JSON.stringify({ name: "Lab", slug: "lab" }),
-                    },
-                    env as any,
-                );
-            expect(res.status).toBe(500);
-            const text = await res.text();
-            expect(text).toContain("Internal Server Error");
-        });
-
-        it("returns 409 for UNIQUE constraint violation race condition", async () => {
-            const token = await createTestJWT({ sub: "user-1", githubId: "123", name: "Tester" });
-
-            mockDb.select = vi.fn(() => makeQuery({ getResult: null }));
-
-            mockDb.insert = vi.fn()
-                .mockImplementationOnce(() => ({
-                    values: vi.fn(async () => {
-                        throw new Error("UNIQUE constraint failed: orgs.slug");
-                    })
-                }))
-                .mockImplementation(() => ({
-                    values: vi.fn(async () => undefined)
-                }));
-
-            const app = await createTestApp();
-            const env = createTestEnv();
-
-            const res = await app.request(
-                "http://localhost/api/orgs",
-                {
-                    method: "POST",
-                    headers: {
-                        Authorization: `Bearer ${token}`,
-                        "Content-Type": "application/json",
-                    },
-                    body: JSON.stringify({ name: "Race Condition Lab", slug: "race-lab" }),
-                },
-                env as any,
-            );
-
-            expect(res.status).toBe(409);
-            const body = (await res.json()) as any;
-            expect(body.error).toBe("slug already in use");
-        });
-
-        it("creates org and returns 201", async () => {
-            const token = await createTestJWT({ sub: "user-1", githubId: "123", name: "Tester" });
-            const createdOrg = { id: "org-1", slug: "my-lab", name: "My Lab", description: null, createdAt: "2026-01-01" };
-            let selectCallCount = 0;
-            mockDb.select = vi.fn(() => {
-                selectCallCount++;
-                // First call: check slug uniqueness (not found)
-                // Second call: fetch created org
-                if (selectCallCount <= 1) return makeQuery({ getResult: null });
-                return makeQuery({ getResult: createdOrg });
-            });
-            mockDb.insert = vi.fn(() => ({ values: vi.fn(async () => undefined) }));
-
-            const app = await createTestApp();
-            const env = createTestEnv();
-
-            const res = await app.request(
-                "http://localhost/api/orgs",
-                {
-                    method: "POST",
-                    headers: {
-                        Authorization: `Bearer ${token}`,
-                        "Content-Type": "application/json",
-                    },
-                    body: JSON.stringify({ name: "My Lab", slug: "my-lab" }),
-                },
-                env as any,
-            );
-
-            expect(res.status).toBe(201);
-            const body = (await res.json()) as any;
-            expect(body.org.slug).toBe("my-lab");
-        });
-
-        it("returns 400 for invalid JSON body", async () => {
-            const token = await createTestJWT({ sub: "user-1", githubId: "123", name: "Tester" });
-
-            const app = await createTestApp();
-            const env = createTestEnv();
-
-            const res = await app.request(
-                "http://localhost/api/orgs",
-                {
-                    method: "POST",
-                    headers: {
-                        Authorization: `Bearer ${token}`,
-                        "Content-Type": "application/json",
-                    },
-                    body: "invalid json string",
-                },
-                env as any,
-            );
-
-            expect(res.status).toBe(400);
-            await expect(res.json()).resolves.toEqual({ error: "Invalid JSON body" });
-        });
-
-        it("returns 400 for invalid slug", async () => {
-            const token = await createTestJWT({ sub: "user-1", githubId: "123", name: "Tester" });
-
-            const app = await createTestApp();
-            const env = createTestEnv();
-
-            const res = await app.request(
-                "http://localhost/api/orgs",
-                {
-                    method: "POST",
-                    headers: {
-                        Authorization: `Bearer ${token}`,
-                        "Content-Type": "application/json",
-                    },
-                    body: JSON.stringify({ name: "Test", slug: "ab" }),
-                },
-                env as any,
-            );
-
-            expect(res.status).toBe(400);
-        });
-
-        it("returns 409 for duplicate slug", async () => {
-            const token = await createTestJWT({ sub: "user-1", githubId: "123", name: "Tester" });
-            mockDb.select = vi.fn(() =>
-                makeQuery({ getResult: { id: "existing", slug: "taken" } }),
-            );
-
-            const app = await createTestApp();
-            const env = createTestEnv();
-
-            const res = await app.request(
-                "http://localhost/api/orgs",
-                {
-                    method: "POST",
-                    headers: {
-                        Authorization: `Bearer ${token}`,
-                        "Content-Type": "application/json",
-                    },
-                    body: JSON.stringify({ name: "Test", slug: "taken" }),
-                },
-                env as any,
-            );
-
-            expect(res.status).toBe(409);
-        });
-
-        it("returns 400 for missing name", async () => {
-            const token = await createTestJWT({ sub: "user-1", githubId: "123", name: "Tester" });
-
-            const app = await createTestApp();
-            const env = createTestEnv();
-
-            const res = await app.request(
-                "http://localhost/api/orgs",
-                {
-                    method: "POST",
-                    headers: {
-                        Authorization: `Bearer ${token}`,
-                        "Content-Type": "application/json",
-                    },
-                    body: JSON.stringify({ slug: "valid-slug" }),
-                },
-                env as any,
-            );
-
-            expect(res.status).toBe(400);
-        });
-
-        it("returns 400 for invalid JSON bodies", async () => {
-            const token = await createTestJWT({ sub: "user-1", githubId: "123", name: "Tester" });
-
-            const app = await createTestApp();
-            const env = createTestEnv();
-
-            const res = await app.request(
-                "http://localhost/api/orgs",
-                {
-                    method: "POST",
-                    headers: {
-                        Authorization: `Bearer ${token}`,
-                        "Content-Type": "application/json",
-                    },
-                    body: "{",
-                },
-                env as any,
-            );
-
-            expect(res.status).toBe(400);
-            await expect(res.json()).resolves.toEqual({ error: "Invalid JSON body" });
-        });
+      const res = await app.request(
+        "http://localhost/api/orgs",
+        {
+          method: "POST",
+          headers: {
+            Authorization: `Bearer ${token}`,
+            "Content-Type": "application/json",
+          },
+          body: JSON.stringify({ name: "Lab", slug: "lab" }),
+        },
+        env as any,
+      );
+      expect(res.status).toBe(500);
+      const text = await res.text();
+      expect(text).toContain("Internal Server Error");
     });
 
-    // ─── GET /api/orgs/:slug ──────────────────────────────────
-    describe("GET /api/orgs/:slug", () => {
-        it("returns org detail", async () => {
-            const org = { id: "org-1", slug: "my-lab", name: "My Lab", description: null, createdAt: "2026-01-01" };
-            queueSelectResponses([
-                { getResult: org },
-                { getResult: { count: 3 } },
-                { getResult: { count: 7 } },
-            ]);
+    it("returns 409 for UNIQUE constraint violation race condition", async () => {
+      const token = await createTestJWT({
+        sub: "user-1",
+        githubId: "123",
+        name: "Tester",
+      });
 
-            const app = await createTestApp();
-            const env = createTestEnv();
+      mockDb.select = vi.fn(() => makeQuery({ getResult: null }));
 
-            const res = await app.request(
-                "http://localhost/api/orgs/my-lab",
-                {},
-                env as any,
-            );
+      mockDb.insert = vi
+        .fn()
+        .mockImplementationOnce(() => ({
+          values: vi.fn(async () => {
+            throw new Error("UNIQUE constraint failed: orgs.slug");
+          }),
+        }))
+        .mockImplementation(() => ({
+          values: vi.fn(async () => undefined),
+        }));
 
-            expect(res.status).toBe(200);
-            const body = (await res.json()) as any;
-            expect(body.org.slug).toBe("my-lab");
-            expect(body.memberCount).toBe(3);
-            expect(body.paperCount).toBe(7);
-        });
+      const app = await createTestApp();
+      const env = createTestEnv();
 
-        it("returns 404 for non-existent org", async () => {
-            mockDb.select = vi.fn(() => makeQuery({ getResult: null }));
+      const res = await app.request(
+        "http://localhost/api/orgs",
+        {
+          method: "POST",
+          headers: {
+            Authorization: `Bearer ${token}`,
+            "Content-Type": "application/json",
+          },
+          body: JSON.stringify({
+            name: "Race Condition Lab",
+            slug: "race-lab",
+          }),
+        },
+        env as any,
+      );
 
-            const app = await createTestApp();
-            const env = createTestEnv();
-
-            const res = await app.request(
-                "http://localhost/api/orgs/not-found",
-                {},
-                env as any,
-            );
-
-            expect(res.status).toBe(404);
-        });
+      expect(res.status).toBe(409);
+      const body = (await res.json()) as any;
+      expect(body.error).toBe("slug already in use");
     });
 
-    describe("PATCH /api/orgs/:slug", () => {
-        it("returns 400 when no fields to update", async () => {
-            const token = await createTestJWT({ sub: "user-1", githubId: "123", name: "Tester" });
-            queueSelectResponses([
-                { getResult: { id: "org-1", slug: "my-lab", name: "My Lab", description: null } },
-                { getResult: { orgId: "org-1", userId: "user-1", role: "owner" } },
-            ]);
+    it("creates org and returns 201", async () => {
+      const token = await createTestJWT({
+        sub: "user-1",
+        githubId: "123",
+        name: "Tester",
+      });
+      const createdOrg = {
+        id: "org-1",
+        slug: "my-lab",
+        name: "My Lab",
+        description: null,
+        createdAt: "2026-01-01",
+      };
+      let selectCallCount = 0;
+      mockDb.select = vi.fn(() => {
+        selectCallCount++;
+        // First call: check slug uniqueness (not found)
+        // Second call: fetch created org
+        if (selectCallCount <= 1) return makeQuery({ getResult: null });
+        return makeQuery({ getResult: createdOrg });
+      });
+      mockDb.insert = vi.fn(() => ({ values: vi.fn(async () => undefined) }));
 
-            const app = await createTestApp();
-            const env = createTestEnv();
+      const app = await createTestApp();
+      const env = createTestEnv();
 
-            const res = await app.request(
-                "http://localhost/api/orgs/my-lab",
-                {
-                    method: "PATCH",
-                    headers: {
-                        Authorization: `Bearer ${token}`,
-                        "Content-Type": "application/json",
-                    },
-                    body: JSON.stringify({}),
-                },
-                env as any,
-            );
+      const res = await app.request(
+        "http://localhost/api/orgs",
+        {
+          method: "POST",
+          headers: {
+            Authorization: `Bearer ${token}`,
+            "Content-Type": "application/json",
+          },
+          body: JSON.stringify({ name: "My Lab", slug: "my-lab" }),
+        },
+        env as any,
+      );
 
-            expect(res.status).toBe(400);
-            await expect(res.json()).resolves.toEqual({ error: "No fields to update" });
-        });
-
-        it("returns 400 for invalid slug", async () => {
-            const token = await createTestJWT({ sub: "user-1", githubId: "123", name: "Tester" });
-            queueSelectResponses([
-                { getResult: { id: "org-1", slug: "my-lab", name: "My Lab", description: null } },
-                { getResult: { orgId: "org-1", userId: "user-1", role: "owner" } },
-            ]);
-
-            const app = await createTestApp();
-            const env = createTestEnv();
-
-            const res = await app.request(
-                "http://localhost/api/orgs/my-lab",
-                {
-                    method: "PATCH",
-                    headers: {
-                        Authorization: `Bearer ${token}`,
-                        "Content-Type": "application/json",
-                    },
-                    body: JSON.stringify({ slug: "ab" }),
-                },
-                env as any,
-            );
-
-            expect(res.status).toBe(400);
-            await expect(res.json()).resolves.toEqual({ error: "slug must be 3–40 characters" });
-        });
-
-        it("returns 409 if new slug already in use", async () => {
-            const token = await createTestJWT({ sub: "user-1", githubId: "123", name: "Tester" });
-            queueSelectResponses([
-                { getResult: { id: "org-1", slug: "my-lab", name: "My Lab", description: null } },
-                { getResult: { orgId: "org-1", userId: "user-1", role: "owner" } },
-                { getResult: { id: "org-2", slug: "taken-lab" } },
-            ]);
-
-            const app = await createTestApp();
-            const env = createTestEnv();
-
-            const res = await app.request(
-                "http://localhost/api/orgs/my-lab",
-                {
-                    method: "PATCH",
-                    headers: {
-                        Authorization: `Bearer ${token}`,
-                        "Content-Type": "application/json",
-                    },
-                    body: JSON.stringify({ slug: "taken-lab" }),
-                },
-                env as any,
-            );
-
-            expect(res.status).toBe(409);
-            await expect(res.json()).resolves.toEqual({ error: "slug already in use" });
-        });
-
-        it("returns 400 for invalid name update", async () => {
-            const token = await createTestJWT({ sub: "user-1", githubId: "123", name: "Tester" });
-            queueSelectResponses([
-                { getResult: { id: "org-1", slug: "my-lab", name: "My Lab", description: null } },
-                { getResult: { orgId: "org-1", userId: "user-1", role: "owner" } },
-            ]);
-
-            const app = await createTestApp();
-            const env = createTestEnv();
-
-            const res = await app.request(
-                "http://localhost/api/orgs/my-lab",
-                {
-                    method: "PATCH",
-                    headers: {
-                        Authorization: `Bearer ${token}`,
-                        "Content-Type": "application/json",
-                    },
-                    body: JSON.stringify({ name: "" }),
-                },
-                env as any,
-            );
-
-            expect(res.status).toBe(400);
-            await expect(res.json()).resolves.toEqual({ error: "name is required" });
-        });
-
-        it("returns 400 for invalid description update", async () => {
-            const token = await createTestJWT({ sub: "user-1", githubId: "123", name: "Tester" });
-            queueSelectResponses([
-                { getResult: { id: "org-1", slug: "my-lab", name: "My Lab", description: null } },
-                { getResult: { orgId: "org-1", userId: "user-1", role: "owner" } },
-            ]);
-
-            const app = await createTestApp();
-            const env = createTestEnv();
-
-            const res = await app.request(
-                "http://localhost/api/orgs/my-lab",
-                {
-                    method: "PATCH",
-                    headers: {
-                        Authorization: `Bearer ${token}`,
-                        "Content-Type": "application/json",
-                    },
-                    body: JSON.stringify({ description: 123 }),
-                },
-                env as any,
-            );
-
-            expect(res.status).toBe(400);
-            await expect(res.json()).resolves.toEqual({ error: "description must be a string" });
-        });
-
-        it("updates the org for admins", async () => {
-            const token = await createTestJWT({ sub: "user-1", githubId: "123", name: "Tester" });
-            queueSelectResponses([
-                { getResult: { id: "org-1", slug: "my-lab", name: "My Lab", description: null } },
-                { getResult: { orgId: "org-1", userId: "user-1", role: "owner" } },
-                { getResult: { id: "org-1", slug: "my-lab", name: "Renamed Lab", description: "Updated" } },
-            ]);
-
-            const setValues = vi.fn(() => ({ where: vi.fn(async () => ({ meta: { changes: 1 } })) }));
-            mockDb.update = vi.fn(() => ({ set: setValues }));
-
-            const app = await createTestApp();
-            const env = createTestEnv();
-
-            const res = await app.request(
-                "http://localhost/api/orgs/my-lab",
-                {
-                    method: "PATCH",
-                    headers: {
-                        Authorization: `Bearer ${token}`,
-                        "Content-Type": "application/json",
-                    },
-                    body: JSON.stringify({
-                        name: " Renamed Lab ",
-                        description: " Updated ",
-                    }),
-                },
-                env as any,
-            );
-
-            expect(res.status).toBe(200);
-            expect(setValues).toHaveBeenCalledWith(
-                expect.objectContaining({
-                    name: "Renamed Lab",
-                    description: "Updated",
-                }),
-            );
-        });
-
-        it("returns 400 for invalid JSON bodies", async () => {
-            const token = await createTestJWT({ sub: "user-1", githubId: "123", name: "Tester" });
-            queueSelectResponses([
-                { getResult: { id: "org-1", slug: "my-lab", name: "My Lab", description: null } },
-                { getResult: { orgId: "org-1", userId: "user-1", role: "owner" } },
-            ]);
-
-            const app = await createTestApp();
-            const env = createTestEnv();
-
-            const res = await app.request(
-                "http://localhost/api/orgs/my-lab",
-                {
-                    method: "PATCH",
-                    headers: {
-                        Authorization: `Bearer ${token}`,
-                        "Content-Type": "application/json",
-                    },
-                    body: "{",
-                },
-                env as any,
-            );
-
-            expect(res.status).toBe(400);
-            await expect(res.json()).resolves.toEqual({ error: "Invalid JSON body" });
-        });
+      expect(res.status).toBe(201);
+      const body = (await res.json()) as any;
+      expect(body.org.slug).toBe("my-lab");
     });
 
-    // ─── DELETE /api/orgs/:slug ────────────────────────────────
-    describe("DELETE /api/orgs/:slug", () => {
-        it("returns 403 if not admin", async () => {
-            const token = await createTestJWT({ sub: "user-1", githubId: "123", name: "Tester" });
-            const org = { id: "org-1", slug: "my-lab" };
-            let selectCallCount = 0;
-            mockDb.select = vi.fn(() => {
-                selectCallCount++;
-                if (selectCallCount === 1) return makeQuery({ getResult: org });
-                // membership check: member, not admin
-                return makeQuery({ getResult: { orgId: "org-1", userId: "user-1", role: "member" } });
-            });
+    it("returns 400 for invalid JSON body", async () => {
+      const token = await createTestJWT({
+        sub: "user-1",
+        githubId: "123",
+        name: "Tester",
+      });
 
-            const app = await createTestApp();
-            const env = createTestEnv();
+      const app = await createTestApp();
+      const env = createTestEnv();
 
-            const res = await app.request(
-                "http://localhost/api/orgs/my-lab",
-                {
-                    method: "DELETE",
-                    headers: { Authorization: `Bearer ${token}` },
-                },
-                env as any,
-            );
+      const res = await app.request(
+        "http://localhost/api/orgs",
+        {
+          method: "POST",
+          headers: {
+            Authorization: `Bearer ${token}`,
+            "Content-Type": "application/json",
+          },
+          body: "invalid json string",
+        },
+        env as any,
+      );
 
-            expect(res.status).toBe(403);
-        });
-
-        it("deletes the org for admins", async () => {
-            const token = await createTestJWT({ sub: "user-1", githubId: "123", name: "Tester" });
-            queueSelectResponses([
-                { getResult: { id: "org-1", slug: "my-lab" } },
-                { getResult: { orgId: "org-1", userId: "user-1", role: "admin" } },
-            ]);
-
-            const deleteWhere = vi.fn(async () => ({ meta: { changes: 1 } }));
-            mockDb.delete = vi.fn(() => ({ where: deleteWhere }));
-
-            const app = await createTestApp();
-            const env = createTestEnv();
-
-            const res = await app.request(
-                "http://localhost/api/orgs/my-lab",
-                {
-                    method: "DELETE",
-                    headers: { Authorization: `Bearer ${token}` },
-                },
-                env as any,
-            );
-
-            expect(res.status).toBe(200);
-            await expect(res.json()).resolves.toEqual({ ok: true });
-            expect(deleteWhere).toHaveBeenCalled();
-        });
+      expect(res.status).toBe(400);
+      await expect(res.json()).resolves.toEqual({ error: "Invalid JSON body" });
     });
 
-    // ─── Member management ────────────────────────────────────
-    describe("POST /api/orgs/:slug/members", () => {
-        it("returns 400 for invalid JSON body", async () => {
-            const token = await createTestJWT({ sub: "user-1", githubId: "123", name: "Tester" });
-            queueSelectResponses([
-                { getResult: { id: "org-1", slug: "my-lab" } },
-                { getResult: { orgId: "org-1", userId: "user-1", role: "admin" } },
-            ]);
+    it("returns 400 for invalid slug", async () => {
+      const token = await createTestJWT({
+        sub: "user-1",
+        githubId: "123",
+        name: "Tester",
+      });
 
-            const app = await createTestApp();
-            const env = createTestEnv();
+      const app = await createTestApp();
+      const env = createTestEnv();
 
-            const res = await app.request(
-                "http://localhost/api/orgs/my-lab/members",
-                {
-                    method: "POST",
-                    headers: {
-                        Authorization: `Bearer ${token}`,
-                        "Content-Type": "application/json",
-                    },
-                    body: "{",
-                },
-                env as any,
-            );
+      const res = await app.request(
+        "http://localhost/api/orgs",
+        {
+          method: "POST",
+          headers: {
+            Authorization: `Bearer ${token}`,
+            "Content-Type": "application/json",
+          },
+          body: JSON.stringify({ name: "Test", slug: "ab" }),
+        },
+        env as any,
+      );
 
-            expect(res.status).toBe(400);
-            await expect(res.json()).resolves.toEqual({ error: "Invalid JSON body" });
-        });
-
-        it("returns 400 for missing userId", async () => {
-            const token = await createTestJWT({ sub: "user-1", githubId: "123", name: "Tester" });
-            queueSelectResponses([
-                { getResult: { id: "org-1", slug: "my-lab" } },
-                { getResult: { orgId: "org-1", userId: "user-1", role: "admin" } },
-            ]);
-
-            const app = await createTestApp();
-            const env = createTestEnv();
-
-            const res = await app.request(
-                "http://localhost/api/orgs/my-lab/members",
-                {
-                    method: "POST",
-                    headers: {
-                        Authorization: `Bearer ${token}`,
-                        "Content-Type": "application/json",
-                    },
-                    body: JSON.stringify({ role: "member" }),
-                },
-                env as any,
-            );
-
-            expect(res.status).toBe(400);
-            await expect(res.json()).resolves.toEqual({ error: "userId is required" });
-        });
-
-        it("returns 400 for invalid role", async () => {
-            const token = await createTestJWT({ sub: "user-1", githubId: "123", name: "Tester" });
-            queueSelectResponses([
-                { getResult: { id: "org-1", slug: "my-lab" } },
-                { getResult: { orgId: "org-1", userId: "user-1", role: "admin" } },
-            ]);
-
-            const app = await createTestApp();
-            const env = createTestEnv();
-
-            const res = await app.request(
-                "http://localhost/api/orgs/my-lab/members",
-                {
-                    method: "POST",
-                    headers: {
-                        Authorization: `Bearer ${token}`,
-                        "Content-Type": "application/json",
-                    },
-                    body: JSON.stringify({ userId: "user-2", role: "superadmin" }),
-                },
-                env as any,
-            );
-
-            expect(res.status).toBe(400);
-            await expect(res.json()).resolves.toEqual({ error: "role must be 'admin' or 'member'" });
-        });
-
-        it("returns 404 when target user is not found", async () => {
-            const token = await createTestJWT({ sub: "user-1", githubId: "123", name: "Tester" });
-            queueSelectResponses([
-                { getResult: { id: "org-1", slug: "my-lab" } },
-                { getResult: { orgId: "org-1", userId: "user-1", role: "admin" } },
-                { getResult: null },
-            ]);
-
-            const app = await createTestApp();
-            const env = createTestEnv();
-
-            const res = await app.request(
-                "http://localhost/api/orgs/my-lab/members",
-                {
-                    method: "POST",
-                    headers: {
-                        Authorization: `Bearer ${token}`,
-                        "Content-Type": "application/json",
-                    },
-                    body: JSON.stringify({ userId: "user-2", role: "member" }),
-                },
-                env as any,
-            );
-
-            expect(res.status).toBe(404);
-            await expect(res.json()).resolves.toEqual({ error: "User not found" });
-        });
-
-        it("throws generic error during insert if not UNIQUE constraint", async () => {
-            const token = await createTestJWT({ sub: "user-1", githubId: "123", name: "Tester" });
-            queueSelectResponses([
-                { getResult: { id: "org-1", slug: "my-lab" } },
-                { getResult: { orgId: "org-1", userId: "user-1", role: "admin" } },
-                { getResult: { id: "user-2" } },
-                { getResult: null },
-            ]);
-
-            mockDb.insert = vi.fn()
-                .mockImplementationOnce(() => ({
-                    values: vi.fn(async () => {
-                        throw new Error("Some other DB error");
-                    })
-                }));
-
-            const app = await createTestApp();
-            const env = createTestEnv();
-
-            const res = await app.request(
-                "http://localhost/api/orgs/my-lab/members",
-                {
-                    method: "POST",
-                    headers: {
-                        Authorization: `Bearer ${token}`,
-                        "Content-Type": "application/json",
-                    },
-                    body: JSON.stringify({ userId: "user-2", role: "member" }),
-                },
-                env as any,
-            );
-
-            expect(res.status).toBe(500);
-        });
-
-        it("returns 403 without auth (CSRF blocks before auth middleware)", async () => {
-            const app = await createTestApp();
-            const env = createTestEnv();
-
-            const res = await app.request(
-                "http://localhost/api/orgs/my-lab/members",
-                {
-                    method: "POST",
-                    headers: { "Content-Type": "application/json" },
-                    body: JSON.stringify({ userId: "user-2", role: "member" }),
-                },
-                env as any,
-            );
-
-            expect(res.status).toBe(403);
-        });
-
-        it("returns 409 when the user is already a member", async () => {
-            const token = await createTestJWT({ sub: "user-1", githubId: "123", name: "Tester" });
-            queueSelectResponses([
-                { getResult: { id: "org-1", slug: "my-lab" } },
-                { getResult: { orgId: "org-1", userId: "user-1", role: "admin" } },
-                { getResult: { id: "user-2", name: "Member" } },
-                { getResult: { orgId: "org-1", userId: "user-2", role: "member" } },
-            ]);
-
-            const app = await createTestApp();
-            const env = createTestEnv();
-
-            const res = await app.request(
-                "http://localhost/api/orgs/my-lab/members",
-                {
-                    method: "POST",
-                    headers: {
-                        Authorization: `Bearer ${token}`,
-                        "Content-Type": "application/json",
-                    },
-                    body: JSON.stringify({ userId: "user-2", role: "member" }),
-                },
-                env as any,
-            );
-
-            expect(res.status).toBe(409);
-            expect(((await res.json()) as any).error).toBe("User is already a member");
-        });
+      expect(res.status).toBe(400);
     });
 
-    describe("PATCH /api/orgs/:slug/members/:userId", () => {
-        it("returns 400 for invalid JSON body", async () => {
-            const token = await createTestJWT({ sub: "user-1", githubId: "123", name: "Tester" });
-            const org = { id: "org-1", slug: "my-lab" };
+    it("returns 409 for duplicate slug", async () => {
+      const token = await createTestJWT({
+        sub: "user-1",
+        githubId: "123",
+        name: "Tester",
+      });
+      mockDb.select = vi.fn(() =>
+        makeQuery({ getResult: { id: "existing", slug: "taken" } }),
+      );
 
-            queueSelectResponses([
-                { getResult: org },
-                { getResult: { orgId: "org-1", userId: "user-1", role: "admin" } },
-            ]);
+      const app = await createTestApp();
+      const env = createTestEnv();
 
-            const app = await createTestApp();
-            const env = createTestEnv();
+      const res = await app.request(
+        "http://localhost/api/orgs",
+        {
+          method: "POST",
+          headers: {
+            Authorization: `Bearer ${token}`,
+            "Content-Type": "application/json",
+          },
+          body: JSON.stringify({ name: "Test", slug: "taken" }),
+        },
+        env as any,
+      );
 
-            const res = await app.request(
-                "http://localhost/api/orgs/my-lab/members/user-2",
-                {
-                    method: "PATCH",
-                    headers: {
-                        Authorization: `Bearer ${token}`,
-                        "Content-Type": "application/json",
-                    },
-                    body: "{",
-                },
-                env as any,
-            );
-
-            expect(res.status).toBe(400);
-            await expect(res.json()).resolves.toEqual({ error: "Invalid JSON body" });
-        });
-
-        it("returns 404 when the target membership does not exist", async () => {
-            const token = await createTestJWT({ sub: "user-1", githubId: "123", name: "Tester" });
-            const org = { id: "org-1", slug: "my-lab" };
-
-            queueSelectResponses([
-                { getResult: org },
-                { getResult: { orgId: "org-1", userId: "user-1", role: "admin" } },
-                { getResult: null },
-            ]);
-
-            const app = await createTestApp();
-            const env = createTestEnv();
-
-            const res = await app.request(
-                "http://localhost/api/orgs/my-lab/members/user-2",
-                {
-                    method: "PATCH",
-                    headers: {
-                        Authorization: `Bearer ${token}`,
-                        "Content-Type": "application/json",
-                    },
-                    body: JSON.stringify({ role: "member" }),
-                },
-                env as any,
-            );
-
-            expect(res.status).toBe(404);
-            await expect(res.json()).resolves.toEqual({ error: "Member not found" });
-        });
-
-        it("returns 200 when an owner modifies another owner role", async () => {
-            const token = await createTestJWT({ sub: "owner-1", githubId: "123", name: "Owner 1" });
-            const org = { id: "org-1", slug: "my-lab" };
-
-            queueSelectResponses([
-                { getResult: org },
-                { getResult: { orgId: "org-1", userId: "owner-1", role: "owner" } }, // requireOrgAdmin
-                { getResult: { orgId: "org-1", userId: "owner-2", role: "owner" } }, // getOrgMembership (target)
-            ]);
-            mockDb.update = vi.fn(() => ({
-                set: vi.fn(() => ({
-                    where: vi.fn(() => ({
-                        meta: { changes: 1 } // simulate successful update
-                    }))
-                }))
-            }));
-
-            const app = await createTestApp();
-            const env = createTestEnv();
-
-            const res = await app.request(
-                "http://localhost/api/orgs/my-lab/members/owner-2",
-                {
-                    method: "PATCH",
-                    headers: {
-                        Authorization: `Bearer ${token}`,
-                        "Content-Type": "application/json",
-                    },
-                    body: JSON.stringify({ role: "member" }),
-                },
-                env as any,
-            );
-
-            expect(res.status).toBe(200);
-            expect(await res.json()).toEqual({ ok: true });
-        });
-        it("returns 403 when an admin tries to modify an owner's role", async () => {
-            const token = await createTestJWT({ sub: "admin-user", githubId: "123", name: "Admin Tester" });
-            const org = { id: "org-1", slug: "my-lab" };
-
-            queueSelectResponses([
-                { getResult: org },
-                { getResult: { orgId: "org-1", userId: "admin-user", role: "admin" } }, // requireOrgAdmin
-                { getResult: { orgId: "org-1", userId: "owner-user", role: "owner" } }, // getOrgMembership (target)
-            ]);
-
-            const app = await createTestApp();
-            const env = createTestEnv();
-
-            const res = await app.request(
-                "http://localhost/api/orgs/my-lab/members/owner-user",
-                {
-                    method: "PATCH",
-                    headers: {
-                        Authorization: `Bearer ${token}`,
-                        "Content-Type": "application/json",
-                    },
-                    body: JSON.stringify({ role: "member" }),
-                },
-                env as any,
-            );
-
-            expect(res.status).toBe(403);
-            expect(((await res.json()) as any).error).toBe("Forbidden: admin cannot modify owner role");
-        });
-        it("returns 400 for invalid role", async () => {
-            const token = await createTestJWT({ sub: "user-1", githubId: "123", name: "Tester" });
-            const org = { id: "org-1", slug: "my-lab" };
-            let selectCallCount = 0;
-            mockDb.select = vi.fn(() => {
-                selectCallCount++;
-                if (selectCallCount === 1) return makeQuery({ getResult: org });
-                return makeQuery({ getResult: { orgId: "org-1", userId: "user-1", role: "admin" } });
-            });
-
-            const app = await createTestApp();
-            const env = createTestEnv();
-
-            const res = await app.request(
-                "http://localhost/api/orgs/my-lab/members/user-2",
-                {
-                    method: "PATCH",
-                    headers: {
-                        Authorization: `Bearer ${token}`,
-                        "Content-Type": "application/json",
-                    },
-                    body: JSON.stringify({ role: "superadmin" }),
-                },
-                env as any,
-            );
-
-            expect(res.status).toBe(400);
-        });
+      expect(res.status).toBe(409);
     });
 
-    // ─── GET /api/orgs/:slug/members ──────────────────────────
-    describe("GET /api/orgs/:slug/members", () => {
-        it("returns 404 when org does not exist", async () => {
-            mockDb.select = vi.fn(() => makeQuery({ getResult: null }));
+    it("returns 400 for missing name", async () => {
+      const token = await createTestJWT({
+        sub: "user-1",
+        githubId: "123",
+        name: "Tester",
+      });
 
-            const app = await createTestApp();
-            const env = createTestEnv();
+      const app = await createTestApp();
+      const env = createTestEnv();
 
-            const res = await app.request(
-                "http://localhost/api/orgs/nonexistent/members",
-                {},
-                env as any,
-            );
+      const res = await app.request(
+        "http://localhost/api/orgs",
+        {
+          method: "POST",
+          headers: {
+            Authorization: `Bearer ${token}`,
+            "Content-Type": "application/json",
+          },
+          body: JSON.stringify({ slug: "valid-slug" }),
+        },
+        env as any,
+      );
 
-            expect(res.status).toBe(404);
-        });
-
-        it("returns members for an existing org", async () => {
-            queueSelectResponses([
-                { getResult: { id: "org-1", slug: "my-lab" } },
-                {
-                    allResult: [
-                        {
-                            userId: "user-1",
-                            role: "admin",
-                            name: "Tester",
-                            displayName: null,
-                            avatarUrl: null,
-                            githubId: "tester",
-                        },
-                    ],
-                },
-            ]);
-
-            const app = await createTestApp();
-            const env = createTestEnv();
-
-            const res = await app.request(
-                "http://localhost/api/orgs/my-lab/members",
-                {},
-                env as any,
-            );
-
-            expect(res.status).toBe(200);
-            expect(((await res.json()) as any).members).toHaveLength(1);
-        });
+      expect(res.status).toBe(400);
     });
 
-    // ─── Paper association ────────────────────────────────────
-    describe("POST /api/orgs/:slug/papers", () => {
-        it("returns 400 for invalid JSON body", async () => {
-            const token = await createTestJWT({ sub: "user-1", githubId: "123", name: "Tester" });
-            queueSelectResponses([
-                { getResult: { id: "org-1", slug: "my-lab" } },
-            ]);
+    it("returns 400 for invalid JSON bodies", async () => {
+      const token = await createTestJWT({
+        sub: "user-1",
+        githubId: "123",
+        name: "Tester",
+      });
 
-            const app = await createTestApp();
-            const env = createTestEnv();
+      const app = await createTestApp();
+      const env = createTestEnv();
 
-            const res = await app.request(
-                "http://localhost/api/orgs/my-lab/papers",
-                {
-                    method: "POST",
-                    headers: {
-                        Authorization: `Bearer ${token}`,
-                        "Content-Type": "application/json",
-                    },
-                    body: "{",
-                },
-                env as any,
-            );
+      const res = await app.request(
+        "http://localhost/api/orgs",
+        {
+          method: "POST",
+          headers: {
+            Authorization: `Bearer ${token}`,
+            "Content-Type": "application/json",
+          },
+          body: "{",
+        },
+        env as any,
+      );
 
-            expect(res.status).toBe(400);
-            await expect(res.json()).resolves.toEqual({ error: "Invalid JSON body" });
-        });
+      expect(res.status).toBe(400);
+      await expect(res.json()).resolves.toEqual({ error: "Invalid JSON body" });
+    });
+  });
 
-        it("returns 400 for missing paperId", async () => {
-            const token = await createTestJWT({ sub: "user-1", githubId: "123", name: "Tester" });
-            queueSelectResponses([
-                { getResult: { id: "org-1", slug: "my-lab" } },
-            ]);
+  // ─── GET /api/orgs/:slug ──────────────────────────────────
+  describe("GET /api/orgs/:slug", () => {
+    it("returns org detail", async () => {
+      const org = {
+        id: "org-1",
+        slug: "my-lab",
+        name: "My Lab",
+        description: null,
+        createdAt: "2026-01-01",
+      };
+      queueSelectResponses([
+        { getResult: org },
+        { getResult: { count: 3 } },
+        { getResult: { count: 7 } },
+      ]);
 
-            const app = await createTestApp();
-            const env = createTestEnv();
+      const app = await createTestApp();
+      const env = createTestEnv();
 
-            const res = await app.request(
-                "http://localhost/api/orgs/my-lab/papers",
-                {
-                    method: "POST",
-                    headers: {
-                        Authorization: `Bearer ${token}`,
-                        "Content-Type": "application/json",
-                    },
-                    body: JSON.stringify({ }),
-                },
-                env as any,
-            );
+      const res = await app.request(
+        "http://localhost/api/orgs/my-lab",
+        {},
+        env as any,
+      );
 
-            expect(res.status).toBe(400);
-            await expect(res.json()).resolves.toEqual({ error: "paperId is required" });
-        });
-
-        it("returns 404 when paper is not found", async () => {
-            const token = await createTestJWT({ sub: "user-1", githubId: "123", name: "Tester" });
-            queueSelectResponses([
-                { getResult: { id: "org-1", slug: "my-lab" } },
-                { getResult: null }, // paper
-            ]);
-
-            const app = await createTestApp();
-            const env = createTestEnv();
-
-            const res = await app.request(
-                "http://localhost/api/orgs/my-lab/papers",
-                {
-                    method: "POST",
-                    headers: {
-                        Authorization: `Bearer ${token}`,
-                        "Content-Type": "application/json",
-                    },
-                    body: JSON.stringify({ paperId: "paper-1" }),
-                },
-                env as any,
-            );
-
-            expect(res.status).toBe(404);
-            await expect(res.json()).resolves.toEqual({ error: "Paper not found" });
-        });
-
-        it("returns 403 when not org admin or paper author", async () => {
-            const token = await createTestJWT({ sub: "user-1", githubId: "123", name: "Tester" });
-            queueSelectResponses([
-                { getResult: { id: "org-1", slug: "my-lab" } },
-                { getResult: { id: "paper-1" } }, // paper
-                { getResult: null }, // not org admin
-                { getResult: null }, // not paper author
-            ]);
-
-            const app = await createTestApp();
-            const env = createTestEnv();
-
-            const res = await app.request(
-                "http://localhost/api/orgs/my-lab/papers",
-                {
-                    method: "POST",
-                    headers: {
-                        Authorization: `Bearer ${token}`,
-                        "Content-Type": "application/json",
-                    },
-                    body: JSON.stringify({ paperId: "paper-1" }),
-                },
-                env as any,
-            );
-
-            expect(res.status).toBe(403);
-            await expect(res.json()).resolves.toEqual({ error: "Forbidden: must be org admin or paper author" });
-        });
-
-        it("throws generic error during insert if not UNIQUE constraint", async () => {
-            const token = await createTestJWT({ sub: "user-1", githubId: "123", name: "Tester" });
-            queueSelectResponses([
-                { getResult: { id: "org-1", slug: "my-lab" } },
-                { getResult: { id: "paper-1", title: "Paper" } },
-                { getResult: { orgId: "org-1", userId: "user-1", role: "admin" } },
-                { getResult: null }, // author check
-                { getResult: null }, // not already associated
-            ]);
-
-            mockDb.insert = vi.fn()
-                .mockImplementationOnce(() => ({
-                    values: vi.fn(async () => {
-                        throw new Error("Some other DB error");
-                    })
-                }));
-
-            const app = await createTestApp();
-            const env = createTestEnv();
-
-            const res = await app.request(
-                "http://localhost/api/orgs/my-lab/papers",
-                {
-                    method: "POST",
-                    headers: {
-                        Authorization: `Bearer ${token}`,
-                        "Content-Type": "application/json",
-                    },
-                    body: JSON.stringify({ paperId: "paper-1" }),
-                },
-                env as any,
-            );
-
-            expect(res.status).toBe(500);
-        });
-
-        it("returns 403 without auth (CSRF blocks before auth middleware)", async () => {
-            const app = await createTestApp();
-            const env = createTestEnv();
-
-            const res = await app.request(
-                "http://localhost/api/orgs/my-lab/papers",
-                {
-                    method: "POST",
-                    headers: { "Content-Type": "application/json" },
-                    body: JSON.stringify({ paperId: "paper-1" }),
-                },
-                env as any,
-            );
-
-            expect(res.status).toBe(403);
-        });
-
-        it("allows paper authors to associate papers without admin membership", async () => {
-            const token = await createTestJWT({ sub: "user-2", githubId: "456", name: "Author" });
-            queueSelectResponses([
-                { getResult: { id: "org-1", slug: "my-lab" } },
-                { getResult: { id: "paper-1", title: "Paper" } },
-                { getResult: null },
-                { getResult: { paperId: "paper-1", userId: "user-2", role: "uploader" } },
-                { getResult: null },
-            ]);
-
-            const insertValues = vi.fn(async () => undefined);
-            mockDb.insert = vi.fn(() => ({ values: insertValues }));
-
-            const app = await createTestApp();
-            const env = createTestEnv();
-
-            const res = await app.request(
-                "http://localhost/api/orgs/my-lab/papers",
-                {
-                    method: "POST",
-                    headers: {
-                        Authorization: `Bearer ${token}`,
-                        "Content-Type": "application/json",
-                    },
-                    body: JSON.stringify({ paperId: "paper-1" }),
-                },
-                env as any,
-            );
-
-            expect(res.status).toBe(201);
-            expect(insertValues).toHaveBeenCalledWith({
-                orgId: "org-1",
-                paperId: "paper-1",
-            });
-        });
-
-        it("returns 409 when the paper is already associated", async () => {
-            const token = await createTestJWT({ sub: "user-1", githubId: "123", name: "Admin" });
-            queueSelectResponses([
-                { getResult: { id: "org-1", slug: "my-lab" } },
-                { getResult: { id: "paper-1", title: "Paper" } },
-                { getResult: { orgId: "org-1", userId: "user-1", role: "admin" } },
-                { getResult: null },
-                { getResult: { paperId: "paper-1", orgId: "org-1" } },
-            ]);
-
-            const app = await createTestApp();
-            const env = createTestEnv();
-
-            const res = await app.request(
-                "http://localhost/api/orgs/my-lab/papers",
-                {
-                    method: "POST",
-                    headers: {
-                        Authorization: `Bearer ${token}`,
-                        "Content-Type": "application/json",
-                    },
-                    body: JSON.stringify({ paperId: "paper-1" }),
-                },
-                env as any,
-            );
-
-            expect(res.status).toBe(409);
-            expect(((await res.json()) as any).error).toBe(
-                "Paper is already associated with this org",
-            );
-        });
+      expect(res.status).toBe(200);
+      const body = (await res.json()) as any;
+      expect(body.org.slug).toBe("my-lab");
+      expect(body.memberCount).toBe(3);
+      expect(body.paperCount).toBe(7);
     });
 
-    describe("GET /api/orgs/:slug/papers", () => {
-        it("returns 404 when org does not exist", async () => {
-            mockDb.select = vi.fn(() => makeQuery({ getResult: null }));
+    it("returns 404 for non-existent org", async () => {
+      mockDb.select = vi.fn(() => makeQuery({ getResult: null }));
 
-            const app = await createTestApp();
-            const env = createTestEnv();
+      const app = await createTestApp();
+      const env = createTestEnv();
 
-            const res = await app.request(
-                "http://localhost/api/orgs/nonexistent/papers",
-                {},
-                env as any,
-            );
+      const res = await app.request(
+        "http://localhost/api/orgs/not-found",
+        {},
+        env as any,
+      );
 
-            expect(res.status).toBe(404);
+      expect(res.status).toBe(404);
+    });
+  });
+
+  describe("PATCH /api/orgs/:slug", () => {
+    it("returns 400 when no fields to update", async () => {
+      const token = await createTestJWT({
+        sub: "user-1",
+        githubId: "123",
+        name: "Tester",
+      });
+      queueSelectResponses([
+        {
+          getResult: {
+            id: "org-1",
+            slug: "my-lab",
+            name: "My Lab",
+            description: null,
+          },
+        },
+        { getResult: { orgId: "org-1", userId: "user-1", role: "owner" } },
+      ]);
+
+      const app = await createTestApp();
+      const env = createTestEnv();
+
+      const res = await app.request(
+        "http://localhost/api/orgs/my-lab",
+        {
+          method: "PATCH",
+          headers: {
+            Authorization: `Bearer ${token}`,
+            "Content-Type": "application/json",
+          },
+          body: JSON.stringify({}),
+        },
+        env as any,
+      );
+
+      expect(res.status).toBe(400);
+      await expect(res.json()).resolves.toEqual({
+        error: "No fields to update",
+      });
+    });
+
+    it("returns 400 for invalid slug", async () => {
+      const token = await createTestJWT({
+        sub: "user-1",
+        githubId: "123",
+        name: "Tester",
+      });
+      queueSelectResponses([
+        {
+          getResult: {
+            id: "org-1",
+            slug: "my-lab",
+            name: "My Lab",
+            description: null,
+          },
+        },
+        { getResult: { orgId: "org-1", userId: "user-1", role: "owner" } },
+      ]);
+
+      const app = await createTestApp();
+      const env = createTestEnv();
+
+      const res = await app.request(
+        "http://localhost/api/orgs/my-lab",
+        {
+          method: "PATCH",
+          headers: {
+            Authorization: `Bearer ${token}`,
+            "Content-Type": "application/json",
+          },
+          body: JSON.stringify({ slug: "ab" }),
+        },
+        env as any,
+      );
+
+      expect(res.status).toBe(400);
+      await expect(res.json()).resolves.toEqual({
+        error: "slug must be 3–40 characters",
+      });
+    });
+
+    it("returns 409 if new slug already in use", async () => {
+      const token = await createTestJWT({
+        sub: "user-1",
+        githubId: "123",
+        name: "Tester",
+      });
+      queueSelectResponses([
+        {
+          getResult: {
+            id: "org-1",
+            slug: "my-lab",
+            name: "My Lab",
+            description: null,
+          },
+        },
+        { getResult: { orgId: "org-1", userId: "user-1", role: "owner" } },
+        { getResult: { id: "org-2", slug: "taken-lab" } },
+      ]);
+
+      const app = await createTestApp();
+      const env = createTestEnv();
+
+      const res = await app.request(
+        "http://localhost/api/orgs/my-lab",
+        {
+          method: "PATCH",
+          headers: {
+            Authorization: `Bearer ${token}`,
+            "Content-Type": "application/json",
+          },
+          body: JSON.stringify({ slug: "taken-lab" }),
+        },
+        env as any,
+      );
+
+      expect(res.status).toBe(409);
+      await expect(res.json()).resolves.toEqual({
+        error: "slug already in use",
+      });
+    });
+
+    it("returns 400 for invalid name update", async () => {
+      const token = await createTestJWT({
+        sub: "user-1",
+        githubId: "123",
+        name: "Tester",
+      });
+      queueSelectResponses([
+        {
+          getResult: {
+            id: "org-1",
+            slug: "my-lab",
+            name: "My Lab",
+            description: null,
+          },
+        },
+        { getResult: { orgId: "org-1", userId: "user-1", role: "owner" } },
+      ]);
+
+      const app = await createTestApp();
+      const env = createTestEnv();
+
+      const res = await app.request(
+        "http://localhost/api/orgs/my-lab",
+        {
+          method: "PATCH",
+          headers: {
+            Authorization: `Bearer ${token}`,
+            "Content-Type": "application/json",
+          },
+          body: JSON.stringify({ name: "" }),
+        },
+        env as any,
+      );
+
+      expect(res.status).toBe(400);
+      await expect(res.json()).resolves.toEqual({ error: "name is required" });
+    });
+
+    it("returns 400 for invalid description update", async () => {
+      const token = await createTestJWT({
+        sub: "user-1",
+        githubId: "123",
+        name: "Tester",
+      });
+      queueSelectResponses([
+        {
+          getResult: {
+            id: "org-1",
+            slug: "my-lab",
+            name: "My Lab",
+            description: null,
+          },
+        },
+        { getResult: { orgId: "org-1", userId: "user-1", role: "owner" } },
+      ]);
+
+      const app = await createTestApp();
+      const env = createTestEnv();
+
+      const res = await app.request(
+        "http://localhost/api/orgs/my-lab",
+        {
+          method: "PATCH",
+          headers: {
+            Authorization: `Bearer ${token}`,
+            "Content-Type": "application/json",
+          },
+          body: JSON.stringify({ description: 123 }),
+        },
+        env as any,
+      );
+
+      expect(res.status).toBe(400);
+      await expect(res.json()).resolves.toEqual({
+        error: "description must be a string",
+      });
+    });
+
+    it("updates the org for admins", async () => {
+      const token = await createTestJWT({
+        sub: "user-1",
+        githubId: "123",
+        name: "Tester",
+      });
+      queueSelectResponses([
+        {
+          getResult: {
+            id: "org-1",
+            slug: "my-lab",
+            name: "My Lab",
+            description: null,
+          },
+        },
+        { getResult: { orgId: "org-1", userId: "user-1", role: "owner" } },
+        {
+          getResult: {
+            id: "org-1",
+            slug: "my-lab",
+            name: "Renamed Lab",
+            description: "Updated",
+          },
+        },
+      ]);
+
+      const setValues = vi.fn(() => ({
+        where: vi.fn(async () => ({ meta: { changes: 1 } })),
+      }));
+      mockDb.update = vi.fn(() => ({ set: setValues }));
+
+      const app = await createTestApp();
+      const env = createTestEnv();
+
+      const res = await app.request(
+        "http://localhost/api/orgs/my-lab",
+        {
+          method: "PATCH",
+          headers: {
+            Authorization: `Bearer ${token}`,
+            "Content-Type": "application/json",
+          },
+          body: JSON.stringify({
+            name: " Renamed Lab ",
+            description: " Updated ",
+          }),
+        },
+        env as any,
+      );
+
+      expect(res.status).toBe(200);
+      expect(setValues).toHaveBeenCalledWith(
+        expect.objectContaining({
+          name: "Renamed Lab",
+          description: "Updated",
+        }),
+      );
+    });
+
+    it("returns 400 for invalid JSON bodies", async () => {
+      const token = await createTestJWT({
+        sub: "user-1",
+        githubId: "123",
+        name: "Tester",
+      });
+      queueSelectResponses([
+        {
+          getResult: {
+            id: "org-1",
+            slug: "my-lab",
+            name: "My Lab",
+            description: null,
+          },
+        },
+        { getResult: { orgId: "org-1", userId: "user-1", role: "owner" } },
+      ]);
+
+      const app = await createTestApp();
+      const env = createTestEnv();
+
+      const res = await app.request(
+        "http://localhost/api/orgs/my-lab",
+        {
+          method: "PATCH",
+          headers: {
+            Authorization: `Bearer ${token}`,
+            "Content-Type": "application/json",
+          },
+          body: "{",
+        },
+        env as any,
+      );
+
+      expect(res.status).toBe(400);
+      await expect(res.json()).resolves.toEqual({ error: "Invalid JSON body" });
+    });
+  });
+
+  // ─── DELETE /api/orgs/:slug ────────────────────────────────
+  describe("DELETE /api/orgs/:slug", () => {
+    it("returns 403 if not admin", async () => {
+      const token = await createTestJWT({
+        sub: "user-1",
+        githubId: "123",
+        name: "Tester",
+      });
+      const org = { id: "org-1", slug: "my-lab" };
+      let selectCallCount = 0;
+      mockDb.select = vi.fn(() => {
+        selectCallCount++;
+        if (selectCallCount === 1) return makeQuery({ getResult: org });
+        // membership check: member, not admin
+        return makeQuery({
+          getResult: { orgId: "org-1", userId: "user-1", role: "member" },
         });
+      });
 
-        it("returns public and org_only papers to org members", async () => {
-            const token = await createTestJWT({ sub: "user-1", githubId: "123", name: "Member" });
-            queueSelectResponses([
-                { getResult: { id: "org-1", slug: "my-lab" } },
-                { getResult: { orgId: "org-1", userId: "user-1", role: "member" } },
-                {
-                    allResult: [],
-                },
-                {
-                    getResult: { maxYear: 2025 },
-                },
-                {
-                    getResult: { count: 2 },
-                },
-                {
-                    allResult: [
-                        { id: "paper-public", title: "Public", visibility: "public", year: 2025 },
-                        { id: "paper-org", title: "Org", visibility: "org_only", year: 2025 },
-                    ],
-                },
-                { allResult: [{ value: 2025, count: 2 }] },
-                { allResult: [{ value: "ASE", count: 1 }] },
-                { allResult: [{ value: "report", count: 2 }] },
-            ]);
+      const app = await createTestApp();
+      const env = createTestEnv();
 
-            const app = await createTestApp();
-            const env = createTestEnv();
+      const res = await app.request(
+        "http://localhost/api/orgs/my-lab",
+        {
+          method: "DELETE",
+          headers: { Authorization: `Bearer ${token}` },
+        },
+        env as any,
+      );
 
-            const res = await app.request(
-                "http://localhost/api/orgs/my-lab/papers?paginate=1&autoYear=1",
-                {
-                    headers: { Authorization: `Bearer ${token}` },
-                },
-                env as any,
-            );
+      expect(res.status).toBe(403);
+    });
 
-            expect(res.status).toBe(200);
-            const body = (await res.json()) as any;
-            expect(body.papers.map((paper: any) => paper.id)).toEqual([
-                "paper-public",
-                "paper-org",
-            ]);
-            expect(body.total).toBe(2);
-            expect(body.appliedFilters.year).toBe(2025);
+    it("deletes the org for admins", async () => {
+      const token = await createTestJWT({
+        sub: "user-1",
+        githubId: "123",
+        name: "Tester",
+      });
+      queueSelectResponses([
+        { getResult: { id: "org-1", slug: "my-lab" } },
+        { getResult: { orgId: "org-1", userId: "user-1", role: "admin" } },
+      ]);
+
+      const deleteWhere = vi.fn(async () => ({ meta: { changes: 1 } }));
+      mockDb.delete = vi.fn(() => ({ where: deleteWhere }));
+
+      const app = await createTestApp();
+      const env = createTestEnv();
+
+      const res = await app.request(
+        "http://localhost/api/orgs/my-lab",
+        {
+          method: "DELETE",
+          headers: { Authorization: `Bearer ${token}` },
+        },
+        env as any,
+      );
+
+      expect(res.status).toBe(200);
+      await expect(res.json()).resolves.toEqual({ ok: true });
+      expect(deleteWhere).toHaveBeenCalled();
+    });
+  });
+
+  // ─── Member management ────────────────────────────────────
+  describe("POST /api/orgs/:slug/members", () => {
+    it("returns 400 for invalid JSON body", async () => {
+      const token = await createTestJWT({
+        sub: "user-1",
+        githubId: "123",
+        name: "Tester",
+      });
+      queueSelectResponses([
+        { getResult: { id: "org-1", slug: "my-lab" } },
+        { getResult: { orgId: "org-1", userId: "user-1", role: "admin" } },
+      ]);
+
+      const app = await createTestApp();
+      const env = createTestEnv();
+
+      const res = await app.request(
+        "http://localhost/api/orgs/my-lab/members",
+        {
+          method: "POST",
+          headers: {
+            Authorization: `Bearer ${token}`,
+            "Content-Type": "application/json",
+          },
+          body: "{",
+        },
+        env as any,
+      );
+
+      expect(res.status).toBe(400);
+      await expect(res.json()).resolves.toEqual({ error: "Invalid JSON body" });
+    });
+
+    it("returns 400 for missing userId", async () => {
+      const token = await createTestJWT({
+        sub: "user-1",
+        githubId: "123",
+        name: "Tester",
+      });
+      queueSelectResponses([
+        { getResult: { id: "org-1", slug: "my-lab" } },
+        { getResult: { orgId: "org-1", userId: "user-1", role: "admin" } },
+      ]);
+
+      const app = await createTestApp();
+      const env = createTestEnv();
+
+      const res = await app.request(
+        "http://localhost/api/orgs/my-lab/members",
+        {
+          method: "POST",
+          headers: {
+            Authorization: `Bearer ${token}`,
+            "Content-Type": "application/json",
+          },
+          body: JSON.stringify({ role: "member" }),
+        },
+        env as any,
+      );
+
+      expect(res.status).toBe(400);
+      await expect(res.json()).resolves.toEqual({
+        error: "userId is required",
+      });
+    });
+
+    it("returns 400 for invalid role", async () => {
+      const token = await createTestJWT({
+        sub: "user-1",
+        githubId: "123",
+        name: "Tester",
+      });
+      queueSelectResponses([
+        { getResult: { id: "org-1", slug: "my-lab" } },
+        { getResult: { orgId: "org-1", userId: "user-1", role: "admin" } },
+      ]);
+
+      const app = await createTestApp();
+      const env = createTestEnv();
+
+      const res = await app.request(
+        "http://localhost/api/orgs/my-lab/members",
+        {
+          method: "POST",
+          headers: {
+            Authorization: `Bearer ${token}`,
+            "Content-Type": "application/json",
+          },
+          body: JSON.stringify({ userId: "user-2", role: "superadmin" }),
+        },
+        env as any,
+      );
+
+      expect(res.status).toBe(400);
+      await expect(res.json()).resolves.toEqual({
+        error: "role must be 'admin' or 'member'",
+      });
+    });
+
+    it("returns 404 when target user is not found", async () => {
+      const token = await createTestJWT({
+        sub: "user-1",
+        githubId: "123",
+        name: "Tester",
+      });
+      queueSelectResponses([
+        { getResult: { id: "org-1", slug: "my-lab" } },
+        { getResult: { orgId: "org-1", userId: "user-1", role: "admin" } },
+        { getResult: null },
+      ]);
+
+      const app = await createTestApp();
+      const env = createTestEnv();
+
+      const res = await app.request(
+        "http://localhost/api/orgs/my-lab/members",
+        {
+          method: "POST",
+          headers: {
+            Authorization: `Bearer ${token}`,
+            "Content-Type": "application/json",
+          },
+          body: JSON.stringify({ userId: "user-2", role: "member" }),
+        },
+        env as any,
+      );
+
+      expect(res.status).toBe(404);
+      await expect(res.json()).resolves.toEqual({ error: "User not found" });
+    });
+
+    it("throws generic error during insert if not UNIQUE constraint", async () => {
+      const token = await createTestJWT({
+        sub: "user-1",
+        githubId: "123",
+        name: "Tester",
+      });
+      queueSelectResponses([
+        { getResult: { id: "org-1", slug: "my-lab" } },
+        { getResult: { orgId: "org-1", userId: "user-1", role: "admin" } },
+        { getResult: { id: "user-2" } },
+        { getResult: null },
+      ]);
+
+      mockDb.insert = vi.fn().mockImplementationOnce(() => ({
+        values: vi.fn(async () => {
+          throw new Error("Some other DB error");
+        }),
+      }));
+
+      const app = await createTestApp();
+      const env = createTestEnv();
+
+      const res = await app.request(
+        "http://localhost/api/orgs/my-lab/members",
+        {
+          method: "POST",
+          headers: {
+            Authorization: `Bearer ${token}`,
+            "Content-Type": "application/json",
+          },
+          body: JSON.stringify({ userId: "user-2", role: "member" }),
+        },
+        env as any,
+      );
+
+      expect(res.status).toBe(500);
+    });
+
+    it("returns 403 without auth (CSRF blocks before auth middleware)", async () => {
+      const app = await createTestApp();
+      const env = createTestEnv();
+
+      const res = await app.request(
+        "http://localhost/api/orgs/my-lab/members",
+        {
+          method: "POST",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({ userId: "user-2", role: "member" }),
+        },
+        env as any,
+      );
+
+      expect(res.status).toBe(403);
+    });
+
+    it("returns 409 when the user is already a member", async () => {
+      const token = await createTestJWT({
+        sub: "user-1",
+        githubId: "123",
+        name: "Tester",
+      });
+      queueSelectResponses([
+        { getResult: { id: "org-1", slug: "my-lab" } },
+        { getResult: { orgId: "org-1", userId: "user-1", role: "admin" } },
+        { getResult: { id: "user-2", name: "Member" } },
+        { getResult: { orgId: "org-1", userId: "user-2", role: "member" } },
+      ]);
+
+      const app = await createTestApp();
+      const env = createTestEnv();
+
+      const res = await app.request(
+        "http://localhost/api/orgs/my-lab/members",
+        {
+          method: "POST",
+          headers: {
+            Authorization: `Bearer ${token}`,
+            "Content-Type": "application/json",
+          },
+          body: JSON.stringify({ userId: "user-2", role: "member" }),
+        },
+        env as any,
+      );
+
+      expect(res.status).toBe(409);
+      expect(((await res.json()) as any).error).toBe(
+        "User is already a member",
+      );
+    });
+  });
+
+  describe("PATCH /api/orgs/:slug/members/:userId", () => {
+    it("returns 400 for invalid JSON body", async () => {
+      const token = await createTestJWT({
+        sub: "user-1",
+        githubId: "123",
+        name: "Tester",
+      });
+      const org = { id: "org-1", slug: "my-lab" };
+
+      queueSelectResponses([
+        { getResult: org },
+        { getResult: { orgId: "org-1", userId: "user-1", role: "admin" } },
+      ]);
+
+      const app = await createTestApp();
+      const env = createTestEnv();
+
+      const res = await app.request(
+        "http://localhost/api/orgs/my-lab/members/user-2",
+        {
+          method: "PATCH",
+          headers: {
+            Authorization: `Bearer ${token}`,
+            "Content-Type": "application/json",
+          },
+          body: "{",
+        },
+        env as any,
+      );
+
+      expect(res.status).toBe(400);
+      await expect(res.json()).resolves.toEqual({ error: "Invalid JSON body" });
+    });
+
+    it("returns 404 when the target membership does not exist", async () => {
+      const token = await createTestJWT({
+        sub: "user-1",
+        githubId: "123",
+        name: "Tester",
+      });
+      const org = { id: "org-1", slug: "my-lab" };
+
+      queueSelectResponses([
+        { getResult: org },
+        { getResult: { orgId: "org-1", userId: "user-1", role: "admin" } },
+        { getResult: null },
+      ]);
+
+      const app = await createTestApp();
+      const env = createTestEnv();
+
+      const res = await app.request(
+        "http://localhost/api/orgs/my-lab/members/user-2",
+        {
+          method: "PATCH",
+          headers: {
+            Authorization: `Bearer ${token}`,
+            "Content-Type": "application/json",
+          },
+          body: JSON.stringify({ role: "member" }),
+        },
+        env as any,
+      );
+
+      expect(res.status).toBe(404);
+      await expect(res.json()).resolves.toEqual({ error: "Member not found" });
+    });
+
+    it("returns 200 when an owner modifies another owner role", async () => {
+      const token = await createTestJWT({
+        sub: "owner-1",
+        githubId: "123",
+        name: "Owner 1",
+      });
+      const org = { id: "org-1", slug: "my-lab" };
+
+      queueSelectResponses([
+        { getResult: org },
+        { getResult: { orgId: "org-1", userId: "owner-1", role: "owner" } }, // requireOrgAdmin
+        { getResult: { orgId: "org-1", userId: "owner-2", role: "owner" } }, // getOrgMembership (target)
+      ]);
+      mockDb.update = vi.fn(() => ({
+        set: vi.fn(() => ({
+          where: vi.fn(() => ({
+            meta: { changes: 1 }, // simulate successful update
+          })),
+        })),
+      }));
+
+      const app = await createTestApp();
+      const env = createTestEnv();
+
+      const res = await app.request(
+        "http://localhost/api/orgs/my-lab/members/owner-2",
+        {
+          method: "PATCH",
+          headers: {
+            Authorization: `Bearer ${token}`,
+            "Content-Type": "application/json",
+          },
+          body: JSON.stringify({ role: "member" }),
+        },
+        env as any,
+      );
+
+      expect(res.status).toBe(200);
+      expect(await res.json()).toEqual({ ok: true });
+    });
+    it("returns 403 when an admin tries to modify an owner's role", async () => {
+      const token = await createTestJWT({
+        sub: "admin-user",
+        githubId: "123",
+        name: "Admin Tester",
+      });
+      const org = { id: "org-1", slug: "my-lab" };
+
+      queueSelectResponses([
+        { getResult: org },
+        { getResult: { orgId: "org-1", userId: "admin-user", role: "admin" } }, // requireOrgAdmin
+        { getResult: { orgId: "org-1", userId: "owner-user", role: "owner" } }, // getOrgMembership (target)
+      ]);
+
+      const app = await createTestApp();
+      const env = createTestEnv();
+
+      const res = await app.request(
+        "http://localhost/api/orgs/my-lab/members/owner-user",
+        {
+          method: "PATCH",
+          headers: {
+            Authorization: `Bearer ${token}`,
+            "Content-Type": "application/json",
+          },
+          body: JSON.stringify({ role: "member" }),
+        },
+        env as any,
+      );
+
+      expect(res.status).toBe(403);
+      expect(((await res.json()) as any).error).toBe(
+        "Forbidden: admin cannot modify owner role",
+      );
+    });
+    it("returns 400 for invalid role", async () => {
+      const token = await createTestJWT({
+        sub: "user-1",
+        githubId: "123",
+        name: "Tester",
+      });
+      const org = { id: "org-1", slug: "my-lab" };
+      let selectCallCount = 0;
+      mockDb.select = vi.fn(() => {
+        selectCallCount++;
+        if (selectCallCount === 1) return makeQuery({ getResult: org });
+        return makeQuery({
+          getResult: { orgId: "org-1", userId: "user-1", role: "admin" },
         });
+      });
 
-        it("returns authored private papers even when the requester is not an org member", async () => {
-            const token = await createTestJWT({ sub: "user-1", githubId: "123", name: "Author" });
-            queueSelectResponses([
-                { getResult: { id: "org-1", slug: "my-lab" } },
-                { getResult: null },
-                {
-                    allResult: [{ paperId: "paper-private" }],
-                },
-                {
-                    getResult: { maxYear: 2024 },
-                },
-                {
-                    getResult: { count: 2 },
-                },
-                {
-                    allResult: [
-                        { id: "paper-public", title: "Public", visibility: "public", year: 2024 },
-                        { id: "paper-private", title: "Private", visibility: "private", year: 2024 },
-                    ],
-                },
-                { allResult: [{ value: 2024, count: 2 }] },
-                { allResult: [] },
-                { allResult: [] },
-            ]);
+      const app = await createTestApp();
+      const env = createTestEnv();
 
-            const app = await createTestApp();
-            const env = createTestEnv();
+      const res = await app.request(
+        "http://localhost/api/orgs/my-lab/members/user-2",
+        {
+          method: "PATCH",
+          headers: {
+            Authorization: `Bearer ${token}`,
+            "Content-Type": "application/json",
+          },
+          body: JSON.stringify({ role: "superadmin" }),
+        },
+        env as any,
+      );
 
-            const res = await app.request(
-                "http://localhost/api/orgs/my-lab/papers?paginate=1&autoYear=1",
-                {
-                    headers: { Authorization: `Bearer ${token}` },
-                },
-                env as any,
-            );
+      expect(res.status).toBe(400);
+    });
+  });
 
-            expect(res.status).toBe(200);
-            const body = (await res.json()) as any;
-            expect(body.papers.map((paper: any) => paper.id)).toEqual([
-                "paper-public",
-                "paper-private",
-            ]);
-            expect(body.appliedFilters.year).toBe(2024);
-        });
+  // ─── GET /api/orgs/:slug/members ──────────────────────────
+  describe("GET /api/orgs/:slug/members", () => {
+    it("returns 404 when org does not exist", async () => {
+      mockDb.select = vi.fn(() => makeQuery({ getResult: null }));
 
-        it("returns all visible papers in non-paginated mode", async () => {
-            const token = await createTestJWT({ sub: "user-1", githubId: "123", name: "Member" });
-            queueSelectResponses([
-                { getResult: { id: "org-1", slug: "my-lab" } },
-                { getResult: { orgId: "org-1", userId: "user-1", role: "member" } },
-                { allResult: [] },
-                {
-                    allResult: [
-                        { id: "paper-public", title: "Public", visibility: "public", year: 2025 },
-                        { id: "paper-org", title: "Org", visibility: "org_only", year: 2025 },
-                    ],
-                },
-            ]);
+      const app = await createTestApp();
+      const env = createTestEnv();
 
-            const app = await createTestApp();
-            const env = createTestEnv();
+      const res = await app.request(
+        "http://localhost/api/orgs/nonexistent/members",
+        {},
+        env as any,
+      );
 
-            const res = await app.request(
-                "http://localhost/api/orgs/my-lab/papers",
-                { headers: { Authorization: `Bearer ${token}` } },
-                env as any,
-            );
+      expect(res.status).toBe(404);
+    });
 
-            expect(res.status).toBe(200);
-            const body = (await res.json()) as any;
-            expect(body.papers.map((paper: any) => paper.id)).toEqual([
-                "paper-public",
-                "paper-org",
-            ]);
-        });
+    it("returns members for an existing org", async () => {
+      queueSelectResponses([
+        { getResult: { id: "org-1", slug: "my-lab" } },
+        {
+          allResult: [
+            {
+              userId: "user-1",
+              role: "admin",
+              name: "Tester",
+              displayName: null,
+              avatarUrl: null,
+              githubId: "tester",
+            },
+          ],
+        },
+      ]);
 
-        it("applies year, venue, category and page query parameters", async () => {
-            const token = await createTestJWT({ sub: "user-1", githubId: "123", name: "Member" });
-            const offsetSpy = vi.fn(() => queryWithOffset);
-            let callIndex = 0;
-            let queryWithOffset: ReturnType<typeof makeQuery>;
-            mockDb.select = vi.fn(() => {
-                callIndex += 1;
-                if (callIndex === 1) return makeQuery({ getResult: { id: "org-1", slug: "my-lab" } });
-                if (callIndex === 2) return makeQuery({ getResult: { orgId: "org-1", userId: "user-1", role: "member" } });
-                if (callIndex === 3) return makeQuery({ allResult: [] });
-                if (callIndex === 4) return makeQuery({ getResult: { count: 1 } });
-                if (callIndex === 5) {
-                    queryWithOffset = makeQuery({
-                        allResult: [
-                            { id: "paper-1", title: "Filtered", visibility: "public", year: 2023, venue: "ASE", category: "report" },
-                        ],
-                    });
-                    queryWithOffset.offset = offsetSpy;
-                    return queryWithOffset;
-                }
-                if (callIndex === 6) return makeQuery({ allResult: [{ value: 2023, count: 1 }] });
-                if (callIndex === 7) return makeQuery({ allResult: [{ value: "ASE", count: 1 }] });
-                if (callIndex === 8) return makeQuery({ allResult: [{ value: "report", count: 1 }] });
-                throw new Error(`unexpected select call #${callIndex}`);
-            });
+      const app = await createTestApp();
+      const env = createTestEnv();
 
-            const app = await createTestApp();
-            const env = createTestEnv();
+      const res = await app.request(
+        "http://localhost/api/orgs/my-lab/members",
+        {},
+        env as any,
+      );
 
-            const res = await app.request(
-                "http://localhost/api/orgs/my-lab/papers?paginate=1&autoYear=1&year=2023&venue=ASE&category=report&page=2",
-                { headers: { Authorization: `Bearer ${token}` } },
-                env as any,
-            );
+      expect(res.status).toBe(200);
+      expect(((await res.json()) as any).members).toHaveLength(1);
+    });
+  });
 
-            expect(res.status).toBe(200);
-            const body = (await res.json()) as any;
-            expect(body.page).toBe(2);
-            expect(offsetSpy).toHaveBeenCalledWith(20);
-            expect(body.appliedFilters).toEqual({
+  // ─── Paper association ────────────────────────────────────
+  describe("POST /api/orgs/:slug/papers", () => {
+    it("returns 400 for invalid JSON body", async () => {
+      const token = await createTestJWT({
+        sub: "user-1",
+        githubId: "123",
+        name: "Tester",
+      });
+      queueSelectResponses([{ getResult: { id: "org-1", slug: "my-lab" } }]);
+
+      const app = await createTestApp();
+      const env = createTestEnv();
+
+      const res = await app.request(
+        "http://localhost/api/orgs/my-lab/papers",
+        {
+          method: "POST",
+          headers: {
+            Authorization: `Bearer ${token}`,
+            "Content-Type": "application/json",
+          },
+          body: "{",
+        },
+        env as any,
+      );
+
+      expect(res.status).toBe(400);
+      await expect(res.json()).resolves.toEqual({ error: "Invalid JSON body" });
+    });
+
+    it("returns 400 for missing paperId", async () => {
+      const token = await createTestJWT({
+        sub: "user-1",
+        githubId: "123",
+        name: "Tester",
+      });
+      queueSelectResponses([{ getResult: { id: "org-1", slug: "my-lab" } }]);
+
+      const app = await createTestApp();
+      const env = createTestEnv();
+
+      const res = await app.request(
+        "http://localhost/api/orgs/my-lab/papers",
+        {
+          method: "POST",
+          headers: {
+            Authorization: `Bearer ${token}`,
+            "Content-Type": "application/json",
+          },
+          body: JSON.stringify({}),
+        },
+        env as any,
+      );
+
+      expect(res.status).toBe(400);
+      await expect(res.json()).resolves.toEqual({
+        error: "paperId is required",
+      });
+    });
+
+    it("returns 404 when paper is not found", async () => {
+      const token = await createTestJWT({
+        sub: "user-1",
+        githubId: "123",
+        name: "Tester",
+      });
+      queueSelectResponses([
+        { getResult: { id: "org-1", slug: "my-lab" } },
+        { getResult: null }, // paper
+      ]);
+
+      const app = await createTestApp();
+      const env = createTestEnv();
+
+      const res = await app.request(
+        "http://localhost/api/orgs/my-lab/papers",
+        {
+          method: "POST",
+          headers: {
+            Authorization: `Bearer ${token}`,
+            "Content-Type": "application/json",
+          },
+          body: JSON.stringify({ paperId: "paper-1" }),
+        },
+        env as any,
+      );
+
+      expect(res.status).toBe(404);
+      await expect(res.json()).resolves.toEqual({ error: "Paper not found" });
+    });
+
+    it("returns 403 when not org admin or paper author", async () => {
+      const token = await createTestJWT({
+        sub: "user-1",
+        githubId: "123",
+        name: "Tester",
+      });
+      queueSelectResponses([
+        { getResult: { id: "org-1", slug: "my-lab" } },
+        { getResult: { id: "paper-1" } }, // paper
+        { getResult: null }, // not org admin
+        { getResult: null }, // not paper author
+      ]);
+
+      const app = await createTestApp();
+      const env = createTestEnv();
+
+      const res = await app.request(
+        "http://localhost/api/orgs/my-lab/papers",
+        {
+          method: "POST",
+          headers: {
+            Authorization: `Bearer ${token}`,
+            "Content-Type": "application/json",
+          },
+          body: JSON.stringify({ paperId: "paper-1" }),
+        },
+        env as any,
+      );
+
+      expect(res.status).toBe(403);
+      await expect(res.json()).resolves.toEqual({
+        error: "Forbidden: must be org admin or paper author",
+      });
+    });
+
+    it("throws generic error during insert if not UNIQUE constraint", async () => {
+      const token = await createTestJWT({
+        sub: "user-1",
+        githubId: "123",
+        name: "Tester",
+      });
+      queueSelectResponses([
+        { getResult: { id: "org-1", slug: "my-lab" } },
+        { getResult: { id: "paper-1", title: "Paper" } },
+        { getResult: { orgId: "org-1", userId: "user-1", role: "admin" } },
+        { getResult: null }, // author check
+        { getResult: null }, // not already associated
+      ]);
+
+      mockDb.insert = vi.fn().mockImplementationOnce(() => ({
+        values: vi.fn(async () => {
+          throw new Error("Some other DB error");
+        }),
+      }));
+
+      const app = await createTestApp();
+      const env = createTestEnv();
+
+      const res = await app.request(
+        "http://localhost/api/orgs/my-lab/papers",
+        {
+          method: "POST",
+          headers: {
+            Authorization: `Bearer ${token}`,
+            "Content-Type": "application/json",
+          },
+          body: JSON.stringify({ paperId: "paper-1" }),
+        },
+        env as any,
+      );
+
+      expect(res.status).toBe(500);
+    });
+
+    it("returns 403 without auth (CSRF blocks before auth middleware)", async () => {
+      const app = await createTestApp();
+      const env = createTestEnv();
+
+      const res = await app.request(
+        "http://localhost/api/orgs/my-lab/papers",
+        {
+          method: "POST",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({ paperId: "paper-1" }),
+        },
+        env as any,
+      );
+
+      expect(res.status).toBe(403);
+    });
+
+    it("allows paper authors to associate papers without admin membership", async () => {
+      const token = await createTestJWT({
+        sub: "user-2",
+        githubId: "456",
+        name: "Author",
+      });
+      queueSelectResponses([
+        { getResult: { id: "org-1", slug: "my-lab" } },
+        { getResult: { id: "paper-1", title: "Paper" } },
+        { getResult: null },
+        {
+          getResult: { paperId: "paper-1", userId: "user-2", role: "uploader" },
+        },
+        { getResult: null },
+      ]);
+
+      const insertValues = vi.fn(async () => undefined);
+      mockDb.insert = vi.fn(() => ({ values: insertValues }));
+
+      const app = await createTestApp();
+      const env = createTestEnv();
+
+      const res = await app.request(
+        "http://localhost/api/orgs/my-lab/papers",
+        {
+          method: "POST",
+          headers: {
+            Authorization: `Bearer ${token}`,
+            "Content-Type": "application/json",
+          },
+          body: JSON.stringify({ paperId: "paper-1" }),
+        },
+        env as any,
+      );
+
+      expect(res.status).toBe(201);
+      expect(insertValues).toHaveBeenCalledWith({
+        orgId: "org-1",
+        paperId: "paper-1",
+      });
+    });
+
+    it("returns 409 when the paper is already associated", async () => {
+      const token = await createTestJWT({
+        sub: "user-1",
+        githubId: "123",
+        name: "Admin",
+      });
+      queueSelectResponses([
+        { getResult: { id: "org-1", slug: "my-lab" } },
+        { getResult: { id: "paper-1", title: "Paper" } },
+        { getResult: { orgId: "org-1", userId: "user-1", role: "admin" } },
+        { getResult: null },
+        { getResult: { paperId: "paper-1", orgId: "org-1" } },
+      ]);
+
+      const app = await createTestApp();
+      const env = createTestEnv();
+
+      const res = await app.request(
+        "http://localhost/api/orgs/my-lab/papers",
+        {
+          method: "POST",
+          headers: {
+            Authorization: `Bearer ${token}`,
+            "Content-Type": "application/json",
+          },
+          body: JSON.stringify({ paperId: "paper-1" }),
+        },
+        env as any,
+      );
+
+      expect(res.status).toBe(409);
+      expect(((await res.json()) as any).error).toBe(
+        "Paper is already associated with this org",
+      );
+    });
+  });
+
+  describe("GET /api/orgs/:slug/papers", () => {
+    it("returns 404 when org does not exist", async () => {
+      mockDb.select = vi.fn(() => makeQuery({ getResult: null }));
+
+      const app = await createTestApp();
+      const env = createTestEnv();
+
+      const res = await app.request(
+        "http://localhost/api/orgs/nonexistent/papers",
+        {},
+        env as any,
+      );
+
+      expect(res.status).toBe(404);
+    });
+
+    it("returns public and org_only papers to org members", async () => {
+      const token = await createTestJWT({
+        sub: "user-1",
+        githubId: "123",
+        name: "Member",
+      });
+      queueSelectResponses([
+        { getResult: { id: "org-1", slug: "my-lab" } },
+        { getResult: { orgId: "org-1", userId: "user-1", role: "member" } },
+        {
+          allResult: [],
+        },
+        {
+          getResult: { maxYear: 2025 },
+        },
+        {
+          getResult: { count: 2 },
+        },
+        {
+          allResult: [
+            {
+              id: "paper-public",
+              title: "Public",
+              visibility: "public",
+              year: 2025,
+            },
+            {
+              id: "paper-org",
+              title: "Org",
+              visibility: "org_only",
+              year: 2025,
+            },
+          ],
+        },
+        { allResult: [{ value: 2025, count: 2 }] },
+        { allResult: [{ value: "ASE", count: 1 }] },
+        { allResult: [{ value: "report", count: 2 }] },
+      ]);
+
+      const app = await createTestApp();
+      const env = createTestEnv();
+
+      const res = await app.request(
+        "http://localhost/api/orgs/my-lab/papers?paginate=1&autoYear=1",
+        {
+          headers: { Authorization: `Bearer ${token}` },
+        },
+        env as any,
+      );
+
+      expect(res.status).toBe(200);
+      const body = (await res.json()) as any;
+      expect(body.papers.map((paper: any) => paper.id)).toEqual([
+        "paper-public",
+        "paper-org",
+      ]);
+      expect(body.total).toBe(2);
+      expect(body.appliedFilters.year).toBe(2025);
+    });
+
+    it("returns authored private papers even when the requester is not an org member", async () => {
+      const token = await createTestJWT({
+        sub: "user-1",
+        githubId: "123",
+        name: "Author",
+      });
+      queueSelectResponses([
+        { getResult: { id: "org-1", slug: "my-lab" } },
+        { getResult: null },
+        {
+          allResult: [{ paperId: "paper-private" }],
+        },
+        {
+          getResult: { maxYear: 2024 },
+        },
+        {
+          getResult: { count: 2 },
+        },
+        {
+          allResult: [
+            {
+              id: "paper-public",
+              title: "Public",
+              visibility: "public",
+              year: 2024,
+            },
+            {
+              id: "paper-private",
+              title: "Private",
+              visibility: "private",
+              year: 2024,
+            },
+          ],
+        },
+        { allResult: [{ value: 2024, count: 2 }] },
+        { allResult: [] },
+        { allResult: [] },
+      ]);
+
+      const app = await createTestApp();
+      const env = createTestEnv();
+
+      const res = await app.request(
+        "http://localhost/api/orgs/my-lab/papers?paginate=1&autoYear=1",
+        {
+          headers: { Authorization: `Bearer ${token}` },
+        },
+        env as any,
+      );
+
+      expect(res.status).toBe(200);
+      const body = (await res.json()) as any;
+      expect(body.papers.map((paper: any) => paper.id)).toEqual([
+        "paper-public",
+        "paper-private",
+      ]);
+      expect(body.appliedFilters.year).toBe(2024);
+    });
+
+    it("returns all visible papers in non-paginated mode", async () => {
+      const token = await createTestJWT({
+        sub: "user-1",
+        githubId: "123",
+        name: "Member",
+      });
+      queueSelectResponses([
+        { getResult: { id: "org-1", slug: "my-lab" } },
+        { getResult: { orgId: "org-1", userId: "user-1", role: "member" } },
+        { allResult: [] },
+        {
+          allResult: [
+            {
+              id: "paper-public",
+              title: "Public",
+              visibility: "public",
+              year: 2025,
+            },
+            {
+              id: "paper-org",
+              title: "Org",
+              visibility: "org_only",
+              year: 2025,
+            },
+          ],
+        },
+      ]);
+
+      const app = await createTestApp();
+      const env = createTestEnv();
+
+      const res = await app.request(
+        "http://localhost/api/orgs/my-lab/papers",
+        { headers: { Authorization: `Bearer ${token}` } },
+        env as any,
+      );
+
+      expect(res.status).toBe(200);
+      const body = (await res.json()) as any;
+      expect(body.papers.map((paper: any) => paper.id)).toEqual([
+        "paper-public",
+        "paper-org",
+      ]);
+    });
+
+    it("applies year, venue, category and page query parameters", async () => {
+      const token = await createTestJWT({
+        sub: "user-1",
+        githubId: "123",
+        name: "Member",
+      });
+      const offsetSpy = vi.fn(() => queryWithOffset);
+      let callIndex = 0;
+      let queryWithOffset: ReturnType<typeof makeQuery>;
+      mockDb.select = vi.fn(() => {
+        callIndex += 1;
+        if (callIndex === 1)
+          return makeQuery({ getResult: { id: "org-1", slug: "my-lab" } });
+        if (callIndex === 2)
+          return makeQuery({
+            getResult: { orgId: "org-1", userId: "user-1", role: "member" },
+          });
+        if (callIndex === 3) return makeQuery({ allResult: [] });
+        if (callIndex === 4) return makeQuery({ getResult: { count: 1 } });
+        if (callIndex === 5) {
+          queryWithOffset = makeQuery({
+            allResult: [
+              {
+                id: "paper-1",
+                title: "Filtered",
+                visibility: "public",
                 year: 2023,
                 venue: "ASE",
                 category: "report",
-            });
-            expect(body.filterOptions.years).toEqual([{ value: 2023, count: 1 }]);
-        });
+              },
+            ],
+          });
+          queryWithOffset.offset = offsetSpy;
+          return queryWithOffset;
+        }
+        if (callIndex === 6)
+          return makeQuery({ allResult: [{ value: 2023, count: 1 }] });
+        if (callIndex === 7)
+          return makeQuery({ allResult: [{ value: "ASE", count: 1 }] });
+        if (callIndex === 8)
+          return makeQuery({ allResult: [{ value: "report", count: 1 }] });
+        throw new Error(`unexpected select call #${callIndex}`);
+      });
 
-        it("returns 400 for invalid venue query", async () => {
-            queueSelectResponses([
-                { getResult: { id: "org-1", slug: "my-lab" } },
-            ]);
+      const app = await createTestApp();
+      const env = createTestEnv();
 
-            const app = await createTestApp();
-            const env = createTestEnv();
+      const res = await app.request(
+        "http://localhost/api/orgs/my-lab/papers?paginate=1&autoYear=1&year=2023&venue=ASE&category=report&page=2",
+        { headers: { Authorization: `Bearer ${token}` } },
+        env as any,
+      );
 
-            const res = await app.request(
-                "http://localhost/api/orgs/my-lab/papers?venue=" + "a".repeat(101),
-                {},
-                env as any,
-            );
-
-            expect(res.status).toBe(400);
-            await expect(res.json()).resolves.toEqual({ error: "venue must be 100 characters or less" });
-        });
-
-        it("returns 400 for invalid category query", async () => {
-            queueSelectResponses([
-                { getResult: { id: "org-1", slug: "my-lab" } },
-            ]);
-
-            const app = await createTestApp();
-            const env = createTestEnv();
-
-            const res = await app.request(
-                "http://localhost/api/orgs/my-lab/papers?category=invalid",
-                {},
-                env as any,
-            );
-
-            expect(res.status).toBe(400);
-            await expect(res.json()).resolves.toEqual({ error: "Invalid category" });
-        });
-
-        it("returns properly filtered papers for non-members who are authors", async () => {
-            const token = await createTestJWT({ sub: "user-1", githubId: "123", name: "Author" });
-            queueSelectResponses([
-                { getResult: { id: "org-1", slug: "my-lab" } },
-                { getResult: null }, // not a member
-                {
-                    allResult: [{ paperId: "paper-org" }, { paperId: "paper-private" }], // authored papers
-                },
-                {
-                    allResult: [
-                        { id: "paper-public", visibility: "public" },
-                        { id: "paper-org", visibility: "org_only" },
-                        { id: "paper-private", visibility: "private" },
-                    ],
-                },
-            ]);
-
-            const app = await createTestApp();
-            const env = createTestEnv();
-
-            const res = await app.request(
-                "http://localhost/api/orgs/my-lab/papers",
-                { headers: { Authorization: `Bearer ${token}` } },
-                env as any,
-            );
-
-            expect(res.status).toBe(200);
-            const body = (await res.json()) as any;
-            expect(body.papers).toBeDefined();
-        });
-
-        it("returns 400 for invalid page query", async () => {
-            queueSelectResponses([
-                { getResult: { id: "org-1", slug: "my-lab" } },
-            ]);
-
-            const app = await createTestApp();
-            const env = createTestEnv();
-
-            const res = await app.request(
-                "http://localhost/api/orgs/my-lab/papers?paginate=1&page=2foo",
-                {},
-                env as any,
-            );
-
-            expect(res.status).toBe(400);
-            await expect(res.json()).resolves.toEqual({ error: "Invalid page" });
-        });
-
-        it("returns 400 for invalid year query", async () => {
-            queueSelectResponses([
-                { getResult: { id: "org-1", slug: "my-lab" } },
-            ]);
-
-            const app = await createTestApp();
-            const env = createTestEnv();
-
-            const res = await app.request(
-                "http://localhost/api/orgs/my-lab/papers?paginate=1&year=2025abc",
-                {},
-                env as any,
-            );
-
-            expect(res.status).toBe(400);
-            await expect(res.json()).resolves.toEqual({ error: "Invalid year" });
-        });
+      expect(res.status).toBe(200);
+      const body = (await res.json()) as any;
+      expect(body.page).toBe(2);
+      expect(offsetSpy).toHaveBeenCalledWith(20);
+      expect(body.appliedFilters).toEqual({
+        year: 2023,
+        venue: "ASE",
+        category: "report",
+      });
+      expect(body.filterOptions.years).toEqual([{ value: 2023, count: 1 }]);
     });
 
-    describe("GET /api/orgs/:slug/tags", () => {
-        it("handles invalid JWT payload in hasJwtSub", async () => {
-            const app = await createTestApp();
-            const env = createTestEnv();
+    it("returns 400 for invalid venue query", async () => {
+      queueSelectResponses([{ getResult: { id: "org-1", slug: "my-lab" } }]);
 
-            // Setup jwt.verify to return an invalid object instead of a valid token
-            const token = await createTestJWT({ invalid: true });
+      const app = await createTestApp();
+      const env = createTestEnv();
 
-            queueSelectResponses([
-                { getResult: { id: "org-1", slug: "my-lab" } },
-                { allResult: [] }, // org papers
-            ]);
+      const res = await app.request(
+        "http://localhost/api/orgs/my-lab/papers?venue=" + "a".repeat(101),
+        {},
+        env as any,
+      );
 
-            const res = await app.request(
-                "http://localhost/api/orgs/my-lab/tags",
-                { headers: { Authorization: `Bearer ${token}` } },
-                env as any,
-            );
-
-            expect(res.status).toBe(200);
-        });
-
-        it("returns tags from visible org papers", async () => {
-            queueSelectResponses([
-                { getResult: { id: "org-1", slug: "my-lab" } },
-                { getResult: { orgId: "org-1", userId: "user-1", role: "member" } },
-                {
-                    allResult: [
-                        {
-                            id: "paper-public",
-                            visibility: "public",
-                            tags: "[\"AI\",\"NLP\"]",
-                            authorUserId: null,
-                        },
-                        {
-                            id: "paper-org",
-                            visibility: "org_only",
-                            tags: "[\"AI\"]",
-                            authorUserId: "user-1",
-                        },
-                    ],
-                },
-            ]);
-
-            const token = await createTestJWT({ sub: "user-1", githubId: "123", name: "Member" });
-            const app = await createTestApp();
-            const env = createTestEnv();
-
-            const res = await app.request(
-                "http://localhost/api/orgs/my-lab/tags",
-                {
-                    headers: { Authorization: `Bearer ${token}` },
-                },
-                env as any,
-            );
-
-            expect(res.status).toBe(200);
-            await expect(res.json()).resolves.toEqual({ tags: ["AI", "NLP"] });
-        });
-
-        it("filters tags by query and handles redundant tags with caching logic", async () => {
-            queueSelectResponses([
-                { getResult: { id: "org-1", slug: "my-lab" } },
-                { getResult: { orgId: "org-1", userId: "user-1", role: "member" } },
-                {
-                    allResult: [
-                        {
-                            id: "paper-1",
-                            visibility: "public",
-                            tags: "[\"AI\",\"NLP\"]",
-                            authorUserId: null,
-                        },
-                        {
-                            id: "paper-2",
-                            visibility: "public",
-                            tags: "[\"AI\",\"NLP\"]", // Triggers tagCache
-                            authorUserId: null,
-                        },
-                        {
-                            id: "paper-3",
-                            visibility: "public",
-                            tags: "[\"AI\",\"Machine Learning\"]", // Triggers lowerCache for "AI"
-                            authorUserId: null,
-                        },
-                    ],
-                },
-            ]);
-
-            const token = await createTestJWT({ sub: "user-1", githubId: "123", name: "Member" });
-            const app = await createTestApp();
-            const env = createTestEnv();
-
-            const res = await app.request(
-                "http://localhost/api/orgs/my-lab/tags?q=m",
-                {
-                    headers: { Authorization: `Bearer ${token}` },
-                },
-                env as any,
-            );
-
-            expect(res.status).toBe(200);
-            // Only "Machine Learning" starts with "m"
-            await expect(res.json()).resolves.toEqual({ tags: ["Machine Learning"] });
-        });
-
-        it("limits public org tag responses to 100 items", async () => {
-            const manyTags = Array.from(
-                { length: 105 },
-                (_, index) => `tag-${String(index).padStart(3, "0")}`,
-            );
-            queueSelectResponses([
-                { getResult: { id: "org-1", slug: "my-lab" } },
-                {
-                    allResult: manyTags.map((tag, index) => ({
-                        id: `paper-${index}`,
-                        visibility: "public",
-                        tags: JSON.stringify([tag]),
-                        authorUserId: null,
-                    })),
-                },
-            ]);
-
-            const app = await createTestApp();
-            const env = createTestEnv();
-            const res = await app.request(
-                "http://localhost/api/orgs/my-lab/tags",
-                {},
-                env as any,
-            );
-
-            expect(res.status).toBe(200);
-            const body = (await res.json()) as { tags: string[] };
-            expect(body.tags).toHaveLength(100);
-            expect(body.tags).toEqual(manyTags.slice(0, 100));
-        });
-
-        it("returns 404 when org does not exist", async () => {
-            mockDb.select = vi.fn(() => makeQuery({ getResult: null }));
-
-            const app = await createTestApp();
-            const env = createTestEnv();
-            const res = await app.request(
-                "http://localhost/api/orgs/missing-org/tags",
-                {},
-                env as any,
-            );
-
-            expect(res.status).toBe(404);
-            await expect(res.json()).resolves.toEqual({ error: "Org not found" });
-        });
+      expect(res.status).toBe(400);
+      await expect(res.json()).resolves.toEqual({
+        error: "venue must be 100 characters or less",
+      });
     });
 
-    describe("DELETE /api/orgs/:slug/members/:userId", () => {
-        it("returns 403 when an admin tries to remove an owner", async () => {
-            const token = await createTestJWT({ sub: "admin-user", githubId: "123", name: "Admin Tester" });
-            const org = { id: "org-1", slug: "my-lab" };
+    it("returns 400 for invalid category query", async () => {
+      queueSelectResponses([{ getResult: { id: "org-1", slug: "my-lab" } }]);
 
-            queueSelectResponses([
-                { getResult: org },
-                { getResult: { orgId: "org-1", userId: "admin-user", role: "admin" } }, // requireOrgAdmin
-                { getResult: { orgId: "org-1", userId: "owner-user", role: "owner" } }, // getOrgMembership (target)
-            ]);
+      const app = await createTestApp();
+      const env = createTestEnv();
 
-            const app = await createTestApp();
-            const env = createTestEnv();
+      const res = await app.request(
+        "http://localhost/api/orgs/my-lab/papers?category=invalid",
+        {},
+        env as any,
+      );
 
-            const res = await app.request(
-                "http://localhost/api/orgs/my-lab/members/owner-user",
-                {
-                    method: "DELETE",
-                    headers: { Authorization: `Bearer ${token}` },
-                },
-                env as any,
-            );
-
-            expect(res.status).toBe(403);
-            expect(((await res.json()) as any).error).toBe("Forbidden: admin cannot remove owner");
-        });
-        it("returns 404 when the target membership does not exist", async () => {
-            const token = await createTestJWT({ sub: "user-1", githubId: "123", name: "Tester" });
-            queueSelectResponses([
-                { getResult: { id: "org-1", slug: "my-lab" } },
-                { getResult: { orgId: "org-1", userId: "user-1", role: "admin" } },
-                { getResult: null },
-            ]);
-
-            const app = await createTestApp();
-            const env = createTestEnv();
-
-            const res = await app.request(
-                "http://localhost/api/orgs/my-lab/members/user-2",
-                {
-                    method: "DELETE",
-                    headers: { Authorization: `Bearer ${token}` },
-                },
-                env as any,
-            );
-
-            expect(res.status).toBe(404);
-            expect(((await res.json()) as any).error).toBe("Member not found");
-        });
+      expect(res.status).toBe(400);
+      await expect(res.json()).resolves.toEqual({ error: "Invalid category" });
     });
 
-    describe("DELETE /api/orgs/:slug/papers/:paperId", () => {
-        it("deletes the association for admins", async () => {
-            const token = await createTestJWT({ sub: "user-1", githubId: "123", name: "Admin" });
-            queueSelectResponses([
-                { getResult: { id: "org-1", slug: "my-lab" } },
-                { getResult: { orgId: "org-1", userId: "user-1", role: "admin" } },
-                { getResult: null }, // not author
-                { getResult: { paperId: "paper-1", orgId: "org-1" } }, // existing association
-            ]);
+    it("returns properly filtered papers for non-members who are authors", async () => {
+      const token = await createTestJWT({
+        sub: "user-1",
+        githubId: "123",
+        name: "Author",
+      });
+      queueSelectResponses([
+        { getResult: { id: "org-1", slug: "my-lab" } },
+        { getResult: null }, // not a member
+        {
+          allResult: [{ paperId: "paper-org" }, { paperId: "paper-private" }], // authored papers
+        },
+        {
+          allResult: [
+            { id: "paper-public", visibility: "public" },
+            { id: "paper-org", visibility: "org_only" },
+            { id: "paper-private", visibility: "private" },
+          ],
+        },
+      ]);
 
-            const deleteWhere = vi.fn(async () => ({ meta: { changes: 1 } }));
-            mockDb.delete = vi.fn(() => ({ where: deleteWhere }));
+      const app = await createTestApp();
+      const env = createTestEnv();
 
-            const app = await createTestApp();
-            const env = createTestEnv();
+      const res = await app.request(
+        "http://localhost/api/orgs/my-lab/papers",
+        { headers: { Authorization: `Bearer ${token}` } },
+        env as any,
+      );
 
-            const res = await app.request(
-                "http://localhost/api/orgs/my-lab/papers/paper-1",
-                {
-                    method: "DELETE",
-                    headers: { Authorization: `Bearer ${token}` },
-                },
-                env as any,
-            );
-
-            expect(res.status).toBe(200);
-            await expect(res.json()).resolves.toEqual({ ok: true });
-            expect(deleteWhere).toHaveBeenCalled();
-        });
-
-        it("returns 403 when not org admin or paper author", async () => {
-            const token = await createTestJWT({ sub: "user-1", githubId: "123", name: "Tester" });
-            queueSelectResponses([
-                { getResult: { id: "org-1", slug: "my-lab" } },
-                { getResult: null }, // not admin
-                { getResult: null }, // not paper author
-            ]);
-
-            const app = await createTestApp();
-            const env = createTestEnv();
-
-            const res = await app.request(
-                "http://localhost/api/orgs/my-lab/papers/paper-1",
-                {
-                    method: "DELETE",
-                    headers: { Authorization: `Bearer ${token}` },
-                },
-                env as any,
-            );
-
-            expect(res.status).toBe(403);
-            await expect(res.json()).resolves.toEqual({ error: "Forbidden: must be org admin or paper author" });
-        });
-
-        it("returns 404 when the association does not exist", async () => {
-            const token = await createTestJWT({ sub: "user-2", githubId: "456", name: "Author" });
-            queueSelectResponses([
-                { getResult: { id: "org-1", slug: "my-lab" } },
-                { getResult: null },
-                { getResult: { paperId: "paper-1", userId: "user-2", role: "uploader" } },
-                { getResult: null },
-            ]);
-
-            const app = await createTestApp();
-            const env = createTestEnv();
-
-            const res = await app.request(
-                "http://localhost/api/orgs/my-lab/papers/paper-1",
-                {
-                    method: "DELETE",
-                    headers: { Authorization: `Bearer ${token}` },
-                },
-                env as any,
-            );
-
-            expect(res.status).toBe(404);
-            expect(((await res.json()) as any).error).toBe(
-                "Paper is not associated with this org",
-            );
-        });
-
+      expect(res.status).toBe(200);
+      const body = (await res.json()) as any;
+      expect(body.papers).toBeDefined();
     });
 
-    // ─── Boundary: last admin protection ──────────────────────
-    describe("last admin protection", () => {
-        it("PATCH prevents demoting the last admin", async () => {
-            const token = await createTestJWT({ sub: "user-1", githubId: "123", name: "Tester" });
-            const org = { id: "org-1", slug: "my-lab" };
-            let selectCallCount = 0;
-            mockDb.select = vi.fn(() => {
-                selectCallCount++;
-                if (selectCallCount === 1) return makeQuery({ getResult: org });
-                // actor is admin
-                if (selectCallCount === 2) return makeQuery({ getResult: { orgId: "org-1", userId: "user-1", role: "admin" } });
-                // target is also admin
-                if (selectCallCount === 3) return makeQuery({ getResult: { orgId: "org-1", userId: "user-2", role: "admin" } });
-                return makeQuery({ getResult: null });
-            });
+    it("returns 400 for invalid page query", async () => {
+      queueSelectResponses([{ getResult: { id: "org-1", slug: "my-lab" } }]);
 
-            mockDb.update = vi.fn(() => ({
-                set: vi.fn(() => ({
-                    where: vi.fn(async () => ({ meta: { changes: 0 } })),
-                })),
-            }));
+      const app = await createTestApp();
+      const env = createTestEnv();
 
-            const app = await createTestApp();
-            const env = createTestEnv();
+      const res = await app.request(
+        "http://localhost/api/orgs/my-lab/papers?paginate=1&page=2foo",
+        {},
+        env as any,
+      );
 
-            const res = await app.request(
-                "http://localhost/api/orgs/my-lab/members/user-2",
-                {
-                    method: "PATCH",
-                    headers: {
-                        Authorization: `Bearer ${token}`,
-                        "Content-Type": "application/json",
-                    },
-                    body: JSON.stringify({ role: "member" }),
-                },
-                env as any,
-            );
-
-            expect(res.status).toBe(400);
-            const body = (await res.json()) as any;
-            expect(body.error).toContain("last admin");
-        });
-
-        it("DELETE prevents removing the last admin", async () => {
-            const token = await createTestJWT({ sub: "user-1", githubId: "123", name: "Tester" });
-            const org = { id: "org-1", slug: "my-lab" };
-            let selectCallCount = 0;
-            mockDb.select = vi.fn(() => {
-                selectCallCount++;
-                if (selectCallCount === 1) return makeQuery({ getResult: org });
-                // actor is admin
-                if (selectCallCount === 2) return makeQuery({ getResult: { orgId: "org-1", userId: "user-1", role: "admin" } });
-                // target is also admin
-                if (selectCallCount === 3) return makeQuery({ getResult: { orgId: "org-1", userId: "user-2", role: "admin" } });
-                return makeQuery({ getResult: null });
-            });
-
-            mockDb.delete = vi.fn(() => ({
-                where: vi.fn(async () => ({ meta: { changes: 0 } })),
-            }));
-
-            const app = await createTestApp();
-            const env = createTestEnv();
-
-            const res = await app.request(
-                "http://localhost/api/orgs/my-lab/members/user-2",
-                {
-                    method: "DELETE",
-                    headers: { Authorization: `Bearer ${token}` },
-                },
-                env as any,
-            );
-
-            expect(res.status).toBe(400);
-            const body = (await res.json()) as any;
-            expect(body.error).toContain("last admin");
-        });
+      expect(res.status).toBe(400);
+      await expect(res.json()).resolves.toEqual({ error: "Invalid page" });
     });
+
+    it("returns 400 for invalid year query", async () => {
+      queueSelectResponses([{ getResult: { id: "org-1", slug: "my-lab" } }]);
+
+      const app = await createTestApp();
+      const env = createTestEnv();
+
+      const res = await app.request(
+        "http://localhost/api/orgs/my-lab/papers?paginate=1&year=2025abc",
+        {},
+        env as any,
+      );
+
+      expect(res.status).toBe(400);
+      await expect(res.json()).resolves.toEqual({ error: "Invalid year" });
+    });
+  });
+
+  describe("GET /api/orgs/:slug/tags", () => {
+    it("handles invalid JWT payload in hasJwtSub", async () => {
+      const app = await createTestApp();
+      const env = createTestEnv();
+
+      // Setup jwt.verify to return an invalid object instead of a valid token
+      const token = await createTestJWT({ invalid: true });
+
+      queueSelectResponses([
+        { getResult: { id: "org-1", slug: "my-lab" } },
+        { allResult: [] }, // org papers
+      ]);
+
+      const res = await app.request(
+        "http://localhost/api/orgs/my-lab/tags",
+        { headers: { Authorization: `Bearer ${token}` } },
+        env as any,
+      );
+
+      expect(res.status).toBe(200);
+    });
+
+    it("returns tags from visible org papers", async () => {
+      queueSelectResponses([
+        { getResult: { id: "org-1", slug: "my-lab" } },
+        { getResult: { orgId: "org-1", userId: "user-1", role: "member" } },
+        {
+          allResult: [
+            {
+              id: "paper-public",
+              visibility: "public",
+              tags: '["AI","NLP"]',
+              authorUserId: null,
+            },
+            {
+              id: "paper-org",
+              visibility: "org_only",
+              tags: '["AI"]',
+              authorUserId: "user-1",
+            },
+          ],
+        },
+      ]);
+
+      const token = await createTestJWT({
+        sub: "user-1",
+        githubId: "123",
+        name: "Member",
+      });
+      const app = await createTestApp();
+      const env = createTestEnv();
+
+      const res = await app.request(
+        "http://localhost/api/orgs/my-lab/tags",
+        {
+          headers: { Authorization: `Bearer ${token}` },
+        },
+        env as any,
+      );
+
+      expect(res.status).toBe(200);
+      await expect(res.json()).resolves.toEqual({ tags: ["AI", "NLP"] });
+    });
+
+    it("filters tags by query and handles redundant tags with caching logic", async () => {
+      queueSelectResponses([
+        { getResult: { id: "org-1", slug: "my-lab" } },
+        { getResult: { orgId: "org-1", userId: "user-1", role: "member" } },
+        {
+          allResult: [
+            {
+              id: "paper-1",
+              visibility: "public",
+              tags: '["AI","NLP"]',
+              authorUserId: null,
+            },
+            {
+              id: "paper-2",
+              visibility: "public",
+              tags: '["AI","NLP"]', // Triggers tagCache
+              authorUserId: null,
+            },
+            {
+              id: "paper-3",
+              visibility: "public",
+              tags: '["AI","Machine Learning"]', // Triggers lowerCache for "AI"
+              authorUserId: null,
+            },
+          ],
+        },
+      ]);
+
+      const token = await createTestJWT({
+        sub: "user-1",
+        githubId: "123",
+        name: "Member",
+      });
+      const app = await createTestApp();
+      const env = createTestEnv();
+
+      const res = await app.request(
+        "http://localhost/api/orgs/my-lab/tags?q=m",
+        {
+          headers: { Authorization: `Bearer ${token}` },
+        },
+        env as any,
+      );
+
+      expect(res.status).toBe(200);
+      // Only "Machine Learning" starts with "m"
+      await expect(res.json()).resolves.toEqual({ tags: ["Machine Learning"] });
+    });
+
+    it("limits public org tag responses to 100 items", async () => {
+      const manyTags = Array.from(
+        { length: 105 },
+        (_, index) => `tag-${String(index).padStart(3, "0")}`,
+      );
+      queueSelectResponses([
+        { getResult: { id: "org-1", slug: "my-lab" } },
+        {
+          allResult: manyTags.map((tag, index) => ({
+            id: `paper-${index}`,
+            visibility: "public",
+            tags: JSON.stringify([tag]),
+            authorUserId: null,
+          })),
+        },
+      ]);
+
+      const app = await createTestApp();
+      const env = createTestEnv();
+      const res = await app.request(
+        "http://localhost/api/orgs/my-lab/tags",
+        {},
+        env as any,
+      );
+
+      expect(res.status).toBe(200);
+      const body = (await res.json()) as { tags: string[] };
+      expect(body.tags).toHaveLength(100);
+      expect(body.tags).toEqual(manyTags.slice(0, 100));
+    });
+
+    it("returns 404 when org does not exist", async () => {
+      mockDb.select = vi.fn(() => makeQuery({ getResult: null }));
+
+      const app = await createTestApp();
+      const env = createTestEnv();
+      const res = await app.request(
+        "http://localhost/api/orgs/missing-org/tags",
+        {},
+        env as any,
+      );
+
+      expect(res.status).toBe(404);
+      await expect(res.json()).resolves.toEqual({ error: "Org not found" });
+    });
+  });
+
+  describe("DELETE /api/orgs/:slug/members/:userId", () => {
+    it("returns 403 when an admin tries to remove an owner", async () => {
+      const token = await createTestJWT({
+        sub: "admin-user",
+        githubId: "123",
+        name: "Admin Tester",
+      });
+      const org = { id: "org-1", slug: "my-lab" };
+
+      queueSelectResponses([
+        { getResult: org },
+        { getResult: { orgId: "org-1", userId: "admin-user", role: "admin" } }, // requireOrgAdmin
+        { getResult: { orgId: "org-1", userId: "owner-user", role: "owner" } }, // getOrgMembership (target)
+      ]);
+
+      const app = await createTestApp();
+      const env = createTestEnv();
+
+      const res = await app.request(
+        "http://localhost/api/orgs/my-lab/members/owner-user",
+        {
+          method: "DELETE",
+          headers: { Authorization: `Bearer ${token}` },
+        },
+        env as any,
+      );
+
+      expect(res.status).toBe(403);
+      expect(((await res.json()) as any).error).toBe(
+        "Forbidden: admin cannot remove owner",
+      );
+    });
+    it("returns 404 when the target membership does not exist", async () => {
+      const token = await createTestJWT({
+        sub: "user-1",
+        githubId: "123",
+        name: "Tester",
+      });
+      queueSelectResponses([
+        { getResult: { id: "org-1", slug: "my-lab" } },
+        { getResult: { orgId: "org-1", userId: "user-1", role: "admin" } },
+        { getResult: null },
+      ]);
+
+      const app = await createTestApp();
+      const env = createTestEnv();
+
+      const res = await app.request(
+        "http://localhost/api/orgs/my-lab/members/user-2",
+        {
+          method: "DELETE",
+          headers: { Authorization: `Bearer ${token}` },
+        },
+        env as any,
+      );
+
+      expect(res.status).toBe(404);
+      expect(((await res.json()) as any).error).toBe("Member not found");
+    });
+  });
+
+  describe("DELETE /api/orgs/:slug/papers/:paperId", () => {
+    it("deletes the association for admins", async () => {
+      const token = await createTestJWT({
+        sub: "user-1",
+        githubId: "123",
+        name: "Admin",
+      });
+      queueSelectResponses([
+        { getResult: { id: "org-1", slug: "my-lab" } },
+        { getResult: { orgId: "org-1", userId: "user-1", role: "admin" } },
+        { getResult: null }, // not author
+        { getResult: { paperId: "paper-1", orgId: "org-1" } }, // existing association
+      ]);
+
+      const deleteWhere = vi.fn(async () => ({ meta: { changes: 1 } }));
+      mockDb.delete = vi.fn(() => ({ where: deleteWhere }));
+
+      const app = await createTestApp();
+      const env = createTestEnv();
+
+      const res = await app.request(
+        "http://localhost/api/orgs/my-lab/papers/paper-1",
+        {
+          method: "DELETE",
+          headers: { Authorization: `Bearer ${token}` },
+        },
+        env as any,
+      );
+
+      expect(res.status).toBe(200);
+      await expect(res.json()).resolves.toEqual({ ok: true });
+      expect(deleteWhere).toHaveBeenCalled();
+    });
+
+    it("returns 403 when not org admin or paper author", async () => {
+      const token = await createTestJWT({
+        sub: "user-1",
+        githubId: "123",
+        name: "Tester",
+      });
+      queueSelectResponses([
+        { getResult: { id: "org-1", slug: "my-lab" } },
+        { getResult: null }, // not admin
+        { getResult: null }, // not paper author
+      ]);
+
+      const app = await createTestApp();
+      const env = createTestEnv();
+
+      const res = await app.request(
+        "http://localhost/api/orgs/my-lab/papers/paper-1",
+        {
+          method: "DELETE",
+          headers: { Authorization: `Bearer ${token}` },
+        },
+        env as any,
+      );
+
+      expect(res.status).toBe(403);
+      await expect(res.json()).resolves.toEqual({
+        error: "Forbidden: must be org admin or paper author",
+      });
+    });
+
+    it("returns 404 when the association does not exist", async () => {
+      const token = await createTestJWT({
+        sub: "user-2",
+        githubId: "456",
+        name: "Author",
+      });
+      queueSelectResponses([
+        { getResult: { id: "org-1", slug: "my-lab" } },
+        { getResult: null },
+        {
+          getResult: { paperId: "paper-1", userId: "user-2", role: "uploader" },
+        },
+        { getResult: null },
+      ]);
+
+      const app = await createTestApp();
+      const env = createTestEnv();
+
+      const res = await app.request(
+        "http://localhost/api/orgs/my-lab/papers/paper-1",
+        {
+          method: "DELETE",
+          headers: { Authorization: `Bearer ${token}` },
+        },
+        env as any,
+      );
+
+      expect(res.status).toBe(404);
+      expect(((await res.json()) as any).error).toBe(
+        "Paper is not associated with this org",
+      );
+    });
+  });
+
+  // ─── Boundary: last admin protection ──────────────────────
+  describe("last admin protection", () => {
+    it("PATCH prevents demoting the last admin", async () => {
+      const token = await createTestJWT({
+        sub: "user-1",
+        githubId: "123",
+        name: "Tester",
+      });
+      const org = { id: "org-1", slug: "my-lab" };
+      let selectCallCount = 0;
+      mockDb.select = vi.fn(() => {
+        selectCallCount++;
+        if (selectCallCount === 1) return makeQuery({ getResult: org });
+        // actor is admin
+        if (selectCallCount === 2)
+          return makeQuery({
+            getResult: { orgId: "org-1", userId: "user-1", role: "admin" },
+          });
+        // target is also admin
+        if (selectCallCount === 3)
+          return makeQuery({
+            getResult: { orgId: "org-1", userId: "user-2", role: "admin" },
+          });
+        return makeQuery({ getResult: null });
+      });
+
+      mockDb.update = vi.fn(() => ({
+        set: vi.fn(() => ({
+          where: vi.fn(async () => ({ meta: { changes: 0 } })),
+        })),
+      }));
+
+      const app = await createTestApp();
+      const env = createTestEnv();
+
+      const res = await app.request(
+        "http://localhost/api/orgs/my-lab/members/user-2",
+        {
+          method: "PATCH",
+          headers: {
+            Authorization: `Bearer ${token}`,
+            "Content-Type": "application/json",
+          },
+          body: JSON.stringify({ role: "member" }),
+        },
+        env as any,
+      );
+
+      expect(res.status).toBe(400);
+      const body = (await res.json()) as any;
+      expect(body.error).toContain("last admin");
+    });
+
+    it("DELETE prevents removing the last admin", async () => {
+      const token = await createTestJWT({
+        sub: "user-1",
+        githubId: "123",
+        name: "Tester",
+      });
+      const org = { id: "org-1", slug: "my-lab" };
+      let selectCallCount = 0;
+      mockDb.select = vi.fn(() => {
+        selectCallCount++;
+        if (selectCallCount === 1) return makeQuery({ getResult: org });
+        // actor is admin
+        if (selectCallCount === 2)
+          return makeQuery({
+            getResult: { orgId: "org-1", userId: "user-1", role: "admin" },
+          });
+        // target is also admin
+        if (selectCallCount === 3)
+          return makeQuery({
+            getResult: { orgId: "org-1", userId: "user-2", role: "admin" },
+          });
+        return makeQuery({ getResult: null });
+      });
+
+      mockDb.delete = vi.fn(() => ({
+        where: vi.fn(async () => ({ meta: { changes: 0 } })),
+      }));
+
+      const app = await createTestApp();
+      const env = createTestEnv();
+
+      const res = await app.request(
+        "http://localhost/api/orgs/my-lab/members/user-2",
+        {
+          method: "DELETE",
+          headers: { Authorization: `Bearer ${token}` },
+        },
+        env as any,
+      );
+
+      expect(res.status).toBe(400);
+      const body = (await res.json()) as any;
+      expect(body.error).toContain("last admin");
+    });
+  });
 });

--- a/apps/api/src/routes/__tests__/papers-preview.test.ts
+++ b/apps/api/src/routes/__tests__/papers-preview.test.ts
@@ -1,125 +1,129 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
-import {
-    createTestApp,
-    createTestEnv,
-    makeQuery,
-} from "../../test/helpers";
+import { createTestApp, createTestEnv, makeQuery } from "../../test/helpers";
 
 let mockDb: any;
 
 vi.mock("drizzle-orm/d1", () => ({
-    drizzle: vi.fn(() => mockDb),
+  drizzle: vi.fn(() => mockDb),
 }));
 
 describe("papers preview routes", () => {
-    beforeEach(() => {
-        vi.restoreAllMocks();
-        vi.resetModules();
-        mockDb = {
-            run: vi.fn(async () => undefined),
-            select: vi.fn(() => makeQuery()),
-            insert: vi.fn(() => ({ values: vi.fn(async () => undefined) })),
-            delete: vi.fn(() => ({ where: vi.fn(async () => undefined) })),
-            batch: vi.fn(async (queries) => Promise.all(queries.map((q: any) => (q.all ? q.all() : q)))),
-        };
+  beforeEach(() => {
+    vi.restoreAllMocks();
+    vi.resetModules();
+    mockDb = {
+      run: vi.fn(async () => undefined),
+      select: vi.fn(() => makeQuery()),
+      insert: vi.fn(() => ({ values: vi.fn(async () => undefined) })),
+      delete: vi.fn(() => ({ where: vi.fn(async () => undefined) })),
+      batch: vi.fn(async (queries) =>
+        Promise.all(queries.map((q: any) => (q.all ? q.all() : q))),
+      ),
+    };
+  });
+
+  it("GET /api/papers/:id/files/:fileId/preview returns signed URL for public paper without auth", async () => {
+    mockDb.select = vi
+      .fn()
+      .mockImplementationOnce(() =>
+        makeQuery({ getResult: { id: "paper-1", visibility: "public" } }),
+      )
+      .mockImplementationOnce(() =>
+        makeQuery({
+          getResult: {
+            id: "file-1",
+            paperId: "paper-1",
+            r2Key: "papers/paper-1/paper/sample.pdf",
+            mimeType: "application/pdf",
+            filename: "sample.pdf",
+          },
+        }),
+      );
+
+    const app = await createTestApp();
+    const env = createTestEnv({
+      BUCKET: {
+        put: vi.fn(async () => undefined),
+        delete: vi.fn(async () => undefined),
+        get: vi.fn(async () => null),
+        createSignedUrl: vi.fn(
+          async () => "https://signed.example/paper.pdf?sig=test",
+        ),
+      } as any,
     });
 
-    it("GET /api/papers/:id/files/:fileId/preview returns signed URL for public paper without auth", async () => {
-        mockDb.select = vi
-            .fn()
-            .mockImplementationOnce(() => makeQuery({ getResult: { id: "paper-1", visibility: "public" } }))
-            .mockImplementationOnce(
-                () =>
-                    makeQuery({
-                        getResult: {
-                            id: "file-1",
-                            paperId: "paper-1",
-                            r2Key: "papers/paper-1/paper/sample.pdf",
-                            mimeType: "application/pdf",
-                            filename: "sample.pdf",
-                        },
-                    }),
-            );
+    const res = await app.request(
+      "http://localhost/api/papers/paper-1/files/file-1/preview",
+      {},
+      env as any,
+    );
 
-        const app = await createTestApp();
-        const env = createTestEnv({
-            BUCKET: {
-                put: vi.fn(async () => undefined),
-                delete: vi.fn(async () => undefined),
-                get: vi.fn(async () => null),
-                createSignedUrl: vi.fn(async () => "https://signed.example/paper.pdf?sig=test"),
-            } as any,
-        });
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as any;
+    expect(body.url).toContain("https://signed.example");
+    expect(body.mimeType).toBe("application/pdf");
+    expect(body.filename).toBe("sample.pdf");
+  });
 
-        const res = await app.request(
-            "http://localhost/api/papers/paper-1/files/file-1/preview",
-            {},
-            env as any,
-        );
+  it("GET /api/papers/:id/files/:fileId/preview returns 401 for private paper without auth", async () => {
+    mockDb.select = vi
+      .fn()
+      .mockImplementationOnce(() =>
+        makeQuery({ getResult: { id: "paper-1", visibility: "private" } }),
+      );
 
-        expect(res.status).toBe(200);
-        const body = (await res.json()) as any;
-        expect(body.url).toContain("https://signed.example");
-        expect(body.mimeType).toBe("application/pdf");
-        expect(body.filename).toBe("sample.pdf");
+    const app = await createTestApp();
+    const env = createTestEnv();
+
+    const res = await app.request(
+      "http://localhost/api/papers/paper-1/files/file-1/preview",
+      {},
+      env as any,
+    );
+
+    expect(res.status).toBe(401);
+  });
+
+  it("GET /api/papers/:id/files/:fileId/preview falls back to stream URL when signed URL generation fails", async () => {
+    mockDb.select = vi
+      .fn()
+      .mockImplementationOnce(() =>
+        makeQuery({ getResult: { id: "paper-1", visibility: "public" } }),
+      )
+      .mockImplementationOnce(() =>
+        makeQuery({
+          getResult: {
+            id: "file-1",
+            paperId: "paper-1",
+            r2Key: "papers/paper-1/paper/sample.pdf",
+            mimeType: "application/pdf",
+            filename: "sample.pdf",
+          },
+        }),
+      );
+
+    const app = await createTestApp();
+    const env = createTestEnv({
+      BUCKET: {
+        put: vi.fn(async () => undefined),
+        delete: vi.fn(async () => undefined),
+        get: vi.fn(async () => null),
+        createSignedUrl: vi.fn(async () => {
+          throw new Error("presign failed");
+        }),
+      } as any,
     });
 
-    it("GET /api/papers/:id/files/:fileId/preview returns 401 for private paper without auth", async () => {
-        mockDb.select = vi
-            .fn()
-            .mockImplementationOnce(() => makeQuery({ getResult: { id: "paper-1", visibility: "private" } }));
+    const res = await app.request(
+      "http://localhost/api/papers/paper-1/files/file-1/preview",
+      {},
+      env as any,
+    );
 
-        const app = await createTestApp();
-        const env = createTestEnv();
-
-        const res = await app.request(
-            "http://localhost/api/papers/paper-1/files/file-1/preview",
-            {},
-            env as any,
-        );
-
-        expect(res.status).toBe(401);
-    });
-
-    it("GET /api/papers/:id/files/:fileId/preview falls back to stream URL when signed URL generation fails", async () => {
-        mockDb.select = vi
-            .fn()
-            .mockImplementationOnce(() => makeQuery({ getResult: { id: "paper-1", visibility: "public" } }))
-            .mockImplementationOnce(
-                () =>
-                    makeQuery({
-                        getResult: {
-                            id: "file-1",
-                            paperId: "paper-1",
-                            r2Key: "papers/paper-1/paper/sample.pdf",
-                            mimeType: "application/pdf",
-                            filename: "sample.pdf",
-                        },
-                    }),
-            );
-
-        const app = await createTestApp();
-        const env = createTestEnv({
-            BUCKET: {
-                put: vi.fn(async () => undefined),
-                delete: vi.fn(async () => undefined),
-                get: vi.fn(async () => null),
-                createSignedUrl: vi.fn(async () => {
-                    throw new Error("presign failed");
-                }),
-            } as any,
-        });
-
-        const res = await app.request(
-            "http://localhost/api/papers/paper-1/files/file-1/preview",
-            {},
-            env as any,
-        );
-
-        expect(res.status).toBe(200);
-        const body = (await res.json()) as any;
-        expect(body.url).toBe("/api/papers/paper-1/files/file-1/stream");
-        expect(body.mimeType).toBe("application/pdf");
-        expect(body.filename).toBe("sample.pdf");
-    });
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as any;
+    expect(body.url).toBe("/api/papers/paper-1/files/file-1/stream");
+    expect(body.mimeType).toBe("application/pdf");
+    expect(body.filename).toBe("sample.pdf");
+  });
 });

--- a/apps/api/src/routes/__tests__/papers.test.ts
+++ b/apps/api/src/routes/__tests__/papers.test.ts
@@ -1,2458 +1,3652 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import {
-    createTestApp,
-    createTestEnv,
-    createTestJWT,
-    makeQuery,
+  createTestApp,
+  createTestEnv,
+  createTestJWT,
+  makeQuery,
 } from "../../test/helpers";
 
 let mockDb: any;
 
 vi.mock("drizzle-orm/d1", () => ({
-    drizzle: vi.fn(() => mockDb)
+  drizzle: vi.fn(() => mockDb),
 }));
 
 describe("papers routes", () => {
+  it("hits the token cache on subsequent calls and removes expired ones", async () => {
+    const app = await createTestApp();
+    const { createTestJWT } = await import("../../test/helpers");
+    const paperId = "test-paper-cache";
+    const fileId = "test-file-cache";
 
-    it("hits the token cache on subsequent calls and removes expired ones", async () => {
-        const app = await createTestApp();
-        const { createTestJWT } = await import("../../test/helpers");
-        const paperId = "test-paper-cache";
-        const fileId = "test-file-cache";
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date(1000000000000));
+    try {
+      const nowSec = 1000000000;
+      const tokenHit = await createTestJWT({
+        sub: "mock-user-id",
+        exp: nowSec + 3600,
+      });
 
-        vi.useFakeTimers();
-        vi.setSystemTime(new Date(1000000000000));
-        try {
-            const nowSec = 1000000000;
-            const tokenHit = await createTestJWT({ sub: "mock-user-id", exp: nowSec + 3600 });
+      mockDb.select.mockReturnValueOnce(
+        makeQuery({ getResult: { id: paperId, visibility: "private" } }),
+      );
+      mockDb.select.mockReturnValueOnce(
+        makeQuery({ getResult: { id: "user-author" } }),
+      );
+      mockDb.select.mockReturnValueOnce(
+        makeQuery({
+          getResult: {
+            id: fileId,
+            paperId,
+            r2Key: "papers/test.pdf",
+            filename: "paper.pdf",
+          },
+        }),
+      );
 
-            mockDb.select.mockReturnValueOnce(makeQuery({ getResult: { id: paperId, visibility: "private" } }));
-            mockDb.select.mockReturnValueOnce(makeQuery({ getResult: { id: "user-author" } }));
-            mockDb.select.mockReturnValueOnce(makeQuery({
-                getResult: { id: fileId, paperId, r2Key: "papers/test.pdf", filename: "paper.pdf" },
-            }));
+      let req = new Request(
+        `http://localhost/api/papers/${paperId}/files/${fileId}/download`,
+        {
+          headers: { Authorization: `Bearer ${tokenHit}` },
+        },
+      );
+      const res1 = await app.request(
+        req,
+        {},
+        {
+          DB: mockDb,
+          JWT_SECRET: "test-jwt-secret",
+          BUCKET: { get: vi.fn().mockResolvedValue({ body: "test" }) },
+        },
+      );
+      expect(res1.status).toBe(200);
 
-            let req = new Request(`http://localhost/api/papers/${paperId}/files/${fileId}/download`, {
-                headers: { Authorization: `Bearer ${tokenHit}` },
-            });
-            const res1 = await app.request(req, {}, {
-                DB: mockDb,
-                JWT_SECRET: "test-jwt-secret",
-                BUCKET: { get: vi.fn().mockResolvedValue({ body: "test" }) },
-            });
-            expect(res1.status).toBe(200);
+      // 2. Second call immediately should hit the cache (expiresAt > now)
+      mockDb.select.mockReturnValueOnce(
+        makeQuery({ getResult: { id: paperId, visibility: "private" } }),
+      );
+      mockDb.select.mockReturnValueOnce(
+        makeQuery({ getResult: { id: "user-author" } }),
+      );
+      mockDb.select.mockReturnValueOnce(
+        makeQuery({
+          getResult: {
+            id: fileId,
+            paperId,
+            r2Key: "papers/test.pdf",
+            filename: "paper.pdf",
+          },
+        }),
+      );
+      req = new Request(
+        `http://localhost/api/papers/${paperId}/files/${fileId}/download`,
+        {
+          headers: { Authorization: `Bearer ${tokenHit}` },
+        },
+      );
+      const res2 = await app.request(
+        req,
+        {},
+        {
+          DB: mockDb,
+          JWT_SECRET: "test-jwt-secret",
+          BUCKET: { get: vi.fn().mockResolvedValue({ body: "test" }) },
+        },
+      );
+      expect(res2.status).toBe(200);
 
-            // 2. Second call immediately should hit the cache (expiresAt > now)
-            mockDb.select.mockReturnValueOnce(makeQuery({ getResult: { id: paperId, visibility: "private" } }));
-            mockDb.select.mockReturnValueOnce(makeQuery({ getResult: { id: "user-author" } }));
-            mockDb.select.mockReturnValueOnce(makeQuery({
-                getResult: { id: fileId, paperId, r2Key: "papers/test.pdf", filename: "paper.pdf" },
-            }));
-            req = new Request(`http://localhost/api/papers/${paperId}/files/${fileId}/download`, {
-                headers: { Authorization: `Bearer ${tokenHit}` },
-            });
-            const res2 = await app.request(req, {}, {
-                DB: mockDb,
-                JWT_SECRET: "test-jwt-secret",
-                BUCKET: { get: vi.fn().mockResolvedValue({ body: "test" }) },
-            });
-            expect(res2.status).toBe(200);
+      // 3. Advance time by 61 seconds (exceeding TOKEN_CACHE_MAX_AGE_MS = 60s)
+      vi.setSystemTime(new Date(1000000000000 + 61000));
 
-            // 3. Advance time by 61 seconds (exceeding TOKEN_CACHE_MAX_AGE_MS = 60s)
-            vi.setSystemTime(new Date(1000000000000 + 61000));
+      mockDb.select.mockReturnValueOnce(
+        makeQuery({ getResult: { id: paperId, visibility: "private" } }),
+      );
+      mockDb.select.mockReturnValueOnce(
+        makeQuery({ getResult: { id: "user-author" } }),
+      );
+      mockDb.select.mockReturnValueOnce(
+        makeQuery({
+          getResult: {
+            id: fileId,
+            paperId,
+            r2Key: "papers/test.pdf",
+            filename: "paper.pdf",
+          },
+        }),
+      );
+      req = new Request(
+        `http://localhost/api/papers/${paperId}/files/${fileId}/download`,
+        {
+          headers: { Authorization: `Bearer ${tokenHit}` },
+        },
+      );
+      const res3 = await app.request(
+        req,
+        {},
+        {
+          DB: mockDb,
+          JWT_SECRET: "test-jwt-secret",
+          BUCKET: { get: vi.fn().mockResolvedValue({ body: "test" }) },
+        },
+      );
+      expect(res3.status).toBe(200);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
 
-            mockDb.select.mockReturnValueOnce(makeQuery({ getResult: { id: paperId, visibility: "private" } }));
-            mockDb.select.mockReturnValueOnce(makeQuery({ getResult: { id: "user-author" } }));
-            mockDb.select.mockReturnValueOnce(makeQuery({
-                getResult: { id: fileId, paperId, r2Key: "papers/test.pdf", filename: "paper.pdf" },
-            }));
-            req = new Request(`http://localhost/api/papers/${paperId}/files/${fileId}/download`, {
-                headers: { Authorization: `Bearer ${tokenHit}` },
-            });
-            const res3 = await app.request(req, {}, {
-                DB: mockDb,
-                JWT_SECRET: "test-jwt-secret",
-                BUCKET: { get: vi.fn().mockResolvedValue({ body: "test" }) },
-            });
-            expect(res3.status).toBe(200);
-        } finally {
-            vi.useRealTimers();
-        }
-    });
+  it("purges expired cache when reaching MAX_CACHE_SIZE", async () => {
+    const app = await createTestApp();
+    const { createTestJWT } = await import("../../test/helpers");
 
-    it("purges expired cache when reaching MAX_CACHE_SIZE", async () => {
-        const app = await createTestApp();
-        const { createTestJWT } = await import("../../test/helpers");
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date(1000000000000));
+    try {
+      const nowSec = 1000000000;
 
-        vi.useFakeTimers();
-        vi.setSystemTime(new Date(1000000000000));
-        try {
-            const nowSec = 1000000000;
+      mockDb.select.mockReturnValue(
+        makeQuery({ getResult: { id: "dummy", visibility: "private" } }),
+      );
 
-            mockDb.select.mockReturnValue(makeQuery({ getResult: { id: "dummy", visibility: "private" } }));
-
-            const tasks = [];
-            for (let i = 0; i <= 1000; i++) {
-                 const token = await createTestJWT({ sub: "mock-user-id" + i, exp: nowSec + 3600 });
-                 const req = new Request(`http://localhost/api/papers/dummy/files/dummy/download`, {
-                     headers: { Authorization: `Bearer ${token}` },
-                 });
-                 tasks.push(app.request(req, {}, {
-                     DB: mockDb,
-                     JWT_SECRET: "test-jwt-secret",
-                     BUCKET: { get: vi.fn().mockResolvedValue({ body: "test" }) },
-                 }));
-            }
-            await Promise.all(tasks);
-
-            vi.setSystemTime(new Date(1000000000000 + 65000));
-
-            const tokenPurge = await createTestJWT({ sub: "mock-user-id-purge", exp: nowSec + 3600 });
-            const purgeReq = new Request(`http://localhost/api/papers/dummy/files/dummy/download`, {
-                headers: { Authorization: `Bearer ${tokenPurge}` },
-            });
-            const purgeRes = await app.request(purgeReq, {}, {
-                DB: mockDb,
-                JWT_SECRET: "test-jwt-secret",
-                BUCKET: { get: vi.fn().mockResolvedValue({ body: "test" }) },
-            });
-            expect(purgeRes.status).toBe(200);
-        } finally {
-            vi.useRealTimers();
-        }
-    });
-
-    it("hits the token cache on subsequent calls and removes expired ones", async () => {
-        const app = await createTestApp();
-        const { createTestJWT } = await import("../../test/helpers");
-        const paperId = "test-paper-cache";
-        const fileId = "test-file-cache";
-
-        vi.useFakeTimers();
-        vi.setSystemTime(new Date(1000000000000));
-
-        const nowSec = 1000000000;
-        const tokenHit = await createTestJWT({ sub: "mock-user-id", exp: nowSec + 3600 });
-
-        mockDb.select.mockReturnValueOnce(makeQuery({ getResult: { id: paperId, visibility: "private" } }));
-        mockDb.select.mockReturnValueOnce(makeQuery({ getResult: { id: "user-author" } }));
-
-        let req = new Request(`http://localhost/api/papers/${paperId}/files/${fileId}/download`, {
-            headers: { Authorization: `Bearer ${tokenHit}` },
+      const tasks = [];
+      for (let i = 0; i <= 1000; i++) {
+        const token = await createTestJWT({
+          sub: "mock-user-id" + i,
+          exp: nowSec + 3600,
         });
-        await app.request(req, {}, {
+        const req = new Request(
+          `http://localhost/api/papers/dummy/files/dummy/download`,
+          {
+            headers: { Authorization: `Bearer ${token}` },
+          },
+        );
+        tasks.push(
+          app.request(
+            req,
+            {},
+            {
+              DB: mockDb,
+              JWT_SECRET: "test-jwt-secret",
+              BUCKET: { get: vi.fn().mockResolvedValue({ body: "test" }) },
+            },
+          ),
+        );
+      }
+      await Promise.all(tasks);
+
+      vi.setSystemTime(new Date(1000000000000 + 65000));
+
+      const tokenPurge = await createTestJWT({
+        sub: "mock-user-id-purge",
+        exp: nowSec + 3600,
+      });
+      const purgeReq = new Request(
+        `http://localhost/api/papers/dummy/files/dummy/download`,
+        {
+          headers: { Authorization: `Bearer ${tokenPurge}` },
+        },
+      );
+      const purgeRes = await app.request(
+        purgeReq,
+        {},
+        {
+          DB: mockDb,
+          JWT_SECRET: "test-jwt-secret",
+          BUCKET: { get: vi.fn().mockResolvedValue({ body: "test" }) },
+        },
+      );
+      expect(purgeRes.status).toBe(200);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it("hits the token cache on subsequent calls and removes expired ones", async () => {
+    const app = await createTestApp();
+    const { createTestJWT } = await import("../../test/helpers");
+    const paperId = "test-paper-cache";
+    const fileId = "test-file-cache";
+
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date(1000000000000));
+
+    const nowSec = 1000000000;
+    const tokenHit = await createTestJWT({
+      sub: "mock-user-id",
+      exp: nowSec + 3600,
+    });
+
+    mockDb.select.mockReturnValueOnce(
+      makeQuery({ getResult: { id: paperId, visibility: "private" } }),
+    );
+    mockDb.select.mockReturnValueOnce(
+      makeQuery({ getResult: { id: "user-author" } }),
+    );
+
+    let req = new Request(
+      `http://localhost/api/papers/${paperId}/files/${fileId}/download`,
+      {
+        headers: { Authorization: `Bearer ${tokenHit}` },
+      },
+    );
+    await app.request(
+      req,
+      {},
+      {
+        DB: mockDb,
+        JWT_SECRET: "test-jwt-secret",
+        BUCKET: { get: vi.fn().mockResolvedValue({ body: "test" }) },
+      },
+    );
+
+    // 2. Second call immediately should hit the cache (expiresAt > now)
+    mockDb.select.mockReturnValueOnce(
+      makeQuery({ getResult: { id: paperId, visibility: "private" } }),
+    );
+    mockDb.select.mockReturnValueOnce(
+      makeQuery({ getResult: { id: "user-author" } }),
+    );
+    req = new Request(
+      `http://localhost/api/papers/${paperId}/files/${fileId}/download`,
+      {
+        headers: { Authorization: `Bearer ${tokenHit}` },
+      },
+    );
+    await app.request(
+      req,
+      {},
+      {
+        DB: mockDb,
+        JWT_SECRET: "test-jwt-secret",
+        BUCKET: { get: vi.fn().mockResolvedValue({ body: "test" }) },
+      },
+    );
+
+    // 3. Advance time by 61 seconds (exceeding TOKEN_CACHE_MAX_AGE_MS = 60s)
+    vi.setSystemTime(new Date(1000000000000 + 61000));
+
+    mockDb.select.mockReturnValueOnce(
+      makeQuery({ getResult: { id: paperId, visibility: "private" } }),
+    );
+    mockDb.select.mockReturnValueOnce(
+      makeQuery({ getResult: { id: "user-author" } }),
+    );
+    req = new Request(
+      `http://localhost/api/papers/${paperId}/files/${fileId}/download`,
+      {
+        headers: { Authorization: `Bearer ${tokenHit}` },
+      },
+    );
+    await app.request(
+      req,
+      {},
+      {
+        DB: mockDb,
+        JWT_SECRET: "test-jwt-secret",
+        BUCKET: { get: vi.fn().mockResolvedValue({ body: "test" }) },
+      },
+    );
+
+    vi.useRealTimers();
+  });
+
+  it("purges expired cache when reaching MAX_CACHE_SIZE", async () => {
+    const app = await createTestApp();
+    const { createTestJWT } = await import("../../test/helpers");
+
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date(1000000000000));
+
+    const nowSec = 1000000000;
+
+    // Use a persistent mock for the loop
+    mockDb.select.mockReturnValue(
+      makeQuery({ getResult: { id: "dummy", visibility: "private" } }),
+    );
+
+    const tasks = [];
+    for (let i = 0; i <= 1000; i++) {
+      const token = await createTestJWT({
+        sub: "mock-user-id" + i,
+        exp: nowSec + 3600,
+      });
+      const r = new Request(
+        `http://localhost/api/papers/dummy/files/dummy/download`,
+        {
+          headers: { Authorization: `Bearer ${token}` },
+        },
+      );
+      tasks.push(
+        app.request(
+          r,
+          {},
+          {
             DB: mockDb,
             JWT_SECRET: "test-jwt-secret",
             BUCKET: { get: vi.fn().mockResolvedValue({ body: "test" }) },
-        });
+          },
+        ),
+      );
+    }
+    await Promise.all(tasks);
 
-        // 2. Second call immediately should hit the cache (expiresAt > now)
-        mockDb.select.mockReturnValueOnce(makeQuery({ getResult: { id: paperId, visibility: "private" } }));
-        mockDb.select.mockReturnValueOnce(makeQuery({ getResult: { id: "user-author" } }));
-        req = new Request(`http://localhost/api/papers/${paperId}/files/${fileId}/download`, {
-            headers: { Authorization: `Bearer ${tokenHit}` },
-        });
-        await app.request(req, {}, {
-            DB: mockDb,
-            JWT_SECRET: "test-jwt-secret",
-            BUCKET: { get: vi.fn().mockResolvedValue({ body: "test" }) },
-        });
+    // Advance time to expire them
+    vi.setSystemTime(new Date(1000000000000 + 65000));
 
-        // 3. Advance time by 61 seconds (exceeding TOKEN_CACHE_MAX_AGE_MS = 60s)
-        vi.setSystemTime(new Date(1000000000000 + 61000));
+    // Add one more to trigger purge
+    const tokenPurge = await createTestJWT({
+      sub: "mock-user-id-purge",
+      exp: nowSec + 3600,
+    });
+    const purgeReq = new Request(
+      `http://localhost/api/papers/dummy/files/dummy/download`,
+      {
+        headers: { Authorization: `Bearer ${tokenPurge}` },
+      },
+    );
+    await app.request(
+      purgeReq,
+      {},
+      {
+        DB: mockDb,
+        JWT_SECRET: "test-jwt-secret",
+        BUCKET: { get: vi.fn().mockResolvedValue({ body: "test" }) },
+      },
+    );
 
-        mockDb.select.mockReturnValueOnce(makeQuery({ getResult: { id: paperId, visibility: "private" } }));
-        mockDb.select.mockReturnValueOnce(makeQuery({ getResult: { id: "user-author" } }));
-        req = new Request(`http://localhost/api/papers/${paperId}/files/${fileId}/download`, {
-            headers: { Authorization: `Bearer ${tokenHit}` },
-        });
-        await app.request(req, {}, {
-            DB: mockDb,
-            JWT_SECRET: "test-jwt-secret",
-            BUCKET: { get: vi.fn().mockResolvedValue({ body: "test" }) },
-        });
+    vi.useRealTimers();
+  });
 
-        vi.useRealTimers();
+  it("hits the token cache on subsequent calls", async () => {
+    const app = await createTestApp();
+    const paperId = "test-paper-cache";
+    const fileId = "test-file-cache";
+
+    mockDb.select.mockReturnValueOnce(
+      makeQuery({ getResult: { id: paperId, visibility: "private" } }),
+    );
+    mockDb.select.mockReturnValueOnce(
+      makeQuery({ getResult: { id: "user-author" } }),
+    ); // Is author
+
+    // First call
+    const req1 = new Request(
+      `http://localhost/api/papers/${paperId}/files/${fileId}/download`,
+      {
+        headers: {
+          Authorization: "Bearer test-token",
+        },
+      },
+    );
+    const viSelectSpy = vi.spyOn(mockDb, "select");
+    await app.request(
+      req1,
+      {},
+      {
+        DB: mockDb,
+        JWT_SECRET: "secret",
+        BUCKET: { get: vi.fn().mockResolvedValue({ body: "test" }) },
+      },
+    );
+
+    // Second call should hit cache
+    mockDb.select.mockReturnValueOnce(
+      makeQuery({ getResult: { id: paperId, visibility: "private" } }),
+    );
+    mockDb.select.mockReturnValueOnce(
+      makeQuery({ getResult: { id: "user-author" } }),
+    ); // Is author
+    const req2 = new Request(
+      `http://localhost/api/papers/${paperId}/files/${fileId}/download`,
+      {
+        headers: {
+          Authorization: "Bearer test-token",
+        },
+      },
+    );
+    await app.request(
+      req2,
+      {},
+      {
+        DB: mockDb,
+        JWT_SECRET: "secret",
+        BUCKET: { get: vi.fn().mockResolvedValue({ body: "test" }) },
+      },
+    );
+
+    // Should only be called 2 times (for req1) instead of 4
+    expect(viSelectSpy).toHaveBeenCalledTimes(2);
+    viSelectSpy.mockRestore();
+  });
+
+  it("purges expired cache when reaching MAX_CACHE_SIZE", async () => {
+    const app = await createTestApp();
+
+    // Generate enough dummy requests to force the cache to purge
+    for (let i = 0; i <= 1000; i++) {
+      mockDb.select.mockReturnValueOnce(
+        makeQuery({ getResult: { id: "dummy", visibility: "private" } }),
+      );
+      mockDb.select.mockReturnValueOnce(
+        makeQuery({ getResult: { id: "user-author" } }),
+      );
+      const req = new Request(
+        `http://localhost/api/papers/dummy/files/dummy/download`,
+        {
+          headers: {
+            Authorization: `Bearer test-token-${i}`,
+          },
+        },
+      );
+      await app.request(
+        req,
+        {},
+        {
+          DB: mockDb,
+          JWT_SECRET: "secret",
+          BUCKET: { get: vi.fn().mockResolvedValue({ body: "test" }) },
+        },
+      );
+    }
+  });
+
+  it("removes explicitly cached entries when expired upon fetching", async () => {
+    const app = await createTestApp();
+    const paperId = "test-paper-cache";
+    const fileId = "test-file-cache";
+
+    // This is tricky because testing Date.now() bypasses need to be done using vi.setSystemTime
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date(1000000000000));
+
+    mockDb.select.mockReturnValueOnce(
+      makeQuery({ getResult: { id: paperId, visibility: "private" } }),
+    );
+    mockDb.select.mockReturnValueOnce(
+      makeQuery({ getResult: { id: "user-author" } }),
+    );
+
+    const req1 = new Request(
+      `http://localhost/api/papers/${paperId}/files/${fileId}/download`,
+      {
+        headers: {
+          Authorization: "Bearer test-token-expire",
+        },
+      },
+    );
+    await app.request(
+      req1,
+      {},
+      {
+        DB: mockDb,
+        JWT_SECRET: "secret",
+        BUCKET: { get: vi.fn().mockResolvedValue({ body: "test" }) },
+      },
+    );
+
+    // Advance time by 2 minutes
+    vi.setSystemTime(new Date(1000000000000 + 120 * 1000));
+
+    mockDb.select.mockReturnValueOnce(
+      makeQuery({ getResult: { id: paperId, visibility: "private" } }),
+    );
+    mockDb.select.mockReturnValueOnce(
+      makeQuery({ getResult: { id: "user-author" } }),
+    );
+    const req2 = new Request(
+      `http://localhost/api/papers/${paperId}/files/${fileId}/download`,
+      {
+        headers: {
+          Authorization: "Bearer test-token-expire",
+        },
+      },
+    );
+    await app.request(
+      req2,
+      {},
+      {
+        DB: mockDb,
+        JWT_SECRET: "secret",
+        BUCKET: { get: vi.fn().mockResolvedValue({ body: "test" }) },
+      },
+    );
+
+    vi.useRealTimers();
+  });
+
+  it("hits the token cache on subsequent calls", async () => {
+    const app = await createTestApp();
+    const paperId = "test-paper-cache";
+    const fileId = "test-file-cache";
+
+    mockDb.select.mockReturnValueOnce(
+      makeQuery({ getResult: { id: paperId, visibility: "private" } }),
+    );
+    mockDb.select.mockReturnValueOnce(
+      makeQuery({ getResult: { id: "user-author" } }),
+    ); // Is author
+
+    // First call
+    const req1 = new Request(
+      `http://localhost/api/papers/${paperId}/files/${fileId}/download`,
+      {
+        headers: {
+          Authorization: "Bearer test-token",
+        },
+      },
+    );
+    await app.request(
+      req1,
+      {},
+      {
+        DB: mockDb,
+        JWT_SECRET: "secret",
+        BUCKET: { get: vi.fn().mockResolvedValue({ body: "test" }) },
+      },
+    );
+
+    // Second call should hit cache
+    mockDb.select.mockReturnValueOnce(
+      makeQuery({ getResult: { id: paperId, visibility: "private" } }),
+    );
+    mockDb.select.mockReturnValueOnce(
+      makeQuery({ getResult: { id: "user-author" } }),
+    ); // Is author
+    const req2 = new Request(
+      `http://localhost/api/papers/${paperId}/files/${fileId}/download`,
+      {
+        headers: {
+          Authorization: "Bearer test-token",
+        },
+      },
+    );
+    await app.request(
+      req2,
+      {},
+      {
+        DB: mockDb,
+        JWT_SECRET: "secret",
+        BUCKET: { get: vi.fn().mockResolvedValue({ body: "test" }) },
+      },
+    );
+  });
+
+  beforeEach(() => {
+    vi.restoreAllMocks();
+    vi.resetModules();
+    mockDb = {
+      run: vi.fn(async () => undefined),
+      prepare: vi.fn(() => ({
+        bind: vi.fn(() => ({
+          run: vi.fn(async () => ({ meta: { changes: 1 } })),
+        })),
+      })),
+      select: vi.fn(() => makeQuery()),
+      insert: vi.fn(() => ({
+        values: vi.fn(() => ({
+          onConflictDoUpdate: vi.fn(async () => undefined),
+          onConflictDoNothing: vi.fn(async () => undefined),
+        })),
+      })),
+      update: vi.fn(() => ({
+        set: vi.fn(() => ({ where: vi.fn(async () => undefined) })),
+      })),
+      delete: vi.fn(() => ({ where: vi.fn(async () => undefined) })),
+      batch: vi.fn(async (queries) =>
+        Promise.all(queries.map((q: any) => (q.all ? q.all() : q))),
+      ),
+    };
+  });
+
+  it("POST /api/papers uploads multipart and creates paper", async () => {
+    const token = await createTestJWT({
+      sub: "user-1",
+      githubId: "123",
+      name: "Uploader",
+    });
+    const app = await createTestApp();
+    const env = createTestEnv({ DB: mockDb as any });
+
+    const form = new FormData();
+    form.set(
+      "metadata",
+      JSON.stringify({ title: "Test Paper", visibility: "private" }),
+    );
+    form.set(
+      "files_0",
+      new File(["%PDF-1.4\n%dummy-pdf"], "paper.pdf", {
+        type: "application/pdf",
+      }),
+    );
+    form.set("file_types_0", "paper");
+
+    const res = await app.request(
+      "http://localhost/api/papers",
+      {
+        method: "POST",
+        headers: {
+          Authorization: `Bearer ${token}`,
+          Origin: "http://localhost:3000",
+        },
+        body: form,
+      },
+      env as any,
+    );
+
+    expect(res.status).toBe(201);
+  });
+
+  it("POST /api/papers deletes uploaded files and paper record on database error", async () => {
+    const token = await createTestJWT({
+      sub: "user-1",
+      githubId: "123",
+      name: "Uploader",
     });
 
-    it("purges expired cache when reaching MAX_CACHE_SIZE", async () => {
-        const app = await createTestApp();
-        const { createTestJWT } = await import("../../test/helpers");
+    // Mock db.insert to succeed for papers, but fail for paperFiles
+    const dbError = new Error("Mock DB Error");
+    mockDb.insert
+      .mockImplementationOnce(() => ({ values: vi.fn(async () => undefined) })) // papers insert
+      .mockImplementationOnce(() => ({ values: vi.fn(async () => undefined) })) // paperAuthors insert
+      .mockImplementationOnce(() => {
+        throw dbError;
+      }); // paperFiles insert
 
-        vi.useFakeTimers();
-        vi.setSystemTime(new Date(1000000000000));
+    const mockDeleteWhere = vi.fn(async () => undefined);
+    mockDb.delete = vi.fn(() => ({ where: mockDeleteWhere }));
 
-        const nowSec = 1000000000;
+    const app = await createTestApp();
+    const env = createTestEnv({ DB: mockDb as any });
 
-        // Use a persistent mock for the loop
-        mockDb.select.mockReturnValue(makeQuery({ getResult: { id: "dummy", visibility: "private" } }));
+    // Spy on BUCKET.delete
+    const bucketDeleteSpy = vi
+      .spyOn(env.BUCKET, "delete")
+      .mockRejectedValue(new Error("Cleanup failed"));
+    const consoleErrorSpy = vi
+      .spyOn(console, "error")
+      .mockImplementation(() => {});
 
-        const tasks = [];
-        for (let i = 0; i <= 1000; i++) {
-             const token = await createTestJWT({ sub: "mock-user-id" + i, exp: nowSec + 3600 });
-             const r = new Request(`http://localhost/api/papers/dummy/files/dummy/download`, {
-                 headers: { Authorization: `Bearer ${token}` },
-             });
-             tasks.push(app.request(r, {}, {
-                 DB: mockDb,
-                 JWT_SECRET: "test-jwt-secret",
-                 BUCKET: { get: vi.fn().mockResolvedValue({ body: "test" }) },
-             }));
-        }
-        await Promise.all(tasks);
+    const form = new FormData();
+    form.set(
+      "metadata",
+      JSON.stringify({ title: "Test Paper", visibility: "private" }),
+    );
+    form.set(
+      "files_0",
+      new File(["%PDF-1.4\n%dummy-pdf"], "paper.pdf", {
+        type: "application/pdf",
+      }),
+    );
+    form.set("file_types_0", "paper");
 
-        // Advance time to expire them
-        vi.setSystemTime(new Date(1000000000000 + 65000));
+    const res = await app.request(
+      "http://localhost/api/papers",
+      {
+        method: "POST",
+        headers: {
+          Authorization: `Bearer ${token}`,
+          Origin: "http://localhost:3000",
+        },
+        body: form,
+      },
+      env as any,
+    );
+    expect(res.status).toBe(500);
 
-        // Add one more to trigger purge
-        const tokenPurge = await createTestJWT({ sub: "mock-user-id-purge", exp: nowSec + 3600 });
-        const purgeReq = new Request(`http://localhost/api/papers/dummy/files/dummy/download`, {
-            headers: { Authorization: `Bearer ${tokenPurge}` },
-        });
-        await app.request(purgeReq, {}, {
-            DB: mockDb,
-            JWT_SECRET: "test-jwt-secret",
-            BUCKET: { get: vi.fn().mockResolvedValue({ body: "test" }) },
-        });
+    // BUCKET.delete should be called with a batch including uploaded paper keys
+    expect(bucketDeleteSpy).toHaveBeenCalledTimes(1);
+    const firstDeleteCall = bucketDeleteSpy.mock.calls[0];
+    const deletedKeys = firstDeleteCall?.[0];
+    expect(deletedKeys).toEqual(
+      expect.arrayContaining([expect.stringContaining("papers/")]),
+    );
+    expect(consoleErrorSpy).toHaveBeenCalledWith(
+      "Cleanup error (non-fatal, rollback continues):",
+      "Cleanup failed",
+    );
 
-        vi.useRealTimers();
+    // db.delete should be called for papers
+    expect(mockDb.delete).toHaveBeenCalledTimes(1);
+    expect(mockDeleteWhere).toHaveBeenCalledTimes(1);
+    consoleErrorSpy.mockRestore();
+    bucketDeleteSpy.mockRestore();
+  });
+
+  it("POST /api/papers logs sanitized errors (both Error instance and string) on upload failure", async () => {
+    const token = await createTestJWT({
+      sub: "user-1",
+      githubId: "123",
+      name: "Uploader",
+    });
+    const app = await createTestApp();
+
+    const sensitiveError = new Error("S3 error: AccessKeyId=SENSITIVE_KEY");
+    (sensitiveError as any).secretInfo = "TOO_SENSITIVE";
+    const stringError = "Some string-based upload error";
+
+    let callCount = 0;
+    const env = createTestEnv({
+      DB: mockDb as any,
+      BUCKET: {
+        put: vi.fn().mockImplementation(() => {
+          callCount++;
+          if (callCount === 1) return Promise.reject(sensitiveError);
+          return Promise.reject(stringError);
+        }),
+        delete: vi.fn().mockResolvedValue(undefined),
+      } as any,
     });
 
-    it("hits the token cache on subsequent calls", async () => {
-        const app = await createTestApp();
-        const paperId = "test-paper-cache";
-        const fileId = "test-file-cache";
+    const consoleErrorSpy = vi
+      .spyOn(console, "error")
+      .mockImplementation(() => {});
 
-        mockDb.select.mockReturnValueOnce(makeQuery({ getResult: { id: paperId, visibility: "private" } }));
-        mockDb.select.mockReturnValueOnce(makeQuery({ getResult: { id: "user-author" } })); // Is author
+    const form = new FormData();
+    form.set(
+      "metadata",
+      JSON.stringify({ title: "Test Paper", visibility: "private" }),
+    );
+    form.set(
+      "files_0",
+      new File(["%PDF-1.4\n%dummy-pdf"], "paper1.pdf", {
+        type: "application/pdf",
+      }),
+    );
+    form.set("file_types_0", "paper");
+    form.set(
+      "files_1",
+      new File(["%PDF-1.4\n%dummy-pdf"], "paper2.pdf", {
+        type: "application/pdf",
+      }),
+    );
+    form.set("file_types_1", "paper");
 
-        // First call
-        const req1 = new Request(`http://localhost/api/papers/${paperId}/files/${fileId}/download`, {
-            headers: {
-                Authorization: "Bearer test-token",
-            },
-        });
-        const viSelectSpy = vi.spyOn(mockDb, 'select');
-        await app.request(req1, {}, {
-            DB: mockDb,
-            JWT_SECRET: "secret",
-            BUCKET: { get: vi.fn().mockResolvedValue({ body: "test" }) },
-        });
+    const res = await app.request(
+      "http://localhost/api/papers",
+      {
+        method: "POST",
+        headers: {
+          Authorization: `Bearer ${token}`,
+          Origin: "http://localhost:3000",
+        },
+        body: form,
+      },
+      env as any,
+    );
 
-        // Second call should hit cache
-        mockDb.select.mockReturnValueOnce(makeQuery({ getResult: { id: paperId, visibility: "private" } }));
-        mockDb.select.mockReturnValueOnce(makeQuery({ getResult: { id: "user-author" } })); // Is author
-        const req2 = new Request(`http://localhost/api/papers/${paperId}/files/${fileId}/download`, {
-            headers: {
-                Authorization: "Bearer test-token",
-            },
-        });
-        await app.request(req2, {}, {
-            DB: mockDb,
-            JWT_SECRET: "secret",
-            BUCKET: { get: vi.fn().mockResolvedValue({ body: "test" }) },
-        });
+    expect(res.status).toBe(500);
 
-        // Should only be called 2 times (for req1) instead of 4
-        expect(viSelectSpy).toHaveBeenCalledTimes(2);
-        viSelectSpy.mockRestore();
+    const uploadErrorCall = consoleErrorSpy.mock.calls.find(
+      (call) => call[0] === "File upload errors:",
+    );
+    expect(uploadErrorCall).toBeDefined();
+
+    const loggedObject = uploadErrorCall![1];
+    expect(loggedObject.errors).toHaveLength(2);
+
+    // Verify Error instance is sanitized
+    const errorLog = loggedObject.errors.find(
+      (e: any) => e === sensitiveError.message,
+    );
+    expect(errorLog).toBeDefined();
+
+    // Verify string error is preserved as string
+    const stringLog = loggedObject.errors.find((e: any) => e === stringError);
+    expect(stringLog).toBeDefined();
+
+    consoleErrorSpy.mockRestore();
+  });
+
+  it("POST /api/papers rejects upload when content does not match declared MIME", async () => {
+    const token = await createTestJWT({
+      sub: "user-1",
+      githubId: "123",
+      name: "Uploader",
     });
+    const app = await createTestApp();
+    const env = createTestEnv({ DB: mockDb as any });
 
-    it("purges expired cache when reaching MAX_CACHE_SIZE", async () => {
-        const app = await createTestApp();
+    const form = new FormData();
+    form.set(
+      "metadata",
+      JSON.stringify({ title: "Mismatched Paper", visibility: "private" }),
+    );
+    // PDF declared but content starts with ZIP header
+    form.set(
+      "files_0",
+      new File(["PK\x03\x04zipcontent"], "paper.pdf", {
+        type: "application/pdf",
+      }),
+    );
+    form.set("file_types_0", "paper");
 
-        // Generate enough dummy requests to force the cache to purge
-        for (let i = 0; i <= 1000; i++) {
-             mockDb.select.mockReturnValueOnce(makeQuery({ getResult: { id: "dummy", visibility: "private" } }));
-             mockDb.select.mockReturnValueOnce(makeQuery({ getResult: { id: "user-author" } }));
-             const req = new Request(`http://localhost/api/papers/dummy/files/dummy/download`, {
-                 headers: {
-                     Authorization: `Bearer test-token-${i}`,
-                 },
-             });
-             await app.request(req, {}, {
-                 DB: mockDb,
-                 JWT_SECRET: "secret",
-                 BUCKET: { get: vi.fn().mockResolvedValue({ body: "test" }) },
-             });
-        }
+    const res = await app.request(
+      "http://localhost/api/papers",
+      {
+        method: "POST",
+        headers: {
+          Authorization: `Bearer ${token}`,
+          Origin: "http://localhost:3000",
+        },
+        body: form,
+      },
+      env as any,
+    );
+
+    expect(res.status).toBe(400);
+    const body = (await res.json()) as any;
+    expect(body.error).toContain("does not match expected format");
+  });
+
+  it("GET /api/papers returns current user's papers", async () => {
+    const token = await createTestJWT({
+      sub: "user-1",
+      githubId: "123",
+      name: "Uploader",
     });
+    mockDb.select = vi.fn(() =>
+      makeQuery({ allResult: [{ paper: { id: "paper-1", title: "P1" } }] }),
+    );
 
-    it("removes explicitly cached entries when expired upon fetching", async () => {
-        const app = await createTestApp();
-        const paperId = "test-paper-cache";
-        const fileId = "test-file-cache";
+    const app = await createTestApp();
+    const env = createTestEnv({ DB: mockDb as any });
+    const res = await app.request(
+      "http://localhost/api/papers",
+      {
+        headers: { Authorization: `Bearer ${token}` },
+      },
+      env as any,
+    );
 
-        // This is tricky because testing Date.now() bypasses need to be done using vi.setSystemTime
-        vi.useFakeTimers();
-        vi.setSystemTime(new Date(1000000000000));
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as any;
+    expect(body.papers[0].id).toBe("paper-1");
+  });
 
-        mockDb.select.mockReturnValueOnce(makeQuery({ getResult: { id: paperId, visibility: "private" } }));
-        mockDb.select.mockReturnValueOnce(makeQuery({ getResult: { id: "user-author" } }));
-
-        const req1 = new Request(`http://localhost/api/papers/${paperId}/files/${fileId}/download`, {
-            headers: {
-                Authorization: "Bearer test-token-expire",
-            },
-        });
-        await app.request(req1, {}, {
-            DB: mockDb,
-            JWT_SECRET: "secret",
-            BUCKET: { get: vi.fn().mockResolvedValue({ body: "test" }) },
-        });
-
-        // Advance time by 2 minutes
-        vi.setSystemTime(new Date(1000000000000 + 120 * 1000));
-
-        mockDb.select.mockReturnValueOnce(makeQuery({ getResult: { id: paperId, visibility: "private" } }));
-        mockDb.select.mockReturnValueOnce(makeQuery({ getResult: { id: "user-author" } }));
-        const req2 = new Request(`http://localhost/api/papers/${paperId}/files/${fileId}/download`, {
-            headers: {
-                Authorization: "Bearer test-token-expire",
-            },
-        });
-        await app.request(req2, {}, {
-            DB: mockDb,
-            JWT_SECRET: "secret",
-            BUCKET: { get: vi.fn().mockResolvedValue({ body: "test" }) },
-        });
-
-        vi.useRealTimers();
+  it("GET /api/papers/:id returns paper details", async () => {
+    const token = await createTestJWT({
+      sub: "user-1",
+      githubId: "123",
+      name: "Uploader",
     });
-
-    it("hits the token cache on subsequent calls", async () => {
-        const app = await createTestApp();
-        const paperId = "test-paper-cache";
-        const fileId = "test-file-cache";
-
-        mockDb.select.mockReturnValueOnce(makeQuery({ getResult: { id: paperId, visibility: "private" } }));
-        mockDb.select.mockReturnValueOnce(makeQuery({ getResult: { id: "user-author" } })); // Is author
-
-        // First call
-        const req1 = new Request(`http://localhost/api/papers/${paperId}/files/${fileId}/download`, {
-            headers: {
-                Authorization: "Bearer test-token",
-            },
-        });
-        await app.request(req1, {}, {
-            DB: mockDb,
-            JWT_SECRET: "secret",
-            BUCKET: { get: vi.fn().mockResolvedValue({ body: "test" }) },
-        });
-
-        // Second call should hit cache
-        mockDb.select.mockReturnValueOnce(makeQuery({ getResult: { id: paperId, visibility: "private" } }));
-        mockDb.select.mockReturnValueOnce(makeQuery({ getResult: { id: "user-author" } })); // Is author
-        const req2 = new Request(`http://localhost/api/papers/${paperId}/files/${fileId}/download`, {
-            headers: {
-                Authorization: "Bearer test-token",
-            },
-        });
-        await app.request(req2, {}, {
-            DB: mockDb,
-            JWT_SECRET: "secret",
-            BUCKET: { get: vi.fn().mockResolvedValue({ body: "test" }) },
-        });
-    });
-
-    beforeEach(() => {
-        vi.restoreAllMocks();
-        vi.resetModules();
-        mockDb = {
-            run: vi.fn(async () => undefined),
-            prepare: vi.fn(() => ({
-                bind: vi.fn(() => ({
-                    run: vi.fn(async () => ({ meta: { changes: 1 } })),
-                })),
-            })),
-            select: vi.fn(() => makeQuery()),
-            insert: vi.fn(() => ({
-                values: vi.fn(() => ({
-                    onConflictDoUpdate: vi.fn(async () => undefined),
-                    onConflictDoNothing: vi.fn(async () => undefined),
-                })),
-            })),
-            update: vi.fn(() => ({ set: vi.fn(() => ({ where: vi.fn(async () => undefined) })) })),
-            delete: vi.fn(() => ({ where: vi.fn(async () => undefined) })),
-            batch: vi.fn(async (queries) => Promise.all(queries.map((q: any) => q.all ? q.all() : q)))
-        };
-    });
-
-    it("POST /api/papers uploads multipart and creates paper", async () => {
-        const token = await createTestJWT({ sub: "user-1", githubId: "123", name: "Uploader" });
-        const app = await createTestApp();
-        const env = createTestEnv({ DB: mockDb as any });
-
-        const form = new FormData();
-        form.set("metadata", JSON.stringify({ title: "Test Paper", visibility: "private" }));
-        form.set("files_0", new File(["%PDF-1.4\n%dummy-pdf"], "paper.pdf", { type: "application/pdf" }));
-        form.set("file_types_0", "paper");
-
-        const res = await app.request(
-            "http://localhost/api/papers",
+    mockDb.select = vi
+      .fn()
+      .mockImplementationOnce(() =>
+        makeQuery({
+          getResult: {
+            id: "paper-1",
+            title: "P1",
+            abstract: "A",
+            description: "## notes",
+            descriptionUpdatedAt: "2026-04-01 12:00:00",
+            visibility: "private",
+            showViewCount: true,
+            language: "ja",
+            doi: "10.1234/example",
+          },
+        }),
+      )
+      .mockImplementationOnce(() =>
+        makeQuery({
+          getResult: { paperId: "paper-1", userId: "user-1", role: "uploader" },
+        }),
+      )
+      .mockImplementationOnce(() =>
+        makeQuery({ allResult: [{ id: "file-1", filename: "paper.pdf" }] }),
+      )
+      .mockImplementationOnce(() =>
+        makeQuery({
+          allResult: [
             {
-                method: "POST",
-                headers: {
-                    Authorization: `Bearer ${token}`,
-                    Origin: "http://localhost:3000"
-                },
-                body: form
+              userId: "user-1",
+              role: "uploader",
+              name: "Uploader",
+              displayName: null,
+              avatarUrl: null,
             },
-            env as any
-        );
+          ],
+        }),
+      )
+      .mockImplementationOnce(() =>
+        makeQuery({ getResult: { views: 4, downloads: 2 } }),
+      );
 
-        expect(res.status).toBe(201);
+    const app = await createTestApp();
+    const env = createTestEnv({ DB: mockDb as any });
+    const res = await app.request(
+      "http://localhost/api/papers/paper-1",
+      { headers: { Authorization: `Bearer ${token}` } },
+      env as any,
+    );
+
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as any;
+    expect(body.paper.id).toBe("paper-1");
+    expect(body.paper.language).toBe("ja");
+    expect(body.paper.doi).toBe("10.1234/example");
+    expect(body.paper.description).toBe("## notes");
+    expect(body.paper.descriptionUpdatedAt).toBe("2026-04-01T12:00:00.000Z");
+    expect(body.paper.showViewCount).toBe(true);
+    expect(body.paper.publicViewCount).toBe(4);
+    expect(body.paper.publicDownloadCount).toBe(2);
+    expect(mockDb.batch).toHaveBeenCalledTimes(1);
+  });
+
+  it("GET /api/papers/:id/cite returns citation in requested format", async () => {
+    const token = await createTestJWT({
+      sub: "user-1",
+      githubId: "123",
+      name: "Uploader",
+    });
+    mockDb.select = vi
+      .fn()
+      .mockImplementationOnce(() =>
+        makeQuery({
+          getResult: {
+            id: "paper-1",
+            title: "Boundary Explorer",
+            visibility: "private",
+            venue: "ASE",
+            venueType: "conference",
+            year: 2026,
+            category: "other",
+            doi: null,
+            externalUrl: null,
+          },
+        }),
+      )
+      .mockImplementationOnce(() =>
+        makeQuery({ getResult: { paperId: "paper-1", userId: "user-1" } }),
+      )
+      .mockImplementationOnce(() =>
+        makeQuery({
+          allResult: [{ name: "hiroki", displayName: "Hiroki Mukai" }],
+        }),
+      );
+
+    const app = await createTestApp();
+    const env = createTestEnv({ DB: mockDb as any });
+    const res = await app.request(
+      "http://localhost/api/papers/paper-1/cite?format=bibtex",
+      { headers: { Authorization: `Bearer ${token}` } },
+      env as any,
+    );
+
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as any;
+    expect(body.format).toBe("bibtex");
+    expect(body.key).toContain("mukai2026");
+    expect(body.citation).toContain("@inproceedings");
+  });
+
+  it("GET /api/papers/:id/cite supports plain format", async () => {
+    const token = await createTestJWT({
+      sub: "user-1",
+      githubId: "123",
+      name: "Uploader",
+    });
+    mockDb.select = vi
+      .fn()
+      .mockImplementationOnce(() =>
+        makeQuery({
+          getResult: {
+            id: "paper-1",
+            title: "Boundary Explorer",
+            visibility: "private",
+            venue: "ASE",
+            venueType: "conference",
+            year: 2026,
+            category: "other",
+            doi: null,
+            externalUrl: null,
+          },
+        }),
+      )
+      .mockImplementationOnce(() =>
+        makeQuery({ getResult: { paperId: "paper-1", userId: "user-1" } }),
+      )
+      .mockImplementationOnce(() =>
+        makeQuery({
+          allResult: [{ name: "hiroki", displayName: "向井 宏樹" }],
+        }),
+      );
+
+    const app = await createTestApp();
+    const env = createTestEnv({ DB: mockDb as any });
+    const res = await app.request(
+      "http://localhost/api/papers/paper-1/cite?format=plain",
+      { headers: { Authorization: `Bearer ${token}` } },
+      env as any,
+    );
+
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as any;
+    expect(body.format).toBe("plain");
+    expect(body.key).toBeNull();
+    expect(body.citation).toContain("向井 宏樹");
+  });
+
+  it("POST /api/papers rejects a non-boolean showViewCount", async () => {
+    const token = await createTestJWT({
+      sub: "user-1",
+      githubId: "123",
+      name: "Uploader",
+    });
+    const app = await createTestApp();
+    const env = createTestEnv({ DB: mockDb as any });
+
+    const form = new FormData();
+    form.set(
+      "metadata",
+      JSON.stringify({
+        title: "View Count Paper",
+        visibility: "private",
+        showViewCount: "yes",
+      }),
+    );
+    form.set(
+      "files_0",
+      new File(["%PDF-1.4\n%dummy-pdf"], "paper.pdf", {
+        type: "application/pdf",
+      }),
+    );
+    form.set("file_types_0", "paper");
+
+    const res = await app.request(
+      "http://localhost/api/papers",
+      {
+        method: "POST",
+        headers: {
+          Authorization: `Bearer ${token}`,
+          Origin: "http://localhost:3000",
+        },
+        body: form,
+      },
+      env as any,
+    );
+
+    expect(res.status).toBe(400);
+    const body = (await res.json()) as any;
+    expect(body.error).toContain("showViewCount");
+  });
+
+  it("POST /api/papers/:id/track accepts view event", async () => {
+    const dedupRun = vi.fn(async () => ({ meta: { changes: 1 } }));
+    const dailyRun = vi.fn(async () => ({ meta: { changes: 1 } }));
+    const totalRun = vi.fn(async () => ({ meta: { changes: 1 } }));
+    const cleanupRun = vi.fn(async () => ({ meta: { changes: 0 } }));
+    mockDb.select = vi
+      .fn()
+      .mockImplementationOnce(() =>
+        makeQuery({ getResult: { id: "paper-1", visibility: "public" } }),
+      );
+    const prepare = vi
+      .fn()
+      .mockImplementationOnce(() => ({
+        bind: vi.fn(() => ({ run: dedupRun })),
+      }))
+      .mockImplementationOnce(() => ({
+        bind: vi.fn(() => ({ run: dailyRun })),
+      }))
+      .mockImplementationOnce(() => ({
+        bind: vi.fn(() => ({ run: totalRun })),
+      }))
+      .mockImplementationOnce(() => ({
+        bind: vi.fn(() => ({ run: cleanupRun })),
+      }));
+    mockDb.prepare = prepare;
+    mockDb.batch = vi.fn(async (queries) =>
+      Promise.all(queries.map((q: any) => q.run())),
+    );
+
+    const app = await createTestApp();
+    const env = createTestEnv({ DB: mockDb as any });
+    const res = await app.request(
+      "http://localhost/api/papers/paper-1/track",
+      {
+        method: "POST",
+        headers: {
+          "Content-Type": "application/json",
+          Origin: "http://localhost:3000",
+          "User-Agent": "Vitest",
+        },
+        body: JSON.stringify({
+          event: "view",
+          referrer: "https://example.com",
+        }),
+      },
+      env as any,
+    );
+
+    expect(res.status).toBe(204);
+    expect(prepare).toHaveBeenCalledTimes(4);
+    expect(dedupRun).toHaveBeenCalled();
+    expect(dailyRun).toHaveBeenCalled();
+    expect(totalRun).toHaveBeenCalled();
+  });
+
+  it("POST /api/papers/:id/track ignores bots", async () => {
+    mockDb.select = vi
+      .fn()
+      .mockImplementationOnce(() =>
+        makeQuery({ getResult: { id: "paper-1", visibility: "public" } }),
+      );
+
+    const app = await createTestApp();
+    const env = createTestEnv({ DB: mockDb as any });
+    const res = await app.request(
+      "http://localhost/api/papers/paper-1/track",
+      {
+        method: "POST",
+        headers: {
+          "Content-Type": "application/json",
+          Origin: "http://localhost:3000",
+          "User-Agent": "googlebot",
+        },
+        body: JSON.stringify({ event: "view" }),
+      },
+      env as any,
+    );
+
+    expect(res.status).toBe(204);
+    expect(mockDb.insert).not.toHaveBeenCalled();
+  });
+
+  it("POST /api/papers/:id/track logs sanitized error on failure (Error instance)", async () => {
+    mockDb.select = vi
+      .fn()
+      .mockImplementationOnce(() =>
+        makeQuery({ getResult: { id: "paper-1", visibility: "public" } }),
+      );
+
+    const trackError = new Error("D1 Error: SENSITIVE_DB_INFO");
+    (trackError as any).query = "INSERT INTO paper_stats_dedup ...";
+
+    mockDb.batch = vi.fn().mockRejectedValue(trackError);
+
+    const consoleErrorSpy = vi
+      .spyOn(console, "error")
+      .mockImplementation(() => {});
+
+    const app = await createTestApp();
+    const env = createTestEnv({ DB: mockDb as any });
+    await app.request(
+      "http://localhost/api/papers/paper-1/track",
+      {
+        method: "POST",
+        headers: {
+          "Content-Type": "application/json",
+          Origin: "http://localhost:3000",
+          "User-Agent": "Vitest",
+        },
+        body: JSON.stringify({ event: "view" }),
+      },
+      env as any,
+    );
+
+    try {
+      await vi.waitFor(() => {
+        const call = consoleErrorSpy.mock.calls.find(
+          (c) => c[0] === "Failed to record paper track event",
+        );
+        if (!call) throw new Error("Log not found");
+        expect(call[1].error).toBe(trackError.message);
+      });
+    } finally {
+      consoleErrorSpy.mockRestore();
+    }
+  });
+
+  it("POST /api/papers/:id/track logs sanitized error on failure (string error)", async () => {
+    mockDb.select = vi
+      .fn()
+      .mockImplementationOnce(() =>
+        makeQuery({ getResult: { id: "paper-1", visibility: "public" } }),
+      );
+
+    const trackError = "Batch failed for some reason";
+    mockDb.batch = vi.fn().mockRejectedValue(trackError);
+
+    const consoleErrorSpy = vi
+      .spyOn(console, "error")
+      .mockImplementation(() => {});
+
+    const app = await createTestApp();
+    const env = createTestEnv({ DB: mockDb as any });
+    await app.request(
+      "http://localhost/api/papers/paper-1/track",
+      {
+        method: "POST",
+        headers: {
+          "Content-Type": "application/json",
+          Origin: "http://localhost:3000",
+          "User-Agent": "Vitest",
+        },
+        body: JSON.stringify({ event: "view" }),
+      },
+      env as any,
+    );
+
+    try {
+      await vi.waitFor(() => {
+        const call = consoleErrorSpy.mock.calls.find(
+          (c) => c[0] === "Failed to record paper track event",
+        );
+        if (!call) throw new Error("Log not found");
+        expect(call[1].error).toBe(trackError);
+      });
+    } finally {
+      consoleErrorSpy.mockRestore();
+    }
+  });
+
+  it("POST /api/papers/:id/track handles duplicate dedup rows", async () => {
+    const dedupRun = vi.fn(async () => ({ meta: { changes: 0 } }));
+    const dailyRun = vi.fn(async () => ({ meta: { changes: 0 } }));
+    const totalRun = vi.fn(async () => ({ meta: { changes: 0 } }));
+    const cleanupRun = vi.fn(async () => ({ meta: { changes: 0 } }));
+    mockDb.prepare = vi
+      .fn()
+      .mockImplementationOnce(() => ({
+        bind: vi.fn(() => ({ run: dedupRun })),
+      }))
+      .mockImplementationOnce(() => ({
+        bind: vi.fn(() => ({ run: dailyRun })),
+      }))
+      .mockImplementationOnce(() => ({
+        bind: vi.fn(() => ({ run: totalRun })),
+      }))
+      .mockImplementationOnce(() => ({
+        bind: vi.fn(() => ({ run: cleanupRun })),
+      }));
+    mockDb.batch = vi.fn(async (queries) =>
+      Promise.all(queries.map((q: any) => q.run())),
+    );
+    mockDb.select = vi
+      .fn()
+      .mockImplementationOnce(() =>
+        makeQuery({ getResult: { id: "paper-1", visibility: "public" } }),
+      );
+
+    const app = await createTestApp();
+    const env = createTestEnv({ DB: mockDb as any });
+    const res = await app.request(
+      "http://localhost/api/papers/paper-1/track",
+      {
+        method: "POST",
+        headers: {
+          "Content-Type": "application/json",
+          Origin: "http://localhost:3000",
+          "User-Agent": "Vitest",
+        },
+        body: JSON.stringify({ event: "download" }),
+      },
+      env as any,
+    );
+
+    expect(res.status).toBe(204);
+  });
+
+  it("DELETE /api/papers/:id handles R2 deletion failure", async () => {
+    const token = await createTestJWT({
+      sub: "user-1",
+      githubId: "123",
+      name: "Uploader",
+    });
+    mockDb.select = vi
+      .fn()
+      .mockImplementationOnce(() =>
+        makeQuery({
+          getResult: { paperId: "paper-1", userId: "user-1", role: "uploader" },
+        }),
+      )
+      .mockImplementationOnce(() =>
+        makeQuery({ allResult: [{ r2Key: "papers/paper-1/paper/file.pdf" }] }),
+      );
+
+    const app = await createTestApp();
+    const env = createTestEnv({ DB: mockDb as any });
+    vi.spyOn(env.BUCKET, "delete").mockRejectedValue(new Error("R2 failure"));
+
+    const res = await app.request(
+      "http://localhost/api/papers/paper-1",
+      {
+        method: "DELETE",
+        headers: {
+          Authorization: `Bearer ${token}`,
+          Origin: "http://localhost:3000",
+        },
+      },
+      env as any,
+    );
+
+    expect(res.status).toBe(500);
+  });
+
+  it("POST /api/papers/:id/track returns 404 when paper does not exist", async () => {
+    mockDb.select = vi
+      .fn()
+      .mockImplementationOnce(() => makeQuery({ getResult: null }));
+
+    const app = await createTestApp();
+    const env = createTestEnv();
+    const res = await app.request(
+      "http://localhost/api/papers/missing-paper/track",
+      {
+        method: "POST",
+        headers: {
+          "Content-Type": "application/json",
+          Origin: "http://localhost:3000",
+          "User-Agent": "Vitest",
+        },
+        body: JSON.stringify({ event: "view" }),
+      },
+      env as any,
+    );
+
+    expect(res.status).toBe(404);
+    expect(mockDb.prepare).not.toHaveBeenCalled();
+  });
+
+  it("GET /api/papers/:id/stats returns author-only statistics", async () => {
+    const token = await createTestJWT({
+      sub: "user-1",
+      githubId: "123",
+      name: "Author",
+    });
+    const today = new Date().toISOString().split("T")[0];
+    const yesterday = new Date(Date.now() - 86400000)
+      .toISOString()
+      .split("T")[0];
+
+    mockDb.select = vi
+      .fn()
+      .mockImplementationOnce(() => makeQuery({ getResult: { id: "paper-1" } }))
+      .mockImplementationOnce(() =>
+        makeQuery({ getResult: { userId: "user-1" } }),
+      )
+      .mockImplementationOnce(() =>
+        makeQuery({ getResult: { views: 42, downloads: 18, previews: 6 } }),
+      )
+      .mockImplementationOnce(() =>
+        makeQuery({
+          allResult: [
+            { date: yesterday, views: 3, downloads: 1, previews: 1 },
+            { date: today, views: 2, downloads: 1, previews: 0 },
+          ],
+        }),
+      );
+
+    const app = await createTestApp();
+    const env = createTestEnv();
+    const res = await app.request(
+      "http://localhost/api/papers/paper-1/stats",
+      {
+        headers: { Authorization: `Bearer ${token}` },
+      },
+      env as any,
+    );
+
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as any;
+    expect(body.total).toEqual({ views: 42, downloads: 18, previews: 6 });
+    expect(body.daily).toHaveLength(30);
+    expect(body.daily.at(-1)).toEqual({
+      date: today,
+      views: 2,
+      downloads: 1,
+      previews: 0,
+    });
+    expect(body.days).toBe(30);
+  });
+
+  it("GET /api/papers/:id omits publicViewCount when showViewCount is false", async () => {
+    const token = await createTestJWT({
+      sub: "user-1",
+      githubId: "123",
+      name: "Uploader",
+    });
+    mockDb.select = vi
+      .fn()
+      .mockImplementationOnce(() =>
+        makeQuery({
+          getResult: {
+            id: "paper-1",
+            title: "P1",
+            visibility: "public",
+            showViewCount: false,
+          },
+        }),
+      )
+      .mockImplementationOnce(() => makeQuery({ allResult: [] }))
+      .mockImplementationOnce(() => makeQuery({ allResult: [] }));
+
+    const app = await createTestApp();
+    const env = createTestEnv();
+    const res = await app.request(
+      "http://localhost/api/papers/paper-1",
+      { headers: { Authorization: `Bearer ${token}` } },
+      env as any,
+    );
+
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as any;
+    expect(body.paper.showViewCount).toBe(false);
+    expect(body.paper.publicViewCount).toBeNull();
+    expect(body.paper.publicDownloadCount).toBeNull();
+  });
+
+  it("POST /api/papers/:id/track returns 401 for private paper without token", async () => {
+    mockDb.select = vi
+      .fn()
+      .mockImplementationOnce(() =>
+        makeQuery({ getResult: { id: "paper-1", visibility: "private" } }),
+      );
+
+    const app = await createTestApp();
+    const env = createTestEnv();
+    const res = await app.request(
+      "http://localhost/api/papers/paper-1/track",
+      {
+        method: "POST",
+        headers: {
+          "Content-Type": "application/json",
+          Origin: "http://localhost:3000",
+        },
+        body: JSON.stringify({ event: "view" }),
+      },
+      env as any,
+    );
+
+    expect(res.status).toBe(401);
+  });
+
+  it("POST /api/papers/:id/track returns 403 for private paper from non-author", async () => {
+    const token = await createTestJWT({
+      sub: "user-2",
+      githubId: "456",
+      name: "Other",
+    });
+    mockDb.select = vi
+      .fn()
+      .mockImplementationOnce(() =>
+        makeQuery({ getResult: { id: "paper-1", visibility: "private" } }),
+      )
+      .mockImplementationOnce(() => makeQuery({ getResult: null }));
+
+    const app = await createTestApp();
+    const env = createTestEnv();
+    const res = await app.request(
+      "http://localhost/api/papers/paper-1/track",
+      {
+        method: "POST",
+        headers: {
+          Authorization: `Bearer ${token}`,
+          "Content-Type": "application/json",
+        },
+        body: JSON.stringify({ event: "view" }),
+      },
+      env as any,
+    );
+
+    expect(res.status).toBe(403);
+  });
+
+  it("GET /api/papers/:id/stats returns 403 for non-authors", async () => {
+    const token = await createTestJWT({
+      sub: "user-2",
+      githubId: "456",
+      name: "Other User",
+    });
+    mockDb.select = vi
+      .fn()
+      .mockImplementationOnce(() => makeQuery({ getResult: { id: "paper-1" } }))
+      .mockImplementationOnce(() => makeQuery({ getResult: null }));
+
+    const app = await createTestApp();
+    const env = createTestEnv();
+    const res = await app.request(
+      "http://localhost/api/papers/paper-1/stats",
+      {
+        headers: { Authorization: `Bearer ${token}` },
+      },
+      env as any,
+    );
+
+    expect(res.status).toBe(403);
+  });
+
+  it("GET /api/papers/:id/stats rejects invalid days", async () => {
+    const token = await createTestJWT({
+      sub: "user-1",
+      githubId: "123",
+      name: "Author",
+    });
+    const app = await createTestApp();
+    const env = createTestEnv();
+    const res = await app.request(
+      "http://localhost/api/papers/paper-1/stats?days=14",
+      {
+        headers: { Authorization: `Bearer ${token}` },
+      },
+      env as any,
+    );
+
+    expect(res.status).toBe(400);
+    const body = (await res.json()) as any;
+    expect(body.error).toContain("days must be one of 7, 30, 90, 365");
+  });
+
+  it("PATCH /api/papers/:id rejects changing a non-org_only paper to org_only", async () => {
+    const token = await createTestJWT({
+      sub: "user-1",
+      githubId: "123",
+      name: "Uploader",
+    });
+    mockDb.select = vi
+      .fn()
+      .mockImplementationOnce(() =>
+        makeQuery({ getResult: { id: "paper-1", visibility: "private" } }),
+      )
+      .mockImplementationOnce(() =>
+        makeQuery({
+          getResult: { paperId: "paper-1", userId: "user-1", role: "uploader" },
+        }),
+      );
+
+    const app = await createTestApp();
+    const env = createTestEnv();
+    const res = await app.request(
+      "http://localhost/api/papers/paper-1",
+      {
+        method: "PATCH",
+        headers: {
+          Authorization: `Bearer ${token}`,
+          "Content-Type": "application/json",
+        },
+        body: JSON.stringify({ visibility: "org_only" }),
+      },
+      env as any,
+    );
+
+    expect(res.status).toBe(400);
+    const body = (await res.json()) as any;
+    expect(body.error).toContain("org_only");
+    expect(mockDb.update).not.toHaveBeenCalled();
+  });
+
+  it("PUT /api/papers/:id/description updates description for authors", async () => {
+    const token = await createTestJWT({
+      sub: "user-1",
+      githubId: "123",
+      name: "Uploader",
+    });
+    const where = vi.fn(async () => undefined);
+    const set = vi.fn(() => ({ where }));
+    mockDb.select = vi
+      .fn()
+      .mockImplementationOnce(() => makeQuery({ getResult: { id: "paper-1" } }))
+      .mockImplementationOnce(() =>
+        makeQuery({ getResult: { userId: "user-1" } }),
+      )
+      .mockImplementationOnce(() =>
+        makeQuery({
+          getResult: {
+            id: "paper-1",
+            description: "## Updated",
+            descriptionUpdatedAt: "2026-04-01 12:00:00",
+          },
+        }),
+      );
+    mockDb.update = vi.fn(() => ({ set }));
+
+    const app = await createTestApp();
+    const env = createTestEnv();
+    const res = await app.request(
+      "http://localhost/api/papers/paper-1/description",
+      {
+        method: "PUT",
+        headers: {
+          Authorization: `Bearer ${token}`,
+          "Content-Type": "application/json",
+        },
+        body: JSON.stringify({ description: "## Updated" }),
+      },
+      env as any,
+    );
+
+    expect(res.status).toBe(200);
+    expect(set).toHaveBeenCalledWith(
+      expect.objectContaining({
+        description: "## Updated",
+      }),
+    );
+    const body = (await res.json()) as any;
+    expect(body.id).toBe("paper-1");
+    expect(body.description).toBe("## Updated");
+    expect(body.descriptionUpdatedAt).toBe("2026-04-01T12:00:00.000Z");
+    expect(body.description_updated_at).toBe("2026-04-01T12:00:00.000Z");
+  });
+
+  it("PUT /api/papers/:id/description rejects non-author", async () => {
+    const token = await createTestJWT({
+      sub: "user-2",
+      githubId: "456",
+      name: "Other User",
+    });
+    mockDb.select = vi
+      .fn()
+      .mockImplementationOnce(() => makeQuery({ getResult: { id: "paper-1" } }))
+      .mockImplementationOnce(() => makeQuery({ getResult: null }));
+
+    const app = await createTestApp();
+    const env = createTestEnv();
+    const res = await app.request(
+      "http://localhost/api/papers/paper-1/description",
+      {
+        method: "PUT",
+        headers: {
+          Authorization: `Bearer ${token}`,
+          "Content-Type": "application/json",
+        },
+        body: JSON.stringify({ description: "updated" }),
+      },
+      env as any,
+    );
+
+    expect(res.status).toBe(403);
+  });
+
+  it.each([
+    { name: "malformed JSON", body: '{"description": "missing brace"' },
+    { name: "JSON array", body: JSON.stringify([{ description: "updated" }]) },
+    { name: "non-object JSON", body: JSON.stringify("just a string") },
+  ])(
+    "PUT /api/papers/:id/description handles invalid JSON body: $name",
+    async ({ body }) => {
+      const token = await createTestJWT({
+        sub: "user-1",
+        githubId: "123",
+        name: "Uploader",
+      });
+      const app = await createTestApp();
+      const env = createTestEnv();
+
+      const res = await app.request(
+        "http://localhost/api/papers/paper-1/description",
+        {
+          method: "PUT",
+          headers: {
+            Authorization: `Bearer ${token}`,
+            "Content-Type": "application/json",
+          },
+          body,
+        },
+        env as any,
+      );
+      expect(res.status).toBe(400);
+      await expect(res.json()).resolves.toEqual({ error: "Invalid JSON body" });
+    },
+  );
+
+  it("PUT /api/papers/:id/description validates description length", async () => {
+    const token = await createTestJWT({
+      sub: "user-1",
+      githubId: "123",
+      name: "Uploader",
     });
 
-    it("POST /api/papers deletes uploaded files and paper record on database error", async () => {
-        const token = await createTestJWT({ sub: "user-1", githubId: "123", name: "Uploader" });
+    const app = await createTestApp();
+    const env = createTestEnv();
+    const res = await app.request(
+      "http://localhost/api/papers/paper-1/description",
+      {
+        method: "PUT",
+        headers: {
+          Authorization: `Bearer ${token}`,
+          "Content-Type": "application/json",
+        },
+        body: JSON.stringify({ description: "a".repeat(50001) }),
+      },
+      env as any,
+    );
 
-        // Mock db.insert to succeed for papers, but fail for paperFiles
-        const dbError = new Error("Mock DB Error");
-        mockDb.insert
-            .mockImplementationOnce(() => ({ values: vi.fn(async () => undefined) })) // papers insert
-            .mockImplementationOnce(() => ({ values: vi.fn(async () => undefined) })) // paperAuthors insert
-            .mockImplementationOnce(() => { throw dbError; }); // paperFiles insert
+    expect(res.status).toBe(400);
+    const body = (await res.json()) as any;
+    expect(body.error).toContain("50000");
+  });
 
-        const mockDeleteWhere = vi.fn(async () => undefined);
-        mockDb.delete = vi.fn(() => ({ where: mockDeleteWhere }));
+  it("PATCH /api/papers/:id validates externalUrl like POST", async () => {
+    const token = await createTestJWT({
+      sub: "user-1",
+      githubId: "123",
+      name: "Uploader",
+    });
+    mockDb.select = vi
+      .fn()
+      .mockImplementationOnce(() =>
+        makeQuery({ getResult: { id: "paper-1", visibility: "private" } }),
+      )
+      .mockImplementationOnce(() =>
+        makeQuery({
+          getResult: { paperId: "paper-1", userId: "user-1", role: "uploader" },
+        }),
+      );
 
-        const app = await createTestApp();
-        const env = createTestEnv({ DB: mockDb as any });
+    const app = await createTestApp();
+    const env = createTestEnv();
+    const res = await app.request(
+      "http://localhost/api/papers/paper-1",
+      {
+        method: "PATCH",
+        headers: {
+          Authorization: `Bearer ${token}`,
+          "Content-Type": "application/json",
+        },
+        body: JSON.stringify({ externalUrl: "ftp://example.com/paper" }),
+      },
+      env as any,
+    );
 
-        // Spy on BUCKET.delete
-        const bucketDeleteSpy = vi.spyOn(env.BUCKET, "delete").mockRejectedValue(new Error("Cleanup failed"));
-        const consoleErrorSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+    expect(res.status).toBe(400);
+    const body = (await res.json()) as any;
+    expect(body.error).toContain("externalUrl");
+    expect(mockDb.update).not.toHaveBeenCalled();
+  });
 
-        const form = new FormData();
-        form.set("metadata", JSON.stringify({ title: "Test Paper", visibility: "private" }));
-        form.set("files_0", new File(["%PDF-1.4\n%dummy-pdf"], "paper.pdf", { type: "application/pdf" }));
-        form.set("file_types_0", "paper");
+  it("PATCH /api/papers/:id rejects overlong abstract", async () => {
+    const token = await createTestJWT({
+      sub: "user-1",
+      githubId: "123",
+      name: "Uploader",
+    });
+    mockDb.select = vi
+      .fn()
+      .mockImplementationOnce(() =>
+        makeQuery({ getResult: { id: "paper-1", visibility: "private" } }),
+      )
+      .mockImplementationOnce(() =>
+        makeQuery({
+          getResult: { paperId: "paper-1", userId: "user-1", role: "uploader" },
+        }),
+      );
 
-        const res = await app.request(
-            "http://localhost/api/papers",
-            {
-                method: "POST",
-                headers: {
-                    Authorization: `Bearer ${token}`,
-                    Origin: "http://localhost:3000"
-                },
-                body: form
+    const app = await createTestApp();
+    const env = createTestEnv();
+    const res = await app.request(
+      "http://localhost/api/papers/paper-1",
+      {
+        method: "PATCH",
+        headers: {
+          Authorization: `Bearer ${token}`,
+          "Content-Type": "application/json",
+        },
+        body: JSON.stringify({ abstract: "a".repeat(5001) }),
+      },
+      env as any,
+    );
+
+    expect(res.status).toBe(400);
+    const body = (await res.json()) as any;
+    expect(body.error).toContain("abstract");
+    expect(mockDb.update).not.toHaveBeenCalled();
+  });
+
+  it("PATCH /api/papers/:id allows keeping org_only on an existing org_only paper", async () => {
+    const token = await createTestJWT({
+      sub: "user-1",
+      githubId: "123",
+      name: "Uploader",
+    });
+    const where = vi.fn(async () => undefined);
+    const set = vi.fn(() => ({ where }));
+    mockDb.select = vi
+      .fn()
+      .mockImplementationOnce(() =>
+        makeQuery({ getResult: { id: "paper-1", visibility: "org_only" } }),
+      )
+      .mockImplementationOnce(() =>
+        makeQuery({
+          getResult: { paperId: "paper-1", userId: "user-1", role: "uploader" },
+        }),
+      );
+    mockDb.update = vi.fn(() => ({ set }));
+
+    const app = await createTestApp();
+    const env = createTestEnv();
+    const res = await app.request(
+      "http://localhost/api/papers/paper-1",
+      {
+        method: "PATCH",
+        headers: {
+          Authorization: `Bearer ${token}`,
+          "Content-Type": "application/json",
+        },
+        body: JSON.stringify({
+          visibility: "org_only",
+          title: "Updated title",
+        }),
+      },
+      env as any,
+    );
+
+    expect(res.status).toBe(200);
+    expect(mockDb.update).toHaveBeenCalledTimes(1);
+    expect(set).toHaveBeenCalledWith(
+      expect.objectContaining({
+        visibility: "org_only",
+        title: "Updated title",
+      }),
+    );
+    expect(where).toHaveBeenCalledTimes(1);
+  });
+
+  it("PATCH /api/papers/:id rejects a primitive JSON body", async () => {
+    const token = await createTestJWT({
+      sub: "user-1",
+      githubId: "123",
+      name: "Uploader",
+    });
+
+    const app = await createTestApp();
+    const env = createTestEnv();
+    const res = await app.request(
+      "http://localhost/api/papers/paper-1",
+      {
+        method: "PATCH",
+        headers: {
+          Authorization: `Bearer ${token}`,
+          "Content-Type": "application/json",
+        },
+        body: "null",
+      },
+      env as any,
+    );
+
+    expect(res.status).toBe(400);
+    const body = (await res.json()) as any;
+    expect(body.error).toContain("Invalid JSON body");
+    expect(mockDb.select).not.toHaveBeenCalled();
+  });
+
+  it("PATCH /api/papers/:id updates tags correctly with normalization and deduplication", async () => {
+    const token = await createTestJWT({
+      sub: "user-1",
+      githubId: "123",
+      name: "Uploader",
+    });
+    const where = vi.fn(async () => undefined);
+    const set = vi.fn(() => ({ where }));
+    mockDb.select = vi
+      .fn()
+      .mockImplementationOnce(() =>
+        makeQuery({ getResult: { id: "paper-1", visibility: "private" } }),
+      )
+      .mockImplementationOnce(() =>
+        makeQuery({
+          getResult: { paperId: "paper-1", userId: "user-1", role: "uploader" },
+        }),
+      );
+    mockDb.update = vi.fn(() => ({ set }));
+
+    const app = await createTestApp();
+    const env = createTestEnv();
+    const res = await app.request(
+      "http://localhost/api/papers/paper-1",
+      {
+        method: "PATCH",
+        headers: {
+          Authorization: `Bearer ${token}`,
+          "Content-Type": "application/json",
+        },
+        body: JSON.stringify({ tags: [" AI", "ML ", "NLP", "ai"] }),
+      },
+      env as any,
+    );
+
+    expect(res.status).toBe(200);
+    expect(set).toHaveBeenCalledWith({
+      tags: JSON.stringify(["ai", "ml", "nlp"]),
+      updatedAt: expect.anything(),
+    });
+  });
+
+  it("PATCH /api/papers/:id rejects invalid tag items", async () => {
+    const token = await createTestJWT({
+      sub: "user-1",
+      githubId: "123",
+      name: "Uploader",
+    });
+    const set = vi.fn();
+    mockDb.select = vi
+      .fn()
+      .mockImplementationOnce(() =>
+        makeQuery({ getResult: { id: "paper-1", visibility: "private" } }),
+      )
+      .mockImplementationOnce(() =>
+        makeQuery({
+          getResult: { paperId: "paper-1", userId: "user-1", role: "uploader" },
+        }),
+      );
+    mockDb.update = vi.fn(() => ({ set }));
+
+    const app = await createTestApp();
+    const env = createTestEnv();
+    const res = await app.request(
+      "http://localhost/api/papers/paper-1",
+      {
+        method: "PATCH",
+        headers: {
+          Authorization: `Bearer ${token}`,
+          "Content-Type": "application/json",
+        },
+        body: JSON.stringify({ tags: ["ai", "A".repeat(100)] }),
+      },
+      env as any,
+    );
+
+    expect(res.status).toBe(400);
+    await expect(res.json()).resolves.toEqual({
+      error: "tags must be 64 chars or less",
+    });
+    expect(mockDb.update).not.toHaveBeenCalled();
+  });
+
+  it("PATCH /api/papers/:id deduplicates mixed-case tags after normalization", async () => {
+    const token = await createTestJWT({
+      sub: "user-1",
+      githubId: "123",
+      name: "Uploader",
+    });
+    const where = vi.fn(async () => undefined);
+    const set = vi.fn(() => ({ where }));
+    mockDb.select = vi
+      .fn()
+      .mockImplementationOnce(() =>
+        makeQuery({ getResult: { id: "paper-1", visibility: "private" } }),
+      )
+      .mockImplementationOnce(() =>
+        makeQuery({
+          getResult: { paperId: "paper-1", userId: "user-1", role: "uploader" },
+        }),
+      );
+    mockDb.update = vi.fn(() => ({ set }));
+
+    const app = await createTestApp();
+    const env = createTestEnv();
+    const res = await app.request(
+      "http://localhost/api/papers/paper-1",
+      {
+        method: "PATCH",
+        headers: {
+          Authorization: `Bearer ${token}`,
+          "Content-Type": "application/json",
+        },
+        body: JSON.stringify({ tags: ["AI", "ai", "Ai", "aI"] }),
+      },
+      env as any,
+    );
+
+    expect(res.status).toBe(200);
+    expect(set).toHaveBeenCalledWith({
+      tags: JSON.stringify(["ai"]),
+      updatedAt: expect.anything(),
+    });
+  });
+
+  it("PATCH /api/papers/:id rejects requests without valid updatable fields", async () => {
+    const token = await createTestJWT({
+      sub: "user-1",
+      githubId: "123",
+      name: "Uploader",
+    });
+    mockDb.select = vi
+      .fn()
+      .mockImplementationOnce(() =>
+        makeQuery({ getResult: { id: "paper-1", visibility: "private" } }),
+      )
+      .mockImplementationOnce(() =>
+        makeQuery({
+          getResult: { paperId: "paper-1", userId: "user-1", role: "uploader" },
+        }),
+      );
+
+    const app = await createTestApp();
+    const env = createTestEnv();
+    const res = await app.request(
+      "http://localhost/api/papers/paper-1",
+      {
+        method: "PATCH",
+        headers: {
+          Authorization: `Bearer ${token}`,
+          "Content-Type": "application/json",
+        },
+        body: JSON.stringify({ unknownField: "ignored" }),
+      },
+      env as any,
+    );
+
+    expect(res.status).toBe(400);
+    const body = (await res.json()) as any;
+    expect(body.error).toContain("No valid fields");
+    expect(mockDb.update).not.toHaveBeenCalled();
+  });
+
+  it("PATCH /api/papers/:id updates showViewCount for authors", async () => {
+    const token = await createTestJWT({
+      sub: "user-1",
+      githubId: "123",
+      name: "Uploader",
+    });
+    const where = vi.fn(async () => undefined);
+    const set = vi.fn(() => ({ where }));
+    mockDb.select = vi
+      .fn()
+      .mockImplementationOnce(() =>
+        makeQuery({ getResult: { id: "paper-1", visibility: "private" } }),
+      )
+      .mockImplementationOnce(() =>
+        makeQuery({
+          getResult: { paperId: "paper-1", userId: "user-1", role: "uploader" },
+        }),
+      );
+    mockDb.update = vi.fn(() => ({ set }));
+
+    const app = await createTestApp();
+    const env = createTestEnv();
+    const res = await app.request(
+      "http://localhost/api/papers/paper-1",
+      {
+        method: "PATCH",
+        headers: {
+          Authorization: `Bearer ${token}`,
+          "Content-Type": "application/json",
+        },
+        body: JSON.stringify({ showViewCount: true }),
+      },
+      env as any,
+    );
+
+    expect(res.status).toBe(200);
+    expect(set).toHaveBeenCalledWith(
+      expect.objectContaining({ showViewCount: true }),
+    );
+    expect(where).toHaveBeenCalledTimes(1);
+  });
+
+  it("PATCH /api/papers/:id updates doi, venue, venueType, year, category, and tags", async () => {
+    const token = await createTestJWT({
+      sub: "user-1",
+      githubId: "123",
+      name: "Uploader",
+    });
+    const set = vi.fn().mockReturnThis();
+    const where = vi.fn().mockReturnThis();
+    mockDb.select = vi
+      .fn()
+      .mockImplementation(() =>
+        makeQuery({
+          getResult: { paperId: "paper-1", userId: "user-1", role: "uploader" },
+        }),
+      );
+    mockDb.update = vi.fn().mockImplementation(() => ({ set, where }) as any);
+
+    const app = await createTestApp();
+    const env = createTestEnv();
+    const res = await app.request(
+      "http://localhost/api/papers/paper-1",
+      {
+        method: "PATCH",
+        headers: {
+          Authorization: `Bearer ${token}`,
+          "Content-Type": "application/json",
+        },
+        body: JSON.stringify({
+          doi: "10.1234/5678",
+          venue: "Test Venue",
+          venueType: "conference",
+          year: 2024,
+          category: "report",
+          tags: ["tag1", "tag2"],
+        }),
+      },
+      env as any,
+    );
+
+    expect(res.status).toBe(200);
+    expect(set).toHaveBeenCalledWith(
+      expect.objectContaining({
+        doi: "10.1234/5678",
+        venue: "Test Venue",
+        venueType: "conference",
+        year: 2024,
+        category: "report",
+        tags: JSON.stringify(["tag1", "tag2"]),
+      }),
+    );
+  });
+
+  it("PATCH /api/papers/:id validates invalid types and values", async () => {
+    const token = await createTestJWT({
+      sub: "user-1",
+      githubId: "123",
+      name: "Uploader",
+    });
+    mockDb.select = vi
+      .fn()
+      .mockImplementation(() =>
+        makeQuery({
+          getResult: { paperId: "paper-1", userId: "user-1", role: "uploader" },
+        }),
+      );
+
+    const app = await createTestApp();
+    const env = createTestEnv();
+
+    let res = await app.request(
+      "http://localhost/api/papers/paper-1",
+      {
+        method: "PATCH",
+        headers: {
+          Authorization: `Bearer ${token}`,
+          "Content-Type": "application/json",
+        },
+        body: JSON.stringify({ venueType: "invalid_venue_type" }),
+      },
+      env as any,
+    );
+    expect(res.status).toBe(400);
+
+    res = await app.request(
+      "http://localhost/api/papers/paper-1",
+      {
+        method: "PATCH",
+        headers: {
+          Authorization: `Bearer ${token}`,
+          "Content-Type": "application/json",
+        },
+        body: JSON.stringify({ category: "invalid_category" }),
+      },
+      env as any,
+    );
+    expect(res.status).toBe(400);
+
+    res = await app.request(
+      "http://localhost/api/papers/paper-1",
+      {
+        method: "PATCH",
+        headers: {
+          Authorization: `Bearer ${token}`,
+          "Content-Type": "application/json",
+        },
+        body: JSON.stringify({ year: "2024" }),
+      },
+      env as any,
+    );
+    expect(res.status).toBe(400);
+
+    res = await app.request(
+      "http://localhost/api/papers/paper-1",
+      {
+        method: "PATCH",
+        headers: {
+          Authorization: `Bearer ${token}`,
+          "Content-Type": "application/json",
+        },
+        body: JSON.stringify({ tags: "not_an_array" }),
+      },
+      env as any,
+    );
+    expect(res.status).toBe(400);
+
+    res = await app.request(
+      "http://localhost/api/papers/paper-1",
+      {
+        method: "PATCH",
+        headers: {
+          Authorization: `Bearer ${token}`,
+          "Content-Type": "application/json",
+        },
+        body: JSON.stringify({ tags: [123] }),
+      },
+      env as any,
+    );
+    expect(res.status).toBe(400);
+
+    res = await app.request(
+      "http://localhost/api/papers/paper-1",
+      {
+        method: "PATCH",
+        headers: {
+          Authorization: `Bearer ${token}`,
+          "Content-Type": "application/json",
+        },
+        body: JSON.stringify({ tags: ["a".repeat(256)] }),
+      },
+      env as any,
+    );
+    expect(res.status).toBe(400);
+
+    res = await app.request(
+      "http://localhost/api/papers/paper-1",
+      {
+        method: "PATCH",
+        headers: {
+          Authorization: `Bearer ${token}`,
+          "Content-Type": "application/json",
+        },
+        body: JSON.stringify({ venue: 123 }),
+      },
+      env as any,
+    );
+    expect(res.status).toBe(400);
+
+    res = await app.request(
+      "http://localhost/api/papers/paper-1",
+      {
+        method: "PATCH",
+        headers: {
+          Authorization: `Bearer ${token}`,
+          "Content-Type": "application/json",
+        },
+        body: JSON.stringify({ doi: 123 }),
+      },
+      env as any,
+    );
+    expect(res.status).toBe(400);
+
+    res = await app.request(
+      "http://localhost/api/papers/paper-1",
+      {
+        method: "PATCH",
+        headers: {
+          Authorization: `Bearer ${token}`,
+          "Content-Type": "application/json",
+        },
+        body: JSON.stringify({ venue: "a".repeat(256) }),
+      },
+      env as any,
+    );
+    expect(res.status).toBe(400);
+
+    res = await app.request(
+      "http://localhost/api/papers/paper-1",
+      {
+        method: "PATCH",
+        headers: {
+          Authorization: `Bearer ${token}`,
+          "Content-Type": "application/json",
+        },
+        body: JSON.stringify({ doi: "a".repeat(256) }),
+      },
+      env as any,
+    );
+    expect(res.status).toBe(400);
+  });
+
+  it("PATCH /api/papers/:id handles null and empty fields", async () => {
+    const token = await createTestJWT({
+      sub: "user-1",
+      githubId: "123",
+      name: "Uploader",
+    });
+    const set = vi.fn().mockReturnThis();
+    const where = vi.fn().mockReturnThis();
+    mockDb.select = vi
+      .fn()
+      .mockImplementation(() =>
+        makeQuery({
+          getResult: { paperId: "paper-1", userId: "user-1", role: "uploader" },
+        }),
+      );
+    mockDb.update = vi.fn().mockImplementation(() => ({ set, where }) as any);
+
+    const app = await createTestApp();
+    const env = createTestEnv();
+    const res = await app.request(
+      "http://localhost/api/papers/paper-1",
+      {
+        method: "PATCH",
+        headers: {
+          Authorization: `Bearer ${token}`,
+          "Content-Type": "application/json",
+        },
+        body: JSON.stringify({
+          doi: null,
+          venue: null,
+          venueType: null,
+          year: null,
+          category: null,
+          tags: null,
+        }),
+      },
+      env as any,
+    );
+
+    expect(res.status).toBe(200);
+    expect(set).toHaveBeenCalledWith(
+      expect.objectContaining({
+        doi: null,
+        venue: null,
+        venueType: null,
+        year: null,
+        category: null,
+        tags: null,
+      }),
+    );
+  });
+
+  it("PATCH /api/papers/:id ignores empty tags", async () => {
+    const token = await createTestJWT({
+      sub: "user-1",
+      githubId: "123",
+      name: "Uploader",
+    });
+    const set = vi.fn().mockReturnThis();
+    const where = vi.fn().mockReturnThis();
+    mockDb.select = vi
+      .fn()
+      .mockImplementation(() =>
+        makeQuery({
+          getResult: { paperId: "paper-1", userId: "user-1", role: "uploader" },
+        }),
+      );
+    mockDb.update = vi.fn().mockImplementation(() => ({ set, where }) as any);
+
+    const app = await createTestApp();
+    const env = createTestEnv();
+    const res = await app.request(
+      "http://localhost/api/papers/paper-1",
+      {
+        method: "PATCH",
+        headers: {
+          Authorization: `Bearer ${token}`,
+          "Content-Type": "application/json",
+        },
+        body: JSON.stringify({
+          tags: [" ", "tag2"],
+        }),
+      },
+      env as any,
+    );
+
+    expect(res.status).toBe(200);
+    expect(set).toHaveBeenCalledWith(
+      expect.objectContaining({
+        tags: JSON.stringify(["tag2"]),
+      }),
+    );
+  });
+
+  it("PATCH /api/papers/:id updates correctly when tags array has only empty strings", async () => {
+    const token = await createTestJWT({
+      sub: "user-1",
+      githubId: "123",
+      name: "Uploader",
+    });
+    const set = vi.fn().mockReturnThis();
+    const where = vi.fn().mockReturnThis();
+    mockDb.select = vi
+      .fn()
+      .mockImplementation(() =>
+        makeQuery({
+          getResult: { paperId: "paper-1", userId: "user-1", role: "uploader" },
+        }),
+      );
+    mockDb.update = vi.fn().mockImplementation(() => ({ set, where }) as any);
+
+    const app = await createTestApp();
+    const env = createTestEnv();
+    const res = await app.request(
+      "http://localhost/api/papers/paper-1",
+      {
+        method: "PATCH",
+        headers: {
+          Authorization: `Bearer ${token}`,
+          "Content-Type": "application/json",
+        },
+        body: JSON.stringify({
+          tags: [" "],
+        }),
+      },
+      env as any,
+    );
+
+    expect(res.status).toBe(200);
+    expect(set).toHaveBeenCalledWith(
+      expect.objectContaining({
+        tags: null,
+      }),
+    );
+  });
+
+  it("PATCH /api/papers/:id update fails when there are no valid fields", async () => {
+    const token = await createTestJWT({
+      sub: "user-1",
+      githubId: "123",
+      name: "Uploader",
+    });
+    mockDb.select = vi
+      .fn()
+      .mockImplementation(() =>
+        makeQuery({
+          getResult: { paperId: "paper-1", userId: "user-1", role: "uploader" },
+        }),
+      );
+
+    const app = await createTestApp();
+    const env = createTestEnv();
+    const res = await app.request(
+      "http://localhost/api/papers/paper-1",
+      {
+        method: "PATCH",
+        headers: {
+          Authorization: `Bearer ${token}`,
+          "Content-Type": "application/json",
+        },
+        body: JSON.stringify({
+          invalidField: "test",
+        }),
+      },
+      env as any,
+    );
+
+    expect(res.status).toBe(400);
+  });
+
+  it("PATCH /api/papers/:id ignores empty array of tags and continues if no other fields", async () => {
+    const token = await createTestJWT({
+      sub: "user-1",
+      githubId: "123",
+      name: "Uploader",
+    });
+    const set = vi.fn().mockReturnThis();
+    const where = vi.fn().mockReturnThis();
+    mockDb.select = vi
+      .fn()
+      .mockImplementation(() =>
+        makeQuery({
+          getResult: { paperId: "paper-1", userId: "user-1", role: "uploader" },
+        }),
+      );
+    mockDb.update = vi.fn().mockImplementation(() => ({ set, where }) as any);
+
+    const app = await createTestApp();
+    const env = createTestEnv();
+    const res = await app.request(
+      "http://localhost/api/papers/paper-1",
+      {
+        method: "PATCH",
+        headers: {
+          Authorization: `Bearer ${token}`,
+          "Content-Type": "application/json",
+        },
+        body: JSON.stringify({
+          tags: [],
+        }),
+      },
+      env as any,
+    );
+
+    expect(res.status).toBe(200);
+    expect(set).toHaveBeenCalledWith(
+      expect.objectContaining({
+        tags: null,
+      }),
+    );
+  });
+
+  it("PATCH /api/papers/:id updates correctly when values exactly match valid enums", async () => {
+    const token = await createTestJWT({
+      sub: "user-1",
+      githubId: "123",
+      name: "Uploader",
+    });
+    const set = vi.fn().mockReturnThis();
+    const where = vi.fn().mockReturnThis();
+    mockDb.select = vi
+      .fn()
+      .mockImplementation(() =>
+        makeQuery({
+          getResult: { paperId: "paper-1", userId: "user-1", role: "uploader" },
+        }),
+      );
+    mockDb.update = vi.fn().mockImplementation(() => ({ set, where }) as any);
+
+    const app = await createTestApp();
+    const env = createTestEnv();
+    const res = await app.request(
+      "http://localhost/api/papers/paper-1",
+      {
+        method: "PATCH",
+        headers: {
+          Authorization: `Bearer ${token}`,
+          "Content-Type": "application/json",
+        },
+        body: JSON.stringify({
+          venueType: "journal",
+          category: "thesis_bachelor",
+        }),
+      },
+      env as any,
+    );
+
+    expect(res.status).toBe(200);
+    expect(set).toHaveBeenCalledWith(
+      expect.objectContaining({
+        venueType: "journal",
+        category: "thesis_bachelor",
+      }),
+    );
+  });
+
+  it("PATCH /api/papers/:id updates correctly when tags array has only empty strings", async () => {
+    const token = await createTestJWT({
+      sub: "user-1",
+      githubId: "123",
+      name: "Uploader",
+    });
+    const set = vi.fn().mockReturnThis();
+    const where = vi.fn().mockReturnThis();
+    mockDb.select = vi
+      .fn()
+      .mockImplementation(() =>
+        makeQuery({
+          getResult: { paperId: "paper-1", userId: "user-1", role: "uploader" },
+        }),
+      );
+    mockDb.update = vi.fn().mockImplementation(() => ({ set, where }) as any);
+
+    const app = await createTestApp();
+    const env = createTestEnv();
+    const res = await app.request(
+      "http://localhost/api/papers/paper-1",
+      {
+        method: "PATCH",
+        headers: {
+          Authorization: `Bearer ${token}`,
+          "Content-Type": "application/json",
+        },
+        body: JSON.stringify({
+          tags: [" "],
+        }),
+      },
+      env as any,
+    );
+
+    expect(res.status).toBe(200);
+    expect(set).toHaveBeenCalledWith(
+      expect.objectContaining({
+        tags: null,
+      }),
+    );
+  });
+
+  it("PATCH /api/papers/:id ignores empty tags", async () => {
+    const token = await createTestJWT({
+      sub: "user-1",
+      githubId: "123",
+      name: "Uploader",
+    });
+    const set = vi.fn().mockReturnThis();
+    const where = vi.fn().mockReturnThis();
+    mockDb.select = vi
+      .fn()
+      .mockImplementation(() =>
+        makeQuery({
+          getResult: { paperId: "paper-1", userId: "user-1", role: "uploader" },
+        }),
+      );
+    mockDb.update = vi.fn().mockImplementation(() => ({ set, where }) as any);
+
+    const app = await createTestApp();
+    const env = createTestEnv();
+    const res = await app.request(
+      "http://localhost/api/papers/paper-1",
+      {
+        method: "PATCH",
+        headers: {
+          Authorization: `Bearer ${token}`,
+          "Content-Type": "application/json",
+        },
+        body: JSON.stringify({
+          tags: [" ", "tag2"],
+        }),
+      },
+      env as any,
+    );
+
+    expect(res.status).toBe(200);
+    expect(set).toHaveBeenCalledWith(
+      expect.objectContaining({
+        tags: JSON.stringify(["tag2"]),
+      }),
+    );
+  });
+
+  it("PATCH /api/papers/:id handles null and empty fields", async () => {
+    const token = await createTestJWT({
+      sub: "user-1",
+      githubId: "123",
+      name: "Uploader",
+    });
+    const set = vi.fn().mockReturnThis();
+    const where = vi.fn().mockReturnThis();
+    mockDb.select = vi
+      .fn()
+      .mockImplementation(() =>
+        makeQuery({
+          getResult: { paperId: "paper-1", userId: "user-1", role: "uploader" },
+        }),
+      );
+    mockDb.update = vi.fn().mockImplementation(() => ({ set, where }) as any);
+
+    const app = await createTestApp();
+    const env = createTestEnv();
+    const res = await app.request(
+      "http://localhost/api/papers/paper-1",
+      {
+        method: "PATCH",
+        headers: {
+          Authorization: `Bearer ${token}`,
+          "Content-Type": "application/json",
+        },
+        body: JSON.stringify({
+          doi: null,
+          venue: null,
+          venueType: null,
+          year: null,
+          category: null,
+          tags: null,
+        }),
+      },
+      env as any,
+    );
+
+    expect(res.status).toBe(200);
+    expect(set).toHaveBeenCalledWith(
+      expect.objectContaining({
+        doi: null,
+        venue: null,
+        venueType: null,
+        year: null,
+        category: null,
+        tags: null,
+      }),
+    );
+  });
+
+  it("PATCH /api/papers/:id validates invalid types and values", async () => {
+    const token = await createTestJWT({
+      sub: "user-1",
+      githubId: "123",
+      name: "Uploader",
+    });
+    mockDb.select = vi
+      .fn()
+      .mockImplementation(() =>
+        makeQuery({
+          getResult: { paperId: "paper-1", userId: "user-1", role: "uploader" },
+        }),
+      );
+
+    const app = await createTestApp();
+    const env = createTestEnv();
+
+    let res = await app.request(
+      "http://localhost/api/papers/paper-1",
+      {
+        method: "PATCH",
+        headers: {
+          Authorization: `Bearer ${token}`,
+          "Content-Type": "application/json",
+        },
+        body: JSON.stringify({ venueType: "invalid_venue_type" }),
+      },
+      env as any,
+    );
+    expect(res.status).toBe(400);
+
+    res = await app.request(
+      "http://localhost/api/papers/paper-1",
+      {
+        method: "PATCH",
+        headers: {
+          Authorization: `Bearer ${token}`,
+          "Content-Type": "application/json",
+        },
+        body: JSON.stringify({ category: "invalid_category" }),
+      },
+      env as any,
+    );
+    expect(res.status).toBe(400);
+
+    res = await app.request(
+      "http://localhost/api/papers/paper-1",
+      {
+        method: "PATCH",
+        headers: {
+          Authorization: `Bearer ${token}`,
+          "Content-Type": "application/json",
+        },
+        body: JSON.stringify({ year: "2024" }),
+      },
+      env as any,
+    );
+    expect(res.status).toBe(400);
+
+    res = await app.request(
+      "http://localhost/api/papers/paper-1",
+      {
+        method: "PATCH",
+        headers: {
+          Authorization: `Bearer ${token}`,
+          "Content-Type": "application/json",
+        },
+        body: JSON.stringify({ tags: "not_an_array" }),
+      },
+      env as any,
+    );
+    expect(res.status).toBe(400);
+
+    res = await app.request(
+      "http://localhost/api/papers/paper-1",
+      {
+        method: "PATCH",
+        headers: {
+          Authorization: `Bearer ${token}`,
+          "Content-Type": "application/json",
+        },
+        body: JSON.stringify({ tags: [123] }),
+      },
+      env as any,
+    );
+    expect(res.status).toBe(400);
+
+    res = await app.request(
+      "http://localhost/api/papers/paper-1",
+      {
+        method: "PATCH",
+        headers: {
+          Authorization: `Bearer ${token}`,
+          "Content-Type": "application/json",
+        },
+        body: JSON.stringify({ tags: ["a".repeat(256)] }),
+      },
+      env as any,
+    );
+    expect(res.status).toBe(400);
+
+    res = await app.request(
+      "http://localhost/api/papers/paper-1",
+      {
+        method: "PATCH",
+        headers: {
+          Authorization: `Bearer ${token}`,
+          "Content-Type": "application/json",
+        },
+        body: JSON.stringify({ venue: 123 }),
+      },
+      env as any,
+    );
+    expect(res.status).toBe(400);
+
+    res = await app.request(
+      "http://localhost/api/papers/paper-1",
+      {
+        method: "PATCH",
+        headers: {
+          Authorization: `Bearer ${token}`,
+          "Content-Type": "application/json",
+        },
+        body: JSON.stringify({ doi: 123 }),
+      },
+      env as any,
+    );
+    expect(res.status).toBe(400);
+
+    res = await app.request(
+      "http://localhost/api/papers/paper-1",
+      {
+        method: "PATCH",
+        headers: {
+          Authorization: `Bearer ${token}`,
+          "Content-Type": "application/json",
+        },
+        body: JSON.stringify({ venue: "a".repeat(256) }),
+      },
+      env as any,
+    );
+    expect(res.status).toBe(400);
+
+    res = await app.request(
+      "http://localhost/api/papers/paper-1",
+      {
+        method: "PATCH",
+        headers: {
+          Authorization: `Bearer ${token}`,
+          "Content-Type": "application/json",
+        },
+        body: JSON.stringify({ doi: "a".repeat(256) }),
+      },
+      env as any,
+    );
+    expect(res.status).toBe(400);
+  });
+
+  it("PATCH /api/papers/:id updates doi, venue, venueType, year, category, and tags", async () => {
+    const token = await createTestJWT({
+      sub: "user-1",
+      githubId: "123",
+      name: "Uploader",
+    });
+    const set = vi.fn().mockReturnThis();
+    const where = vi.fn().mockReturnThis();
+    mockDb.select = vi
+      .fn()
+      .mockImplementation(() =>
+        makeQuery({
+          getResult: { paperId: "paper-1", userId: "user-1", role: "uploader" },
+        }),
+      );
+    mockDb.update = vi.fn().mockImplementation(() => ({ set, where }) as any);
+
+    const app = await createTestApp();
+    const env = createTestEnv();
+    const res = await app.request(
+      "http://localhost/api/papers/paper-1",
+      {
+        method: "PATCH",
+        headers: {
+          Authorization: `Bearer ${token}`,
+          "Content-Type": "application/json",
+        },
+        body: JSON.stringify({
+          doi: "10.1234/5678",
+          venue: "Test Venue",
+          venueType: "conference",
+          year: 2024,
+          category: "report",
+          tags: ["tag1", "tag2"],
+        }),
+      },
+      env as any,
+    );
+
+    expect(res.status).toBe(200);
+    expect(set).toHaveBeenCalledWith(
+      expect.objectContaining({
+        doi: "10.1234/5678",
+        venue: "Test Venue",
+        venueType: "conference",
+        year: 2024,
+        category: "report",
+        tags: JSON.stringify(["tag1", "tag2"]),
+      }),
+    );
+  });
+
+  it("GET /api/papers/:id returns 401 for private paper without Bearer token", async () => {
+    mockDb.select = vi
+      .fn()
+      .mockImplementationOnce(() =>
+        makeQuery({
+          getResult: { id: "paper-1", title: "P1", visibility: "private" },
+        }),
+      );
+
+    const app = await createTestApp();
+    const env = createTestEnv();
+    const res = await app.request(
+      "http://localhost/api/papers/paper-1",
+      {},
+      env as any,
+    );
+
+    expect(res.status).toBe(401);
+  });
+
+  it("GET /api/papers/:id returns 403 for private paper when requester is not an author", async () => {
+    const token = await createTestJWT({
+      sub: "user-2",
+      githubId: "456",
+      name: "Other User",
+    });
+    mockDb.select = vi
+      .fn()
+      .mockImplementationOnce(() =>
+        makeQuery({
+          getResult: { id: "paper-1", title: "P1", visibility: "private" },
+        }),
+      )
+      .mockImplementationOnce(() => makeQuery({ getResult: null }));
+
+    const app = await createTestApp();
+    const env = createTestEnv();
+    const res = await app.request(
+      "http://localhost/api/papers/paper-1",
+      { headers: { Authorization: `Bearer ${token}` } },
+      env as any,
+    );
+
+    expect(res.status).toBe(403);
+  });
+
+  it("GET /api/papers/:id returns 500 (not 401) on database error during author check", async () => {
+    const token = await createTestJWT({
+      sub: "user-1",
+      githubId: "123",
+      name: "Uploader",
+    });
+    mockDb.select = vi
+      .fn()
+      .mockImplementationOnce(() =>
+        makeQuery({
+          getResult: { id: "paper-1", title: "P1", visibility: "private" },
+        }),
+      )
+      .mockImplementationOnce(() => {
+        throw new Error("DB Error");
+      });
+
+    const app = await createTestApp();
+    const env = createTestEnv();
+    const res = await app.request(
+      "http://localhost/api/papers/paper-1",
+      { headers: { Authorization: `Bearer ${token}` } },
+      env as any,
+    );
+
+    expect(res.status).toBe(500);
+  });
+
+  it("DELETE /api/papers/:id deletes a paper", async () => {
+    const token = await createTestJWT({
+      sub: "user-1",
+      githubId: "123",
+      name: "Uploader",
+    });
+    mockDb.select = vi
+      .fn()
+      .mockImplementationOnce(() =>
+        makeQuery({
+          getResult: { paperId: "paper-1", userId: "user-1", role: "uploader" },
+        }),
+      )
+      .mockImplementationOnce(() =>
+        makeQuery({ allResult: [{ r2Key: "papers/paper-1/paper/file.pdf" }] }),
+      );
+
+    const app = await createTestApp();
+    const env = createTestEnv();
+    const res = await app.request(
+      "http://localhost/api/papers/paper-1",
+      {
+        method: "DELETE",
+        headers: {
+          Authorization: `Bearer ${token}`,
+          Origin: "http://localhost:3000",
+        },
+      },
+      env as any,
+    );
+
+    expect(res.status).toBe(200);
+  });
+
+  it("DELETE /api/papers/:id bounds concurrent R2 batch deletes", async () => {
+    const token = await createTestJWT({
+      sub: "user-1",
+      githubId: "123",
+      name: "Uploader",
+    });
+    const files = Array.from({ length: 2001 }, (_, index) => ({
+      r2Key: `papers/paper-1/file-${index}.pdf`,
+    }));
+    mockDb.select = vi
+      .fn()
+      .mockImplementationOnce(() =>
+        makeQuery({
+          getResult: { paperId: "paper-1", userId: "user-1", role: "uploader" },
+        }),
+      )
+      .mockImplementationOnce(() => makeQuery({ allResult: files }));
+
+    const app = await createTestApp();
+    const env = createTestEnv();
+    const pendingDeletes: Array<() => void> = [];
+    let activeDeletes = 0;
+    let maxActiveDeletes = 0;
+    const bucketDeleteSpy = vi.spyOn(env.BUCKET, "delete").mockImplementation(
+      async () =>
+        new Promise<void>((resolve) => {
+          activeDeletes += 1;
+          maxActiveDeletes = Math.max(maxActiveDeletes, activeDeletes);
+          pendingDeletes.push(() => {
+            activeDeletes -= 1;
+            resolve();
+          });
+        }),
+    );
+
+    const responsePromise = app.request(
+      "http://localhost/api/papers/paper-1",
+      {
+        method: "DELETE",
+        headers: {
+          Authorization: `Bearer ${token}`,
+          Origin: "http://localhost:3000",
+        },
+      },
+      env as any,
+    );
+
+    await vi.waitFor(() => {
+      expect(bucketDeleteSpy).toHaveBeenCalledTimes(2);
+    });
+    expect(maxActiveDeletes).toBe(2);
+
+    pendingDeletes.shift()?.();
+    await vi.waitFor(() => {
+      expect(bucketDeleteSpy).toHaveBeenCalledTimes(3);
+    });
+    expect(maxActiveDeletes).toBe(2);
+
+    pendingDeletes.shift()?.();
+    pendingDeletes.shift()?.();
+
+    const res = await responsePromise;
+    expect(res.status).toBe(200);
+    bucketDeleteSpy.mockRestore();
+  });
+
+  it("GET /api/papers/:id returns 404 when paper does not exist", async () => {
+    mockDb.select = vi.fn(() => makeQuery({ getResult: null }));
+
+    const app = await createTestApp();
+    const env = createTestEnv();
+    const res = await app.request(
+      "http://localhost/api/papers/not-found",
+      {},
+      env as any,
+    );
+
+    expect(res.status).toBe(404);
+  });
+
+  describe("POST /api/papers/:id/invites database error handling", () => {
+    const UNIQUE_INVITE_ERROR =
+      "UNIQUE constraint failed: coauthor_invites.paperId_inviteeId";
+
+    const setupInviteChecks = () => {
+      mockDb.select = vi
+        .fn()
+        .mockImplementationOnce(() =>
+          makeQuery({
+            getResult: {
+              paperId: "paper-1",
+              userId: "user-uploader",
+              role: "uploader",
             },
-            env as any
-        );
-        expect(res.status).toBe(500);
+          }),
+        ) // isUploader check
+        .mockImplementationOnce(() => makeQuery({ getResult: null })) // alreadyAuthor check
+        .mockImplementationOnce(() =>
+          makeQuery({ getResult: { id: "user-invitee" } }),
+        ); // invitee exists check
+    };
 
-        // BUCKET.delete should be called with a batch including uploaded paper keys
-        expect(bucketDeleteSpy).toHaveBeenCalledTimes(1);
-        const firstDeleteCall = bucketDeleteSpy.mock.calls[0];
-        const deletedKeys = firstDeleteCall?.[0];
-        expect(deletedKeys).toEqual(
-            expect.arrayContaining([expect.stringContaining("papers/")]),
-        );
-        expect(consoleErrorSpy).toHaveBeenCalledWith(
-            "Cleanup error (non-fatal, rollback continues):",
-            "Cleanup failed",
-        );
+    const sendInviteRequest = async (token: string, app: any, env: any) => {
+      return await app.request(
+        "http://localhost/api/papers/paper-1/invites",
+        {
+          method: "POST",
+          headers: {
+            "Content-Type": "application/json",
+            Authorization: `Bearer ${token}`,
+          },
+          body: JSON.stringify({ inviteeId: "user-invitee" }),
+        },
+        env as any,
+      );
+    };
 
-        // db.delete should be called for papers
-        expect(mockDb.delete).toHaveBeenCalledTimes(1);
-        expect(mockDeleteWhere).toHaveBeenCalledTimes(1);
-        consoleErrorSpy.mockRestore();
-        bucketDeleteSpy.mockRestore();
+    it("POST /api/papers/:id/invites returns 409 when invite already exists", async () => {
+      const token = await createTestJWT({
+        sub: "user-uploader",
+        githubId: "123",
+        name: "Uploader",
+      });
+      setupInviteChecks();
+
+      mockDb.insert = vi.fn().mockReturnValue({
+        values: vi.fn().mockRejectedValue(new Error(UNIQUE_INVITE_ERROR)),
+      });
+
+      const app = await createTestApp();
+      const env = createTestEnv();
+      const res = await sendInviteRequest(token, app, env);
+
+      expect(res.status).toBe(409);
+      const data = (await res.json()) as any;
+      expect(data.error).toBe("Invite already sent");
     });
 
-    it("POST /api/papers logs sanitized errors (both Error instance and string) on upload failure", async () => {
-        const token = await createTestJWT({ sub: "user-1", githubId: "123", name: "Uploader" });
-        const app = await createTestApp();
+    it("POST /api/papers/:id/invites returns 500 for non-UNIQUE database errors", async () => {
+      const token = await createTestJWT({
+        sub: "user-uploader",
+        githubId: "123",
+        name: "Uploader",
+      });
+      setupInviteChecks();
 
-        const sensitiveError = new Error("S3 error: AccessKeyId=SENSITIVE_KEY");
-        (sensitiveError as any).secretInfo = "TOO_SENSITIVE";
-        const stringError = "Some string-based upload error";
+      mockDb.insert = vi.fn().mockReturnValue({
+        values: vi.fn().mockRejectedValue(new Error("Some other DB Error")),
+      });
 
-        let callCount = 0;
-        const env = createTestEnv({
-            DB: mockDb as any,
-            BUCKET: {
-                put: vi.fn().mockImplementation(() => {
-                    callCount++;
-                    if (callCount === 1) return Promise.reject(sensitiveError);
-                    return Promise.reject(stringError);
-                }),
-                delete: vi.fn().mockResolvedValue(undefined)
-            } as any
-        });
+      const app = await createTestApp();
+      const env = createTestEnv();
+      const res = await sendInviteRequest(token, app, env);
 
-        const consoleErrorSpy = vi.spyOn(console, "error").mockImplementation(() => {});
-
-        const form = new FormData();
-        form.set("metadata", JSON.stringify({ title: "Test Paper", visibility: "private" }));
-        form.set("files_0", new File(["%PDF-1.4\n%dummy-pdf"], "paper1.pdf", { type: "application/pdf" }));
-        form.set("file_types_0", "paper");
-        form.set("files_1", new File(["%PDF-1.4\n%dummy-pdf"], "paper2.pdf", { type: "application/pdf" }));
-        form.set("file_types_1", "paper");
-
-        const res = await app.request(
-            "http://localhost/api/papers",
-            {
-                method: "POST",
-                headers: {
-                    Authorization: `Bearer ${token}`,
-                    Origin: "http://localhost:3000"
-                },
-                body: form
-            },
-            env as any
-        );
-
-        expect(res.status).toBe(500);
-
-        const uploadErrorCall = consoleErrorSpy.mock.calls.find(call => call[0] === "File upload errors:");
-        expect(uploadErrorCall).toBeDefined();
-
-        const loggedObject = uploadErrorCall![1];
-        expect(loggedObject.errors).toHaveLength(2);
-
-        // Verify Error instance is sanitized
-        const errorLog = loggedObject.errors.find((e: any) => e === sensitiveError.message);
-        expect(errorLog).toBeDefined();
-
-        // Verify string error is preserved as string
-        const stringLog = loggedObject.errors.find((e: any) => e === stringError);
-        expect(stringLog).toBeDefined();
-
-        consoleErrorSpy.mockRestore();
+      expect(res.status).toBe(500);
     });
-
-    it("POST /api/papers rejects upload when content does not match declared MIME", async () => {
-        const token = await createTestJWT({ sub: "user-1", githubId: "123", name: "Uploader" });
-        const app = await createTestApp();
-        const env = createTestEnv({ DB: mockDb as any });
-
-        const form = new FormData();
-        form.set("metadata", JSON.stringify({ title: "Mismatched Paper", visibility: "private" }));
-        // PDF declared but content starts with ZIP header
-        form.set("files_0", new File(["PK\x03\x04zipcontent"], "paper.pdf", { type: "application/pdf" }));
-        form.set("file_types_0", "paper");
-
-        const res = await app.request(
-            "http://localhost/api/papers",
-            {
-                method: "POST",
-                headers: {
-                    Authorization: `Bearer ${token}`,
-                    Origin: "http://localhost:3000"
-                },
-                body: form
-            },
-            env as any
-        );
-
-        expect(res.status).toBe(400);
-        const body = (await res.json()) as any;
-        expect(body.error).toContain("does not match expected format");
-    });
-
-    it("GET /api/papers returns current user's papers", async () => {
-        const token = await createTestJWT({ sub: "user-1", githubId: "123", name: "Uploader" });
-        mockDb.select = vi.fn(() => makeQuery({ allResult: [{ paper: { id: "paper-1", title: "P1" } }] }));
-
-        const app = await createTestApp();
-        const env = createTestEnv({ DB: mockDb as any });
-        const res = await app.request(
-            "http://localhost/api/papers",
-            {
-                headers: { Authorization: `Bearer ${token}` }
-            },
-            env as any
-        );
-
-        expect(res.status).toBe(200);
-        const body = (await res.json()) as any;
-        expect(body.papers[0].id).toBe("paper-1");
-    });
-
-    it("GET /api/papers/:id returns paper details", async () => {
-        const token = await createTestJWT({ sub: "user-1", githubId: "123", name: "Uploader" });
-        mockDb.select = vi
-            .fn()
-            .mockImplementationOnce(() => makeQuery({ getResult: { id: "paper-1", title: "P1", abstract: "A", description: "## notes", descriptionUpdatedAt: "2026-04-01 12:00:00", visibility: "private", showViewCount: true, language: "ja", doi: "10.1234/example" } }))
-            .mockImplementationOnce(() => makeQuery({ getResult: { paperId: "paper-1", userId: "user-1", role: "uploader" } }))
-            .mockImplementationOnce(() => makeQuery({ allResult: [{ id: "file-1", filename: "paper.pdf" }] }))
-            .mockImplementationOnce(() => makeQuery({ allResult: [{ userId: "user-1", role: "uploader", name: "Uploader", displayName: null, avatarUrl: null }] }))
-            .mockImplementationOnce(() => makeQuery({ getResult: { views: 4, downloads: 2 } }));
-
-        const app = await createTestApp();
-        const env = createTestEnv({ DB: mockDb as any });
-        const res = await app.request(
-            "http://localhost/api/papers/paper-1",
-            { headers: { Authorization: `Bearer ${token}` } },
-            env as any
-        );
-
-        expect(res.status).toBe(200);
-        const body = (await res.json()) as any;
-        expect(body.paper.id).toBe("paper-1");
-        expect(body.paper.language).toBe("ja");
-        expect(body.paper.doi).toBe("10.1234/example");
-        expect(body.paper.description).toBe("## notes");
-        expect(body.paper.descriptionUpdatedAt).toBe("2026-04-01T12:00:00.000Z");
-        expect(body.paper.showViewCount).toBe(true);
-        expect(body.paper.publicViewCount).toBe(4);
-        expect(body.paper.publicDownloadCount).toBe(2);
-        expect(mockDb.batch).toHaveBeenCalledTimes(1);
-    });
-
-    it("GET /api/papers/:id/cite returns citation in requested format", async () => {
-        const token = await createTestJWT({ sub: "user-1", githubId: "123", name: "Uploader" });
-        mockDb.select = vi
-            .fn()
-            .mockImplementationOnce(() => makeQuery({
-                getResult: {
-                    id: "paper-1",
-                    title: "Boundary Explorer",
-                    visibility: "private",
-                    venue: "ASE",
-                    venueType: "conference",
-                    year: 2026,
-                    category: "other",
-                    doi: null,
-                    externalUrl: null,
-                },
-            }))
-            .mockImplementationOnce(() => makeQuery({ getResult: { paperId: "paper-1", userId: "user-1" } }))
-            .mockImplementationOnce(() => makeQuery({ allResult: [{ name: "hiroki", displayName: "Hiroki Mukai" }] }));
-
-        const app = await createTestApp();
-        const env = createTestEnv({ DB: mockDb as any });
-        const res = await app.request(
-            "http://localhost/api/papers/paper-1/cite?format=bibtex",
-            { headers: { Authorization: `Bearer ${token}` } },
-            env as any,
-        );
-
-        expect(res.status).toBe(200);
-        const body = (await res.json()) as any;
-        expect(body.format).toBe("bibtex");
-        expect(body.key).toContain("mukai2026");
-        expect(body.citation).toContain("@inproceedings");
-    });
-
-    it("GET /api/papers/:id/cite supports plain format", async () => {
-        const token = await createTestJWT({ sub: "user-1", githubId: "123", name: "Uploader" });
-        mockDb.select = vi
-            .fn()
-            .mockImplementationOnce(() => makeQuery({
-                getResult: {
-                    id: "paper-1",
-                    title: "Boundary Explorer",
-                    visibility: "private",
-                    venue: "ASE",
-                    venueType: "conference",
-                    year: 2026,
-                    category: "other",
-                    doi: null,
-                    externalUrl: null,
-                },
-            }))
-            .mockImplementationOnce(() => makeQuery({ getResult: { paperId: "paper-1", userId: "user-1" } }))
-            .mockImplementationOnce(() => makeQuery({ allResult: [{ name: "hiroki", displayName: "向井 宏樹" }] }));
-
-        const app = await createTestApp();
-        const env = createTestEnv({ DB: mockDb as any });
-        const res = await app.request(
-            "http://localhost/api/papers/paper-1/cite?format=plain",
-            { headers: { Authorization: `Bearer ${token}` } },
-            env as any,
-        );
-
-        expect(res.status).toBe(200);
-        const body = (await res.json()) as any;
-        expect(body.format).toBe("plain");
-        expect(body.key).toBeNull();
-        expect(body.citation).toContain("向井 宏樹");
-    });
-
-    it("POST /api/papers rejects a non-boolean showViewCount", async () => {
-        const token = await createTestJWT({ sub: "user-1", githubId: "123", name: "Uploader" });
-        const app = await createTestApp();
-        const env = createTestEnv({ DB: mockDb as any });
-
-        const form = new FormData();
-        form.set(
-            "metadata",
-            JSON.stringify({
-                title: "View Count Paper",
-                visibility: "private",
-                showViewCount: "yes",
-            }),
-        );
-        form.set("files_0", new File(["%PDF-1.4\n%dummy-pdf"], "paper.pdf", { type: "application/pdf" }));
-        form.set("file_types_0", "paper");
-
-        const res = await app.request(
-            "http://localhost/api/papers",
-            {
-                method: "POST",
-                headers: {
-                    Authorization: `Bearer ${token}`,
-                    Origin: "http://localhost:3000",
-                },
-                body: form,
-            },
-            env as any,
-        );
-
-        expect(res.status).toBe(400);
-        const body = (await res.json()) as any;
-        expect(body.error).toContain("showViewCount");
-    });
-
-    it("POST /api/papers/:id/track accepts view event", async () => {
-        const dedupRun = vi.fn(async () => ({ meta: { changes: 1 } }));
-        const dailyRun = vi.fn(async () => ({ meta: { changes: 1 } }));
-        const totalRun = vi.fn(async () => ({ meta: { changes: 1 } }));
-        const cleanupRun = vi.fn(async () => ({ meta: { changes: 0 } }));
-        mockDb.select = vi
-            .fn()
-            .mockImplementationOnce(() => makeQuery({ getResult: { id: "paper-1", visibility: "public" } }));
-        const prepare = vi
-            .fn()
-            .mockImplementationOnce(() => ({ bind: vi.fn(() => ({ run: dedupRun })) }))
-            .mockImplementationOnce(() => ({ bind: vi.fn(() => ({ run: dailyRun })) }))
-            .mockImplementationOnce(() => ({ bind: vi.fn(() => ({ run: totalRun })) }))
-            .mockImplementationOnce(() => ({ bind: vi.fn(() => ({ run: cleanupRun })) }));
-        mockDb.prepare = prepare;
-        mockDb.batch = vi.fn(async (queries) =>
-            Promise.all(queries.map((q: any) => q.run())),
-        );
-
-        const app = await createTestApp();
-        const env = createTestEnv({ DB: mockDb as any });
-        const res = await app.request(
-            "http://localhost/api/papers/paper-1/track",
-            {
-                method: "POST",
-                headers: {
-                    "Content-Type": "application/json",
-                    Origin: "http://localhost:3000",
-                    "User-Agent": "Vitest",
-                },
-                body: JSON.stringify({ event: "view", referrer: "https://example.com" }),
-            },
-            env as any,
-        );
-
-        expect(res.status).toBe(204);
-        expect(prepare).toHaveBeenCalledTimes(4);
-        expect(dedupRun).toHaveBeenCalled();
-        expect(dailyRun).toHaveBeenCalled();
-        expect(totalRun).toHaveBeenCalled();
-    });
-
-    it("POST /api/papers/:id/track ignores bots", async () => {
-        mockDb.select = vi
-            .fn()
-            .mockImplementationOnce(() => makeQuery({ getResult: { id: "paper-1", visibility: "public" } }));
-
-        const app = await createTestApp();
-        const env = createTestEnv({ DB: mockDb as any });
-        const res = await app.request(
-            "http://localhost/api/papers/paper-1/track",
-            {
-                method: "POST",
-                headers: {
-                    "Content-Type": "application/json",
-                    Origin: "http://localhost:3000",
-                    "User-Agent": "googlebot",
-                },
-                body: JSON.stringify({ event: "view" }),
-            },
-            env as any,
-        );
-
-        expect(res.status).toBe(204);
-        expect(mockDb.insert).not.toHaveBeenCalled();
-    });
-
-    it("POST /api/papers/:id/track logs sanitized error on failure (Error instance)", async () => {
-        mockDb.select = vi
-            .fn()
-            .mockImplementationOnce(() => makeQuery({ getResult: { id: "paper-1", visibility: "public" } }));
-
-        const trackError = new Error("D1 Error: SENSITIVE_DB_INFO");
-        (trackError as any).query = "INSERT INTO paper_stats_dedup ...";
-
-        mockDb.batch = vi.fn().mockRejectedValue(trackError);
-
-        const consoleErrorSpy = vi.spyOn(console, "error").mockImplementation(() => {});
-
-        const app = await createTestApp();
-        const env = createTestEnv({ DB: mockDb as any });
-        await app.request(
-            "http://localhost/api/papers/paper-1/track",
-            {
-                method: "POST",
-                headers: {
-                    "Content-Type": "application/json",
-                    Origin: "http://localhost:3000",
-                    "User-Agent": "Vitest",
-                },
-                body: JSON.stringify({ event: "view" }),
-            },
-            env as any,
-        );
-
-        try {
-            await vi.waitFor(() => {
-                const call = consoleErrorSpy.mock.calls.find(c => c[0] === "Failed to record paper track event");
-                if (!call) throw new Error("Log not found");
-                expect(call[1].error).toBe(trackError.message);
-            });
-        } finally {
-            consoleErrorSpy.mockRestore();
-        }
-    });
-
-    it("POST /api/papers/:id/track logs sanitized error on failure (string error)", async () => {
-        mockDb.select = vi
-            .fn()
-            .mockImplementationOnce(() => makeQuery({ getResult: { id: "paper-1", visibility: "public" } }));
-
-        const trackError = "Batch failed for some reason";
-        mockDb.batch = vi.fn().mockRejectedValue(trackError);
-
-        const consoleErrorSpy = vi.spyOn(console, "error").mockImplementation(() => {});
-
-        const app = await createTestApp();
-        const env = createTestEnv({ DB: mockDb as any });
-        await app.request(
-            "http://localhost/api/papers/paper-1/track",
-            {
-                method: "POST",
-                headers: {
-                    "Content-Type": "application/json",
-                    Origin: "http://localhost:3000",
-                    "User-Agent": "Vitest",
-                },
-                body: JSON.stringify({ event: "view" }),
-            },
-            env as any,
-        );
-
-        try {
-            await vi.waitFor(() => {
-                const call = consoleErrorSpy.mock.calls.find(c => c[0] === "Failed to record paper track event");
-                if (!call) throw new Error("Log not found");
-                expect(call[1].error).toBe(trackError);
-            });
-        } finally {
-            consoleErrorSpy.mockRestore();
-        }
-    });
-
-    it("POST /api/papers/:id/track handles duplicate dedup rows", async () => {
-        const dedupRun = vi.fn(async () => ({ meta: { changes: 0 } }));
-        const dailyRun = vi.fn(async () => ({ meta: { changes: 0 } }));
-        const totalRun = vi.fn(async () => ({ meta: { changes: 0 } }));
-        const cleanupRun = vi.fn(async () => ({ meta: { changes: 0 } }));
-        mockDb.prepare = vi
-            .fn()
-            .mockImplementationOnce(() => ({ bind: vi.fn(() => ({ run: dedupRun })) }))
-            .mockImplementationOnce(() => ({ bind: vi.fn(() => ({ run: dailyRun })) }))
-            .mockImplementationOnce(() => ({ bind: vi.fn(() => ({ run: totalRun })) }))
-            .mockImplementationOnce(() => ({ bind: vi.fn(() => ({ run: cleanupRun })) }));
-        mockDb.batch = vi.fn(async (queries) =>
-            Promise.all(queries.map((q: any) => q.run())),
-        );
-        mockDb.select = vi
-            .fn()
-            .mockImplementationOnce(() => makeQuery({ getResult: { id: "paper-1", visibility: "public" } }));
-
-        const app = await createTestApp();
-        const env = createTestEnv({ DB: mockDb as any });
-        const res = await app.request(
-            "http://localhost/api/papers/paper-1/track",
-            {
-                method: "POST",
-                headers: {
-                    "Content-Type": "application/json",
-                    Origin: "http://localhost:3000",
-                    "User-Agent": "Vitest",
-                },
-                body: JSON.stringify({ event: "download" }),
-            },
-            env as any,
-        );
-
-        expect(res.status).toBe(204);
-    });
-
-    it("DELETE /api/papers/:id handles R2 deletion failure", async () => {
-        const token = await createTestJWT({ sub: "user-1", githubId: "123", name: "Uploader" });
-        mockDb.select = vi
-            .fn()
-            .mockImplementationOnce(() => makeQuery({ getResult: { paperId: "paper-1", userId: "user-1", role: "uploader" } }))
-            .mockImplementationOnce(() => makeQuery({ allResult: [{ r2Key: "papers/paper-1/paper/file.pdf" }] }));
-
-        const app = await createTestApp();
-        const env = createTestEnv({ DB: mockDb as any });
-        vi.spyOn(env.BUCKET, "delete").mockRejectedValue(new Error("R2 failure"));
-
-        const res = await app.request(
-            "http://localhost/api/papers/paper-1",
-            {
-                method: "DELETE",
-                headers: {
-                    Authorization: `Bearer ${token}`,
-                    Origin: "http://localhost:3000"
-                }
-            },
-            env as any
-        );
-
-        expect(res.status).toBe(500);
-    });
-
-    it("POST /api/papers/:id/track returns 404 when paper does not exist", async () => {
-        mockDb.select = vi
-            .fn()
-            .mockImplementationOnce(() => makeQuery({ getResult: null }));
-
-        const app = await createTestApp();
-        const env = createTestEnv();
-        const res = await app.request(
-            "http://localhost/api/papers/missing-paper/track",
-            {
-                method: "POST",
-                headers: {
-                    "Content-Type": "application/json",
-                    Origin: "http://localhost:3000",
-                    "User-Agent": "Vitest",
-                },
-                body: JSON.stringify({ event: "view" }),
-            },
-            env as any,
-        );
-
-        expect(res.status).toBe(404);
-        expect(mockDb.prepare).not.toHaveBeenCalled();
-    });
-
-    it("GET /api/papers/:id/stats returns author-only statistics", async () => {
-        const token = await createTestJWT({ sub: "user-1", githubId: "123", name: "Author" });
-        const today = new Date().toISOString().split("T")[0];
-        const yesterday = new Date(Date.now() - 86400000).toISOString().split("T")[0];
-
-        mockDb.select = vi
-            .fn()
-            .mockImplementationOnce(() => makeQuery({ getResult: { id: "paper-1" } }))
-            .mockImplementationOnce(() => makeQuery({ getResult: { userId: "user-1" } }))
-            .mockImplementationOnce(() => makeQuery({ getResult: { views: 42, downloads: 18, previews: 6 } }))
-            .mockImplementationOnce(() =>
-                makeQuery({
-                    allResult: [
-                        { date: yesterday, views: 3, downloads: 1, previews: 1 },
-                        { date: today, views: 2, downloads: 1, previews: 0 },
-                    ],
-                }),
-            );
-
-        const app = await createTestApp();
-        const env = createTestEnv();
-        const res = await app.request(
-            "http://localhost/api/papers/paper-1/stats",
-            {
-                headers: { Authorization: `Bearer ${token}` },
-            },
-            env as any,
-        );
-
-        expect(res.status).toBe(200);
-        const body = (await res.json()) as any;
-        expect(body.total).toEqual({ views: 42, downloads: 18, previews: 6 });
-        expect(body.daily).toHaveLength(30);
-        expect(body.daily.at(-1)).toEqual({ date: today, views: 2, downloads: 1, previews: 0 });
-        expect(body.days).toBe(30);
-    });
-
-    it("GET /api/papers/:id omits publicViewCount when showViewCount is false", async () => {
-        const token = await createTestJWT({ sub: "user-1", githubId: "123", name: "Uploader" });
-        mockDb.select = vi
-            .fn()
-            .mockImplementationOnce(() => makeQuery({ getResult: { id: "paper-1", title: "P1", visibility: "public", showViewCount: false } }))
-            .mockImplementationOnce(() => makeQuery({ allResult: [] }))
-            .mockImplementationOnce(() => makeQuery({ allResult: [] }));
-
-        const app = await createTestApp();
-        const env = createTestEnv();
-        const res = await app.request(
-            "http://localhost/api/papers/paper-1",
-            { headers: { Authorization: `Bearer ${token}` } },
-            env as any
-        );
-
-        expect(res.status).toBe(200);
-        const body = (await res.json()) as any;
-        expect(body.paper.showViewCount).toBe(false);
-        expect(body.paper.publicViewCount).toBeNull();
-        expect(body.paper.publicDownloadCount).toBeNull();
-    });
-
-    it("POST /api/papers/:id/track returns 401 for private paper without token", async () => {
-        mockDb.select = vi
-            .fn()
-            .mockImplementationOnce(() => makeQuery({ getResult: { id: "paper-1", visibility: "private" } }));
-
-        const app = await createTestApp();
-        const env = createTestEnv();
-        const res = await app.request(
-            "http://localhost/api/papers/paper-1/track",
-            {
-                method: "POST",
-                headers: {
-                    "Content-Type": "application/json",
-                    Origin: "http://localhost:3000",
-                },
-                body: JSON.stringify({ event: "view" }),
-            },
-            env as any,
-        );
-
-        expect(res.status).toBe(401);
-    });
-
-    it("POST /api/papers/:id/track returns 403 for private paper from non-author", async () => {
-        const token = await createTestJWT({ sub: "user-2", githubId: "456", name: "Other" });
-        mockDb.select = vi
-            .fn()
-            .mockImplementationOnce(() => makeQuery({ getResult: { id: "paper-1", visibility: "private" } }))
-            .mockImplementationOnce(() => makeQuery({ getResult: null }));
-
-        const app = await createTestApp();
-        const env = createTestEnv();
-        const res = await app.request(
-            "http://localhost/api/papers/paper-1/track",
-            {
-                method: "POST",
-                headers: {
-                    Authorization: `Bearer ${token}`,
-                    "Content-Type": "application/json",
-                },
-                body: JSON.stringify({ event: "view" }),
-            },
-            env as any,
-        );
-
-        expect(res.status).toBe(403);
-    });
-
-    it("GET /api/papers/:id/stats returns 403 for non-authors", async () => {
-        const token = await createTestJWT({ sub: "user-2", githubId: "456", name: "Other User" });
-        mockDb.select = vi
-            .fn()
-            .mockImplementationOnce(() => makeQuery({ getResult: { id: "paper-1" } }))
-            .mockImplementationOnce(() => makeQuery({ getResult: null }));
-
-        const app = await createTestApp();
-        const env = createTestEnv();
-        const res = await app.request(
-            "http://localhost/api/papers/paper-1/stats",
-            {
-                headers: { Authorization: `Bearer ${token}` },
-            },
-            env as any,
-        );
-
-        expect(res.status).toBe(403);
-    });
-
-    it("GET /api/papers/:id/stats rejects invalid days", async () => {
-        const token = await createTestJWT({ sub: "user-1", githubId: "123", name: "Author" });
-        const app = await createTestApp();
-        const env = createTestEnv();
-        const res = await app.request(
-            "http://localhost/api/papers/paper-1/stats?days=14",
-            {
-                headers: { Authorization: `Bearer ${token}` },
-            },
-            env as any,
-        );
-
-        expect(res.status).toBe(400);
-        const body = (await res.json()) as any;
-        expect(body.error).toContain("days must be one of 7, 30, 90, 365");
-    });
-
-    it("PATCH /api/papers/:id rejects changing a non-org_only paper to org_only", async () => {
-        const token = await createTestJWT({ sub: "user-1", githubId: "123", name: "Uploader" });
-        mockDb.select = vi
-            .fn()
-            .mockImplementationOnce(() => makeQuery({ getResult: { id: "paper-1", visibility: "private" } }))
-            .mockImplementationOnce(() => makeQuery({ getResult: { paperId: "paper-1", userId: "user-1", role: "uploader" } }));
-
-        const app = await createTestApp();
-        const env = createTestEnv();
-        const res = await app.request(
-            "http://localhost/api/papers/paper-1",
-            {
-                method: "PATCH",
-                headers: {
-                    Authorization: `Bearer ${token}`,
-                    "Content-Type": "application/json",
-                },
-                body: JSON.stringify({ visibility: "org_only" }),
-            },
-            env as any
-        );
-
-        expect(res.status).toBe(400);
-        const body = (await res.json()) as any;
-        expect(body.error).toContain("org_only");
-        expect(mockDb.update).not.toHaveBeenCalled();
-    });
-
-    it("PUT /api/papers/:id/description updates description for authors", async () => {
-        const token = await createTestJWT({ sub: "user-1", githubId: "123", name: "Uploader" });
-        const where = vi.fn(async () => undefined);
-        const set = vi.fn(() => ({ where }));
-        mockDb.select = vi
-            .fn()
-            .mockImplementationOnce(() => makeQuery({ getResult: { id: "paper-1" } }))
-            .mockImplementationOnce(() => makeQuery({ getResult: { userId: "user-1" } }))
-            .mockImplementationOnce(() => makeQuery({ getResult: { id: "paper-1", description: "## Updated", descriptionUpdatedAt: "2026-04-01 12:00:00" } }));
-        mockDb.update = vi.fn(() => ({ set }));
-
-        const app = await createTestApp();
-        const env = createTestEnv();
-        const res = await app.request(
-            "http://localhost/api/papers/paper-1/description",
-            {
-                method: "PUT",
-                headers: {
-                    Authorization: `Bearer ${token}`,
-                    "Content-Type": "application/json",
-                },
-                body: JSON.stringify({ description: "## Updated" }),
-            },
-            env as any,
-        );
-
-        expect(res.status).toBe(200);
-        expect(set).toHaveBeenCalledWith(
-            expect.objectContaining({
-                description: "## Updated",
-            }),
-        );
-        const body = (await res.json()) as any;
-        expect(body.id).toBe("paper-1");
-        expect(body.description).toBe("## Updated");
-        expect(body.descriptionUpdatedAt).toBe("2026-04-01T12:00:00.000Z");
-        expect(body.description_updated_at).toBe("2026-04-01T12:00:00.000Z");
-    });
-
-    it("PUT /api/papers/:id/description rejects non-author", async () => {
-        const token = await createTestJWT({ sub: "user-2", githubId: "456", name: "Other User" });
-        mockDb.select = vi
-            .fn()
-            .mockImplementationOnce(() => makeQuery({ getResult: { id: "paper-1" } }))
-            .mockImplementationOnce(() => makeQuery({ getResult: null }));
-
-        const app = await createTestApp();
-        const env = createTestEnv();
-        const res = await app.request(
-            "http://localhost/api/papers/paper-1/description",
-            {
-                method: "PUT",
-                headers: {
-                    Authorization: `Bearer ${token}`,
-                    "Content-Type": "application/json",
-                },
-                body: JSON.stringify({ description: "updated" }),
-            },
-            env as any,
-        );
-
-        expect(res.status).toBe(403);
-    });
-
-    it.each([
-        { name: "malformed JSON", body: '{"description": "missing brace"' },
-        { name: "JSON array", body: JSON.stringify([{ description: "updated" }]) },
-        { name: "non-object JSON", body: JSON.stringify("just a string") },
-    ])("PUT /api/papers/:id/description handles invalid JSON body: $name", async ({ body }) => {
-        const token = await createTestJWT({ sub: "user-1", githubId: "123", name: "Uploader" });
-        const app = await createTestApp();
-        const env = createTestEnv();
-
-        const res = await app.request(
-            "http://localhost/api/papers/paper-1/description",
-            {
-                method: "PUT",
-                headers: {
-                    Authorization: `Bearer ${token}`,
-                    "Content-Type": "application/json",
-                },
-                body,
-            },
-            env as any,
-        );
-        expect(res.status).toBe(400);
-        await expect(res.json()).resolves.toEqual({ error: "Invalid JSON body" });
-    });
-
-    it("PUT /api/papers/:id/description validates description length", async () => {
-        const token = await createTestJWT({ sub: "user-1", githubId: "123", name: "Uploader" });
-
-        const app = await createTestApp();
-        const env = createTestEnv();
-        const res = await app.request(
-            "http://localhost/api/papers/paper-1/description",
-            {
-                method: "PUT",
-                headers: {
-                    Authorization: `Bearer ${token}`,
-                    "Content-Type": "application/json",
-                },
-                body: JSON.stringify({ description: "a".repeat(50001) }),
-            },
-            env as any,
-        );
-
-        expect(res.status).toBe(400);
-        const body = (await res.json()) as any;
-        expect(body.error).toContain("50000");
-    });
-
-    it("PATCH /api/papers/:id validates externalUrl like POST", async () => {
-        const token = await createTestJWT({ sub: "user-1", githubId: "123", name: "Uploader" });
-        mockDb.select = vi
-            .fn()
-            .mockImplementationOnce(() => makeQuery({ getResult: { id: "paper-1", visibility: "private" } }))
-            .mockImplementationOnce(() => makeQuery({ getResult: { paperId: "paper-1", userId: "user-1", role: "uploader" } }));
-
-        const app = await createTestApp();
-        const env = createTestEnv();
-        const res = await app.request(
-            "http://localhost/api/papers/paper-1",
-            {
-                method: "PATCH",
-                headers: {
-                    Authorization: `Bearer ${token}`,
-                    "Content-Type": "application/json",
-                },
-                body: JSON.stringify({ externalUrl: "ftp://example.com/paper" }),
-            },
-            env as any
-        );
-
-        expect(res.status).toBe(400);
-        const body = (await res.json()) as any;
-        expect(body.error).toContain("externalUrl");
-        expect(mockDb.update).not.toHaveBeenCalled();
-    });
-
-    it("PATCH /api/papers/:id rejects overlong abstract", async () => {
-        const token = await createTestJWT({ sub: "user-1", githubId: "123", name: "Uploader" });
-        mockDb.select = vi
-            .fn()
-            .mockImplementationOnce(() => makeQuery({ getResult: { id: "paper-1", visibility: "private" } }))
-            .mockImplementationOnce(() => makeQuery({ getResult: { paperId: "paper-1", userId: "user-1", role: "uploader" } }));
-
-        const app = await createTestApp();
-        const env = createTestEnv();
-        const res = await app.request(
-            "http://localhost/api/papers/paper-1",
-            {
-                method: "PATCH",
-                headers: {
-                    Authorization: `Bearer ${token}`,
-                    "Content-Type": "application/json",
-                },
-                body: JSON.stringify({ abstract: "a".repeat(5001) }),
-            },
-            env as any
-        );
-
-        expect(res.status).toBe(400);
-        const body = (await res.json()) as any;
-        expect(body.error).toContain("abstract");
-        expect(mockDb.update).not.toHaveBeenCalled();
-    });
-
-    it("PATCH /api/papers/:id allows keeping org_only on an existing org_only paper", async () => {
-        const token = await createTestJWT({ sub: "user-1", githubId: "123", name: "Uploader" });
-        const where = vi.fn(async () => undefined);
-        const set = vi.fn(() => ({ where }));
-        mockDb.select = vi
-            .fn()
-            .mockImplementationOnce(() => makeQuery({ getResult: { id: "paper-1", visibility: "org_only" } }))
-            .mockImplementationOnce(() => makeQuery({ getResult: { paperId: "paper-1", userId: "user-1", role: "uploader" } }));
-        mockDb.update = vi.fn(() => ({ set }));
-
-        const app = await createTestApp();
-        const env = createTestEnv();
-        const res = await app.request(
-            "http://localhost/api/papers/paper-1",
-            {
-                method: "PATCH",
-                headers: {
-                    Authorization: `Bearer ${token}`,
-                    "Content-Type": "application/json",
-                },
-                body: JSON.stringify({ visibility: "org_only", title: "Updated title" }),
-            },
-            env as any
-        );
-
-        expect(res.status).toBe(200);
-        expect(mockDb.update).toHaveBeenCalledTimes(1);
-        expect(set).toHaveBeenCalledWith(
-            expect.objectContaining({
-                visibility: "org_only",
-                title: "Updated title",
-            }),
-        );
-        expect(where).toHaveBeenCalledTimes(1);
-    });
-
-    it("PATCH /api/papers/:id rejects a primitive JSON body", async () => {
-        const token = await createTestJWT({ sub: "user-1", githubId: "123", name: "Uploader" });
-
-        const app = await createTestApp();
-        const env = createTestEnv();
-        const res = await app.request(
-            "http://localhost/api/papers/paper-1",
-            {
-                method: "PATCH",
-                headers: {
-                    Authorization: `Bearer ${token}`,
-                    "Content-Type": "application/json",
-                },
-                body: "null",
-            },
-            env as any
-        );
-
-        expect(res.status).toBe(400);
-        const body = (await res.json()) as any;
-        expect(body.error).toContain("Invalid JSON body");
-        expect(mockDb.select).not.toHaveBeenCalled();
-    });
-
-
-    it("PATCH /api/papers/:id updates tags correctly with normalization and deduplication", async () => {
-        const token = await createTestJWT({ sub: "user-1", githubId: "123", name: "Uploader" });
-        const where = vi.fn(async () => undefined);
-        const set = vi.fn(() => ({ where }));
-        mockDb.select = vi
-            .fn()
-            .mockImplementationOnce(() => makeQuery({ getResult: { id: "paper-1", visibility: "private" } }))
-            .mockImplementationOnce(() => makeQuery({ getResult: { paperId: "paper-1", userId: "user-1", role: "uploader" } }));
-        mockDb.update = vi.fn(() => ({ set }));
-
-        const app = await createTestApp();
-        const env = createTestEnv();
-        const res = await app.request(
-            "http://localhost/api/papers/paper-1",
-            {
-                method: "PATCH",
-                headers: {
-                    Authorization: `Bearer ${token}`,
-                    "Content-Type": "application/json",
-                },
-                body: JSON.stringify({ tags: [" AI", "ML ", "NLP", "ai"] }),
-            },
-            env as any,
-        );
-
-        expect(res.status).toBe(200);
-        expect(set).toHaveBeenCalledWith({
-            tags: JSON.stringify(["ai", "ml", "nlp"]),
-            updatedAt: expect.anything(),
-        });
-    });
-
-    it("PATCH /api/papers/:id rejects invalid tag items", async () => {
-        const token = await createTestJWT({ sub: "user-1", githubId: "123", name: "Uploader" });
-        const set = vi.fn();
-        mockDb.select = vi
-            .fn()
-            .mockImplementationOnce(() => makeQuery({ getResult: { id: "paper-1", visibility: "private" } }))
-            .mockImplementationOnce(() => makeQuery({ getResult: { paperId: "paper-1", userId: "user-1", role: "uploader" } }));
-        mockDb.update = vi.fn(() => ({ set }));
-
-        const app = await createTestApp();
-        const env = createTestEnv();
-        const res = await app.request(
-            "http://localhost/api/papers/paper-1",
-            {
-                method: "PATCH",
-                headers: {
-                    Authorization: `Bearer ${token}`,
-                    "Content-Type": "application/json",
-                },
-                body: JSON.stringify({ tags: ["ai", "A".repeat(100)] }),
-            },
-            env as any,
-        );
-
-        expect(res.status).toBe(400);
-        await expect(res.json()).resolves.toEqual({ error: "tags must be 64 chars or less" });
-        expect(mockDb.update).not.toHaveBeenCalled();
-    });
-
-    it("PATCH /api/papers/:id deduplicates mixed-case tags after normalization", async () => {
-        const token = await createTestJWT({ sub: "user-1", githubId: "123", name: "Uploader" });
-        const where = vi.fn(async () => undefined);
-        const set = vi.fn(() => ({ where }));
-        mockDb.select = vi
-            .fn()
-            .mockImplementationOnce(() => makeQuery({ getResult: { id: "paper-1", visibility: "private" } }))
-            .mockImplementationOnce(() => makeQuery({ getResult: { paperId: "paper-1", userId: "user-1", role: "uploader" } }));
-        mockDb.update = vi.fn(() => ({ set }));
-
-        const app = await createTestApp();
-        const env = createTestEnv();
-        const res = await app.request(
-            "http://localhost/api/papers/paper-1",
-            {
-                method: "PATCH",
-                headers: {
-                    Authorization: `Bearer ${token}`,
-                    "Content-Type": "application/json",
-                },
-                body: JSON.stringify({ tags: ["AI", "ai", "Ai", "aI"] }),
-            },
-            env as any,
-        );
-
-        expect(res.status).toBe(200);
-        expect(set).toHaveBeenCalledWith({
-            tags: JSON.stringify(["ai"]),
-            updatedAt: expect.anything(),
-        });
-    });
-
-    it("PATCH /api/papers/:id rejects requests without valid updatable fields", async () => {
-        const token = await createTestJWT({ sub: "user-1", githubId: "123", name: "Uploader" });
-        mockDb.select = vi
-            .fn()
-            .mockImplementationOnce(() => makeQuery({ getResult: { id: "paper-1", visibility: "private" } }))
-            .mockImplementationOnce(() => makeQuery({ getResult: { paperId: "paper-1", userId: "user-1", role: "uploader" } }));
-
-        const app = await createTestApp();
-        const env = createTestEnv();
-        const res = await app.request(
-            "http://localhost/api/papers/paper-1",
-            {
-                method: "PATCH",
-                headers: {
-                    Authorization: `Bearer ${token}`,
-                    "Content-Type": "application/json",
-                },
-                body: JSON.stringify({ unknownField: "ignored" }),
-            },
-            env as any
-        );
-
-        expect(res.status).toBe(400);
-        const body = (await res.json()) as any;
-        expect(body.error).toContain("No valid fields");
-        expect(mockDb.update).not.toHaveBeenCalled();
-    });
-
-    it("PATCH /api/papers/:id updates showViewCount for authors", async () => {
-        const token = await createTestJWT({ sub: "user-1", githubId: "123", name: "Uploader" });
-        const where = vi.fn(async () => undefined);
-        const set = vi.fn(() => ({ where }));
-        mockDb.select = vi
-            .fn()
-            .mockImplementationOnce(() => makeQuery({ getResult: { id: "paper-1", visibility: "private" } }))
-            .mockImplementationOnce(() => makeQuery({ getResult: { paperId: "paper-1", userId: "user-1", role: "uploader" } }));
-        mockDb.update = vi.fn(() => ({ set }));
-
-        const app = await createTestApp();
-        const env = createTestEnv();
-        const res = await app.request(
-            "http://localhost/api/papers/paper-1",
-            {
-                method: "PATCH",
-                headers: {
-                    Authorization: `Bearer ${token}`,
-                    "Content-Type": "application/json",
-                },
-                body: JSON.stringify({ showViewCount: true }),
-            },
-            env as any,
-        );
-
-        expect(res.status).toBe(200);
-        expect(set).toHaveBeenCalledWith(
-            expect.objectContaining({ showViewCount: true }),
-        );
-        expect(where).toHaveBeenCalledTimes(1);
-    });
-
-
-    it("PATCH /api/papers/:id updates doi, venue, venueType, year, category, and tags", async () => {
-        const token = await createTestJWT({ sub: "user-1", githubId: "123", name: "Uploader" });
-        const set = vi.fn().mockReturnThis();
-        const where = vi.fn().mockReturnThis();
-        mockDb.select = vi.fn().mockImplementation(() => makeQuery({ getResult: { paperId: "paper-1", userId: "user-1", role: "uploader" } }));
-        mockDb.update = vi.fn().mockImplementation(() => ({ set, where } as any));
-
-        const app = await createTestApp();
-        const env = createTestEnv();
-        const res = await app.request(
-            "http://localhost/api/papers/paper-1",
-            {
-                method: "PATCH",
-                headers: {
-                    Authorization: `Bearer ${token}`,
-                    "Content-Type": "application/json",
-                },
-                body: JSON.stringify({
-                    doi: "10.1234/5678",
-                    venue: "Test Venue",
-                    venueType: "conference",
-                    year: 2024,
-                    category: "report",
-                    tags: ["tag1", "tag2"]
-                }),
-            },
-            env as any,
-        );
-
-        expect(res.status).toBe(200);
-        expect(set).toHaveBeenCalledWith(
-            expect.objectContaining({
-                doi: "10.1234/5678",
-                venue: "Test Venue",
-                venueType: "conference",
-                year: 2024,
-                category: "report",
-                tags: JSON.stringify(["tag1", "tag2"])
-            }),
-        );
-    });
-
-    it("PATCH /api/papers/:id validates invalid types and values", async () => {
-        const token = await createTestJWT({ sub: "user-1", githubId: "123", name: "Uploader" });
-        mockDb.select = vi.fn().mockImplementation(() => makeQuery({ getResult: { paperId: "paper-1", userId: "user-1", role: "uploader" } }));
-
-        const app = await createTestApp();
-        const env = createTestEnv();
-
-        let res = await app.request("http://localhost/api/papers/paper-1", { method: "PATCH", headers: { Authorization: `Bearer ${token}`, "Content-Type": "application/json" }, body: JSON.stringify({ venueType: "invalid_venue_type" }) }, env as any);
-        expect(res.status).toBe(400);
-
-        res = await app.request("http://localhost/api/papers/paper-1", { method: "PATCH", headers: { Authorization: `Bearer ${token}`, "Content-Type": "application/json" }, body: JSON.stringify({ category: "invalid_category" }) }, env as any);
-        expect(res.status).toBe(400);
-
-        res = await app.request("http://localhost/api/papers/paper-1", { method: "PATCH", headers: { Authorization: `Bearer ${token}`, "Content-Type": "application/json" }, body: JSON.stringify({ year: "2024" }) }, env as any);
-        expect(res.status).toBe(400);
-
-        res = await app.request("http://localhost/api/papers/paper-1", { method: "PATCH", headers: { Authorization: `Bearer ${token}`, "Content-Type": "application/json" }, body: JSON.stringify({ tags: "not_an_array" }) }, env as any);
-        expect(res.status).toBe(400);
-
-        res = await app.request("http://localhost/api/papers/paper-1", { method: "PATCH", headers: { Authorization: `Bearer ${token}`, "Content-Type": "application/json" }, body: JSON.stringify({ tags: [123] }) }, env as any);
-        expect(res.status).toBe(400);
-
-        res = await app.request("http://localhost/api/papers/paper-1", { method: "PATCH", headers: { Authorization: `Bearer ${token}`, "Content-Type": "application/json" }, body: JSON.stringify({ tags: ["a".repeat(256)] }) }, env as any);
-        expect(res.status).toBe(400);
-
-        res = await app.request("http://localhost/api/papers/paper-1", { method: "PATCH", headers: { Authorization: `Bearer ${token}`, "Content-Type": "application/json" }, body: JSON.stringify({ venue: 123 }) }, env as any);
-        expect(res.status).toBe(400);
-
-        res = await app.request("http://localhost/api/papers/paper-1", { method: "PATCH", headers: { Authorization: `Bearer ${token}`, "Content-Type": "application/json" }, body: JSON.stringify({ doi: 123 }) }, env as any);
-        expect(res.status).toBe(400);
-
-        res = await app.request("http://localhost/api/papers/paper-1", { method: "PATCH", headers: { Authorization: `Bearer ${token}`, "Content-Type": "application/json" }, body: JSON.stringify({ venue: "a".repeat(256) }) }, env as any);
-        expect(res.status).toBe(400);
-
-        res = await app.request("http://localhost/api/papers/paper-1", { method: "PATCH", headers: { Authorization: `Bearer ${token}`, "Content-Type": "application/json" }, body: JSON.stringify({ doi: "a".repeat(256) }) }, env as any);
-        expect(res.status).toBe(400);
-    });
-
-    it("PATCH /api/papers/:id handles null and empty fields", async () => {
-        const token = await createTestJWT({ sub: "user-1", githubId: "123", name: "Uploader" });
-        const set = vi.fn().mockReturnThis();
-        const where = vi.fn().mockReturnThis();
-        mockDb.select = vi.fn().mockImplementation(() => makeQuery({ getResult: { paperId: "paper-1", userId: "user-1", role: "uploader" } }));
-        mockDb.update = vi.fn().mockImplementation(() => ({ set, where } as any));
-
-        const app = await createTestApp();
-        const env = createTestEnv();
-        const res = await app.request(
-            "http://localhost/api/papers/paper-1",
-            {
-                method: "PATCH",
-                headers: {
-                    Authorization: `Bearer ${token}`,
-                    "Content-Type": "application/json",
-                },
-                body: JSON.stringify({
-                    doi: null,
-                    venue: null,
-                    venueType: null,
-                    year: null,
-                    category: null,
-                    tags: null
-                }),
-            },
-            env as any,
-        );
-
-        expect(res.status).toBe(200);
-        expect(set).toHaveBeenCalledWith(
-            expect.objectContaining({
-                doi: null,
-                venue: null,
-                venueType: null,
-                year: null,
-                category: null,
-                tags: null
-            }),
-        );
-    });
-
-
-    it("PATCH /api/papers/:id ignores empty tags", async () => {
-        const token = await createTestJWT({ sub: "user-1", githubId: "123", name: "Uploader" });
-        const set = vi.fn().mockReturnThis();
-        const where = vi.fn().mockReturnThis();
-        mockDb.select = vi.fn().mockImplementation(() => makeQuery({ getResult: { paperId: "paper-1", userId: "user-1", role: "uploader" } }));
-        mockDb.update = vi.fn().mockImplementation(() => ({ set, where } as any));
-
-        const app = await createTestApp();
-        const env = createTestEnv();
-        const res = await app.request(
-            "http://localhost/api/papers/paper-1",
-            {
-                method: "PATCH",
-                headers: {
-                    Authorization: `Bearer ${token}`,
-                    "Content-Type": "application/json",
-                },
-                body: JSON.stringify({
-                    tags: [" ", "tag2"]
-                }),
-            },
-            env as any,
-        );
-
-        expect(res.status).toBe(200);
-        expect(set).toHaveBeenCalledWith(
-            expect.objectContaining({
-                tags: JSON.stringify(["tag2"])
-            }),
-        );
-    });
-
-    it("PATCH /api/papers/:id updates correctly when tags array has only empty strings", async () => {
-        const token = await createTestJWT({ sub: "user-1", githubId: "123", name: "Uploader" });
-        const set = vi.fn().mockReturnThis();
-        const where = vi.fn().mockReturnThis();
-        mockDb.select = vi.fn().mockImplementation(() => makeQuery({ getResult: { paperId: "paper-1", userId: "user-1", role: "uploader" } }));
-        mockDb.update = vi.fn().mockImplementation(() => ({ set, where } as any));
-
-        const app = await createTestApp();
-        const env = createTestEnv();
-        const res = await app.request(
-            "http://localhost/api/papers/paper-1",
-            {
-                method: "PATCH",
-                headers: {
-                    Authorization: `Bearer ${token}`,
-                    "Content-Type": "application/json",
-                },
-                body: JSON.stringify({
-                    tags: [" "]
-                }),
-            },
-            env as any,
-        );
-
-        expect(res.status).toBe(200);
-        expect(set).toHaveBeenCalledWith(
-            expect.objectContaining({
-                tags: null
-            }),
-        );
-    });
-
-
-    it("PATCH /api/papers/:id update fails when there are no valid fields", async () => {
-        const token = await createTestJWT({ sub: "user-1", githubId: "123", name: "Uploader" });
-        mockDb.select = vi.fn().mockImplementation(() => makeQuery({ getResult: { paperId: "paper-1", userId: "user-1", role: "uploader" } }));
-
-        const app = await createTestApp();
-        const env = createTestEnv();
-        const res = await app.request(
-            "http://localhost/api/papers/paper-1",
-            {
-                method: "PATCH",
-                headers: {
-                    Authorization: `Bearer ${token}`,
-                    "Content-Type": "application/json",
-                },
-                body: JSON.stringify({
-                    invalidField: "test"
-                }),
-            },
-            env as any,
-        );
-
-        expect(res.status).toBe(400);
-    });
-
-    it("PATCH /api/papers/:id ignores empty array of tags and continues if no other fields", async () => {
-        const token = await createTestJWT({ sub: "user-1", githubId: "123", name: "Uploader" });
-        const set = vi.fn().mockReturnThis();
-        const where = vi.fn().mockReturnThis();
-        mockDb.select = vi.fn().mockImplementation(() => makeQuery({ getResult: { paperId: "paper-1", userId: "user-1", role: "uploader" } }));
-        mockDb.update = vi.fn().mockImplementation(() => ({ set, where } as any));
-
-        const app = await createTestApp();
-        const env = createTestEnv();
-        const res = await app.request(
-            "http://localhost/api/papers/paper-1",
-            {
-                method: "PATCH",
-                headers: {
-                    Authorization: `Bearer ${token}`,
-                    "Content-Type": "application/json",
-                },
-                body: JSON.stringify({
-                    tags: []
-                }),
-            },
-            env as any,
-        );
-
-        expect(res.status).toBe(200);
-        expect(set).toHaveBeenCalledWith(
-            expect.objectContaining({
-                tags: null
-            }),
-        );
-    });
-
-    it("PATCH /api/papers/:id updates correctly when values exactly match valid enums", async () => {
-        const token = await createTestJWT({ sub: "user-1", githubId: "123", name: "Uploader" });
-        const set = vi.fn().mockReturnThis();
-        const where = vi.fn().mockReturnThis();
-        mockDb.select = vi.fn().mockImplementation(() => makeQuery({ getResult: { paperId: "paper-1", userId: "user-1", role: "uploader" } }));
-        mockDb.update = vi.fn().mockImplementation(() => ({ set, where } as any));
-
-        const app = await createTestApp();
-        const env = createTestEnv();
-        const res = await app.request(
-            "http://localhost/api/papers/paper-1",
-            {
-                method: "PATCH",
-                headers: {
-                    Authorization: `Bearer ${token}`,
-                    "Content-Type": "application/json",
-                },
-                body: JSON.stringify({
-                    venueType: "journal",
-                    category: "thesis_bachelor"
-                }),
-            },
-            env as any,
-        );
-
-        expect(res.status).toBe(200);
-        expect(set).toHaveBeenCalledWith(
-            expect.objectContaining({
-                venueType: "journal",
-                category: "thesis_bachelor"
-            }),
-        );
-    });
-
-    it("PATCH /api/papers/:id updates correctly when tags array has only empty strings", async () => {
-        const token = await createTestJWT({ sub: "user-1", githubId: "123", name: "Uploader" });
-        const set = vi.fn().mockReturnThis();
-        const where = vi.fn().mockReturnThis();
-        mockDb.select = vi.fn().mockImplementation(() => makeQuery({ getResult: { paperId: "paper-1", userId: "user-1", role: "uploader" } }));
-        mockDb.update = vi.fn().mockImplementation(() => ({ set, where } as any));
-
-        const app = await createTestApp();
-        const env = createTestEnv();
-        const res = await app.request(
-            "http://localhost/api/papers/paper-1",
-            {
-                method: "PATCH",
-                headers: {
-                    Authorization: `Bearer ${token}`,
-                    "Content-Type": "application/json",
-                },
-                body: JSON.stringify({
-                    tags: [" "]
-                }),
-            },
-            env as any,
-        );
-
-        expect(res.status).toBe(200);
-        expect(set).toHaveBeenCalledWith(
-            expect.objectContaining({
-                tags: null
-            }),
-        );
-    });
-
-    it("PATCH /api/papers/:id ignores empty tags", async () => {
-        const token = await createTestJWT({ sub: "user-1", githubId: "123", name: "Uploader" });
-        const set = vi.fn().mockReturnThis();
-        const where = vi.fn().mockReturnThis();
-        mockDb.select = vi.fn().mockImplementation(() => makeQuery({ getResult: { paperId: "paper-1", userId: "user-1", role: "uploader" } }));
-        mockDb.update = vi.fn().mockImplementation(() => ({ set, where } as any));
-
-        const app = await createTestApp();
-        const env = createTestEnv();
-        const res = await app.request(
-            "http://localhost/api/papers/paper-1",
-            {
-                method: "PATCH",
-                headers: {
-                    Authorization: `Bearer ${token}`,
-                    "Content-Type": "application/json",
-                },
-                body: JSON.stringify({
-                    tags: [" ", "tag2"]
-                }),
-            },
-            env as any,
-        );
-
-        expect(res.status).toBe(200);
-        expect(set).toHaveBeenCalledWith(
-            expect.objectContaining({
-                tags: JSON.stringify(["tag2"])
-            }),
-        );
-    });
-
-    it("PATCH /api/papers/:id handles null and empty fields", async () => {
-        const token = await createTestJWT({ sub: "user-1", githubId: "123", name: "Uploader" });
-        const set = vi.fn().mockReturnThis();
-        const where = vi.fn().mockReturnThis();
-        mockDb.select = vi.fn().mockImplementation(() => makeQuery({ getResult: { paperId: "paper-1", userId: "user-1", role: "uploader" } }));
-        mockDb.update = vi.fn().mockImplementation(() => ({ set, where } as any));
-
-        const app = await createTestApp();
-        const env = createTestEnv();
-        const res = await app.request(
-            "http://localhost/api/papers/paper-1",
-            {
-                method: "PATCH",
-                headers: {
-                    Authorization: `Bearer ${token}`,
-                    "Content-Type": "application/json",
-                },
-                body: JSON.stringify({
-                    doi: null,
-                    venue: null,
-                    venueType: null,
-                    year: null,
-                    category: null,
-                    tags: null
-                }),
-            },
-            env as any,
-        );
-
-        expect(res.status).toBe(200);
-        expect(set).toHaveBeenCalledWith(
-            expect.objectContaining({
-                doi: null,
-                venue: null,
-                venueType: null,
-                year: null,
-                category: null,
-                tags: null
-            }),
-        );
-    });
-
-    it("PATCH /api/papers/:id validates invalid types and values", async () => {
-        const token = await createTestJWT({ sub: "user-1", githubId: "123", name: "Uploader" });
-        mockDb.select = vi.fn().mockImplementation(() => makeQuery({ getResult: { paperId: "paper-1", userId: "user-1", role: "uploader" } }));
-
-        const app = await createTestApp();
-        const env = createTestEnv();
-
-        let res = await app.request("http://localhost/api/papers/paper-1", { method: "PATCH", headers: { Authorization: `Bearer ${token}`, "Content-Type": "application/json" }, body: JSON.stringify({ venueType: "invalid_venue_type" }) }, env as any);
-        expect(res.status).toBe(400);
-
-        res = await app.request("http://localhost/api/papers/paper-1", { method: "PATCH", headers: { Authorization: `Bearer ${token}`, "Content-Type": "application/json" }, body: JSON.stringify({ category: "invalid_category" }) }, env as any);
-        expect(res.status).toBe(400);
-
-        res = await app.request("http://localhost/api/papers/paper-1", { method: "PATCH", headers: { Authorization: `Bearer ${token}`, "Content-Type": "application/json" }, body: JSON.stringify({ year: "2024" }) }, env as any);
-        expect(res.status).toBe(400);
-
-        res = await app.request("http://localhost/api/papers/paper-1", { method: "PATCH", headers: { Authorization: `Bearer ${token}`, "Content-Type": "application/json" }, body: JSON.stringify({ tags: "not_an_array" }) }, env as any);
-        expect(res.status).toBe(400);
-
-        res = await app.request("http://localhost/api/papers/paper-1", { method: "PATCH", headers: { Authorization: `Bearer ${token}`, "Content-Type": "application/json" }, body: JSON.stringify({ tags: [123] }) }, env as any);
-        expect(res.status).toBe(400);
-
-        res = await app.request("http://localhost/api/papers/paper-1", { method: "PATCH", headers: { Authorization: `Bearer ${token}`, "Content-Type": "application/json" }, body: JSON.stringify({ tags: ["a".repeat(256)] }) }, env as any);
-        expect(res.status).toBe(400);
-
-        res = await app.request("http://localhost/api/papers/paper-1", { method: "PATCH", headers: { Authorization: `Bearer ${token}`, "Content-Type": "application/json" }, body: JSON.stringify({ venue: 123 }) }, env as any);
-        expect(res.status).toBe(400);
-
-        res = await app.request("http://localhost/api/papers/paper-1", { method: "PATCH", headers: { Authorization: `Bearer ${token}`, "Content-Type": "application/json" }, body: JSON.stringify({ doi: 123 }) }, env as any);
-        expect(res.status).toBe(400);
-
-        res = await app.request("http://localhost/api/papers/paper-1", { method: "PATCH", headers: { Authorization: `Bearer ${token}`, "Content-Type": "application/json" }, body: JSON.stringify({ venue: "a".repeat(256) }) }, env as any);
-        expect(res.status).toBe(400);
-
-        res = await app.request("http://localhost/api/papers/paper-1", { method: "PATCH", headers: { Authorization: `Bearer ${token}`, "Content-Type": "application/json" }, body: JSON.stringify({ doi: "a".repeat(256) }) }, env as any);
-        expect(res.status).toBe(400);
-    });
-
-    it("PATCH /api/papers/:id updates doi, venue, venueType, year, category, and tags", async () => {
-        const token = await createTestJWT({ sub: "user-1", githubId: "123", name: "Uploader" });
-        const set = vi.fn().mockReturnThis();
-        const where = vi.fn().mockReturnThis();
-        mockDb.select = vi.fn().mockImplementation(() => makeQuery({ getResult: { paperId: "paper-1", userId: "user-1", role: "uploader" } }));
-        mockDb.update = vi.fn().mockImplementation(() => ({ set, where } as any));
-
-        const app = await createTestApp();
-        const env = createTestEnv();
-        const res = await app.request(
-            "http://localhost/api/papers/paper-1",
-            {
-                method: "PATCH",
-                headers: {
-                    Authorization: `Bearer ${token}`,
-                    "Content-Type": "application/json",
-                },
-                body: JSON.stringify({
-                    doi: "10.1234/5678",
-                    venue: "Test Venue",
-                    venueType: "conference",
-                    year: 2024,
-                    category: "report",
-                    tags: ["tag1", "tag2"]
-                }),
-            },
-            env as any,
-        );
-
-        expect(res.status).toBe(200);
-        expect(set).toHaveBeenCalledWith(
-            expect.objectContaining({
-                doi: "10.1234/5678",
-                venue: "Test Venue",
-                venueType: "conference",
-                year: 2024,
-                category: "report",
-                tags: JSON.stringify(["tag1", "tag2"])
-            }),
-        );
-    });
-
-    it("GET /api/papers/:id returns 401 for private paper without Bearer token", async () => {
-        mockDb.select = vi
-            .fn()
-            .mockImplementationOnce(() => makeQuery({ getResult: { id: "paper-1", title: "P1", visibility: "private" } }));
-
-        const app = await createTestApp();
-        const env = createTestEnv();
-        const res = await app.request("http://localhost/api/papers/paper-1", {}, env as any);
-
-        expect(res.status).toBe(401);
-    });
-
-    it("GET /api/papers/:id returns 403 for private paper when requester is not an author", async () => {
-        const token = await createTestJWT({ sub: "user-2", githubId: "456", name: "Other User" });
-        mockDb.select = vi
-            .fn()
-            .mockImplementationOnce(() => makeQuery({ getResult: { id: "paper-1", title: "P1", visibility: "private" } }))
-            .mockImplementationOnce(() => makeQuery({ getResult: null }));
-
-        const app = await createTestApp();
-        const env = createTestEnv();
-        const res = await app.request(
-            "http://localhost/api/papers/paper-1",
-            { headers: { Authorization: `Bearer ${token}` } },
-            env as any
-        );
-
-        expect(res.status).toBe(403);
-    });
-
-    it("GET /api/papers/:id returns 500 (not 401) on database error during author check", async () => {
-        const token = await createTestJWT({ sub: "user-1", githubId: "123", name: "Uploader" });
-        mockDb.select = vi
-            .fn()
-            .mockImplementationOnce(() => makeQuery({ getResult: { id: "paper-1", title: "P1", visibility: "private" } }))
-            .mockImplementationOnce(() => { throw new Error("DB Error") });
-
-        const app = await createTestApp();
-        const env = createTestEnv();
-        const res = await app.request(
-            "http://localhost/api/papers/paper-1",
-            { headers: { Authorization: `Bearer ${token}` } },
-            env as any
-        );
-
-        expect(res.status).toBe(500);
-    });
-
-    it("DELETE /api/papers/:id deletes a paper", async () => {
-        const token = await createTestJWT({ sub: "user-1", githubId: "123", name: "Uploader" });
-        mockDb.select = vi
-            .fn()
-            .mockImplementationOnce(() => makeQuery({ getResult: { paperId: "paper-1", userId: "user-1", role: "uploader" } }))
-            .mockImplementationOnce(() => makeQuery({ allResult: [{ r2Key: "papers/paper-1/paper/file.pdf" }] }));
-
-        const app = await createTestApp();
-        const env = createTestEnv();
-        const res = await app.request(
-            "http://localhost/api/papers/paper-1",
-            {
-                method: "DELETE",
-                headers: {
-                    Authorization: `Bearer ${token}`,
-                    Origin: "http://localhost:3000"
-                }
-            },
-            env as any
-        );
-
-        expect(res.status).toBe(200);
-    });
-
-    it("DELETE /api/papers/:id bounds concurrent R2 batch deletes", async () => {
-        const token = await createTestJWT({ sub: "user-1", githubId: "123", name: "Uploader" });
-        const files = Array.from({ length: 2001 }, (_, index) => ({
-            r2Key: `papers/paper-1/file-${index}.pdf`,
-        }));
-        mockDb.select = vi
-            .fn()
-            .mockImplementationOnce(() => makeQuery({ getResult: { paperId: "paper-1", userId: "user-1", role: "uploader" } }))
-            .mockImplementationOnce(() => makeQuery({ allResult: files }));
-
-        const app = await createTestApp();
-        const env = createTestEnv();
-        const pendingDeletes: Array<() => void> = [];
-        let activeDeletes = 0;
-        let maxActiveDeletes = 0;
-        const bucketDeleteSpy = vi.spyOn(env.BUCKET, "delete").mockImplementation(
-            async () =>
-                new Promise<void>((resolve) => {
-                    activeDeletes += 1;
-                    maxActiveDeletes = Math.max(maxActiveDeletes, activeDeletes);
-                    pendingDeletes.push(() => {
-                        activeDeletes -= 1;
-                        resolve();
-                    });
-                }),
-        );
-
-        const responsePromise = app.request(
-            "http://localhost/api/papers/paper-1",
-            {
-                method: "DELETE",
-                headers: {
-                    Authorization: `Bearer ${token}`,
-                    Origin: "http://localhost:3000",
-                },
-            },
-            env as any,
-        );
-
-        await vi.waitFor(() => {
-            expect(bucketDeleteSpy).toHaveBeenCalledTimes(2);
-        });
-        expect(maxActiveDeletes).toBe(2);
-
-        pendingDeletes.shift()?.();
-        await vi.waitFor(() => {
-            expect(bucketDeleteSpy).toHaveBeenCalledTimes(3);
-        });
-        expect(maxActiveDeletes).toBe(2);
-
-        pendingDeletes.shift()?.();
-        pendingDeletes.shift()?.();
-
-        const res = await responsePromise;
-        expect(res.status).toBe(200);
-        bucketDeleteSpy.mockRestore();
-    });
-
-    it("GET /api/papers/:id returns 404 when paper does not exist", async () => {
-        mockDb.select = vi.fn(() => makeQuery({ getResult: null }));
-
-        const app = await createTestApp();
-        const env = createTestEnv();
-        const res = await app.request("http://localhost/api/papers/not-found", {}, env as any);
-
-        expect(res.status).toBe(404);
-    });
-
-    describe("POST /api/papers/:id/invites database error handling", () => {
-        const UNIQUE_INVITE_ERROR = "UNIQUE constraint failed: coauthor_invites.paperId_inviteeId";
-
-        const setupInviteChecks = () => {
-            mockDb.select = vi
-                .fn()
-                .mockImplementationOnce(() => makeQuery({ getResult: { paperId: "paper-1", userId: "user-uploader", role: "uploader" } })) // isUploader check
-                .mockImplementationOnce(() => makeQuery({ getResult: null })) // alreadyAuthor check
-                .mockImplementationOnce(() => makeQuery({ getResult: { id: "user-invitee" } })); // invitee exists check
-        };
-
-        const sendInviteRequest = async (token: string, app: any, env: any) => {
-            return await app.request(
-                "http://localhost/api/papers/paper-1/invites",
-                {
-                    method: "POST",
-                    headers: {
-                        "Content-Type": "application/json",
-                        Authorization: `Bearer ${token}`
-                    },
-                    body: JSON.stringify({ inviteeId: "user-invitee" })
-                },
-                env as any
-            );
-        };
-
-        it("POST /api/papers/:id/invites returns 409 when invite already exists", async () => {
-            const token = await createTestJWT({ sub: "user-uploader", githubId: "123", name: "Uploader" });
-            setupInviteChecks();
-
-            mockDb.insert = vi.fn().mockReturnValue({
-                values: vi.fn().mockRejectedValue(new Error(UNIQUE_INVITE_ERROR))
-            });
-
-            const app = await createTestApp();
-            const env = createTestEnv();
-            const res = await sendInviteRequest(token, app, env);
-
-            expect(res.status).toBe(409);
-            const data = (await res.json()) as any;
-            expect(data.error).toBe("Invite already sent");
-        });
-
-        it("POST /api/papers/:id/invites returns 500 for non-UNIQUE database errors", async () => {
-            const token = await createTestJWT({ sub: "user-uploader", githubId: "123", name: "Uploader" });
-            setupInviteChecks();
-
-            mockDb.insert = vi.fn().mockReturnValue({
-                values: vi.fn().mockRejectedValue(new Error("Some other DB Error"))
-            });
-
-            const app = await createTestApp();
-            const env = createTestEnv();
-            const res = await sendInviteRequest(token, app, env);
-
-            expect(res.status).toBe(500);
-        });
-    });
+  });
 });
 
-    describe("Error handling and untested branches", () => {
-        let app: any;
-        let env: any;
-        let token: string;
+describe("Error handling and untested branches", () => {
+  let app: any;
+  let env: any;
+  let token: string;
 
-        beforeEach(async () => {
-            app = await createTestApp();
-            env = createTestEnv();
-            const { createTestJWT } = await import("../../test/helpers");
-            token = await createTestJWT({ sub: "user-test", githubId: "123", name: "Test" });
-        });
-
-        it("POST /api/papers/:id/invites handles malformed JSON body", async () => {
-            const res = await app.request("http://localhost/api/papers/paper-1/invites", {
-                method: "POST",
-                headers: { Authorization: `Bearer ${token}`, "Content-Type": "application/json" },
-                body: "{"
-            }, env as any);
-            expect(res.status).toBe(400);
-            expect(await res.json()).toEqual({ error: "Invalid JSON body" });
-        });
-
-        it("POST /api/papers/:id/invites handles missing invitee info", async () => {
-            const res = await app.request("http://localhost/api/papers/paper-1/invites", {
-                method: "POST",
-                headers: { Authorization: `Bearer ${token}`, "Content-Type": "application/json" },
-                body: "{}"
-            }, env as any);
-            expect(res.status).toBe(400);
-            expect(await res.json()).toEqual({ error: "inviteeId or inviteeEmail is required" });
-        });
-
-        it("DELETE /api/papers/:id handles R2 batch deletion chunking failures", async () => {
-            const { makeQuery } = await import("../../test/helpers");
-            mockDb.select = vi.fn()
-                .mockImplementationOnce(() => makeQuery({ getResult: { paperId: "paper-1", userId: "user-1", role: "uploader" } })) // isAuthor
-                .mockImplementationOnce(() => makeQuery({ allResult: [{ id: "file-1", r2Key: "fake-key" }] })); // get files
-
-            const fakeBucket = {
-                delete: vi.fn().mockRejectedValue(new Error("AWS batch error")),
-            };
-            env.BUCKET = fakeBucket;
-
-            const { createTestJWT } = await import("../../test/helpers");
-            const testToken = await createTestJWT({ sub: "user-1", githubId: "123", name: "Uploader" });
-            const res = await app.request("http://localhost/api/papers/paper-1", {
-                method: "DELETE",
-                headers: { Authorization: `Bearer ${testToken}` }
-            }, env as any);
-            expect(res.status).toBe(500); // Throws an error up instead of being captured transparently
-            await vi.waitFor(() => {
-                expect(fakeBucket.delete).toHaveBeenCalled();
-            });
-        });
-
-        it("GET /api/papers/:id/stats handles invalid date ranges and 0 defaults", async () => {
-            const { makeQuery } = await import("../../test/helpers");
-            mockDb.select = vi.fn()
-                .mockImplementationOnce(() => makeQuery({ getResult: { id: "paper-1", visibility: "public" } })) // paper fetch
-                .mockImplementationOnce(() => makeQuery({ getResult: { userId: "user-test" } })) // isAuthor
-                .mockImplementationOnce(() => makeQuery({ getResult: null })) // totalRow
-                .mockImplementationOnce(() => makeQuery({ allResult: [] })); // dailyRows
-
-            const res = await app.request("http://localhost/api/papers/paper-1/stats?days=7", {
-                method: "GET",
-                headers: { Authorization: `Bearer ${token}` }
-            }, env as any);
-
-            expect(res.status).toBe(200);
-            const json = await res.json() as any;
-            expect(json.total.views).toBe(0);
-        });
-
-        it("GET /api/papers/:id/files/:fileId/stream returns 404 if file is not in R2", async () => {
-            const { makeQuery } = await import("../../test/helpers");
-            mockDb.select = vi.fn()
-                .mockImplementationOnce(() => makeQuery({ getResult: { id: "paper-1", visibility: "public" } })) // paper fetch
-                .mockImplementationOnce(() => makeQuery({ getResult: { id: "file-1", r2Key: "fake-key" } })); // get file
-
-            env.BUCKET = {
-                get: vi.fn().mockResolvedValue(null),
-            };
-
-            const res = await app.request("http://localhost/api/papers/paper-1/files/file-1/stream", {
-                method: "GET",
-                headers: { Authorization: `Bearer ${token}` }
-            }, env as any);
-
-            expect(res.status).toBe(404);
-            expect(await res.json()).toEqual({ error: "File not found in storage" });
-        });
-
-        it("POST /api/papers handles malformed files_ metadata correctly", async () => {
-            const formData = new FormData();
-            formData.append("metadata", JSON.stringify({
-                title: "Test Paper",
-                abstract: "Abstract",
-                visibility: "public",
-                showViewCount: true,
-                language: "en",
-                externalUrl: "https://example.com",
-                doi: null,
-                venue: null,
-                venueType: null,
-                year: null,
-                category: null,
-                tags: []
-            }));
-            formData.append("files_0", "not a file"); // string
-
-            const res = await app.request("http://localhost/api/papers", {
-                method: "POST",
-                headers: { Authorization: `Bearer ${token}` },
-                body: formData
-            }, env as any);
-            expect(res.status).toBe(400);
-            expect(await res.json()).toEqual({ error: "Field files_0 is not a valid file" });
-        });
-
-        it("POST /api/papers handles file sizes exceeding the maximum limit", async () => {
-            const formData = new FormData();
-            formData.append("metadata", JSON.stringify({
-                title: "Test Paper",
-                abstract: "Abstract",
-                visibility: "public",
-                showViewCount: true,
-                language: "en",
-                externalUrl: "https://example.com",
-                doi: null,
-                venue: null,
-                venueType: null,
-                year: null,
-                category: null,
-                tags: []
-            }));
-            const file = new File([new ArrayBuffer(50 * 1024 * 1024 + 1)], "bigfile.pdf", { type: "application/pdf" });
-            formData.append("files_0", file);
-
-            const res = await app.request("http://localhost/api/papers", {
-                method: "POST",
-                headers: { Authorization: `Bearer ${token}` },
-                body: formData
-            }, env as any);
-            expect(res.status).toBe(400);
-            expect(await res.json()).toEqual({ error: "File bigfile.pdf exceeds 50 MB limit" });
-        });
-
-        it("POST /api/papers handles missing/invalid metadata JSON correctly", async () => {
-            const formData = new FormData();
-            formData.append("metadata", "{"); // invalid JSON
-
-            const res = await app.request("http://localhost/api/papers", {
-                method: "POST",
-                headers: { Authorization: `Bearer ${token}` },
-                body: formData
-            }, env as any);
-            expect(res.status).toBe(400);
-            expect(await res.json()).toEqual({ error: "Invalid metadata JSON" });
-        });
-
-        it("generateSignedPreviewUrl catches and returns null", async () => {
-            const fakeBucket = {
-                createSignedUrl: vi.fn().mockRejectedValue(new Error("AWS error")),
-            };
-            env.BUCKET = fakeBucket;
-
-            const { makeQuery } = await import("../../test/helpers");
-            mockDb.select = vi.fn()
-                .mockImplementationOnce(() => makeQuery({ getResult: { id: "paper-1", visibility: "public", showViewCount: false } }))
-                .mockImplementationOnce(() => makeQuery({ getResult: { id: "file-1", r2Key: "fake-key", mimeType: "application/pdf", filename: "test.pdf" } }));
-
-            const res = await app.request("http://localhost/api/papers/paper-1/files/file-1/preview", {}, env as any);
-            expect(res.status).toBe(200);
-            const json = await res.json() as any;
-            expect(json.url).toBe("/api/papers/paper-1/files/file-1/stream"); // Falls back to stream
-        });
-
-        it("generateSignedPreviewUrl handles presign falling back to stream when no sign function exists", async () => {
-            const fakeBucket = {
-                // no methods
-            };
-            env.BUCKET = fakeBucket;
-
-            const { makeQuery } = await import("../../test/helpers");
-            mockDb.select = vi.fn()
-                .mockImplementationOnce(() => makeQuery({ getResult: { id: "paper-1", visibility: "public", showViewCount: false } }))
-                .mockImplementationOnce(() => makeQuery({ getResult: { id: "file-1", r2Key: "fake-key", mimeType: "application/pdf", filename: "test.pdf" } }));
-
-            const res = await app.request("http://localhost/api/papers/paper-1/files/file-1/preview", {}, env as any);
-            expect(res.status).toBe(200);
-            const json = await res.json() as any;
-            expect(json.url).toBe("/api/papers/paper-1/files/file-1/stream"); // Falls back to stream
-        });
-
-        it("generateSignedPreviewUrl presign succeeds", async () => {
-            const fakeBucket = {
-                presign: vi.fn().mockResolvedValue("https://fake-presigned-url"),
-            };
-            env.BUCKET = fakeBucket;
-
-            const { makeQuery } = await import("../../test/helpers");
-            mockDb.select = vi.fn()
-                .mockImplementationOnce(() => makeQuery({ getResult: { id: "paper-1", visibility: "public", showViewCount: false } }))
-                .mockImplementationOnce(() => makeQuery({ getResult: { id: "file-1", r2Key: "fake-key", mimeType: "application/pdf", filename: "test.pdf" } }));
-
-            const res = await app.request("http://localhost/api/papers/paper-1/files/file-1/preview", {}, env as any);
-            expect(res.status).toBe(200);
-            const json = await res.json() as any;
-            expect(json.url).toBe("https://fake-presigned-url");
-        });
-
-        it("PUT /api/papers/:id/description handles malformed JSON body", async () => {
-            const res = await app.request("http://localhost/api/papers/paper-1/description", {
-                method: "PUT",
-                headers: { Authorization: `Bearer ${token}`, "Content-Type": "application/json" },
-                body: "{"
-            }, env as any);
-            expect(res.status).toBe(400);
-            expect(await res.json()).toEqual({ error: "Invalid JSON body" });
-        });
-
-        it("PUT /api/papers/:id/description handles non-object JSON body", async () => {
-            const res = await app.request("http://localhost/api/papers/paper-1/description", {
-                method: "PUT",
-                headers: { Authorization: `Bearer ${token}`, "Content-Type": "application/json" },
-                body: "[]"
-            }, env as any);
-            expect(res.status).toBe(400);
-            expect(await res.json()).toEqual({ error: "Invalid JSON body" });
-        });
-
-        it("PATCH /api/papers/:id handles malformed JSON body", async () => {
-            const res = await app.request("http://localhost/api/papers/paper-1", {
-                method: "PATCH",
-                headers: { Authorization: `Bearer ${token}`, "Content-Type": "application/json" },
-                body: "{"
-            }, env as any);
-            expect(res.status).toBe(400);
-            expect(await res.json()).toEqual({ error: "Invalid JSON body" });
-        });
-
-        it("PATCH /api/papers/:id handles non-object JSON body", async () => {
-            const res = await app.request("http://localhost/api/papers/paper-1", {
-                method: "PATCH",
-                headers: { Authorization: `Bearer ${token}`, "Content-Type": "application/json" },
-                body: "[]"
-            }, env as any);
-            expect(res.status).toBe(400);
-            expect(await res.json()).toEqual({ error: "Invalid JSON body" });
-        });
-
-        it("POST /api/papers/:id/track handles missing json payload", async () => {
-            const res = await app.request("http://localhost/api/papers/paper-1/track", {
-                method: "POST",
-                headers: { "Content-Type": "application/json", "Origin": "http://localhost:3000" },
-                body: "{"
-            }, env as any);
-            expect(res.status).toBe(400);
-            expect(await res.json()).toEqual({ error: "Invalid JSON body" });
-        });
-
-        it("POST /api/papers/:id/track handles non-object JSON body", async () => {
-            const res = await app.request("http://localhost/api/papers/paper-1/track", {
-                method: "POST",
-                headers: { "Content-Type": "application/json", "Origin": "http://localhost:3000" },
-                body: "[]"
-            }, env as any);
-            expect(res.status).toBe(400);
-            expect(await res.json()).toEqual({ error: "Invalid JSON body" });
-        });
-
-        it("POST /api/papers/:id/track captures parsing errors in promise", async () => {
-            const { makeQuery } = await import("../../test/helpers");
-            mockDb.select = vi.fn()
-                .mockImplementationOnce(() => makeQuery({ getResult: { id: "paper-1", visibility: "public" } }));
-            mockDb.prepare = vi.fn().mockImplementation(() => ({
-                bind: vi.fn().mockReturnThis(),
-                all: vi.fn().mockRejectedValue(new Error("Track DB failure"))
-            }));
-
-            const consoleErrorSpy = vi.spyOn(console, "error").mockImplementation(() => {});
-
-            const res = await app.request("http://localhost/api/papers/paper-1/track", {
-                method: "POST",
-                headers: { "Content-Type": "application/json", "Origin": "http://localhost:3000" },
-                body: JSON.stringify({ event: "view" })
-            }, env as any);
-
-            expect(res.status).toBe(204);
-
-            await vi.waitFor(() => {
-                expect(consoleErrorSpy).toHaveBeenCalled();
-            });
-
-            consoleErrorSpy.mockRestore();
-        });
+  beforeEach(async () => {
+    app = await createTestApp();
+    env = createTestEnv();
+    const { createTestJWT } = await import("../../test/helpers");
+    token = await createTestJWT({
+      sub: "user-test",
+      githubId: "123",
+      name: "Test",
     });
+  });
+
+  it("POST /api/papers/:id/invites handles malformed JSON body", async () => {
+    const res = await app.request(
+      "http://localhost/api/papers/paper-1/invites",
+      {
+        method: "POST",
+        headers: {
+          Authorization: `Bearer ${token}`,
+          "Content-Type": "application/json",
+        },
+        body: "{",
+      },
+      env as any,
+    );
+    expect(res.status).toBe(400);
+    expect(await res.json()).toEqual({ error: "Invalid JSON body" });
+  });
+
+  it("POST /api/papers/:id/invites handles missing invitee info", async () => {
+    const res = await app.request(
+      "http://localhost/api/papers/paper-1/invites",
+      {
+        method: "POST",
+        headers: {
+          Authorization: `Bearer ${token}`,
+          "Content-Type": "application/json",
+        },
+        body: "{}",
+      },
+      env as any,
+    );
+    expect(res.status).toBe(400);
+    expect(await res.json()).toEqual({
+      error: "inviteeId or inviteeEmail is required",
+    });
+  });
+
+  it("DELETE /api/papers/:id handles R2 batch deletion chunking failures", async () => {
+    const { makeQuery } = await import("../../test/helpers");
+    mockDb.select = vi
+      .fn()
+      .mockImplementationOnce(() =>
+        makeQuery({
+          getResult: { paperId: "paper-1", userId: "user-1", role: "uploader" },
+        }),
+      ) // isAuthor
+      .mockImplementationOnce(() =>
+        makeQuery({ allResult: [{ id: "file-1", r2Key: "fake-key" }] }),
+      ); // get files
+
+    const fakeBucket = {
+      delete: vi.fn().mockRejectedValue(new Error("AWS batch error")),
+    };
+    env.BUCKET = fakeBucket;
+
+    const { createTestJWT } = await import("../../test/helpers");
+    const testToken = await createTestJWT({
+      sub: "user-1",
+      githubId: "123",
+      name: "Uploader",
+    });
+    const res = await app.request(
+      "http://localhost/api/papers/paper-1",
+      {
+        method: "DELETE",
+        headers: { Authorization: `Bearer ${testToken}` },
+      },
+      env as any,
+    );
+    expect(res.status).toBe(500); // Throws an error up instead of being captured transparently
+    await vi.waitFor(() => {
+      expect(fakeBucket.delete).toHaveBeenCalled();
+    });
+  });
+
+  it("GET /api/papers/:id/stats handles invalid date ranges and 0 defaults", async () => {
+    const { makeQuery } = await import("../../test/helpers");
+    mockDb.select = vi
+      .fn()
+      .mockImplementationOnce(() =>
+        makeQuery({ getResult: { id: "paper-1", visibility: "public" } }),
+      ) // paper fetch
+      .mockImplementationOnce(() =>
+        makeQuery({ getResult: { userId: "user-test" } }),
+      ) // isAuthor
+      .mockImplementationOnce(() => makeQuery({ getResult: null })) // totalRow
+      .mockImplementationOnce(() => makeQuery({ allResult: [] })); // dailyRows
+
+    const res = await app.request(
+      "http://localhost/api/papers/paper-1/stats?days=7",
+      {
+        method: "GET",
+        headers: { Authorization: `Bearer ${token}` },
+      },
+      env as any,
+    );
+
+    expect(res.status).toBe(200);
+    const json = (await res.json()) as any;
+    expect(json.total.views).toBe(0);
+  });
+
+  it("GET /api/papers/:id/files/:fileId/stream returns 404 if file is not in R2", async () => {
+    const { makeQuery } = await import("../../test/helpers");
+    mockDb.select = vi
+      .fn()
+      .mockImplementationOnce(() =>
+        makeQuery({ getResult: { id: "paper-1", visibility: "public" } }),
+      ) // paper fetch
+      .mockImplementationOnce(() =>
+        makeQuery({ getResult: { id: "file-1", r2Key: "fake-key" } }),
+      ); // get file
+
+    env.BUCKET = {
+      get: vi.fn().mockResolvedValue(null),
+    };
+
+    const res = await app.request(
+      "http://localhost/api/papers/paper-1/files/file-1/stream",
+      {
+        method: "GET",
+        headers: { Authorization: `Bearer ${token}` },
+      },
+      env as any,
+    );
+
+    expect(res.status).toBe(404);
+    expect(await res.json()).toEqual({ error: "File not found in storage" });
+  });
+
+  it("POST /api/papers handles malformed files_ metadata correctly", async () => {
+    const formData = new FormData();
+    formData.append(
+      "metadata",
+      JSON.stringify({
+        title: "Test Paper",
+        abstract: "Abstract",
+        visibility: "public",
+        showViewCount: true,
+        language: "en",
+        externalUrl: "https://example.com",
+        doi: null,
+        venue: null,
+        venueType: null,
+        year: null,
+        category: null,
+        tags: [],
+      }),
+    );
+    formData.append("files_0", "not a file"); // string
+
+    const res = await app.request(
+      "http://localhost/api/papers",
+      {
+        method: "POST",
+        headers: { Authorization: `Bearer ${token}` },
+        body: formData,
+      },
+      env as any,
+    );
+    expect(res.status).toBe(400);
+    expect(await res.json()).toEqual({
+      error: "Field files_0 is not a valid file",
+    });
+  });
+
+  it("POST /api/papers handles file sizes exceeding the maximum limit", async () => {
+    const formData = new FormData();
+    formData.append(
+      "metadata",
+      JSON.stringify({
+        title: "Test Paper",
+        abstract: "Abstract",
+        visibility: "public",
+        showViewCount: true,
+        language: "en",
+        externalUrl: "https://example.com",
+        doi: null,
+        venue: null,
+        venueType: null,
+        year: null,
+        category: null,
+        tags: [],
+      }),
+    );
+    const file = new File(
+      [new ArrayBuffer(50 * 1024 * 1024 + 1)],
+      "bigfile.pdf",
+      { type: "application/pdf" },
+    );
+    formData.append("files_0", file);
+
+    const res = await app.request(
+      "http://localhost/api/papers",
+      {
+        method: "POST",
+        headers: { Authorization: `Bearer ${token}` },
+        body: formData,
+      },
+      env as any,
+    );
+    expect(res.status).toBe(400);
+    expect(await res.json()).toEqual({
+      error: "File bigfile.pdf exceeds 50 MB limit",
+    });
+  });
+
+  it("POST /api/papers handles missing/invalid metadata JSON correctly", async () => {
+    const formData = new FormData();
+    formData.append("metadata", "{"); // invalid JSON
+
+    const res = await app.request(
+      "http://localhost/api/papers",
+      {
+        method: "POST",
+        headers: { Authorization: `Bearer ${token}` },
+        body: formData,
+      },
+      env as any,
+    );
+    expect(res.status).toBe(400);
+    expect(await res.json()).toEqual({ error: "Invalid metadata JSON" });
+  });
+
+  it("generateSignedPreviewUrl catches and returns null", async () => {
+    const fakeBucket = {
+      createSignedUrl: vi.fn().mockRejectedValue(new Error("AWS error")),
+    };
+    env.BUCKET = fakeBucket;
+
+    const { makeQuery } = await import("../../test/helpers");
+    mockDb.select = vi
+      .fn()
+      .mockImplementationOnce(() =>
+        makeQuery({
+          getResult: {
+            id: "paper-1",
+            visibility: "public",
+            showViewCount: false,
+          },
+        }),
+      )
+      .mockImplementationOnce(() =>
+        makeQuery({
+          getResult: {
+            id: "file-1",
+            r2Key: "fake-key",
+            mimeType: "application/pdf",
+            filename: "test.pdf",
+          },
+        }),
+      );
+
+    const res = await app.request(
+      "http://localhost/api/papers/paper-1/files/file-1/preview",
+      {},
+      env as any,
+    );
+    expect(res.status).toBe(200);
+    const json = (await res.json()) as any;
+    expect(json.url).toBe("/api/papers/paper-1/files/file-1/stream"); // Falls back to stream
+  });
+
+  it("generateSignedPreviewUrl handles presign falling back to stream when no sign function exists", async () => {
+    const fakeBucket = {
+      // no methods
+    };
+    env.BUCKET = fakeBucket;
+
+    const { makeQuery } = await import("../../test/helpers");
+    mockDb.select = vi
+      .fn()
+      .mockImplementationOnce(() =>
+        makeQuery({
+          getResult: {
+            id: "paper-1",
+            visibility: "public",
+            showViewCount: false,
+          },
+        }),
+      )
+      .mockImplementationOnce(() =>
+        makeQuery({
+          getResult: {
+            id: "file-1",
+            r2Key: "fake-key",
+            mimeType: "application/pdf",
+            filename: "test.pdf",
+          },
+        }),
+      );
+
+    const res = await app.request(
+      "http://localhost/api/papers/paper-1/files/file-1/preview",
+      {},
+      env as any,
+    );
+    expect(res.status).toBe(200);
+    const json = (await res.json()) as any;
+    expect(json.url).toBe("/api/papers/paper-1/files/file-1/stream"); // Falls back to stream
+  });
+
+  it("generateSignedPreviewUrl presign succeeds", async () => {
+    const fakeBucket = {
+      presign: vi.fn().mockResolvedValue("https://fake-presigned-url"),
+    };
+    env.BUCKET = fakeBucket;
+
+    const { makeQuery } = await import("../../test/helpers");
+    mockDb.select = vi
+      .fn()
+      .mockImplementationOnce(() =>
+        makeQuery({
+          getResult: {
+            id: "paper-1",
+            visibility: "public",
+            showViewCount: false,
+          },
+        }),
+      )
+      .mockImplementationOnce(() =>
+        makeQuery({
+          getResult: {
+            id: "file-1",
+            r2Key: "fake-key",
+            mimeType: "application/pdf",
+            filename: "test.pdf",
+          },
+        }),
+      );
+
+    const res = await app.request(
+      "http://localhost/api/papers/paper-1/files/file-1/preview",
+      {},
+      env as any,
+    );
+    expect(res.status).toBe(200);
+    const json = (await res.json()) as any;
+    expect(json.url).toBe("https://fake-presigned-url");
+  });
+
+  it("PUT /api/papers/:id/description handles malformed JSON body", async () => {
+    const res = await app.request(
+      "http://localhost/api/papers/paper-1/description",
+      {
+        method: "PUT",
+        headers: {
+          Authorization: `Bearer ${token}`,
+          "Content-Type": "application/json",
+        },
+        body: "{",
+      },
+      env as any,
+    );
+    expect(res.status).toBe(400);
+    expect(await res.json()).toEqual({ error: "Invalid JSON body" });
+  });
+
+  it("PUT /api/papers/:id/description handles non-object JSON body", async () => {
+    const res = await app.request(
+      "http://localhost/api/papers/paper-1/description",
+      {
+        method: "PUT",
+        headers: {
+          Authorization: `Bearer ${token}`,
+          "Content-Type": "application/json",
+        },
+        body: "[]",
+      },
+      env as any,
+    );
+    expect(res.status).toBe(400);
+    expect(await res.json()).toEqual({ error: "Invalid JSON body" });
+  });
+
+  it("PATCH /api/papers/:id handles malformed JSON body", async () => {
+    const res = await app.request(
+      "http://localhost/api/papers/paper-1",
+      {
+        method: "PATCH",
+        headers: {
+          Authorization: `Bearer ${token}`,
+          "Content-Type": "application/json",
+        },
+        body: "{",
+      },
+      env as any,
+    );
+    expect(res.status).toBe(400);
+    expect(await res.json()).toEqual({ error: "Invalid JSON body" });
+  });
+
+  it("PATCH /api/papers/:id handles non-object JSON body", async () => {
+    const res = await app.request(
+      "http://localhost/api/papers/paper-1",
+      {
+        method: "PATCH",
+        headers: {
+          Authorization: `Bearer ${token}`,
+          "Content-Type": "application/json",
+        },
+        body: "[]",
+      },
+      env as any,
+    );
+    expect(res.status).toBe(400);
+    expect(await res.json()).toEqual({ error: "Invalid JSON body" });
+  });
+
+  it("POST /api/papers/:id/track handles missing json payload", async () => {
+    const res = await app.request(
+      "http://localhost/api/papers/paper-1/track",
+      {
+        method: "POST",
+        headers: {
+          "Content-Type": "application/json",
+          Origin: "http://localhost:3000",
+        },
+        body: "{",
+      },
+      env as any,
+    );
+    expect(res.status).toBe(400);
+    expect(await res.json()).toEqual({ error: "Invalid JSON body" });
+  });
+
+  it("POST /api/papers/:id/track handles non-object JSON body", async () => {
+    const res = await app.request(
+      "http://localhost/api/papers/paper-1/track",
+      {
+        method: "POST",
+        headers: {
+          "Content-Type": "application/json",
+          Origin: "http://localhost:3000",
+        },
+        body: "[]",
+      },
+      env as any,
+    );
+    expect(res.status).toBe(400);
+    expect(await res.json()).toEqual({ error: "Invalid JSON body" });
+  });
+
+  it("POST /api/papers/:id/track captures parsing errors in promise", async () => {
+    const { makeQuery } = await import("../../test/helpers");
+    mockDb.select = vi
+      .fn()
+      .mockImplementationOnce(() =>
+        makeQuery({ getResult: { id: "paper-1", visibility: "public" } }),
+      );
+    mockDb.prepare = vi.fn().mockImplementation(() => ({
+      bind: vi.fn().mockReturnThis(),
+      all: vi.fn().mockRejectedValue(new Error("Track DB failure")),
+    }));
+
+    const consoleErrorSpy = vi
+      .spyOn(console, "error")
+      .mockImplementation(() => {});
+
+    const res = await app.request(
+      "http://localhost/api/papers/paper-1/track",
+      {
+        method: "POST",
+        headers: {
+          "Content-Type": "application/json",
+          Origin: "http://localhost:3000",
+        },
+        body: JSON.stringify({ event: "view" }),
+      },
+      env as any,
+    );
+
+    expect(res.status).toBe(204);
+
+    await vi.waitFor(() => {
+      expect(consoleErrorSpy).toHaveBeenCalled();
+    });
+
+    consoleErrorSpy.mockRestore();
+  });
+});

--- a/apps/api/src/routes/__tests__/staging-config.test.ts
+++ b/apps/api/src/routes/__tests__/staging-config.test.ts
@@ -1,25 +1,29 @@
 import { readFileSync } from "node:fs";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import {
-    createMockD1Binding,
-    createTestApp,
-    createTestEnv,
-    makeQuery,
+  createMockD1Binding,
+  createTestApp,
+  createTestEnv,
+  makeQuery,
 } from "../../test/helpers";
 
 const WRANGLER_TOML = readFileSync(
-    new URL("../../../wrangler.toml", import.meta.url),
-    "utf8",
+  new URL("../../../wrangler.toml", import.meta.url),
+  "utf8",
 );
 const STAGING_VARS_SECTION =
-    WRANGLER_TOML.match(/\[env\.staging\.vars\]([\s\S]*?)(?:\n\[|$)/)?.[1] ?? "";
+  WRANGLER_TOML.match(/\[env\.staging\.vars\]([\s\S]*?)(?:\n\[|$)/)?.[1] ?? "";
 
 function readStagingVar(name: "FRONTEND_URL" | "ALLOWED_ORIGINS") {
-    const match = STAGING_VARS_SECTION.match(new RegExp(`^${name}\\s*=\\s*"([^"]+)"$`, "m"));
-    if (!match) {
-        throw new Error(`Missing ${name} in apps/api/wrangler.toml [env.staging.vars]`);
-    }
-    return match[1];
+  const match = STAGING_VARS_SECTION.match(
+    new RegExp(`^${name}\\s*=\\s*"([^"]+)"$`, "m"),
+  );
+  if (!match) {
+    throw new Error(
+      `Missing ${name} in apps/api/wrangler.toml [env.staging.vars]`,
+    );
+  }
+  return match[1];
 }
 
 const STAGING_URL = readStagingVar("FRONTEND_URL");
@@ -29,71 +33,71 @@ const HTTP_STAGING_URL = STAGING_URL.replace(/^https:/, "http:");
 let mockDb: any;
 
 vi.mock("drizzle-orm/d1", () => ({
-    drizzle: vi.fn(() => mockDb),
+  drizzle: vi.fn(() => mockDb),
 }));
 
 vi.mock("../../db/schema", () => ({
-    users: { id: "id", githubId: "github_id" },
-    orgs: { id: "id" },
-    orgMembers: { orgId: "org_id" },
-    papers: {
-        id: "id",
-        title: "title",
-        abstract: "abstract",
-        category: "category",
-        tags: "tags",
-        createdAt: "created_at",
-        updatedAt: "updated_at",
-        visibility: "visibility",
-    },
-    paperAuthors: {
-        paperId: "paper_id",
-        role: "role",
-        name: "name",
-        displayName: "display_name",
-        userId: "user_id",
-    },
-    paperFiles: {
-        paperId: "paper_id",
-        id: "id",
-        filename: "filename",
-        sizeBytes: "size_bytes",
-        mimeType: "mime_type",
-        fileType: "file_type",
-        createdAt: "created_at",
-    },
-    paperOrgs: { paperId: "paper_id", orgId: "org_id" },
-    collections: {
-        id: "id",
-        ownerType: "owner_type",
-        ownerId: "owner_id",
-        orgSlug: "org_slug",
-        slug: "slug",
-        name: "name",
-        visibility: "visibility",
-        updatedAt: "updated_at",
-    },
-    collectionPapers: {
-        collectionId: "collection_id",
-        paperId: "paper_id",
-        sortOrder: "sort_order",
-    },
-    enableForeignKeys: vi.fn(() => Promise.resolve()),
-    touchUpdatedAt: vi.fn(() => ({})),
+  users: { id: "id", githubId: "github_id" },
+  orgs: { id: "id" },
+  orgMembers: { orgId: "org_id" },
+  papers: {
+    id: "id",
+    title: "title",
+    abstract: "abstract",
+    category: "category",
+    tags: "tags",
+    createdAt: "created_at",
+    updatedAt: "updated_at",
+    visibility: "visibility",
+  },
+  paperAuthors: {
+    paperId: "paper_id",
+    role: "role",
+    name: "name",
+    displayName: "display_name",
+    userId: "user_id",
+  },
+  paperFiles: {
+    paperId: "paper_id",
+    id: "id",
+    filename: "filename",
+    sizeBytes: "size_bytes",
+    mimeType: "mime_type",
+    fileType: "file_type",
+    createdAt: "created_at",
+  },
+  paperOrgs: { paperId: "paper_id", orgId: "org_id" },
+  collections: {
+    id: "id",
+    ownerType: "owner_type",
+    ownerId: "owner_id",
+    orgSlug: "org_slug",
+    slug: "slug",
+    name: "name",
+    visibility: "visibility",
+    updatedAt: "updated_at",
+  },
+  collectionPapers: {
+    collectionId: "collection_id",
+    paperId: "paper_id",
+    sortOrder: "sort_order",
+  },
+  enableForeignKeys: vi.fn(() => Promise.resolve()),
+  touchUpdatedAt: vi.fn(() => ({})),
 }));
 
 beforeEach(() => {
-    vi.restoreAllMocks();
-    vi.resetModules();
-    mockDb = {
-        run: vi.fn(async () => undefined),
-        select: vi.fn(() => makeQuery()),
-        insert: vi.fn(() => ({
-            values: vi.fn(() => ({
-                onConflictDoUpdate: vi.fn(async () => undefined),
-            })),
-        })),
-    };
+  vi.restoreAllMocks();
+  vi.resetModules();
+  mockDb = {
+    run: vi.fn(async () => undefined),
+    select: vi.fn(() => makeQuery()),
+    insert: vi.fn(() => ({
+      values: vi.fn(() => ({
+        onConflictDoUpdate: vi.fn(async () => undefined),
+      })),
+    })),
+  };
 });
 
 // ---------------------------------------------------------------------------
@@ -101,92 +105,92 @@ beforeEach(() => {
 // ---------------------------------------------------------------------------
 
 describe("CORS – staging Vercel URL in ALLOWED_ORIGINS", () => {
-    it("accepts the staging Vercel URL as a valid CORS origin", async () => {
-        const app = await createTestApp();
-        const env = createTestEnv({
-            DB: createMockD1Binding(),
-            FRONTEND_URL: STAGING_URL,
-            ALLOWED_ORIGINS: STAGING_ALLOWED_ORIGINS,
-        });
-
-        const res = await app.request(
-            "http://localhost/api/auth/github",
-            { headers: { Origin: STAGING_URL } },
-            env as any,
-        );
-
-        expect(res.headers.get("access-control-allow-origin")).toBe(STAGING_URL);
+  it("accepts the staging Vercel URL as a valid CORS origin", async () => {
+    const app = await createTestApp();
+    const env = createTestEnv({
+      DB: createMockD1Binding(),
+      FRONTEND_URL: STAGING_URL,
+      ALLOWED_ORIGINS: STAGING_ALLOWED_ORIGINS,
     });
 
-    it("blocks localhost:3000 when ALLOWED_ORIGINS contains only the staging URL (regression: old value removed)", async () => {
-        const app = await createTestApp();
-        const env = createTestEnv({
-            DB: createMockD1Binding(),
-            FRONTEND_URL: STAGING_URL,
-            ALLOWED_ORIGINS: STAGING_ALLOWED_ORIGINS,
-        });
+    const res = await app.request(
+      "http://localhost/api/auth/github",
+      { headers: { Origin: STAGING_URL } },
+      env as any,
+    );
 
-        const res = await app.request(
-            "http://localhost/api/auth/github",
-            { headers: { Origin: "http://localhost:3000" } },
-            env as any,
-        );
+    expect(res.headers.get("access-control-allow-origin")).toBe(STAGING_URL);
+  });
 
-        // localhost:3000 is no longer in ALLOWED_ORIGINS – it must be blocked.
-        expect(res.headers.get("access-control-allow-origin")).toBeNull();
+  it("blocks localhost:3000 when ALLOWED_ORIGINS contains only the staging URL (regression: old value removed)", async () => {
+    const app = await createTestApp();
+    const env = createTestEnv({
+      DB: createMockD1Binding(),
+      FRONTEND_URL: STAGING_URL,
+      ALLOWED_ORIGINS: STAGING_ALLOWED_ORIGINS,
     });
 
-    it("blocks the HTTP (non-HTTPS) variant of the staging URL", async () => {
-        const app = await createTestApp();
-        const env = createTestEnv({
-            DB: createMockD1Binding(),
-            FRONTEND_URL: STAGING_URL,
-            ALLOWED_ORIGINS: STAGING_ALLOWED_ORIGINS,
-        });
+    const res = await app.request(
+      "http://localhost/api/auth/github",
+      { headers: { Origin: "http://localhost:3000" } },
+      env as any,
+    );
 
-        const res = await app.request(
-            "http://localhost/api/auth/github",
-            { headers: { Origin: HTTP_STAGING_URL } },
-            env as any,
-        );
+    // localhost:3000 is no longer in ALLOWED_ORIGINS – it must be blocked.
+    expect(res.headers.get("access-control-allow-origin")).toBeNull();
+  });
 
-        // The allowed list contains only the HTTPS URL; the HTTP variant is different.
-        expect(res.headers.get("access-control-allow-origin")).toBeNull();
+  it("blocks the HTTP (non-HTTPS) variant of the staging URL", async () => {
+    const app = await createTestApp();
+    const env = createTestEnv({
+      DB: createMockD1Binding(),
+      FRONTEND_URL: STAGING_URL,
+      ALLOWED_ORIGINS: STAGING_ALLOWED_ORIGINS,
     });
 
-    it("blocks an unrelated origin when ALLOWED_ORIGINS is set to the staging URL", async () => {
-        const app = await createTestApp();
-        const env = createTestEnv({
-            DB: createMockD1Binding(),
-            FRONTEND_URL: STAGING_URL,
-            ALLOWED_ORIGINS: STAGING_ALLOWED_ORIGINS,
-        });
+    const res = await app.request(
+      "http://localhost/api/auth/github",
+      { headers: { Origin: HTTP_STAGING_URL } },
+      env as any,
+    );
 
-        const res = await app.request(
-            "http://localhost/api/auth/github",
-            { headers: { Origin: "https://attacker.example.com" } },
-            env as any,
-        );
+    // The allowed list contains only the HTTPS URL; the HTTP variant is different.
+    expect(res.headers.get("access-control-allow-origin")).toBeNull();
+  });
 
-        expect(res.headers.get("access-control-allow-origin")).toBeNull();
+  it("blocks an unrelated origin when ALLOWED_ORIGINS is set to the staging URL", async () => {
+    const app = await createTestApp();
+    const env = createTestEnv({
+      DB: createMockD1Binding(),
+      FRONTEND_URL: STAGING_URL,
+      ALLOWED_ORIGINS: STAGING_ALLOWED_ORIGINS,
     });
 
-    it("uses the staging URL as CORS origin fallback when ALLOWED_ORIGINS is absent", async () => {
-        const app = await createTestApp();
-        const env = createTestEnv({
-            DB: createMockD1Binding(),
-            FRONTEND_URL: STAGING_URL,
-            ALLOWED_ORIGINS: undefined,
-        });
+    const res = await app.request(
+      "http://localhost/api/auth/github",
+      { headers: { Origin: "https://attacker.example.com" } },
+      env as any,
+    );
 
-        const res = await app.request(
-            "http://localhost/api/auth/github",
-            { headers: { Origin: STAGING_URL } },
-            env as any,
-        );
+    expect(res.headers.get("access-control-allow-origin")).toBeNull();
+  });
 
-        expect(res.headers.get("access-control-allow-origin")).toBe(STAGING_URL);
+  it("uses the staging URL as CORS origin fallback when ALLOWED_ORIGINS is absent", async () => {
+    const app = await createTestApp();
+    const env = createTestEnv({
+      DB: createMockD1Binding(),
+      FRONTEND_URL: STAGING_URL,
+      ALLOWED_ORIGINS: undefined,
     });
+
+    const res = await app.request(
+      "http://localhost/api/auth/github",
+      { headers: { Origin: STAGING_URL } },
+      env as any,
+    );
+
+    expect(res.headers.get("access-control-allow-origin")).toBe(STAGING_URL);
+  });
 });
 
 // ---------------------------------------------------------------------------
@@ -194,77 +198,77 @@ describe("CORS – staging Vercel URL in ALLOWED_ORIGINS", () => {
 // ---------------------------------------------------------------------------
 
 describe("CORS preflight – staging Vercel URL in ALLOWED_ORIGINS", () => {
-    it("returns correct preflight headers for the staging Vercel URL", async () => {
-        const app = await createTestApp();
-        const env = createTestEnv({
-            DB: createMockD1Binding(),
-            FRONTEND_URL: STAGING_URL,
-            ALLOWED_ORIGINS: STAGING_ALLOWED_ORIGINS,
-        });
-
-        const res = await app.request(
-            "http://localhost/api/auth/github",
-            {
-                method: "OPTIONS",
-                headers: {
-                    Origin: STAGING_URL,
-                    "Access-Control-Request-Method": "POST",
-                },
-            },
-            env as any,
-        );
-
-        expect(res.headers.get("access-control-allow-origin")).toBe(STAGING_URL);
-        expect(res.headers.get("access-control-allow-methods")).toContain("POST");
-        expect(res.headers.get("access-control-allow-headers")).toBeTruthy();
+  it("returns correct preflight headers for the staging Vercel URL", async () => {
+    const app = await createTestApp();
+    const env = createTestEnv({
+      DB: createMockD1Binding(),
+      FRONTEND_URL: STAGING_URL,
+      ALLOWED_ORIGINS: STAGING_ALLOWED_ORIGINS,
     });
 
-    it("blocks preflight for localhost:3000 now that staging URL is the sole ALLOWED_ORIGINS", async () => {
-        const app = await createTestApp();
-        const env = createTestEnv({
-            DB: createMockD1Binding(),
-            FRONTEND_URL: STAGING_URL,
-            ALLOWED_ORIGINS: STAGING_ALLOWED_ORIGINS,
-        });
+    const res = await app.request(
+      "http://localhost/api/auth/github",
+      {
+        method: "OPTIONS",
+        headers: {
+          Origin: STAGING_URL,
+          "Access-Control-Request-Method": "POST",
+        },
+      },
+      env as any,
+    );
 
-        const res = await app.request(
-            "http://localhost/api/auth/github",
-            {
-                method: "OPTIONS",
-                headers: {
-                    Origin: "http://localhost:3000",
-                    "Access-Control-Request-Method": "POST",
-                },
-            },
-            env as any,
-        );
+    expect(res.headers.get("access-control-allow-origin")).toBe(STAGING_URL);
+    expect(res.headers.get("access-control-allow-methods")).toContain("POST");
+    expect(res.headers.get("access-control-allow-headers")).toBeTruthy();
+  });
 
-        // localhost:3000 is no longer allowed – preflight must be blocked.
-        expect(res.headers.get("access-control-allow-origin")).toBeNull();
+  it("blocks preflight for localhost:3000 now that staging URL is the sole ALLOWED_ORIGINS", async () => {
+    const app = await createTestApp();
+    const env = createTestEnv({
+      DB: createMockD1Binding(),
+      FRONTEND_URL: STAGING_URL,
+      ALLOWED_ORIGINS: STAGING_ALLOWED_ORIGINS,
     });
 
-    it("blocks preflight for the HTTP variant of the staging URL", async () => {
-        const app = await createTestApp();
-        const env = createTestEnv({
-            DB: createMockD1Binding(),
-            FRONTEND_URL: STAGING_URL,
-            ALLOWED_ORIGINS: STAGING_ALLOWED_ORIGINS,
-        });
+    const res = await app.request(
+      "http://localhost/api/auth/github",
+      {
+        method: "OPTIONS",
+        headers: {
+          Origin: "http://localhost:3000",
+          "Access-Control-Request-Method": "POST",
+        },
+      },
+      env as any,
+    );
 
-        const res = await app.request(
-            "http://localhost/api/auth/github",
-            {
-                method: "OPTIONS",
-                headers: {
-                    Origin: HTTP_STAGING_URL,
-                    "Access-Control-Request-Method": "DELETE",
-                },
-            },
-            env as any,
-        );
+    // localhost:3000 is no longer allowed – preflight must be blocked.
+    expect(res.headers.get("access-control-allow-origin")).toBeNull();
+  });
 
-        expect(res.headers.get("access-control-allow-origin")).toBeNull();
+  it("blocks preflight for the HTTP variant of the staging URL", async () => {
+    const app = await createTestApp();
+    const env = createTestEnv({
+      DB: createMockD1Binding(),
+      FRONTEND_URL: STAGING_URL,
+      ALLOWED_ORIGINS: STAGING_ALLOWED_ORIGINS,
     });
+
+    const res = await app.request(
+      "http://localhost/api/auth/github",
+      {
+        method: "OPTIONS",
+        headers: {
+          Origin: HTTP_STAGING_URL,
+          "Access-Control-Request-Method": "DELETE",
+        },
+      },
+      env as any,
+    );
+
+    expect(res.headers.get("access-control-allow-origin")).toBeNull();
+  });
 });
 
 // ---------------------------------------------------------------------------
@@ -272,104 +276,104 @@ describe("CORS preflight – staging Vercel URL in ALLOWED_ORIGINS", () => {
 // ---------------------------------------------------------------------------
 
 describe("CSRF – staging Vercel URL configuration", () => {
-    it("allows a mutative request whose Origin matches the staging FRONTEND_URL", async () => {
-        const app = await createTestApp();
-        const env = createTestEnv({
-            FRONTEND_URL: STAGING_URL,
-            ALLOWED_ORIGINS: STAGING_URL,
-            ENABLE_TEST_AUTH: "false",
-        });
-
-        const res = await app.request(
-            "http://localhost/api/auth/logout",
-            {
-                method: "POST",
-                headers: { Origin: STAGING_URL },
-            },
-            env as any,
-        );
-
-        // CSRF check passes; result depends on auth, but must NOT be 403 Forbidden.
-        expect(res.status).not.toBe(403);
+  it("allows a mutative request whose Origin matches the staging FRONTEND_URL", async () => {
+    const app = await createTestApp();
+    const env = createTestEnv({
+      FRONTEND_URL: STAGING_URL,
+      ALLOWED_ORIGINS: STAGING_URL,
+      ENABLE_TEST_AUTH: "false",
     });
 
-    it("blocks a mutative request whose Origin is localhost:3000 when staging URL is FRONTEND_URL", async () => {
-        const app = await createTestApp();
-        const env = createTestEnv({
-            FRONTEND_URL: STAGING_URL,
-            ALLOWED_ORIGINS: STAGING_URL,
-            ENABLE_TEST_AUTH: "false",
-        });
+    const res = await app.request(
+      "http://localhost/api/auth/logout",
+      {
+        method: "POST",
+        headers: { Origin: STAGING_URL },
+      },
+      env as any,
+    );
 
-        const res = await app.request(
-            "http://localhost/api/auth/logout",
-            {
-                method: "POST",
-                headers: { Origin: "http://localhost:3000" },
-            },
-            env as any,
-        );
+    // CSRF check passes; result depends on auth, but must NOT be 403 Forbidden.
+    expect(res.status).not.toBe(403);
+  });
 
-        expect(res.status).toBe(403);
+  it("blocks a mutative request whose Origin is localhost:3000 when staging URL is FRONTEND_URL", async () => {
+    const app = await createTestApp();
+    const env = createTestEnv({
+      FRONTEND_URL: STAGING_URL,
+      ALLOWED_ORIGINS: STAGING_URL,
+      ENABLE_TEST_AUTH: "false",
     });
 
-    it("blocks a mutative request whose Origin is the HTTP variant of the staging URL", async () => {
-        const app = await createTestApp();
-        const env = createTestEnv({
-            FRONTEND_URL: STAGING_URL,
-            ALLOWED_ORIGINS: STAGING_URL,
-            ENABLE_TEST_AUTH: "false",
-        });
+    const res = await app.request(
+      "http://localhost/api/auth/logout",
+      {
+        method: "POST",
+        headers: { Origin: "http://localhost:3000" },
+      },
+      env as any,
+    );
 
-        const res = await app.request(
-            "http://localhost/api/auth/logout",
-            {
-                method: "POST",
-                headers: { Origin: HTTP_STAGING_URL },
-            },
-            env as any,
-        );
+    expect(res.status).toBe(403);
+  });
 
-        expect(res.status).toBe(403);
+  it("blocks a mutative request whose Origin is the HTTP variant of the staging URL", async () => {
+    const app = await createTestApp();
+    const env = createTestEnv({
+      FRONTEND_URL: STAGING_URL,
+      ALLOWED_ORIGINS: STAGING_URL,
+      ENABLE_TEST_AUTH: "false",
     });
 
-    it("allows a mutative request whose Referer is under the staging URL", async () => {
-        const app = await createTestApp();
-        const env = createTestEnv({
-            FRONTEND_URL: STAGING_URL,
-            ALLOWED_ORIGINS: STAGING_URL,
-            ENABLE_TEST_AUTH: "false",
-        });
+    const res = await app.request(
+      "http://localhost/api/auth/logout",
+      {
+        method: "POST",
+        headers: { Origin: HTTP_STAGING_URL },
+      },
+      env as any,
+    );
 
-        const res = await app.request(
-            "http://localhost/api/auth/logout",
-            {
-                method: "POST",
-                headers: {
-                    // No Origin header – CSRF relies on Referer only.
-                    Referer: `${STAGING_URL}/some/page`,
-                },
-            },
-            env as any,
-        );
+    expect(res.status).toBe(403);
+  });
 
-        expect(res.status).not.toBe(403);
+  it("allows a mutative request whose Referer is under the staging URL", async () => {
+    const app = await createTestApp();
+    const env = createTestEnv({
+      FRONTEND_URL: STAGING_URL,
+      ALLOWED_ORIGINS: STAGING_URL,
+      ENABLE_TEST_AUTH: "false",
     });
 
-    it("blocks a mutative request with no Origin and no Referer", async () => {
-        const app = await createTestApp();
-        const env = createTestEnv({
-            FRONTEND_URL: STAGING_URL,
-            ALLOWED_ORIGINS: STAGING_URL,
-            ENABLE_TEST_AUTH: "false",
-        });
+    const res = await app.request(
+      "http://localhost/api/auth/logout",
+      {
+        method: "POST",
+        headers: {
+          // No Origin header – CSRF relies on Referer only.
+          Referer: `${STAGING_URL}/some/page`,
+        },
+      },
+      env as any,
+    );
 
-        const res = await app.request(
-            "http://localhost/api/auth/logout",
-            { method: "POST" },
-            env as any,
-        );
+    expect(res.status).not.toBe(403);
+  });
 
-        expect(res.status).toBe(403);
+  it("blocks a mutative request with no Origin and no Referer", async () => {
+    const app = await createTestApp();
+    const env = createTestEnv({
+      FRONTEND_URL: STAGING_URL,
+      ALLOWED_ORIGINS: STAGING_URL,
+      ENABLE_TEST_AUTH: "false",
     });
+
+    const res = await app.request(
+      "http://localhost/api/auth/logout",
+      { method: "POST" },
+      env as any,
+    );
+
+    expect(res.status).toBe(403);
+  });
 });

--- a/apps/api/src/routes/__tests__/tags.test.ts
+++ b/apps/api/src/routes/__tests__/tags.test.ts
@@ -1,113 +1,148 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import {
-    createMockDb as createSharedMockDb,
-    createTestApp,
-    createTestEnv,
-    createTestJWT,
-    makeQuery,
-    queueSelectResponses as queueSharedSelectResponses,
+  createMockDb as createSharedMockDb,
+  createTestApp,
+  createTestEnv,
+  createTestJWT,
+  makeQuery,
+  queueSelectResponses as queueSharedSelectResponses,
 } from "../../test/helpers";
 
 let mockDb: any;
 
 vi.mock("drizzle-orm/d1", () => ({
-    drizzle: vi.fn(() => mockDb),
+  drizzle: vi.fn(() => mockDb),
 }));
 
 function createMockDb(overrides: Record<string, any> = {}) {
-    return createSharedMockDb(overrides);
+  return createSharedMockDb(overrides);
 }
 
 function queueSelectResponses(
-    responses: Array<{ getResult?: unknown; allResult?: unknown[] }>,
+  responses: Array<{ getResult?: unknown; allResult?: unknown[] }>,
 ) {
-    queueSharedSelectResponses(mockDb, responses);
+  queueSharedSelectResponses(mockDb, responses);
 }
 
 describe("tags routes", () => {
-    beforeEach(() => {
-        vi.restoreAllMocks();
-        vi.resetModules();
-        mockDb = createMockDb();
+  beforeEach(() => {
+    vi.restoreAllMocks();
+    vi.resetModules();
+    mockDb = createMockDb();
+  });
+
+  it("GET /api/tags/suggest returns empty for short queries", async () => {
+    const token = await createTestJWT({
+      sub: "user-1",
+      githubId: "123",
+      name: "Uploader",
     });
+    const app = await createTestApp();
+    const env = createTestEnv();
 
-    it("GET /api/tags/suggest returns empty for short queries", async () => {
-        const token = await createTestJWT({ sub: "user-1", githubId: "123", name: "Uploader" });
-        const app = await createTestApp();
-        const env = createTestEnv();
+    const res = await app.request(
+      "http://localhost/api/tags/suggest?q=a",
+      {
+        headers: { Authorization: `Bearer ${token}` },
+      },
+      env as any,
+    );
 
-        const res = await app.request(
-            "http://localhost/api/tags/suggest?q=a",
-            {
-                headers: { Authorization: `Bearer ${token}` },
-            },
-            env as any,
-        );
+    expect(res.status).toBe(200);
+    await expect(res.json()).resolves.toEqual({ tags: [] });
+    expect(mockDb.select).not.toHaveBeenCalled();
+  });
 
-        expect(res.status).toBe(200);
-        await expect(res.json()).resolves.toEqual({ tags: [] });
-        expect(mockDb.select).not.toHaveBeenCalled();
+  it("GET /api/tags/suggest returns prefix-matched tags for current user", async () => {
+    const token = await createTestJWT({
+      sub: "user-1",
+      githubId: "123",
+      name: "Uploader",
     });
+    const app = await createTestApp();
+    const env = createTestEnv();
+    (env.DB as any).prepare = vi
+      .fn()
+      .mockReturnValue({
+        bind: vi
+          .fn()
+          .mockReturnValue({
+            all: vi.fn().mockResolvedValue({ results: [{ tag: "AI" }] }),
+          }),
+      });
+    const res = await app.request(
+      "http://localhost/api/tags/suggest?q=AI",
+      {
+        headers: { Authorization: `Bearer ${token}` },
+      },
+      env as any,
+    );
 
-    it("GET /api/tags/suggest returns prefix-matched tags for current user", async () => {
-        const token = await createTestJWT({ sub: "user-1", githubId: "123", name: "Uploader" });
-        const app = await createTestApp();
-        const env = createTestEnv();
-        (env.DB as any).prepare = vi.fn().mockReturnValue({ bind: vi.fn().mockReturnValue({ all: vi.fn().mockResolvedValue({ results: [{ tag: "AI" }] }) }) });
-        const res = await app.request(
-            "http://localhost/api/tags/suggest?q=AI",
-            {
-                headers: { Authorization: `Bearer ${token}` },
-            },
-            env as any,
-        );
+    expect(res.status).toBe(200);
+    await expect(res.json()).resolves.toEqual({ tags: ["AI"] });
+  });
 
-        expect(res.status).toBe(200);
-        await expect(res.json()).resolves.toEqual({ tags: ["AI"] });
+  it("GET /api/tags/suggest returns 403 when org slug is specified by non-member", async () => {
+    const token = await createTestJWT({
+      sub: "user-1",
+      githubId: "123",
+      name: "Uploader",
     });
+    queueSelectResponses([{ getResult: { id: "org-1" } }, { getResult: null }]);
 
-    it("GET /api/tags/suggest returns 403 when org slug is specified by non-member", async () => {
-        const token = await createTestJWT({ sub: "user-1", githubId: "123", name: "Uploader" });
-        queueSelectResponses([
-            { getResult: { id: "org-1" } },
-            { getResult: null },
-        ]);
+    const app = await createTestApp();
+    const env = createTestEnv();
+    const res = await app.request(
+      "http://localhost/api/tags/suggest?q=AI&orgSlug=my-lab",
+      {
+        headers: { Authorization: `Bearer ${token}` },
+      },
+      env as any,
+    );
 
-        const app = await createTestApp();
-        const env = createTestEnv();
-        const res = await app.request(
-            "http://localhost/api/tags/suggest?q=AI&orgSlug=my-lab",
-            {
-                headers: { Authorization: `Bearer ${token}` },
-            },
-            env as any,
-        );
+    expect(res.status).toBe(403);
+    await expect(res.json()).resolves.toEqual({ error: "Forbidden" });
+  });
 
-        expect(res.status).toBe(403);
-        await expect(res.json()).resolves.toEqual({ error: "Forbidden" });
+  it("GET /api/tags/suggest excludes private org paper tags for non-authors", async () => {
+    const token = await createTestJWT({
+      sub: "user-1",
+      githubId: "123",
+      name: "Uploader",
     });
+    queueSelectResponses([
+      { getResult: { id: "org-1" } },
+      { getResult: { userId: "user-1" } },
+    ]);
 
-    it("GET /api/tags/suggest excludes private org paper tags for non-authors", async () => {
-        const token = await createTestJWT({ sub: "user-1", githubId: "123", name: "Uploader" });
-        queueSelectResponses([
-            { getResult: { id: "org-1" } },
-            { getResult: { userId: "user-1" } },
-        ]);
+    const app = await createTestApp();
+    const env = createTestEnv();
+    env.DB = {
+      prepare: vi
+        .fn()
+        .mockReturnValue({
+          bind: vi
+            .fn()
+            .mockReturnValue({
+              all: vi
+                .fn()
+                .mockResolvedValue({
+                  results: [{ tag: "Search" }, { tag: "Secret Notes" }],
+                }),
+            }),
+        }),
+    };
+    const res = await app.request(
+      "http://localhost/api/tags/suggest?q=Se&orgSlug=my-lab",
+      {
+        headers: { Authorization: `Bearer ${token}` },
+      },
+      env as any,
+    );
 
-        const app = await createTestApp();
-        const env = createTestEnv();
-        env.DB = { prepare: vi.fn().mockReturnValue({ bind: vi.fn().mockReturnValue({ all: vi.fn().mockResolvedValue({ results: [{ tag: "Search" }, { tag: "Secret Notes" }] }) }) }) };
-        const res = await app.request(
-            "http://localhost/api/tags/suggest?q=Se&orgSlug=my-lab",
-            {
-                headers: { Authorization: `Bearer ${token}` },
-            },
-            env as any,
-        );
-
-        expect(res.status).toBe(200);
-        await expect(res.json()).resolves.toEqual({
-            tags: ["Search", "Secret Notes"],
-        });
+    expect(res.status).toBe(200);
+    await expect(res.json()).resolves.toEqual({
+      tags: ["Search", "Secret Notes"],
     });
+  });
 });

--- a/apps/api/src/routes/__tests__/test-auth.test.ts
+++ b/apps/api/src/routes/__tests__/test-auth.test.ts
@@ -2,70 +2,70 @@ import { describe, expect, it } from "vitest";
 import { createTestApp, createTestEnv } from "../../test/helpers";
 
 describe("test-auth routes", () => {
-    it("returns 404 if ENABLE_TEST_AUTH is not true", async () => {
-        const app = await createTestApp();
-        const env = createTestEnv({
-            ENABLE_TEST_AUTH: "false",
-            TEST_AUTH_SECRET: "wrong-secret",
-            FRONTEND_URL: "http://localhost",
-        });
-
-        const res = await app.request(
-            "http://localhost/api/test-auth/test-token",
-            {
-                method: "POST",
-                headers: {
-                    "x-test-auth-secret": "wrong-secret",
-                    "origin": "http://localhost",
-                    "referer": "http://localhost"
-                }
-            },
-            env as any
-        );
-        expect(res.status).toBe(404);
+  it("returns 404 if ENABLE_TEST_AUTH is not true", async () => {
+    const app = await createTestApp();
+    const env = createTestEnv({
+      ENABLE_TEST_AUTH: "false",
+      TEST_AUTH_SECRET: "wrong-secret",
+      FRONTEND_URL: "http://localhost",
     });
 
-    it("returns 404 if TEST_AUTH_SECRET is not configured", async () => {
-        const app = await createTestApp();
-        const env = createTestEnv({
-            ENABLE_TEST_AUTH: "true",
-            FRONTEND_URL: "http://localhost",
-        });
+    const res = await app.request(
+      "http://localhost/api/test-auth/test-token",
+      {
+        method: "POST",
+        headers: {
+          "x-test-auth-secret": "wrong-secret",
+          origin: "http://localhost",
+          referer: "http://localhost",
+        },
+      },
+      env as any,
+    );
+    expect(res.status).toBe(404);
+  });
 
-        const res = await app.request(
-            "http://localhost/api/test-auth/test-token",
-            {
-                method: "POST",
-                headers: {
-                    "origin": "http://localhost",
-                    "referer": "http://localhost"
-                }
-            },
-            env as any
-        );
-        expect(res.status).toBe(404);
+  it("returns 404 if TEST_AUTH_SECRET is not configured", async () => {
+    const app = await createTestApp();
+    const env = createTestEnv({
+      ENABLE_TEST_AUTH: "true",
+      FRONTEND_URL: "http://localhost",
     });
 
-    it("returns 401 if provided secret does not match", async () => {
-        const app = await createTestApp();
-        const env = createTestEnv({
-            ENABLE_TEST_AUTH: "true",
-            TEST_AUTH_SECRET: "correct-secret",
-            FRONTEND_URL: "http://localhost",
-        });
+    const res = await app.request(
+      "http://localhost/api/test-auth/test-token",
+      {
+        method: "POST",
+        headers: {
+          origin: "http://localhost",
+          referer: "http://localhost",
+        },
+      },
+      env as any,
+    );
+    expect(res.status).toBe(404);
+  });
 
-        const res = await app.request(
-            "http://localhost/api/test-auth/test-token",
-            {
-                method: "POST",
-                headers: {
-                    "x-test-auth-secret": "wrong-secret",
-                    "origin": "http://localhost",
-                    "referer": "http://localhost"
-                }
-            },
-            env as any
-        );
-        expect(res.status).toBe(401);
+  it("returns 401 if provided secret does not match", async () => {
+    const app = await createTestApp();
+    const env = createTestEnv({
+      ENABLE_TEST_AUTH: "true",
+      TEST_AUTH_SECRET: "correct-secret",
+      FRONTEND_URL: "http://localhost",
     });
+
+    const res = await app.request(
+      "http://localhost/api/test-auth/test-token",
+      {
+        method: "POST",
+        headers: {
+          "x-test-auth-secret": "wrong-secret",
+          origin: "http://localhost",
+          referer: "http://localhost",
+        },
+      },
+      env as any,
+    );
+    expect(res.status).toBe(401);
+  });
 });

--- a/apps/api/src/routes/__tests__/users.test.ts
+++ b/apps/api/src/routes/__tests__/users.test.ts
@@ -1,274 +1,333 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import {
-    createTestApp,
-    createTestEnv,
-    createTestJWT,
-    makeQuery,
+  createTestApp,
+  createTestEnv,
+  createTestJWT,
+  makeQuery,
 } from "../../test/helpers";
-
 
 let mockDb: any;
 
 vi.mock("drizzle-orm/d1", () => ({
-    drizzle: vi.fn(() => mockDb)
+  drizzle: vi.fn(() => mockDb),
 }));
 
 describe("users routes", () => {
-    beforeEach(() => {
-        vi.restoreAllMocks();
-        vi.resetModules();
-        mockDb = {
-            run: vi.fn(async () => undefined),
-            select: vi.fn(() => makeQuery()),
-            update: vi.fn(() => ({
-                set: vi.fn(() => ({ where: vi.fn(async () => undefined) }))
-            }))
-        };
+  beforeEach(() => {
+    vi.restoreAllMocks();
+    vi.resetModules();
+    mockDb = {
+      run: vi.fn(async () => undefined),
+      select: vi.fn(() => makeQuery()),
+      update: vi.fn(() => ({
+        set: vi.fn(() => ({ where: vi.fn(async () => undefined) })),
+      })),
+    };
+  });
+
+  it("GET /api/users/me returns profile for authenticated user", async () => {
+    const token = await createTestJWT({
+      sub: "user-1",
+      githubId: "123",
+      name: "Tester",
+    });
+    mockDb.select = vi.fn(() =>
+      makeQuery({ getResult: { id: "user-1", name: "Tester" } }),
+    );
+
+    const app = await createTestApp();
+    const env = createTestEnv();
+
+    const res = await app.request(
+      "http://localhost/api/users/me",
+      {
+        headers: { Authorization: `Bearer ${token}` },
+      },
+      env as any,
+    );
+
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as any;
+    expect(body.user.id).toBe("user-1");
+  });
+
+  it("PUT /api/users/me updates display_name", async () => {
+    const token = await createTestJWT({
+      sub: "user-1",
+      githubId: "123",
+      name: "Tester",
+    });
+    mockDb.select = vi.fn(() =>
+      makeQuery({
+        getResult: { id: "user-1", name: "Tester", displayName: "Updated" },
+      }),
+    );
+
+    const app = await createTestApp();
+    const env = createTestEnv();
+
+    const res = await app.request(
+      "http://localhost/api/users/me",
+      {
+        method: "PUT",
+        headers: {
+          Authorization: `Bearer ${token}`,
+          "Content-Type": "application/json",
+        },
+        body: JSON.stringify({ displayName: "Updated" }),
+      },
+      env as any,
+    );
+
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as any;
+    expect(body.user.displayName).toBe("Updated");
+  });
+
+  it("PATCH /api/users/me with malformed JSON returns 400", async () => {
+    const token = await createTestJWT({
+      sub: "user-1",
+      githubId: "123",
+      name: "Tester",
     });
 
-    it("GET /api/users/me returns profile for authenticated user", async () => {
-        const token = await createTestJWT({ sub: "user-1", githubId: "123", name: "Tester" });
-        mockDb.select = vi.fn(() => makeQuery({ getResult: { id: "user-1", name: "Tester" } }));
+    const app = await createTestApp();
+    const env = createTestEnv();
 
-        const app = await createTestApp();
-        const env = createTestEnv();
+    const res = await app.request(
+      "http://localhost/api/users/me",
+      {
+        method: "PATCH",
+        headers: {
+          Authorization: `Bearer ${token}`,
+          "Content-Type": "application/json",
+        },
+        body: '{ "displayName": "New Name", ', // Missing closing brace
+      },
+      env as any,
+    );
 
-        const res = await app.request(
-            "http://localhost/api/users/me",
-            {
-                headers: { Authorization: `Bearer ${token}` }
-            },
-            env as any
-        );
+    expect(res.status).toBe(400);
+    const body = (await res.json()) as any;
+    expect(body.error).toBe("Invalid JSON body");
+  });
 
-        expect(res.status).toBe(200);
-        const body = (await res.json()) as any;
-        expect(body.user.id).toBe("user-1");
+  it("GET /api/users/search?q=... returns search results", async () => {
+    const token = await createTestJWT({
+      sub: "user-1",
+      githubId: "123",
+      name: "Tester",
+    });
+    mockDb.select = vi.fn(() =>
+      makeQuery({
+        allResult: [{ id: "user-2", name: "Alice", githubId: "alice" }],
+      }),
+    );
+
+    const app = await createTestApp();
+    const env = createTestEnv();
+
+    const res = await app.request(
+      "http://localhost/api/users/search?q=ali",
+      {
+        headers: { Authorization: `Bearer ${token}` },
+      },
+      env as any,
+    );
+
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as any;
+    expect(body.users).toHaveLength(1);
+    expect(body.users[0].name).toBe("Alice");
+  });
+
+  it("PATCH /api/users/me rejects non-string display names", async () => {
+    const token = await createTestJWT({
+      sub: "user-1",
+      githubId: "123",
+      name: "Tester",
     });
 
-    it("PUT /api/users/me updates display_name", async () => {
-        const token = await createTestJWT({ sub: "user-1", githubId: "123", name: "Tester" });
-        mockDb.select = vi.fn(() => makeQuery({ getResult: { id: "user-1", name: "Tester", displayName: "Updated" } }));
+    const app = await createTestApp();
+    const env = createTestEnv();
 
-        const app = await createTestApp();
-        const env = createTestEnv();
+    const res = await app.request(
+      "http://localhost/api/users/me",
+      {
+        method: "PATCH",
+        headers: {
+          Authorization: `Bearer ${token}`,
+          "Content-Type": "application/json",
+        },
+        body: JSON.stringify({ displayName: 123 }),
+      },
+      env as any,
+    );
 
-        const res = await app.request(
-            "http://localhost/api/users/me",
-            {
-                method: "PUT",
-                headers: {
-                    Authorization: `Bearer ${token}`,
-                    "Content-Type": "application/json"
-                },
-                body: JSON.stringify({ displayName: "Updated" })
-            },
-            env as any
-        );
+    expect(res.status).toBe(400);
+    expect(((await res.json()) as any).error).toBe(
+      "displayName must be a string or null",
+    );
+  });
 
-        expect(res.status).toBe(200);
-        const body = (await res.json()) as any;
-        expect(body.user.displayName).toBe("Updated");
+  it("PATCH /api/users/me trims blank display names to null", async () => {
+    const token = await createTestJWT({
+      sub: "user-1",
+      githubId: "123",
+      name: "Tester",
+    });
+    const setValues = vi.fn(() => ({ where: vi.fn(async () => undefined) }));
+    mockDb.update = vi.fn(() => ({ set: setValues }));
+    mockDb.select = vi.fn(() =>
+      makeQuery({
+        getResult: { id: "user-1", name: "Tester", displayName: null },
+      }),
+    );
+
+    const app = await createTestApp();
+    const env = createTestEnv();
+
+    const res = await app.request(
+      "http://localhost/api/users/me",
+      {
+        method: "PATCH",
+        headers: {
+          Authorization: `Bearer ${token}`,
+          "Content-Type": "application/json",
+        },
+        body: JSON.stringify({ displayName: "   " }),
+      },
+      env as any,
+    );
+
+    expect(res.status).toBe(200);
+    expect(setValues).toHaveBeenCalledWith(
+      expect.objectContaining({
+        displayName: null,
+        updatedAt: expect.anything(),
+      }),
+    );
+  });
+
+  it("GET /api/users/search returns cached results on repeat queries", async () => {
+    const token = await createTestJWT({
+      sub: "user-1",
+      githubId: "123",
+      name: "Tester",
+    });
+    mockDb.select = vi.fn(() =>
+      makeQuery({
+        allResult: [{ id: "user-2", name: "Alice", githubId: "alice" }],
+      }),
+    );
+
+    const app = await createTestApp();
+    const env = createTestEnv();
+
+    const first = await app.request(
+      "http://localhost/api/users/search?q=ali",
+      {
+        headers: { Authorization: `Bearer ${token}` },
+      },
+      env as any,
+    );
+    expect(first.status).toBe(200);
+
+    const second = await app.request(
+      "http://localhost/api/users/search?q=ali",
+      {
+        headers: { Authorization: `Bearer ${token}` },
+      },
+      env as any,
+    );
+
+    expect(second.status).toBe(200);
+    expect(mockDb.select).toHaveBeenCalledTimes(1);
+  });
+
+  it("GET /api/users/search returns an empty list for short queries", async () => {
+    const token = await createTestJWT({
+      sub: "user-1",
+      githubId: "123",
+      name: "Tester",
     });
 
-    it("PATCH /api/users/me with malformed JSON returns 400", async () => {
-        const token = await createTestJWT({ sub: "user-1", githubId: "123", name: "Tester" });
+    const app = await createTestApp();
+    const env = createTestEnv();
 
-        const app = await createTestApp();
-        const env = createTestEnv();
+    const res = await app.request(
+      "http://localhost/api/users/search?q=a",
+      {
+        headers: { Authorization: `Bearer ${token}` },
+      },
+      env as any,
+    );
 
-        const res = await app.request(
-            "http://localhost/api/users/me",
-            {
-                method: "PATCH",
-                headers: {
-                    Authorization: `Bearer ${token}`,
-                    "Content-Type": "application/json"
-                },
-                body: '{ "displayName": "New Name", ' // Missing closing brace
-            },
-            env as any
-        );
+    expect(res.status).toBe(200);
+    expect(((await res.json()) as any).users).toEqual([]);
+    expect(mockDb.select).not.toHaveBeenCalled();
+  });
 
-        expect(res.status).toBe(400);
-        const body = (await res.json()) as any;
-        expect(body.error).toBe("Invalid JSON body");
+  it("GET /api/users/:id returns 404 when the user does not exist", async () => {
+    mockDb.select = vi.fn(() => makeQuery({ getResult: null }));
+
+    const app = await createTestApp();
+    const env = createTestEnv();
+
+    const res = await app.request(
+      "http://localhost/api/users/missing",
+      {},
+      env as any,
+    );
+
+    expect(res.status).toBe(404);
+    expect(((await res.json()) as any).error).toBe("User not found");
+  });
+
+  it("GET /api/users/search evicts the oldest item when MAX_CACHE_SIZE is reached", async () => {
+    const token = await createTestJWT({
+      sub: "user-1",
+      githubId: "123",
+      name: "Tester",
     });
+    mockDb.select = vi.fn(() =>
+      makeQuery({
+        allResult: [{ id: "user-2", name: "Alice", githubId: "alice" }],
+      }),
+    );
 
-    it("GET /api/users/search?q=... returns search results", async () => {
-        const token = await createTestJWT({ sub: "user-1", githubId: "123", name: "Tester" });
-        mockDb.select = vi.fn(() => makeQuery({ allResult: [{ id: "user-2", name: "Alice", githubId: "alice" }] }));
+    const app = await createTestApp();
+    const env = createTestEnv();
 
-        const app = await createTestApp();
-        const env = createTestEnv();
+    // MAX_CACHE_SIZE is 1000
+    for (let i = 0; i < 1002; i++) {
+      await app.request(
+        `http://localhost/api/users/search?q=ali${i}`,
+        {
+          headers: { Authorization: `Bearer ${token}` },
+        },
+        env as any,
+      );
+    }
 
-        const res = await app.request(
-            "http://localhost/api/users/search?q=ali",
-            {
-                headers: { Authorization: `Bearer ${token}` }
-            },
-            env as any
-        );
+    // The first item `ali0` should be evicted. We mock DB to return Bob if it fetches, otherwise cache.
+    mockDb.select = vi.fn(() =>
+      makeQuery({
+        allResult: [{ id: "user-3", name: "Bob", githubId: "bob" }],
+      }),
+    );
 
-        expect(res.status).toBe(200);
-        const body = (await res.json()) as any;
-        expect(body.users).toHaveLength(1);
-        expect(body.users[0].name).toBe("Alice");
-    });
+    const res = await app.request(
+      "http://localhost/api/users/search?q=ali0",
+      {
+        headers: { Authorization: `Bearer ${token}` },
+      },
+      env as any,
+    );
 
-    it("PATCH /api/users/me rejects non-string display names", async () => {
-        const token = await createTestJWT({ sub: "user-1", githubId: "123", name: "Tester" });
-
-        const app = await createTestApp();
-        const env = createTestEnv();
-
-        const res = await app.request(
-            "http://localhost/api/users/me",
-            {
-                method: "PATCH",
-                headers: {
-                    Authorization: `Bearer ${token}`,
-                    "Content-Type": "application/json"
-                },
-                body: JSON.stringify({ displayName: 123 })
-            },
-            env as any
-        );
-
-        expect(res.status).toBe(400);
-        expect(((await res.json()) as any).error).toBe("displayName must be a string or null");
-    });
-
-    it("PATCH /api/users/me trims blank display names to null", async () => {
-        const token = await createTestJWT({ sub: "user-1", githubId: "123", name: "Tester" });
-        const setValues = vi.fn(() => ({ where: vi.fn(async () => undefined) }));
-        mockDb.update = vi.fn(() => ({ set: setValues }));
-        mockDb.select = vi.fn(() =>
-            makeQuery({ getResult: { id: "user-1", name: "Tester", displayName: null } }),
-        );
-
-        const app = await createTestApp();
-        const env = createTestEnv();
-
-        const res = await app.request(
-            "http://localhost/api/users/me",
-            {
-                method: "PATCH",
-                headers: {
-                    Authorization: `Bearer ${token}`,
-                    "Content-Type": "application/json"
-                },
-                body: JSON.stringify({ displayName: "   " })
-            },
-            env as any
-        );
-
-        expect(res.status).toBe(200);
-        expect(setValues).toHaveBeenCalledWith(
-            expect.objectContaining({
-                displayName: null,
-                updatedAt: expect.anything(),
-            }),
-        );
-    });
-
-    it("GET /api/users/search returns cached results on repeat queries", async () => {
-        const token = await createTestJWT({ sub: "user-1", githubId: "123", name: "Tester" });
-        mockDb.select = vi.fn(() =>
-            makeQuery({ allResult: [{ id: "user-2", name: "Alice", githubId: "alice" }] }),
-        );
-
-        const app = await createTestApp();
-        const env = createTestEnv();
-
-        const first = await app.request(
-            "http://localhost/api/users/search?q=ali",
-            {
-                headers: { Authorization: `Bearer ${token}` }
-            },
-            env as any
-        );
-        expect(first.status).toBe(200);
-
-        const second = await app.request(
-            "http://localhost/api/users/search?q=ali",
-            {
-                headers: { Authorization: `Bearer ${token}` }
-            },
-            env as any
-        );
-
-        expect(second.status).toBe(200);
-        expect(mockDb.select).toHaveBeenCalledTimes(1);
-    });
-
-    it("GET /api/users/search returns an empty list for short queries", async () => {
-        const token = await createTestJWT({ sub: "user-1", githubId: "123", name: "Tester" });
-
-        const app = await createTestApp();
-        const env = createTestEnv();
-
-        const res = await app.request(
-            "http://localhost/api/users/search?q=a",
-            {
-                headers: { Authorization: `Bearer ${token}` }
-            },
-            env as any
-        );
-
-        expect(res.status).toBe(200);
-        expect(((await res.json()) as any).users).toEqual([]);
-        expect(mockDb.select).not.toHaveBeenCalled();
-    });
-
-    it("GET /api/users/:id returns 404 when the user does not exist", async () => {
-        mockDb.select = vi.fn(() => makeQuery({ getResult: null }));
-
-        const app = await createTestApp();
-        const env = createTestEnv();
-
-        const res = await app.request(
-            "http://localhost/api/users/missing",
-            {},
-            env as any
-        );
-
-        expect(res.status).toBe(404);
-        expect(((await res.json()) as any).error).toBe("User not found");
-    });
-
-    it("GET /api/users/search evicts the oldest item when MAX_CACHE_SIZE is reached", async () => {
-        const token = await createTestJWT({ sub: "user-1", githubId: "123", name: "Tester" });
-        mockDb.select = vi.fn(() => makeQuery({ allResult: [{ id: "user-2", name: "Alice", githubId: "alice" }] }));
-
-        const app = await createTestApp();
-        const env = createTestEnv();
-
-        // MAX_CACHE_SIZE is 1000
-        for (let i = 0; i < 1002; i++) {
-            await app.request(
-                `http://localhost/api/users/search?q=ali${i}`,
-                {
-                    headers: { Authorization: `Bearer ${token}` }
-                },
-                env as any
-            );
-        }
-
-        // The first item `ali0` should be evicted. We mock DB to return Bob if it fetches, otherwise cache.
-        mockDb.select = vi.fn(() => makeQuery({ allResult: [{ id: "user-3", name: "Bob", githubId: "bob" }] }));
-
-        const res = await app.request(
-            "http://localhost/api/users/search?q=ali0",
-            {
-                headers: { Authorization: `Bearer ${token}` }
-            },
-            env as any
-        );
-
-        expect(res.status).toBe(200);
-        const body = (await res.json()) as any;
-        expect(body.users).toHaveLength(1);
-        expect(body.users[0].name).toBe("Bob"); // Fetched from DB since cache was evicted
-    });
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as any;
+    expect(body.users).toHaveLength(1);
+    expect(body.users[0].name).toBe("Bob"); // Fetched from DB since cache was evicted
+  });
 });

--- a/apps/api/src/routes/auth.ts
+++ b/apps/api/src/routes/auth.ts
@@ -17,257 +17,267 @@ const OAUTH_FLOW_ORIGIN_COOKIE = "oauth_flow_origin";
 
 // GET /api/auth/github — redirect to GitHub OAuth
 auth.get("/github", async (c) => {
-    const state = crypto.randomUUID();
-    const flowNonce = crypto.randomUUID();
-    const requestedFrontendOrigin = c.req.query("frontend_origin");
-    const requestSignalOrigin = c.req.header("Origin") ?? c.req.header("Referer");
-    const frontendOrigin = resolveAllowedOrigin(
-        [requestSignalOrigin, requestedFrontendOrigin],
-        c.env.FRONTEND_URL,
-        parseOriginList(c.env.ALLOWED_ORIGINS),
-        { allowWildcard: false },
-    );
+  const state = crypto.randomUUID();
+  const flowNonce = crypto.randomUUID();
+  const requestedFrontendOrigin = c.req.query("frontend_origin");
+  const requestSignalOrigin = c.req.header("Origin") ?? c.req.header("Referer");
+  const frontendOrigin = resolveAllowedOrigin(
+    [requestSignalOrigin, requestedFrontendOrigin],
+    c.env.FRONTEND_URL,
+    parseOriginList(c.env.ALLOWED_ORIGINS),
+    { allowWildcard: false },
+  );
 
-    // Opportunistically clean up expired states to prevent unbounded growth.
-    await c.env.DB.prepare(
-        "DELETE FROM oauth_states WHERE created_at <= datetime('now', '-5 minutes')",
-    ).run();
+  // Opportunistically clean up expired states to prevent unbounded growth.
+  await c.env.DB.prepare(
+    "DELETE FROM oauth_states WHERE created_at <= datetime('now', '-5 minutes')",
+  ).run();
 
-    await c.env.DB.prepare(
-        "INSERT INTO oauth_states (state, browser_nonce) VALUES (?, ?)",
-    )
-        .bind(state, flowNonce)
-        .run();
+  await c.env.DB.prepare(
+    "INSERT INTO oauth_states (state, browser_nonce) VALUES (?, ?)",
+  )
+    .bind(state, flowNonce)
+    .run();
 
-    setCookie(c, OAUTH_FLOW_NONCE_COOKIE, flowNonce, {
-        httpOnly: true,
-        secure: new URL(c.req.url).protocol === "https:",
-        sameSite: "Lax",
-        maxAge: OAUTH_STATE_TTL_SECONDS,
-        path: "/",
-    });
-    setCookie(c, OAUTH_FLOW_ORIGIN_COOKIE, frontendOrigin, {
-        httpOnly: true,
-        secure: new URL(c.req.url).protocol === "https:",
-        sameSite: "Lax",
-        maxAge: OAUTH_STATE_TTL_SECONDS,
-        path: "/",
-    });
+  setCookie(c, OAUTH_FLOW_NONCE_COOKIE, flowNonce, {
+    httpOnly: true,
+    secure: new URL(c.req.url).protocol === "https:",
+    sameSite: "Lax",
+    maxAge: OAUTH_STATE_TTL_SECONDS,
+    path: "/",
+  });
+  setCookie(c, OAUTH_FLOW_ORIGIN_COOKIE, frontendOrigin, {
+    httpOnly: true,
+    secure: new URL(c.req.url).protocol === "https:",
+    sameSite: "Lax",
+    maxAge: OAUTH_STATE_TTL_SECONDS,
+    path: "/",
+  });
 
-    const params = new URLSearchParams({
-        client_id: c.env.GITHUB_CLIENT_ID,
-        redirect_uri: `${new URL(c.req.url).origin}/api/auth/github/callback`,
-        scope: "read:user user:email",
-        state,
-    });
-    return c.redirect(
-        `https://github.com/login/oauth/authorize?${params}`,
-    );
+  const params = new URLSearchParams({
+    client_id: c.env.GITHUB_CLIENT_ID,
+    redirect_uri: `${new URL(c.req.url).origin}/api/auth/github/callback`,
+    scope: "read:user user:email",
+    state,
+  });
+  return c.redirect(`https://github.com/login/oauth/authorize?${params}`);
 });
 
 // GET /api/auth/github/callback — exchange code, upsert user, issue JWT
 auth.get("/github/callback", async (c) => {
-    const code = c.req.query("code");
-    const stateParam = c.req.query("state");
-    const flowNonce = getCookie(c, OAUTH_FLOW_NONCE_COOKIE);
-    const flowOrigin = getCookie(c, OAUTH_FLOW_ORIGIN_COOKIE);
+  const code = c.req.query("code");
+  const stateParam = c.req.query("state");
+  const flowNonce = getCookie(c, OAUTH_FLOW_NONCE_COOKIE);
+  const flowOrigin = getCookie(c, OAUTH_FLOW_ORIGIN_COOKIE);
 
-    deleteCookie(c, OAUTH_FLOW_NONCE_COOKIE, { path: "/" });
-    deleteCookie(c, OAUTH_FLOW_ORIGIN_COOKIE, { path: "/" });
+  deleteCookie(c, OAUTH_FLOW_NONCE_COOKIE, { path: "/" });
+  deleteCookie(c, OAUTH_FLOW_ORIGIN_COOKIE, { path: "/" });
 
-    if (!stateParam) {
-        return c.json({ error: "Missing state parameter" }, 400);
-    }
+  if (!stateParam) {
+    return c.json({ error: "Missing state parameter" }, 400);
+  }
 
-    if (!flowNonce) {
-        return c.json({ error: "Missing OAuth flow cookie" }, 400);
-    }
+  if (!flowNonce) {
+    return c.json({ error: "Missing OAuth flow cookie" }, 400);
+  }
 
-    const row = await c.env.DB.prepare(
-        "DELETE FROM oauth_states WHERE state = ? AND browser_nonce = ? RETURNING created_at",
-    )
-        .bind(stateParam, flowNonce)
-        .first<{ created_at: string }>();
+  const row = await c.env.DB.prepare(
+    "DELETE FROM oauth_states WHERE state = ? AND browser_nonce = ? RETURNING created_at",
+  )
+    .bind(stateParam, flowNonce)
+    .first<{ created_at: string }>();
 
-    if (!row) {
-        return c.json({ error: "Invalid or expired state" }, 400);
-    }
+  if (!row) {
+    return c.json({ error: "Invalid or expired state" }, 400);
+  }
 
-    const createdAt = new Date(`${row.created_at}Z`);
-    const nowDate = new Date();
-    if (nowDate.getTime() - createdAt.getTime() > OAUTH_STATE_TTL_MS) {
-        return c.json({ error: "State expired" }, 400);
-    }
+  const createdAt = new Date(`${row.created_at}Z`);
+  const nowDate = new Date();
+  if (nowDate.getTime() - createdAt.getTime() > OAUTH_STATE_TTL_MS) {
+    return c.json({ error: "State expired" }, 400);
+  }
 
-    if (!code) {
-        return c.json({ error: "Missing code parameter" }, 400);
-    }
+  if (!code) {
+    return c.json({ error: "Missing code parameter" }, 400);
+  }
 
-    // Exchange code for access token
-    const tokenRes = await fetch(
-        "https://github.com/login/oauth/access_token",
-        {
-            method: "POST",
-            headers: {
-                "Content-Type": "application/json",
-                Accept: "application/json",
-            },
-            body: JSON.stringify({
-                client_id: c.env.GITHUB_CLIENT_ID,
-                client_secret: c.env.GITHUB_CLIENT_SECRET,
-                code,
-            }),
-        },
+  // Exchange code for access token
+  const tokenRes = await fetch("https://github.com/login/oauth/access_token", {
+    method: "POST",
+    headers: {
+      "Content-Type": "application/json",
+      Accept: "application/json",
+    },
+    body: JSON.stringify({
+      client_id: c.env.GITHUB_CLIENT_ID,
+      client_secret: c.env.GITHUB_CLIENT_SECRET,
+      code,
+    }),
+  });
+
+  if (!tokenRes.ok) {
+    const tokenErr = await tokenRes.text();
+    return c.json(
+      {
+        error: "Failed to exchange OAuth code",
+        details: tokenErr.slice(0, 200),
+      },
+      502,
     );
+  }
 
-    if (!tokenRes.ok) {
-        const tokenErr = await tokenRes.text();
-        return c.json(
-            {
-                error: "Failed to exchange OAuth code",
-                details: tokenErr.slice(0, 200),
-            },
-            502,
-        );
-    }
+  const rawTokenData = (await tokenRes.json()) as unknown;
+  if (
+    !rawTokenData ||
+    typeof rawTokenData !== "object" ||
+    typeof (rawTokenData as { access_token?: unknown }).access_token !==
+      "string"
+  ) {
+    return c.json({ error: "Failed to get access token" }, 400);
+  }
+  const accessToken = (rawTokenData as { access_token: string }).access_token;
 
-    const rawTokenData = (await tokenRes.json()) as unknown;
-    if (
-        !rawTokenData ||
-        typeof rawTokenData !== "object" ||
-        typeof (rawTokenData as { access_token?: unknown }).access_token !==
-        "string"
-    ) {
-        return c.json({ error: "Failed to get access token" }, 400);
-    }
-    const accessToken = (rawTokenData as { access_token: string }).access_token;
+  // Get GitHub user info
+  const userRes = await fetch("https://api.github.com/user", {
+    headers: {
+      Authorization: `Bearer ${accessToken}`,
+      "User-Agent": "OpenShelf",
+    },
+  });
 
-    // Get GitHub user info
-    const userRes = await fetch("https://api.github.com/user", {
-        headers: {
-            Authorization: `Bearer ${accessToken}`,
-            "User-Agent": "OpenShelf",
-        },
+  if (!userRes.ok) {
+    const userErr = await userRes.text();
+    return c.json(
+      {
+        error: "Failed to fetch GitHub user",
+        details: userErr.slice(0, 200),
+      },
+      502,
+    );
+  }
+
+  const rawGhUser = (await userRes.json()) as unknown;
+  if (!rawGhUser || typeof rawGhUser !== "object") {
+    return c.json({ error: "Invalid GitHub user payload" }, 502);
+  }
+
+  const ghUser = rawGhUser as {
+    id?: unknown;
+    login?: unknown;
+    name?: unknown;
+    avatar_url?: unknown;
+    email?: unknown;
+  };
+
+  if (typeof ghUser.id !== "number" || typeof ghUser.login !== "string") {
+    return c.json({ error: "Invalid GitHub user payload" }, 502);
+  }
+
+  const ghName =
+    typeof ghUser.name === "string" && ghUser.name.length > 0
+      ? ghUser.name
+      : ghUser.login;
+  const ghAvatar =
+    typeof ghUser.avatar_url === "string" ? ghUser.avatar_url : null;
+  const ghEmail = typeof ghUser.email === "string" ? ghUser.email : null;
+
+  const db = drizzle(c.env.DB);
+  await enableForeignKeys(db);
+
+  // Upsert user atomically by githubId.
+  const githubId = String(ghUser.id);
+  const insertedUserId = crypto.randomUUID();
+  await db
+    .insert(users)
+    .values({
+      id: insertedUserId,
+      githubId,
+      name: ghName,
+      avatarUrl: ghAvatar,
+      email: ghEmail,
+      ...touchUpdatedAt(),
+    })
+    .onConflictDoUpdate({
+      target: users.githubId,
+      set: {
+        name: ghName,
+        avatarUrl: ghAvatar,
+        email: ghEmail,
+        ...touchUpdatedAt(),
+      },
     });
 
-    if (!userRes.ok) {
-        const userErr = await userRes.text();
-        return c.json(
-            {
-                error: "Failed to fetch GitHub user",
-                details: userErr.slice(0, 200),
-            },
-            502,
-        );
-    }
+  const upsertedUser = await db
+    .select({ id: users.id })
+    .from(users)
+    .where(eq(users.githubId, githubId))
+    .get();
+  if (!upsertedUser) {
+    return c.json({ error: "Failed to upsert user" }, 500);
+  }
+  const userId = upsertedUser.id;
 
-    const rawGhUser = (await userRes.json()) as unknown;
-    if (!rawGhUser || typeof rawGhUser !== "object") {
-        return c.json({ error: "Invalid GitHub user payload" }, 502);
-    }
+  // Generate JWT (7-day expiry)
+  const now = Math.floor(Date.now() / 1000);
+  const jwt = await sign(
+    {
+      sub: userId,
+      githubId,
+      name: ghName,
+      iat: now,
+      exp: now + JWT_EXPIRY_SECONDS,
+    },
+    c.env.JWT_SECRET,
+    "HS256",
+  );
 
-    const ghUser = rawGhUser as {
-        id?: unknown;
-        login?: unknown;
-        name?: unknown;
-        avatar_url?: unknown;
-        email?: unknown;
-    };
+  const frontendUrl = resolveAllowedOrigin(
+    [flowOrigin],
+    c.env.FRONTEND_URL,
+    parseOriginList(c.env.ALLOWED_ORIGINS),
+    { allowWildcard: false },
+  );
+  if (!frontendUrl) {
+    console.error("FATAL: FRONTEND_URL environment variable is not set.");
+    return c.json({ error: "Server configuration error" }, 500);
+  }
 
-    if (typeof ghUser.id !== "number" || typeof ghUser.login !== "string") {
-        return c.json({ error: "Invalid GitHub user payload" }, 502);
-    }
+  const frontendUrlObj = new URL(frontendUrl);
+  const isSecure = frontendUrlObj.protocol === "https:";
 
-    const ghName =
-        typeof ghUser.name === "string" && ghUser.name.length > 0
-            ? ghUser.name
-            : ghUser.login;
-    const ghAvatar =
-        typeof ghUser.avatar_url === "string" ? ghUser.avatar_url : null;
-    const ghEmail = typeof ghUser.email === "string" ? ghUser.email : null;
+  setCookie(c, "auth_token", jwt, {
+    httpOnly: true,
+    secure: isSecure,
+    sameSite: "Lax",
+    maxAge: JWT_EXPIRY_SECONDS,
+    path: "/",
+    domain:
+      frontendUrlObj.hostname === "localhost"
+        ? undefined
+        : frontendUrlObj.hostname,
+  });
 
-    const db = drizzle(c.env.DB);
-    await enableForeignKeys(db);
-
-    // Upsert user atomically by githubId.
-    const githubId = String(ghUser.id);
-    const insertedUserId = crypto.randomUUID();
-    await db
-        .insert(users)
-        .values({
-            id: insertedUserId,
-            githubId,
-            name: ghName,
-            avatarUrl: ghAvatar,
-            email: ghEmail,
-            ...touchUpdatedAt(),
-        })
-        .onConflictDoUpdate({
-            target: users.githubId,
-            set: {
-                name: ghName,
-                avatarUrl: ghAvatar,
-                email: ghEmail,
-                ...touchUpdatedAt(),
-            },
-        });
-
-    const upsertedUser = await db
-        .select({ id: users.id })
-        .from(users)
-        .where(eq(users.githubId, githubId))
-        .get();
-    if (!upsertedUser) {
-        return c.json({ error: "Failed to upsert user" }, 500);
-    }
-    const userId = upsertedUser.id;
-
-    // Generate JWT (7-day expiry)
-    const now = Math.floor(Date.now() / 1000);
-    const jwt = await sign(
-        {
-            sub: userId,
-            githubId,
-            name: ghName,
-            iat: now,
-            exp: now + JWT_EXPIRY_SECONDS,
-        },
-        c.env.JWT_SECRET,
-        "HS256",
-    );
-
-    const frontendUrl = resolveAllowedOrigin(
-        [flowOrigin],
-        c.env.FRONTEND_URL,
-        parseOriginList(c.env.ALLOWED_ORIGINS),
-        { allowWildcard: false },
-    );
-    if (!frontendUrl) {
-        console.error("FATAL: FRONTEND_URL environment variable is not set.");
-        return c.json({ error: "Server configuration error" }, 500);
-    }
-
-    const callbackUrl = new URL("/auth/callback", frontendUrl);
-    callbackUrl.hash = new URLSearchParams({ token: jwt }).toString();
-    return c.redirect(callbackUrl.toString());
+  const callbackUrl = new URL("/auth/callback", frontendUrl);
+  return c.redirect(callbackUrl.toString());
 });
 
 // GET /api/auth/me — current user info
 auth.get("/me", authMiddleware, async (c) => {
-    const payload = c.get("user");
-    const db = drizzle(c.env.DB);
-    const user = await db
-        .select()
-        .from(users)
-        .where(eq(users.id, payload.sub))
-        .get();
-    if (!user) return c.json({ error: "User not found" }, 404);
-    return c.json({ user });
+  const payload = c.get("user");
+  const db = drizzle(c.env.DB);
+  const user = await db
+    .select()
+    .from(users)
+    .where(eq(users.id, payload.sub))
+    .get();
+  if (!user) return c.json({ error: "User not found" }, 404);
+  return c.json({ user });
 });
 
 // POST /api/auth/logout
 auth.post("/logout", async (c) => {
-    return c.json({ ok: true });
+  deleteCookie(c, "auth_token", { path: "/" });
+  return c.json({ ok: true });
 });
 
 export default auth;

--- a/apps/api/src/routes/badge.ts
+++ b/apps/api/src/routes/badge.ts
@@ -5,16 +5,16 @@ import { eq } from "drizzle-orm";
 import { papers } from "../db/schema";
 import type { Env, Variables } from "../types";
 import {
-    BADGE_CACHE_CONTROL,
-    buildBadgeMessage,
-    buildBadgeSvg,
-    buildLeftText,
-    buildNotFoundBadge,
-    buildShieldsEndpointPayload,
-    createEtag,
-    normalizeBadgeColor,
-    normalizeBadgeLabel,
-    normalizeBadgeStyle,
+  BADGE_CACHE_CONTROL,
+  buildBadgeMessage,
+  buildBadgeSvg,
+  buildLeftText,
+  buildNotFoundBadge,
+  buildShieldsEndpointPayload,
+  createEtag,
+  normalizeBadgeColor,
+  normalizeBadgeLabel,
+  normalizeBadgeStyle,
 } from "../utils/badge";
 
 const badgeRoute = new Hono<{ Bindings: Env; Variables: Variables }>();
@@ -22,122 +22,122 @@ const badgeRoute = new Hono<{ Bindings: Env; Variables: Variables }>();
 type BadgeContext = Context<{ Bindings: Env; Variables: Variables }>;
 
 function setCacheHeaders(c: BadgeContext, etag: string): void {
-    c.header("Cache-Control", BADGE_CACHE_CONTROL);
-    c.header("ETag", etag);
-    c.header("Vary", "Accept-Encoding");
+  c.header("Cache-Control", BADGE_CACHE_CONTROL);
+  c.header("ETag", etag);
+  c.header("Vary", "Accept-Encoding");
 }
 
 function normalizeEtagValue(value: string): string {
-    const trimmed = value.trim();
-    return trimmed.startsWith("W/") ? trimmed.slice(2).trim() : trimmed;
+  const trimmed = value.trim();
+  return trimmed.startsWith("W/") ? trimmed.slice(2).trim() : trimmed;
 }
 
 function applyConditionalResponse(c: BadgeContext, etag: string): boolean {
-    const ifNoneMatch = c.req.header("If-None-Match");
-    if (!ifNoneMatch) return false;
+  const ifNoneMatch = c.req.header("If-None-Match");
+  if (!ifNoneMatch) return false;
 
-    const candidates = ifNoneMatch
-        .split(",")
-        .map((value) => normalizeEtagValue(value))
-        .filter((value) => value.length > 0);
+  const candidates = ifNoneMatch
+    .split(",")
+    .map((value) => normalizeEtagValue(value))
+    .filter((value) => value.length > 0);
 
-    if (candidates.includes("*") || candidates.includes(etag)) {
-        setCacheHeaders(c, etag);
-        c.status(304);
-        return true;
-    }
-    return false;
+  if (candidates.includes("*") || candidates.includes(etag)) {
+    setCacheHeaders(c, etag);
+    c.status(304);
+    return true;
+  }
+  return false;
 }
 
 async function fetchPublicPaper(
-    c: BadgeContext,
-    paperId: string,
+  c: BadgeContext,
+  paperId: string,
 ): Promise<{
-    id: string;
-    title: string;
-    year: number | null;
-    visibility: string;
+  id: string;
+  title: string;
+  year: number | null;
+  visibility: string;
 } | null> {
-    const db = drizzle(c.env.DB);
-    const paper = await db
-        .select({
-            id: papers.id,
-            title: papers.title,
-            year: papers.year,
-            visibility: papers.visibility,
-        })
-        .from(papers)
-        .where(eq(papers.id, paperId))
-        .get();
+  const db = drizzle(c.env.DB);
+  const paper = await db
+    .select({
+      id: papers.id,
+      title: papers.title,
+      year: papers.year,
+      visibility: papers.visibility,
+    })
+    .from(papers)
+    .where(eq(papers.id, paperId))
+    .get();
 
-    if (!paper || paper.visibility !== "public") return null;
-    return paper;
+  if (!paper || paper.visibility !== "public") return null;
+  return paper;
 }
 
 function readBadgeOptions(c: BadgeContext) {
-    const style = normalizeBadgeStyle(c.req.query("style"));
-    const color = normalizeBadgeColor(c.req.query("color"));
-    const label = normalizeBadgeLabel(c.req.query("label"));
-    return { style, color, label };
+  const style = normalizeBadgeStyle(c.req.query("style"));
+  const color = normalizeBadgeColor(c.req.query("color"));
+  const label = normalizeBadgeLabel(c.req.query("label"));
+  return { style, color, label };
 }
 
 badgeRoute.get("/:paperId", async (c) => {
-    const paperId = c.req.param("paperId");
-    const options = readBadgeOptions(c);
-    const paper = await fetchPublicPaper(c, paperId);
+  const paperId = c.req.param("paperId");
+  const options = readBadgeOptions(c);
+  const paper = await fetchPublicPaper(c, paperId);
 
-    if (!paper) {
-        const notFound = buildNotFoundBadge(options);
-        const etag = createEtag(notFound.svg);
-        if (applyConditionalResponse(c, etag)) {
-            return c.body(null);
-        }
-        setCacheHeaders(c, etag);
-        c.header("Content-Type", "image/svg+xml; charset=utf-8");
-        return c.body(notFound.svg, 404);
-    }
-
-    const leftText = buildLeftText(options.label);
-    const message = buildBadgeMessage(paper.title, paper.year, options.style);
-    const svg = buildBadgeSvg(leftText, message, options.color);
-    const etag = createEtag(svg);
-
+  if (!paper) {
+    const notFound = buildNotFoundBadge(options);
+    const etag = createEtag(notFound.svg);
     if (applyConditionalResponse(c, etag)) {
-        return c.body(null);
+      return c.body(null);
     }
     setCacheHeaders(c, etag);
     c.header("Content-Type", "image/svg+xml; charset=utf-8");
-    return c.body(svg);
+    return c.body(notFound.svg, 404);
+  }
+
+  const leftText = buildLeftText(options.label);
+  const message = buildBadgeMessage(paper.title, paper.year, options.style);
+  const svg = buildBadgeSvg(leftText, message, options.color);
+  const etag = createEtag(svg);
+
+  if (applyConditionalResponse(c, etag)) {
+    return c.body(null);
+  }
+  setCacheHeaders(c, etag);
+  c.header("Content-Type", "image/svg+xml; charset=utf-8");
+  return c.body(svg);
 });
 
 badgeRoute.get("/api/:paperId", async (c) => {
-    const paperId = c.req.param("paperId");
-    const options = readBadgeOptions(c);
-    const paper = await fetchPublicPaper(c, paperId);
+  const paperId = c.req.param("paperId");
+  const options = readBadgeOptions(c);
+  const paper = await fetchPublicPaper(c, paperId);
 
-    // This endpoint intentionally keeps shields.io-compatible JSON for both 200 and
-    // 404 responses so external badge consumers can use the same contract.
-    if (!paper) {
-        const notFound = buildNotFoundBadge(options);
-        const payload = JSON.stringify(notFound.json);
-        const etag = createEtag(payload);
-        if (applyConditionalResponse(c, etag)) {
-            return c.body(null);
-        }
-        setCacheHeaders(c, etag);
-        return c.json(notFound.json, 404);
-    }
-
-    const leftText = buildLeftText(options.label);
-    const message = buildBadgeMessage(paper.title, paper.year, options.style);
-    const json = buildShieldsEndpointPayload(leftText, message, options.color);
-    const payload = JSON.stringify(json);
+  // This endpoint intentionally keeps shields.io-compatible JSON for both 200 and
+  // 404 responses so external badge consumers can use the same contract.
+  if (!paper) {
+    const notFound = buildNotFoundBadge(options);
+    const payload = JSON.stringify(notFound.json);
     const etag = createEtag(payload);
     if (applyConditionalResponse(c, etag)) {
-        return c.body(null);
+      return c.body(null);
     }
     setCacheHeaders(c, etag);
-    return c.json(json);
+    return c.json(notFound.json, 404);
+  }
+
+  const leftText = buildLeftText(options.label);
+  const message = buildBadgeMessage(paper.title, paper.year, options.style);
+  const json = buildShieldsEndpointPayload(leftText, message, options.color);
+  const payload = JSON.stringify(json);
+  const etag = createEtag(payload);
+  if (applyConditionalResponse(c, etag)) {
+    return c.body(null);
+  }
+  setCacheHeaders(c, etag);
+  return c.json(json);
 });
 
 export default badgeRoute;

--- a/apps/api/src/routes/collections.ts
+++ b/apps/api/src/routes/collections.ts
@@ -257,9 +257,7 @@ collectionsRoute.post("/collections", authMiddleware, async (c) => {
         ? payload.org_slug.trim().toLowerCase()
         : "";
     const inputOwnerId =
-      typeof payload.owner_id === "string"
-        ? payload.owner_id.trim()
-        : "";
+      typeof payload.owner_id === "string" ? payload.owner_id.trim() : "";
 
     let org = null;
     if (inputOrgSlug) {
@@ -525,7 +523,8 @@ collectionsRoute.post("/collections/:id/papers", authMiddleware, async (c) => {
   const payload = body as AddPaperToCollectionBody;
 
   const paperId = normalizePaperId(payload.paper_id);
-  if (!paperId) return c.json({ error: "paper_id is invalid or too long" }, 400);
+  if (!paperId)
+    return c.json({ error: "paper_id is invalid or too long" }, 400);
 
   const paper = await db
     .select()

--- a/apps/api/src/routes/feed.ts
+++ b/apps/api/src/routes/feed.ts
@@ -2,14 +2,14 @@ import { and, asc, desc, eq, inArray, sql } from "drizzle-orm";
 import { drizzle } from "drizzle-orm/d1";
 import { Hono, type Context } from "hono";
 import {
-    collectionPapers,
-    collections,
-    orgs,
-    paperAuthors,
-    paperFiles,
-    paperOrgs,
-    papers,
-    users,
+  collectionPapers,
+  collections,
+  orgs,
+  paperAuthors,
+  paperFiles,
+  paperOrgs,
+  papers,
+  users,
 } from "../db/schema";
 import type { Env, Variables } from "../types";
 import { parseStoredTags } from "../utils/tags";
@@ -18,531 +18,593 @@ const feedRoute = new Hono<{ Bindings: Env; Variables: Variables }>();
 const FEED_LIMIT = 50;
 const SLUG_REGEX = /^[a-z0-9][a-z0-9-]*[a-z0-9]$|^[a-z0-9]$/;
 const PAPER_FEED_SELECT = {
-    id: papers.id,
-    title: papers.title,
-    abstract: papers.abstract,
-    category: papers.category,
-    tags: papers.tags,
-    createdAt: papers.createdAt,
-    updatedAt: papers.updatedAt,
+  id: papers.id,
+  title: papers.title,
+  abstract: papers.abstract,
+  category: papers.category,
+  tags: papers.tags,
+  createdAt: papers.createdAt,
+  updatedAt: papers.updatedAt,
 } as const;
 
 type FeedContext = Context<{ Bindings: Env; Variables: Variables }>;
 
 type FeedMeta = {
-    title: string;
-    link: string;
-    selfLink: string;
-    id: string;
-    updated: string;
-    authorName: string;
+  title: string;
+  link: string;
+  selfLink: string;
+  id: string;
+  updated: string;
+  authorName: string;
 };
 
 type FeedEntry = {
-    title: string;
-    link: string;
-    id: string;
-    published: string;
-    updated: string;
-    summary: string;
-    authors: string[];
-    category?: string | null;
-    enclosure?: {
-        href: string;
-        type: string;
-        length: number;
-    };
+  title: string;
+  link: string;
+  id: string;
+  published: string;
+  updated: string;
+  summary: string;
+  authors: string[];
+  category?: string | null;
+  enclosure?: {
+    href: string;
+    type: string;
+    length: number;
+  };
 };
 
 type PaperRow = {
-    id: string;
-    title: string;
-    abstract: string | null;
-    category: string | null;
-    tags?: string | null;
-    createdAt: string;
-    updatedAt: string;
+  id: string;
+  title: string;
+  abstract: string | null;
+  category: string | null;
+  tags?: string | null;
+  createdAt: string;
+  updatedAt: string;
 };
 
 type AuthorRow = {
-    paperId: string;
-    role: string;
-    name: string;
-    displayName: string | null;
+  paperId: string;
+  role: string;
+  name: string;
+  displayName: string | null;
 };
 
 type FileRow = {
-    paperId: string;
-    id: string;
-    filename: string;
-    sizeBytes: number;
-    mimeType: string | null;
+  paperId: string;
+  id: string;
+  filename: string;
+  sizeBytes: number;
+  mimeType: string | null;
 };
 
 function normalizeBaseUrl(value: string): string {
-    return value.replace(/\/+$/, "");
+  return value.replace(/\/+$/, "");
 }
 
 function escapeXml(value: string): string {
-    return value
-        .replaceAll("&", "&amp;")
-        .replaceAll("<", "&lt;")
-        .replaceAll(">", "&gt;")
-        .replaceAll('"', "&quot;")
-        .replaceAll("'", "&apos;");
+  return value
+    .replaceAll("&", "&amp;")
+    .replaceAll("<", "&lt;")
+    .replaceAll(">", "&gt;")
+    .replaceAll('"', "&quot;")
+    .replaceAll("'", "&apos;");
 }
 
 function toIsoString(dateStr: string): string {
-    const normalized = /[zZ]|[+-]\d{2}:\d{2}$/.test(dateStr)
-        ? dateStr
-        : `${dateStr.replace(" ", "T")}Z`;
-    const date = new Date(normalized);
-    if (Number.isNaN(date.getTime())) {
-        throw new Error(`Invalid database datetime: ${dateStr}`);
-    }
-    return date.toISOString();
+  const normalized = /[zZ]|[+-]\d{2}:\d{2}$/.test(dateStr)
+    ? dateStr
+    : `${dateStr.replace(" ", "T")}Z`;
+  const date = new Date(normalized);
+  if (Number.isNaN(date.getTime())) {
+    throw new Error(`Invalid database datetime: ${dateStr}`);
+  }
+  return date.toISOString();
 }
 
-function latestTimestamp(rows: Array<{ updatedAt: string }>, fallback: string): string {
-    if (rows.length === 0) {
-        return fallback;
-    }
+function latestTimestamp(
+  rows: Array<{ updatedAt: string }>,
+  fallback: string,
+): string {
+  if (rows.length === 0) {
+    return fallback;
+  }
 
-    // Database timestamps should already be ISO-like or parseable directly via string comparison.
-    let latest = fallback;
+  // Database timestamps should already be ISO-like or parseable directly via string comparison.
+  let latest = fallback;
 
-    for (const row of rows) {
-        if (row.updatedAt > latest) {
-            latest = row.updatedAt;
-        }
+  for (const row of rows) {
+    if (row.updatedAt > latest) {
+      latest = row.updatedAt;
     }
-    return latest;
+  }
+  return latest;
 }
 
-function groupByPaperId<T extends { paperId: string }>(rows: T[]): Map<string, T[]> {
-    const groups = new Map<string, T[]>();
-    for (const row of rows) {
-        const existing = groups.get(row.paperId);
-        if (existing) {
-            existing.push(row);
-        } else {
-            groups.set(row.paperId, [row]);
-        }
+function groupByPaperId<T extends { paperId: string }>(
+  rows: T[],
+): Map<string, T[]> {
+  const groups = new Map<string, T[]>();
+  for (const row of rows) {
+    const existing = groups.get(row.paperId);
+    if (existing) {
+      existing.push(row);
+    } else {
+      groups.set(row.paperId, [row]);
     }
-    return groups;
+  }
+  return groups;
 }
 
 function dedupePaperRows(rows: PaperRow[]): PaperRow[] {
-    const seen = new Set<string>();
-    const uniqueRows: PaperRow[] = [];
-    for (const row of rows) {
-        if (seen.has(row.id)) continue;
-        seen.add(row.id);
-        uniqueRows.push(row);
-    }
-    return uniqueRows;
+  const seen = new Set<string>();
+  const uniqueRows: PaperRow[] = [];
+  for (const row of rows) {
+    if (seen.has(row.id)) continue;
+    seen.add(row.id);
+    uniqueRows.push(row);
+  }
+  return uniqueRows;
 }
 
 function normalizeTagFilter(value: string | undefined): string | null {
-    if (typeof value !== "string") return null;
-    const trimmed = value.trim();
-    return trimmed.length > 0 ? trimmed : null;
+  if (typeof value !== "string") return null;
+  const trimmed = value.trim();
+  return trimmed.length > 0 ? trimmed : null;
 }
 
 function buildTagFilterCondition(tagFilter: string | null) {
-    if (!tagFilter) return undefined;
+  if (!tagFilter) return undefined;
 
-    const normalizedTag = tagFilter.toLowerCase();
-    return sql<boolean>`EXISTS (
+  const normalizedTag = tagFilter.toLowerCase();
+  return sql<boolean>`EXISTS (
         SELECT 1
         FROM json_each(COALESCE(${papers.tags}, '[]'))
         WHERE lower(trim(value)) = ${normalizedTag}
     )`;
 }
 
-function filterPaperRowsByTag(rows: PaperRow[], tag: string | null): PaperRow[] {
-    const uniqueRows = dedupePaperRows(rows);
-    if (!tag) return uniqueRows;
+function filterPaperRowsByTag(
+  rows: PaperRow[],
+  tag: string | null,
+): PaperRow[] {
+  const uniqueRows = dedupePaperRows(rows);
+  if (!tag) return uniqueRows;
 
-    const normalizedTag = tag.toLowerCase();
-    return uniqueRows.filter((paper) =>
-        parseStoredTags(paper.tags ?? null).some(
-            (storedTag) => storedTag.toLowerCase() === normalizedTag,
-        ),
-    );
+  const normalizedTag = tag.toLowerCase();
+  return uniqueRows.filter((paper) =>
+    parseStoredTags(paper.tags ?? null).some(
+      (storedTag) => storedTag.toLowerCase() === normalizedTag,
+    ),
+  );
 }
 
 function authorLabel(author: AuthorRow): string {
-    return author.displayName?.trim() || author.name;
+  return author.displayName?.trim() || author.name;
 }
 
 function sortAuthors(authors: AuthorRow[]): AuthorRow[] {
-    return [...authors].sort((a, b) => {
-        if (a.role !== b.role) {
-            return a.role === "uploader" ? -1 : 1;
-        }
-        return authorLabel(a).localeCompare(authorLabel(b));
-    });
+  return [...authors].sort((a, b) => {
+    if (a.role !== b.role) {
+      return a.role === "uploader" ? -1 : 1;
+    }
+    return authorLabel(a).localeCompare(authorLabel(b));
+  });
 }
 
 function buildAtomFeed(meta: FeedMeta, entries: FeedEntry[]): string {
-    const lines = [
-        '<?xml version="1.0" encoding="utf-8"?>',
-        '<feed xmlns="http://www.w3.org/2005/Atom">',
-        `  <title>${escapeXml(meta.title)}</title>`,
-        `  <link href="${escapeXml(meta.link)}" rel="alternate" type="text/html"/>`,
-        `  <link href="${escapeXml(meta.selfLink)}" rel="self" type="application/atom+xml"/>`,
-        `  <id>${escapeXml(meta.id)}</id>`,
-        `  <updated>${escapeXml(meta.updated)}</updated>`,
-        `  <author><name>${escapeXml(meta.authorName)}</name></author>`,
-    ];
+  const lines = [
+    '<?xml version="1.0" encoding="utf-8"?>',
+    '<feed xmlns="http://www.w3.org/2005/Atom">',
+    `  <title>${escapeXml(meta.title)}</title>`,
+    `  <link href="${escapeXml(meta.link)}" rel="alternate" type="text/html"/>`,
+    `  <link href="${escapeXml(meta.selfLink)}" rel="self" type="application/atom+xml"/>`,
+    `  <id>${escapeXml(meta.id)}</id>`,
+    `  <updated>${escapeXml(meta.updated)}</updated>`,
+    `  <author><name>${escapeXml(meta.authorName)}</name></author>`,
+  ];
 
-    for (const entry of entries) {
-        lines.push("  <entry>");
-        lines.push(`    <title>${escapeXml(entry.title)}</title>`);
-        lines.push(`    <link href="${escapeXml(entry.link)}"/>`);
-        lines.push(`    <id>${escapeXml(entry.id)}</id>`);
-        lines.push(`    <published>${escapeXml(entry.published)}</published>`);
-        lines.push(`    <updated>${escapeXml(entry.updated)}</updated>`);
-        lines.push(`    <summary>${escapeXml(entry.summary)}</summary>`);
-        if (entry.authors.length > 0) {
-            lines.push(
-                entry.authors
-                    .map((author) => `    <author><name>${escapeXml(author)}</name></author>`)
-                    .join("\n")
-            );
-        }
-        if (entry.category) {
-            lines.push(`    <category term="${escapeXml(entry.category)}"/>`);
-        }
-        if (entry.enclosure) {
-            lines.push(
-                `    <link rel="enclosure" href="${escapeXml(entry.enclosure.href)}" type="${escapeXml(entry.enclosure.type)}" length="${entry.enclosure.length}"/>`,
-            );
-        }
-        lines.push("  </entry>");
+  for (const entry of entries) {
+    lines.push("  <entry>");
+    lines.push(`    <title>${escapeXml(entry.title)}</title>`);
+    lines.push(`    <link href="${escapeXml(entry.link)}"/>`);
+    lines.push(`    <id>${escapeXml(entry.id)}</id>`);
+    lines.push(`    <published>${escapeXml(entry.published)}</published>`);
+    lines.push(`    <updated>${escapeXml(entry.updated)}</updated>`);
+    lines.push(`    <summary>${escapeXml(entry.summary)}</summary>`);
+    if (entry.authors.length > 0) {
+      lines.push(
+        entry.authors
+          .map(
+            (author) =>
+              `    <author><name>${escapeXml(author)}</name></author>`,
+          )
+          .join("\n"),
+      );
     }
+    if (entry.category) {
+      lines.push(`    <category term="${escapeXml(entry.category)}"/>`);
+    }
+    if (entry.enclosure) {
+      lines.push(
+        `    <link rel="enclosure" href="${escapeXml(entry.enclosure.href)}" type="${escapeXml(entry.enclosure.type)}" length="${entry.enclosure.length}"/>`,
+      );
+    }
+    lines.push("  </entry>");
+  }
 
-    lines.push("</feed>");
-    return lines.join("\n");
+  lines.push("</feed>");
+  return lines.join("\n");
 }
 
 async function loadPaperAuthors(
-    db: ReturnType<typeof drizzle>,
-    paperIds: string[],
+  db: ReturnType<typeof drizzle>,
+  paperIds: string[],
 ): Promise<Map<string, AuthorRow[]>> {
-    if (paperIds.length === 0) return new Map();
+  if (paperIds.length === 0) return new Map();
 
-    const rows = await db
-        .select({
-            paperId: paperAuthors.paperId,
-            role: paperAuthors.role,
-            name: users.name,
-            displayName: users.displayName,
-        })
-        .from(paperAuthors)
-        .innerJoin(users, eq(paperAuthors.userId, users.id))
-        .where(inArray(paperAuthors.paperId, paperIds))
-        .all();
+  const rows = await db
+    .select({
+      paperId: paperAuthors.paperId,
+      role: paperAuthors.role,
+      name: users.name,
+      displayName: users.displayName,
+    })
+    .from(paperAuthors)
+    .innerJoin(users, eq(paperAuthors.userId, users.id))
+    .where(inArray(paperAuthors.paperId, paperIds))
+    .all();
 
-    const grouped = groupByPaperId(rows);
-    const authorsByPaperId = new Map<string, AuthorRow[]>();
-    for (const [paperId, authors] of grouped.entries()) {
-        authorsByPaperId.set(paperId, sortAuthors(authors));
-    }
-    return authorsByPaperId;
+  const grouped = groupByPaperId(rows);
+  const authorsByPaperId = new Map<string, AuthorRow[]>();
+  for (const [paperId, authors] of grouped.entries()) {
+    authorsByPaperId.set(paperId, sortAuthors(authors));
+  }
+  return authorsByPaperId;
 }
 
 async function loadPaperFiles(
-    db: ReturnType<typeof drizzle>,
-    paperIds: string[],
+  db: ReturnType<typeof drizzle>,
+  paperIds: string[],
 ): Promise<Map<string, FileRow[]>> {
-    if (paperIds.length === 0) return new Map();
+  if (paperIds.length === 0) return new Map();
 
-    const rows = await db
-        .select({
-            paperId: paperFiles.paperId,
-            id: paperFiles.id,
-            filename: paperFiles.filename,
-            sizeBytes: paperFiles.sizeBytes,
-            mimeType: paperFiles.mimeType,
-        })
-        .from(paperFiles)
-        .where(and(eq(paperFiles.fileType, "paper"), inArray(paperFiles.paperId, paperIds)))
-        .orderBy(desc(paperFiles.createdAt))
-        .all();
+  const rows = await db
+    .select({
+      paperId: paperFiles.paperId,
+      id: paperFiles.id,
+      filename: paperFiles.filename,
+      sizeBytes: paperFiles.sizeBytes,
+      mimeType: paperFiles.mimeType,
+    })
+    .from(paperFiles)
+    .where(
+      and(
+        eq(paperFiles.fileType, "paper"),
+        inArray(paperFiles.paperId, paperIds),
+      ),
+    )
+    .orderBy(desc(paperFiles.createdAt))
+    .all();
 
-    return groupByPaperId(rows);
+  return groupByPaperId(rows);
 }
 
 function buildPaperEntries(
-    papersRows: PaperRow[],
-    authorsByPaperId: Map<string, AuthorRow[]>,
-    filesByPaperId: Map<string, FileRow[]>,
-    frontendBaseUrl: string,
-    apiBaseUrl: string,
-    fallbackAuthorName: string,
+  papersRows: PaperRow[],
+  authorsByPaperId: Map<string, AuthorRow[]>,
+  filesByPaperId: Map<string, FileRow[]>,
+  frontendBaseUrl: string,
+  apiBaseUrl: string,
+  fallbackAuthorName: string,
 ): FeedEntry[] {
-    const frontendBase = normalizeBaseUrl(frontendBaseUrl);
-    const apiBase = normalizeBaseUrl(apiBaseUrl);
-    const fallback = fallbackAuthorName.trim() || "OpenShelf";
+  const frontendBase = normalizeBaseUrl(frontendBaseUrl);
+  const apiBase = normalizeBaseUrl(apiBaseUrl);
+  const fallback = fallbackAuthorName.trim() || "OpenShelf";
 
-    return papersRows.map((paper) => {
-        const authors = (authorsByPaperId.get(paper.id) ?? []).map(authorLabel);
-        const entryAuthors = authors.length > 0 ? authors : [fallback];
-        const enclosure = filesByPaperId.get(paper.id)?.[0];
+  return papersRows.map((paper) => {
+    const authors = (authorsByPaperId.get(paper.id) ?? []).map(authorLabel);
+    const entryAuthors = authors.length > 0 ? authors : [fallback];
+    const enclosure = filesByPaperId.get(paper.id)?.[0];
 
-        return {
-            title: paper.title,
-            link: `${frontendBase}/papers/${encodeURIComponent(paper.id)}`,
-            id: `urn:openshelf:paper:${paper.id}`,
-            published: toIsoString(paper.createdAt),
-            updated: toIsoString(paper.updatedAt),
-            summary: paper.abstract ?? "",
-            authors: entryAuthors,
-            category: paper.category ?? undefined,
-            enclosure: enclosure
-                ? {
-                      href: `${apiBase}/api/papers/${encodeURIComponent(paper.id)}/files/${encodeURIComponent(enclosure.id)}/stream`,
-                      type: enclosure.mimeType ?? "application/pdf",
-                      length: enclosure.sizeBytes,
-                  }
-                : undefined,
-        };
-    });
+    return {
+      title: paper.title,
+      link: `${frontendBase}/papers/${encodeURIComponent(paper.id)}`,
+      id: `urn:openshelf:paper:${paper.id}`,
+      published: toIsoString(paper.createdAt),
+      updated: toIsoString(paper.updatedAt),
+      summary: paper.abstract ?? "",
+      authors: entryAuthors,
+      category: paper.category ?? undefined,
+      enclosure: enclosure
+        ? {
+            href: `${apiBase}/api/papers/${encodeURIComponent(paper.id)}/files/${encodeURIComponent(enclosure.id)}/stream`,
+            type: enclosure.mimeType ?? "application/pdf",
+            length: enclosure.sizeBytes,
+          }
+        : undefined,
+    };
+  });
 }
 
 async function buildFeedResponse(
-    c: FeedContext,
-    meta: Omit<FeedMeta, "updated"> & { updatedFallback: string },
-    papersRows: PaperRow[],
+  c: FeedContext,
+  meta: Omit<FeedMeta, "updated"> & { updatedFallback: string },
+  papersRows: PaperRow[],
 ): Promise<Response> {
-    const db = drizzle(c.env.DB);
-    const paperIds = papersRows.map((paper) => paper.id);
-    const [authorsByPaperId, filesByPaperId] = await Promise.all([
-        loadPaperAuthors(db, paperIds),
-        loadPaperFiles(db, paperIds),
-    ]);
-    const entries = buildPaperEntries(
-        papersRows,
-        authorsByPaperId,
-        filesByPaperId,
-        c.env.FRONTEND_URL,
-        new URL(c.req.url).origin,
-        meta.authorName,
-    );
-    const xml = buildAtomFeed(
-        {
-            title: meta.title,
-            link: meta.link,
-            selfLink: meta.selfLink,
-            id: meta.id,
-            updated: toIsoString(latestTimestamp(papersRows, meta.updatedFallback)),
-            authorName: meta.authorName,
-        },
-        entries,
-    );
+  const db = drizzle(c.env.DB);
+  const paperIds = papersRows.map((paper) => paper.id);
+  const [authorsByPaperId, filesByPaperId] = await Promise.all([
+    loadPaperAuthors(db, paperIds),
+    loadPaperFiles(db, paperIds),
+  ]);
+  const entries = buildPaperEntries(
+    papersRows,
+    authorsByPaperId,
+    filesByPaperId,
+    c.env.FRONTEND_URL,
+    new URL(c.req.url).origin,
+    meta.authorName,
+  );
+  const xml = buildAtomFeed(
+    {
+      title: meta.title,
+      link: meta.link,
+      selfLink: meta.selfLink,
+      id: meta.id,
+      updated: toIsoString(latestTimestamp(papersRows, meta.updatedFallback)),
+      authorName: meta.authorName,
+    },
+    entries,
+  );
 
-    return new Response(xml, {
-        headers: {
-            "Content-Type": "application/atom+xml; charset=utf-8",
-            "Cache-Control": "public, max-age=3600, stale-while-revalidate=600",
-        },
-    });
+  return new Response(xml, {
+    headers: {
+      "Content-Type": "application/atom+xml; charset=utf-8",
+      "Cache-Control": "public, max-age=3600, stale-while-revalidate=600",
+    },
+  });
 }
 
-async function buildOrgFeedResponse(c: FeedContext, slug: string): Promise<Response> {
-    if (!SLUG_REGEX.test(slug)) {
-        return c.json({ error: "invalid slug" }, 400);
-    }
-    const db = drizzle(c.env.DB);
-    const tagFilter = normalizeTagFilter(c.req.query("tag") ?? undefined);
-    const tagCondition = buildTagFilterCondition(tagFilter);
+async function buildOrgFeedResponse(
+  c: FeedContext,
+  slug: string,
+): Promise<Response> {
+  if (!SLUG_REGEX.test(slug)) {
+    return c.json({ error: "invalid slug" }, 400);
+  }
+  const db = drizzle(c.env.DB);
+  const tagFilter = normalizeTagFilter(c.req.query("tag") ?? undefined);
+  const tagCondition = buildTagFilterCondition(tagFilter);
 
-    const org = await db.select().from(orgs).where(eq(orgs.slug, slug)).get();
-    if (!org) return c.json({ error: "Org not found" }, 404);
+  const org = await db.select().from(orgs).where(eq(orgs.slug, slug)).get();
+  if (!org) return c.json({ error: "Org not found" }, 404);
 
-    const papersRows = await db
-        .select(PAPER_FEED_SELECT)
-        .from(paperOrgs)
-        .innerJoin(papers, eq(paperOrgs.paperId, papers.id))
-        .where(and(eq(paperOrgs.orgId, org.id), eq(papers.visibility, "public"), tagCondition))
-        .orderBy(desc(papers.createdAt))
-        .limit(FEED_LIMIT)
-        .all();
+  const papersRows = await db
+    .select(PAPER_FEED_SELECT)
+    .from(paperOrgs)
+    .innerJoin(papers, eq(paperOrgs.paperId, papers.id))
+    .where(
+      and(
+        eq(paperOrgs.orgId, org.id),
+        eq(papers.visibility, "public"),
+        tagCondition,
+      ),
+    )
+    .orderBy(desc(papers.createdAt))
+    .limit(FEED_LIMIT)
+    .all();
 
-    return await buildFeedResponse(
-        c,
-        {
-            title: `${org.name} - OpenShelf`,
-            link: `${normalizeBaseUrl(c.env.FRONTEND_URL)}/orgs/${encodeURIComponent(slug)}`,
-            selfLink: c.req.url,
-            id: `urn:openshelf:org:${slug}`,
-            updatedFallback: org.updatedAt,
-            authorName: org.name,
-        },
-        // SQLで絞り込み済みだが、フィルタの整合性確認と重複排除を兼ねて再利用する
-        filterPaperRowsByTag(papersRows, tagFilter),
-    );
+  return await buildFeedResponse(
+    c,
+    {
+      title: `${org.name} - OpenShelf`,
+      link: `${normalizeBaseUrl(c.env.FRONTEND_URL)}/orgs/${encodeURIComponent(slug)}`,
+      selfLink: c.req.url,
+      id: `urn:openshelf:org:${slug}`,
+      updatedFallback: org.updatedAt,
+      authorName: org.name,
+    },
+    // SQLで絞り込み済みだが、フィルタの整合性確認と重複排除を兼ねて再利用する
+    filterPaperRowsByTag(papersRows, tagFilter),
+  );
 }
 
-async function buildUserFeedResponse(c: FeedContext, id: string): Promise<Response> {
-    const db = drizzle(c.env.DB);
-    const tagFilter = normalizeTagFilter(c.req.query("tag") ?? undefined);
-    const tagCondition = buildTagFilterCondition(tagFilter);
+async function buildUserFeedResponse(
+  c: FeedContext,
+  id: string,
+): Promise<Response> {
+  const db = drizzle(c.env.DB);
+  const tagFilter = normalizeTagFilter(c.req.query("tag") ?? undefined);
+  const tagCondition = buildTagFilterCondition(tagFilter);
 
-    const user = await db.select().from(users).where(eq(users.id, id)).get();
-    if (!user) return c.json({ error: "User not found" }, 404);
-    const authorName = (user.displayName ?? user.name ?? "").trim() || "OpenShelf";
+  const user = await db.select().from(users).where(eq(users.id, id)).get();
+  if (!user) return c.json({ error: "User not found" }, 404);
+  const authorName =
+    (user.displayName ?? user.name ?? "").trim() || "OpenShelf";
 
-    const papersRows = await db
-        .select(PAPER_FEED_SELECT)
-        .from(paperAuthors)
-        .innerJoin(papers, eq(paperAuthors.paperId, papers.id))
-        .where(and(eq(paperAuthors.userId, id), eq(papers.visibility, "public"), tagCondition))
-        .orderBy(desc(papers.createdAt))
-        .limit(FEED_LIMIT)
-        .all();
+  const papersRows = await db
+    .select(PAPER_FEED_SELECT)
+    .from(paperAuthors)
+    .innerJoin(papers, eq(paperAuthors.paperId, papers.id))
+    .where(
+      and(
+        eq(paperAuthors.userId, id),
+        eq(papers.visibility, "public"),
+        tagCondition,
+      ),
+    )
+    .orderBy(desc(papers.createdAt))
+    .limit(FEED_LIMIT)
+    .all();
 
-    return await buildFeedResponse(
-        c,
-        {
-            title: `${authorName} - OpenShelf`,
-            link: `${normalizeBaseUrl(c.env.FRONTEND_URL)}/users/${encodeURIComponent(id)}`,
-            selfLink: c.req.url,
-            id: `urn:openshelf:user:${id}`,
-            updatedFallback: user.updatedAt,
-            authorName,
-        },
-        // SQLで絞り込み済みだが、フィルタの整合性確認と重複排除を兼ねて再利用する
-        filterPaperRowsByTag(papersRows, tagFilter),
-    );
+  return await buildFeedResponse(
+    c,
+    {
+      title: `${authorName} - OpenShelf`,
+      link: `${normalizeBaseUrl(c.env.FRONTEND_URL)}/users/${encodeURIComponent(id)}`,
+      selfLink: c.req.url,
+      id: `urn:openshelf:user:${id}`,
+      updatedFallback: user.updatedAt,
+      authorName,
+    },
+    // SQLで絞り込み済みだが、フィルタの整合性確認と重複排除を兼ねて再利用する
+    filterPaperRowsByTag(papersRows, tagFilter),
+  );
 }
 
 async function buildOrgCollectionFeedResponse(
-    c: FeedContext,
-    slug: string,
-    collectionSlug: string,
+  c: FeedContext,
+  slug: string,
+  collectionSlug: string,
 ): Promise<Response> {
-    if (!SLUG_REGEX.test(slug) || !SLUG_REGEX.test(collectionSlug)) {
-        return c.json({ error: "invalid slug" }, 400);
-    }
-    const db = drizzle(c.env.DB);
+  if (!SLUG_REGEX.test(slug) || !SLUG_REGEX.test(collectionSlug)) {
+    return c.json({ error: "invalid slug" }, 400);
+  }
+  const db = drizzle(c.env.DB);
 
-    const org = await db.select().from(orgs).where(eq(orgs.slug, slug)).get();
-    if (!org) return c.json({ error: "Org not found" }, 404);
+  const org = await db.select().from(orgs).where(eq(orgs.slug, slug)).get();
+  if (!org) return c.json({ error: "Org not found" }, 404);
 
-    const collection = await db
-        .select()
-        .from(collections)
-        .where(
-            and(
-                eq(collections.ownerType, "org"),
-                eq(collections.ownerId, org.id),
-                eq(collections.slug, collectionSlug),
-            ),
-        )
-        .get();
+  const collection = await db
+    .select()
+    .from(collections)
+    .where(
+      and(
+        eq(collections.ownerType, "org"),
+        eq(collections.ownerId, org.id),
+        eq(collections.slug, collectionSlug),
+      ),
+    )
+    .get();
 
-    if (!collection || collection.visibility !== "public") {
-        return c.json({ error: "Collection not found" }, 404);
-    }
+  if (!collection || collection.visibility !== "public") {
+    return c.json({ error: "Collection not found" }, 404);
+  }
 
-    const papersRows = await db
-        .select(PAPER_FEED_SELECT)
-        .from(collectionPapers)
-        .innerJoin(papers, eq(collectionPapers.paperId, papers.id))
-        .where(and(eq(collectionPapers.collectionId, collection.id), eq(papers.visibility, "public")))
-        .orderBy(asc(collectionPapers.sortOrder))
-        .limit(FEED_LIMIT)
-        .all();
+  const papersRows = await db
+    .select(PAPER_FEED_SELECT)
+    .from(collectionPapers)
+    .innerJoin(papers, eq(collectionPapers.paperId, papers.id))
+    .where(
+      and(
+        eq(collectionPapers.collectionId, collection.id),
+        eq(papers.visibility, "public"),
+      ),
+    )
+    .orderBy(asc(collectionPapers.sortOrder))
+    .limit(FEED_LIMIT)
+    .all();
 
-    return await buildFeedResponse(
-        c,
-        {
-            title: `${collection.name} - ${org.name} - OpenShelf`,
-            link: `${normalizeBaseUrl(c.env.FRONTEND_URL)}/orgs/${encodeURIComponent(slug)}/c/${encodeURIComponent(collectionSlug)}`,
-            selfLink: c.req.url,
-            id: `urn:openshelf:collection:${collection.id}`,
-            updatedFallback: collection.updatedAt,
-            authorName: org.name,
-        },
-        dedupePaperRows(papersRows),
-    );
+  return await buildFeedResponse(
+    c,
+    {
+      title: `${collection.name} - ${org.name} - OpenShelf`,
+      link: `${normalizeBaseUrl(c.env.FRONTEND_URL)}/orgs/${encodeURIComponent(slug)}/c/${encodeURIComponent(collectionSlug)}`,
+      selfLink: c.req.url,
+      id: `urn:openshelf:collection:${collection.id}`,
+      updatedFallback: collection.updatedAt,
+      authorName: org.name,
+    },
+    dedupePaperRows(papersRows),
+  );
 }
 
 async function buildUserCollectionFeedResponse(
-    c: FeedContext,
-    id: string,
-    collectionSlug: string,
+  c: FeedContext,
+  id: string,
+  collectionSlug: string,
 ): Promise<Response> {
-    if (!SLUG_REGEX.test(collectionSlug)) {
-        return c.json({ error: "invalid slug" }, 400);
-    }
+  if (!SLUG_REGEX.test(collectionSlug)) {
+    return c.json({ error: "invalid slug" }, 400);
+  }
 
-    const db = drizzle(c.env.DB);
+  const db = drizzle(c.env.DB);
 
-    const user = await db.select().from(users).where(eq(users.id, id)).get();
-    if (!user) return c.json({ error: "User not found" }, 404);
-    const authorName = (user.displayName ?? user.name ?? "").trim() || "OpenShelf";
+  const user = await db.select().from(users).where(eq(users.id, id)).get();
+  if (!user) return c.json({ error: "User not found" }, 404);
+  const authorName =
+    (user.displayName ?? user.name ?? "").trim() || "OpenShelf";
 
-    const collection = await db
-        .select()
-        .from(collections)
-        .where(
-            and(
-                eq(collections.ownerType, "user"),
-                eq(collections.ownerId, id),
-                eq(collections.slug, collectionSlug),
-            ),
-        )
-        .get();
+  const collection = await db
+    .select()
+    .from(collections)
+    .where(
+      and(
+        eq(collections.ownerType, "user"),
+        eq(collections.ownerId, id),
+        eq(collections.slug, collectionSlug),
+      ),
+    )
+    .get();
 
-    if (!collection || collection.visibility !== "public") {
-        return c.json({ error: "Collection not found" }, 404);
-    }
+  if (!collection || collection.visibility !== "public") {
+    return c.json({ error: "Collection not found" }, 404);
+  }
 
-    const papersRows = await db
-        .select(PAPER_FEED_SELECT)
-        .from(collectionPapers)
-        .innerJoin(papers, eq(collectionPapers.paperId, papers.id))
-        .where(and(eq(collectionPapers.collectionId, collection.id), eq(papers.visibility, "public")))
-        .orderBy(asc(collectionPapers.sortOrder))
-        .limit(FEED_LIMIT)
-        .all();
+  const papersRows = await db
+    .select(PAPER_FEED_SELECT)
+    .from(collectionPapers)
+    .innerJoin(papers, eq(collectionPapers.paperId, papers.id))
+    .where(
+      and(
+        eq(collectionPapers.collectionId, collection.id),
+        eq(papers.visibility, "public"),
+      ),
+    )
+    .orderBy(asc(collectionPapers.sortOrder))
+    .limit(FEED_LIMIT)
+    .all();
 
-    return await buildFeedResponse(
-        c,
-        {
-            title: `${collection.name} - ${authorName} - OpenShelf`,
-            link: `${normalizeBaseUrl(c.env.FRONTEND_URL)}/users/${encodeURIComponent(id)}/c/${encodeURIComponent(collectionSlug)}`,
-            selfLink: c.req.url,
-            id: `urn:openshelf:collection:${collection.id}`,
-            updatedFallback: collection.updatedAt,
-            authorName,
-        },
-        dedupePaperRows(papersRows),
-    );
+  return await buildFeedResponse(
+    c,
+    {
+      title: `${collection.name} - ${authorName} - OpenShelf`,
+      link: `${normalizeBaseUrl(c.env.FRONTEND_URL)}/users/${encodeURIComponent(id)}/c/${encodeURIComponent(collectionSlug)}`,
+      selfLink: c.req.url,
+      id: `urn:openshelf:collection:${collection.id}`,
+      updatedFallback: collection.updatedAt,
+      authorName,
+    },
+    dedupePaperRows(papersRows),
+  );
 }
 
-feedRoute.get("/orgs/:slug/atom.xml", async (c) => buildOrgFeedResponse(c, c.req.param("slug")));
-feedRoute.get("/org/:slug", async (c) => buildOrgFeedResponse(c, c.req.param("slug")));
+feedRoute.get("/orgs/:slug/atom.xml", async (c) =>
+  buildOrgFeedResponse(c, c.req.param("slug")),
+);
+feedRoute.get("/org/:slug", async (c) =>
+  buildOrgFeedResponse(c, c.req.param("slug")),
+);
 
-feedRoute.get("/users/:id/atom.xml", async (c) => buildUserFeedResponse(c, c.req.param("id")));
-feedRoute.get("/user/:id", async (c) => buildUserFeedResponse(c, c.req.param("id")));
+feedRoute.get("/users/:id/atom.xml", async (c) =>
+  buildUserFeedResponse(c, c.req.param("id")),
+);
+feedRoute.get("/user/:id", async (c) =>
+  buildUserFeedResponse(c, c.req.param("id")),
+);
 
 feedRoute.get("/orgs/:slug/collections/:cSlug/atom.xml", async (c) =>
-    buildOrgCollectionFeedResponse(c, c.req.param("slug"), c.req.param("cSlug")),
+  buildOrgCollectionFeedResponse(c, c.req.param("slug"), c.req.param("cSlug")),
 );
 feedRoute.get("/org/:slug/collection/:collectionSlug", async (c) =>
-    buildOrgCollectionFeedResponse(c, c.req.param("slug"), c.req.param("collectionSlug")),
+  buildOrgCollectionFeedResponse(
+    c,
+    c.req.param("slug"),
+    c.req.param("collectionSlug"),
+  ),
 );
 
 feedRoute.get("/users/:id/collections/:cSlug/atom.xml", async (c) =>
-    buildUserCollectionFeedResponse(c, c.req.param("id"), c.req.param("cSlug")),
+  buildUserCollectionFeedResponse(c, c.req.param("id"), c.req.param("cSlug")),
 );
 feedRoute.get("/user/:id/collection/:collectionSlug", async (c) =>
-    buildUserCollectionFeedResponse(c, c.req.param("id"), c.req.param("collectionSlug")),
+  buildUserCollectionFeedResponse(
+    c,
+    c.req.param("id"),
+    c.req.param("collectionSlug"),
+  ),
 );
 
 export default feedRoute;

--- a/apps/api/src/routes/invites.ts
+++ b/apps/api/src/routes/invites.ts
@@ -2,11 +2,11 @@ import { Hono } from "hono";
 import { drizzle } from "drizzle-orm/d1";
 import { and, eq, sql } from "drizzle-orm";
 import {
-    coauthorInvites,
-    paperAuthors,
-    papers,
-    users,
-    enableForeignKeys,
+  coauthorInvites,
+  paperAuthors,
+  papers,
+  users,
+  enableForeignKeys,
 } from "../db/schema";
 import type { Env, Variables } from "../types";
 import { authMiddleware } from "../middleware/auth";
@@ -15,95 +15,94 @@ const invitesRoute = new Hono<{ Bindings: Env; Variables: Variables }>();
 
 // GET /api/invites/received — invites sent to the current user
 invitesRoute.get("/received", authMiddleware, async (c) => {
-    const db = drizzle(c.env.DB);
-    const userId = c.get("user").sub;
+  const db = drizzle(c.env.DB);
+  const userId = c.get("user").sub;
 
-    const rows = await db
-        .select({
-            id: coauthorInvites.id,
-            paperId: coauthorInvites.paperId,
-            paperTitle: papers.title,
-            inviterId: coauthorInvites.inviterId,
-            inviterName: users.name,
-            status: coauthorInvites.status,
-            createdAt: coauthorInvites.createdAt,
-        })
-        .from(coauthorInvites)
-        .innerJoin(papers, eq(coauthorInvites.paperId, papers.id))
-        .innerJoin(users, eq(coauthorInvites.inviterId, users.id))
-        .where(
-            and(
-                eq(coauthorInvites.inviteeId, userId),
-                eq(coauthorInvites.status, "pending"),
-            ),
-        )
-        .all();
+  const rows = await db
+    .select({
+      id: coauthorInvites.id,
+      paperId: coauthorInvites.paperId,
+      paperTitle: papers.title,
+      inviterId: coauthorInvites.inviterId,
+      inviterName: users.name,
+      status: coauthorInvites.status,
+      createdAt: coauthorInvites.createdAt,
+    })
+    .from(coauthorInvites)
+    .innerJoin(papers, eq(coauthorInvites.paperId, papers.id))
+    .innerJoin(users, eq(coauthorInvites.inviterId, users.id))
+    .where(
+      and(
+        eq(coauthorInvites.inviteeId, userId),
+        eq(coauthorInvites.status, "pending"),
+      ),
+    )
+    .all();
 
-    return c.json({ invites: rows });
+  return c.json({ invites: rows });
 });
 
 const respondInviteHandler = async (c: any) => {
-    const inviteId = c.req.param("inviteId");
-    let body: { action?: unknown };
-    try {
-        body = await c.req.json();
-    } catch {
-        return c.json({ error: "Invalid JSON body" }, 400);
-    }
+  const inviteId = c.req.param("inviteId");
+  let body: { action?: unknown };
+  try {
+    body = await c.req.json();
+  } catch {
+    return c.json({ error: "Invalid JSON body" }, 400);
+  }
 
-    const action = body.action;
+  const action = body.action;
 
-    if (
-        !action ||
-        typeof action !== "string" ||
-        !["accept", "decline"].includes(action)
-    ) {
-        return c.json({ error: "action must be accept or decline" }, 400);
-    }
+  if (
+    !action ||
+    typeof action !== "string" ||
+    !["accept", "decline"].includes(action)
+  ) {
+    return c.json({ error: "action must be accept or decline" }, 400);
+  }
 
-    const db = drizzle(c.env.DB);
-    await enableForeignKeys(db);
-    const userId = c.get("user").sub;
+  const db = drizzle(c.env.DB);
+  await enableForeignKeys(db);
+  const userId = c.get("user").sub;
 
-    const invite = await db
-        .select()
-        .from(coauthorInvites)
-        .where(eq(coauthorInvites.id, inviteId))
-        .get();
-    if (!invite) return c.json({ error: "Invite not found" }, 404);
-    if (invite.inviteeId !== userId)
-        return c.json({ error: "Forbidden" }, 403);
-    if (invite.status !== "pending")
-        return c.json({ error: "Invite already responded" }, 400);
+  const invite = await db
+    .select()
+    .from(coauthorInvites)
+    .where(eq(coauthorInvites.id, inviteId))
+    .get();
+  if (!invite) return c.json({ error: "Invite not found" }, 404);
+  if (invite.inviteeId !== userId) return c.json({ error: "Forbidden" }, 403);
+  if (invite.status !== "pending")
+    return c.json({ error: "Invite already responded" }, 400);
 
-    const newStatus = action === "accept" ? "accepted" : "declined";
+  const newStatus = action === "accept" ? "accepted" : "declined";
 
-    if (action === "accept") {
-        await db.batch([
-            db
-                .update(coauthorInvites)
-                .set({
-                    status: newStatus,
-                    respondedAt: sql`(datetime('now'))`,
-                })
-                .where(eq(coauthorInvites.id, inviteId)),
-            db.insert(paperAuthors).values({
-                paperId: invite.paperId,
-                userId,
-                role: "coauthor",
-            }),
-        ]);
-    } else {
-        await db
-            .update(coauthorInvites)
-            .set({
-                status: newStatus,
-                respondedAt: sql`(datetime('now'))`,
-            })
-            .where(eq(coauthorInvites.id, inviteId));
-    }
+  if (action === "accept") {
+    await db.batch([
+      db
+        .update(coauthorInvites)
+        .set({
+          status: newStatus,
+          respondedAt: sql`(datetime('now'))`,
+        })
+        .where(eq(coauthorInvites.id, inviteId)),
+      db.insert(paperAuthors).values({
+        paperId: invite.paperId,
+        userId,
+        role: "coauthor",
+      }),
+    ]);
+  } else {
+    await db
+      .update(coauthorInvites)
+      .set({
+        status: newStatus,
+        respondedAt: sql`(datetime('now'))`,
+      })
+      .where(eq(coauthorInvites.id, inviteId));
+  }
 
-    return c.json({ ok: true, status: newStatus });
+  return c.json({ ok: true, status: newStatus });
 };
 
 // PATCH/PUT /api/invites/:inviteId — accept or decline

--- a/apps/api/src/routes/orgs.ts
+++ b/apps/api/src/routes/orgs.ts
@@ -571,7 +571,10 @@ orgsRoute.post("/:slug/members", authMiddleware, async (c) => {
 // PATCH /api/orgs/:slug/members/:userId — change role
 orgsRoute.patch("/:slug/members/:userId", authMiddleware, async (c) => {
   const slug = c.req.param("slug");
-  const targetUserIdResult = normalizeBoundedId(c.req.param("userId"), "userId");
+  const targetUserIdResult = normalizeBoundedId(
+    c.req.param("userId"),
+    "userId",
+  );
   if (targetUserIdResult.error) {
     return c.json({ error: targetUserIdResult.error }, 400);
   }
@@ -649,7 +652,10 @@ orgsRoute.patch("/:slug/members/:userId", authMiddleware, async (c) => {
 // DELETE /api/orgs/:slug/members/:userId — remove member
 orgsRoute.delete("/:slug/members/:userId", authMiddleware, async (c) => {
   const slug = c.req.param("slug");
-  const targetUserIdResult = normalizeBoundedId(c.req.param("userId"), "userId");
+  const targetUserIdResult = normalizeBoundedId(
+    c.req.param("userId"),
+    "userId",
+  );
   if (targetUserIdResult.error) {
     return c.json({ error: targetUserIdResult.error }, 400);
   }
@@ -1014,9 +1020,7 @@ orgsRoute.post("/:slug/papers", authMiddleware, async (c) => {
   const existing = await db
     .select()
     .from(paperOrgs)
-    .where(
-      and(eq(paperOrgs.paperId, paperId), eq(paperOrgs.orgId, org.id)),
-    )
+    .where(and(eq(paperOrgs.paperId, paperId), eq(paperOrgs.orgId, org.id)))
     .get();
   if (existing)
     return c.json({ error: "Paper is already associated with this org" }, 409);

--- a/apps/api/src/routes/papers.ts
+++ b/apps/api/src/routes/papers.ts
@@ -3,21 +3,21 @@ import type { ContentfulStatusCode } from "hono/utils/http-status";
 import { drizzle } from "drizzle-orm/d1";
 import { eq, and, gte, sql } from "drizzle-orm";
 import {
-    papers,
-    paperFiles,
-    paperAuthors,
-    paperStatsDaily,
-    paperStatsTotal,
-    users,
-    coauthorInvites,
-    orgMembers,
-    paperOrgs,
-    enableForeignKeys,
-    touchUpdatedAt,
-    VALID_VENUE_TYPES,
-    VALID_CATEGORIES,
-    type VenueType,
-    type CategoryType,
+  papers,
+  paperFiles,
+  paperAuthors,
+  paperStatsDaily,
+  paperStatsTotal,
+  users,
+  coauthorInvites,
+  orgMembers,
+  paperOrgs,
+  enableForeignKeys,
+  touchUpdatedAt,
+  VALID_VENUE_TYPES,
+  VALID_CATEGORIES,
+  type VenueType,
+  type CategoryType,
 } from "../db/schema";
 import type { Env, Variables } from "../types";
 import { authMiddleware } from "../middleware/auth";
@@ -32,11 +32,11 @@ const MAX_CONCURRENT_UPLOADS = 3;
 const R2_DELETE_BATCH_SIZE = 1000;
 const MAX_CONCURRENT_R2_DELETES = 2;
 const ALLOWED_MIME_TYPES = [
-    "application/pdf",
-    "application/vnd.ms-powerpoint",
-    "application/vnd.openxmlformats-officedocument.presentationml.presentation",
-    "image/png",
-    "image/jpeg",
+  "application/pdf",
+  "application/vnd.ms-powerpoint",
+  "application/vnd.openxmlformats-officedocument.presentationml.presentation",
+  "image/png",
+  "image/jpeg",
 ];
 const VALID_FILE_TYPES = ["paper", "slides", "poster", "supplementary"];
 const VALID_VISIBILITY = ["public", "org_only", "private"];
@@ -53,98 +53,97 @@ const TRACK_DEDUP_RETENTION_DAYS = 90;
 const TRACKABLE_EVENTS = ["view", "download", "preview"] as const;
 const TRACK_STATS_ALLOWED_DAYS = [7, 30, 90, 365] as const;
 const BOT_USER_AGENT_KEYWORDS = [
-    "bot",
-    "crawler",
-    "spider",
-    "googlebot",
-    "bingbot",
-    "facebookexternalhit",
-    "bytespider",
+  "bot",
+  "crawler",
+  "spider",
+  "googlebot",
+  "bingbot",
+  "facebookexternalhit",
+  "bytespider",
 ];
 
-type TrackEvent = typeof TRACKABLE_EVENTS[number];
+type TrackEvent = (typeof TRACKABLE_EVENTS)[number];
 type DeleteBatchErrorInfo = {
-    chunkStart: number;
-    chunkEndExclusive: number;
-    chunkSize: number;
-    chunkSample: string[];
-    error: string;
+  chunkStart: number;
+  chunkEndExclusive: number;
+  chunkSize: number;
+  chunkSample: string[];
+  error: string;
 };
 
 function formatDateKey(date: Date): string {
-    return date.toISOString().slice(0, 10);
+  return date.toISOString().slice(0, 10);
 }
-
 
 function toIsoUtc(value: string | null | undefined): string | null {
-    if (!value) return null;
-    return new Date(value.replace(" ", "T") + "Z").toISOString();
+  if (!value) return null;
+  return new Date(value.replace(" ", "T") + "Z").toISOString();
 }
 function getDateRange(days: number, now = new Date()): string[] {
-    const start = new Date(Date.UTC(
-        now.getUTCFullYear(),
-        now.getUTCMonth(),
-        now.getUTCDate(),
-    ));
-    start.setUTCDate(start.getUTCDate() - (days - 1));
+  const start = new Date(
+    Date.UTC(now.getUTCFullYear(), now.getUTCMonth(), now.getUTCDate()),
+  );
+  start.setUTCDate(start.getUTCDate() - (days - 1));
 
-    return Array.from({ length: days }, (_, index) => {
-        const day = new Date(start);
-        day.setUTCDate(start.getUTCDate() + index);
-        return formatDateKey(day);
-    });
+  return Array.from({ length: days }, (_, index) => {
+    const day = new Date(start);
+    day.setUTCDate(start.getUTCDate() + index);
+    return formatDateKey(day);
+  });
 }
 
 function isTrackEvent(value: unknown): value is TrackEvent {
-    return typeof value === "string"
-        && (TRACKABLE_EVENTS as readonly string[]).includes(value);
+  return (
+    typeof value === "string" &&
+    (TRACKABLE_EVENTS as readonly string[]).includes(value)
+  );
 }
 
 function parseTrackDays(value: string | undefined): number | null {
-    if (value === undefined) return 30;
-    const parsed = Number(value);
-    if (!Number.isInteger(parsed)) return null;
-    return (TRACK_STATS_ALLOWED_DAYS as readonly number[]).includes(parsed)
-        ? parsed
-        : null;
+  if (value === undefined) return 30;
+  const parsed = Number(value);
+  if (!Number.isInteger(parsed)) return null;
+  return (TRACK_STATS_ALLOWED_DAYS as readonly number[]).includes(parsed)
+    ? parsed
+    : null;
 }
 
 function normalizeReferrer(value: unknown): string | null {
-    if (typeof value !== "string") return null;
-    const trimmed = value.trim();
-    if (!trimmed) return null;
-    return trimmed.slice(0, MAX_REFERRER_LENGTH);
+  if (typeof value !== "string") return null;
+  const trimmed = value.trim();
+  if (!trimmed) return null;
+  return trimmed.slice(0, MAX_REFERRER_LENGTH);
 }
 
 async function deleteKeysInBatches(
-    bucket: Env["BUCKET"],
-    keys: string[],
-    onChunkError?: (info: DeleteBatchErrorInfo) => void,
+  bucket: Env["BUCKET"],
+  keys: string[],
+  onChunkError?: (info: DeleteBatchErrorInfo) => void,
 ): Promise<void> {
-    const chunkStarts = Array.from(
-        { length: Math.ceil(keys.length / R2_DELETE_BATCH_SIZE) },
-        (_, index) => index * R2_DELETE_BATCH_SIZE,
-    );
+  const chunkStarts = Array.from(
+    { length: Math.ceil(keys.length / R2_DELETE_BATCH_SIZE) },
+    (_, index) => index * R2_DELETE_BATCH_SIZE,
+  );
 
-    await pMap(
-        chunkStarts,
-        async (chunkStart) => {
-            const chunk = keys.slice(chunkStart, chunkStart + R2_DELETE_BATCH_SIZE);
-            try {
-                await bucket.delete(chunk);
-            } catch (error) {
-                if (!onChunkError) throw error;
-                onChunkError({
-                    chunkStart,
-                    chunkEndExclusive: chunkStart + chunk.length,
-                    chunkSize: chunk.length,
-                    chunkSample: chunk.slice(0, 3),
-                    error: error instanceof Error ? error.message : String(error),
-                });
-            }
-        },
-        { concurrency: MAX_CONCURRENT_R2_DELETES },
-    );
+  await pMap(
+    chunkStarts,
+    async (chunkStart) => {
+      const chunk = keys.slice(chunkStart, chunkStart + R2_DELETE_BATCH_SIZE);
+      try {
+        await bucket.delete(chunk);
+      } catch (error) {
+        if (!onChunkError) throw error;
+        onChunkError({
+          chunkStart,
+          chunkEndExclusive: chunkStart + chunk.length,
+          chunkSize: chunk.length,
+          chunkSample: chunk.slice(0, 3),
+          error: error instanceof Error ? error.message : String(error),
+        });
+      }
+    },
+    { concurrency: MAX_CONCURRENT_R2_DELETES },
+  );
 }
 
 /**
@@ -152,81 +151,92 @@ async function deleteKeysInBatches(
  * Requests without a User-Agent header are therefore counted as human traffic.
  */
 function isBotUserAgent(userAgent: string | undefined): boolean {
-    if (!userAgent) return false;
-    const normalized = userAgent.toLowerCase();
-    return BOT_USER_AGENT_KEYWORDS.some((keyword) => normalized.includes(keyword));
+  if (!userAgent) return false;
+  const normalized = userAgent.toLowerCase();
+  return BOT_USER_AGENT_KEYWORDS.some((keyword) =>
+    normalized.includes(keyword),
+  );
 }
 
-function getClientIp(c: Context<{ Bindings: Env; Variables: Variables }>): string {
-    return c.req.header("CF-Connecting-IP")
-        ?? c.req.header("cf-connecting-ip")
-        ?? c.req.header("X-Forwarded-For")?.split(",")[0]?.trim()
-        ?? c.req.header("x-forwarded-for")?.split(",")[0]?.trim()
-        ?? "unknown-ip";
+function getClientIp(
+  c: Context<{ Bindings: Env; Variables: Variables }>,
+): string {
+  return (
+    c.req.header("CF-Connecting-IP") ??
+    c.req.header("cf-connecting-ip") ??
+    c.req.header("X-Forwarded-For")?.split(",")[0]?.trim() ??
+    c.req.header("x-forwarded-for")?.split(",")[0]?.trim() ??
+    "unknown-ip"
+  );
 }
 
 async function runInBackground(
-    c: Context<{ Bindings: Env; Variables: Variables }>,
-    promise: Promise<unknown>,
+  c: Context<{ Bindings: Env; Variables: Variables }>,
+  promise: Promise<unknown>,
 ): Promise<void> {
-    let executionCtx: { waitUntil?: (p: Promise<unknown>) => void } | undefined;
-    try {
-        executionCtx = c.executionCtx as { waitUntil?: (p: Promise<unknown>) => void } | undefined;
-    } catch {
-        executionCtx = undefined;
-    }
-    if (executionCtx?.waitUntil) {
-        executionCtx.waitUntil(promise);
-        return;
-    }
-    await promise;
+  let executionCtx: { waitUntil?: (p: Promise<unknown>) => void } | undefined;
+  try {
+    executionCtx = c.executionCtx as
+      | { waitUntil?: (p: Promise<unknown>) => void }
+      | undefined;
+  } catch {
+    executionCtx = undefined;
+  }
+  if (executionCtx?.waitUntil) {
+    executionCtx.waitUntil(promise);
+    return;
+  }
+  await promise;
 }
 
 async function buildTrackSessionHash(
-    c: Context<{ Bindings: Env; Variables: Variables }>,
-    date: string,
-    paperId: string,
+  c: Context<{ Bindings: Env; Variables: Variables }>,
+  date: string,
+  paperId: string,
 ): Promise<string> {
-    const ip = getClientIp(c);
-    return hashString(`${c.env.JWT_SECRET}:track:${paperId}:${ip}:${date}`);
+  const ip = getClientIp(c);
+  return hashString(`${c.env.JWT_SECRET}:track:${paperId}:${ip}:${date}`);
 }
 
 function eventIncrements(event: TrackEvent) {
-    return {
-        views: event === "view" ? 1 : 0,
-        downloads: event === "download" ? 1 : 0,
-        previews: event === "preview" ? 1 : 0,
-    };
+  return {
+    views: event === "view" ? 1 : 0,
+    downloads: event === "download" ? 1 : 0,
+    previews: event === "preview" ? 1 : 0,
+  };
 }
 
 type RecordTrackEventInput = {
-    db: Env["DB"];
-    paperId: string;
-    event: TrackEvent;
-    date: string;
-    sessionHash: string;
-    referrer: string | null;
+  db: Env["DB"];
+  paperId: string;
+  event: TrackEvent;
+  date: string;
+  sessionHash: string;
+  referrer: string | null;
 };
 
 async function recordTrackEvent({
-    db,
-    paperId,
-    event,
-    date,
-    sessionHash,
-    referrer,
+  db,
+  paperId,
+  event,
+  date,
+  sessionHash,
+  referrer,
 }: RecordTrackEventInput): Promise<boolean> {
-    const increments = eventIncrements(event);
-    const dedupStmt = db
-        .prepare(`
+  const increments = eventIncrements(event);
+  const dedupStmt = db
+    .prepare(
+      `
             INSERT INTO paper_stats_dedup (paper_id, event, date, session_hash, referrer)
             VALUES (?1, ?2, ?3, ?4, ?5)
             ON CONFLICT(paper_id, event, date, session_hash) DO NOTHING
-        `)
-        .bind(paperId, event, date, sessionHash, referrer);
+        `,
+    )
+    .bind(paperId, event, date, sessionHash, referrer);
 
-    const dailyStmt = db
-        .prepare(`
+  const dailyStmt = db
+    .prepare(
+      `
             INSERT INTO paper_stats_daily (paper_id, date, views, downloads, previews)
             SELECT ?1, ?2, ?3, ?4, ?5
             WHERE changes() > 0
@@ -234,17 +244,19 @@ async function recordTrackEvent({
                 views = views + excluded.views,
                 downloads = downloads + excluded.downloads,
                 previews = previews + excluded.previews
-        `)
-        .bind(
-            paperId,
-            date,
-            increments.views,
-            increments.downloads,
-            increments.previews,
-        );
+        `,
+    )
+    .bind(
+      paperId,
+      date,
+      increments.views,
+      increments.downloads,
+      increments.previews,
+    );
 
-    const totalStmt = db
-        .prepare(`
+  const totalStmt = db
+    .prepare(
+      `
             INSERT INTO paper_stats_total (paper_id, total_views, total_downloads, total_previews)
             SELECT ?1, ?2, ?3, ?4
             WHERE changes() > 0
@@ -253,1390 +265,1541 @@ async function recordTrackEvent({
                 total_downloads = total_downloads + excluded.total_downloads,
                 total_previews = total_previews + excluded.total_previews,
                 last_updated = datetime('now')
-        `)
-        .bind(
-            paperId,
-            increments.views,
-            increments.downloads,
-            increments.previews,
-        );
+        `,
+    )
+    .bind(paperId, increments.views, increments.downloads, increments.previews);
 
-    const cleanupStmt = db
-        .prepare(`
+  const cleanupStmt = db
+    .prepare(
+      `
             DELETE FROM paper_stats_dedup
             WHERE date < date(?1, ?2)
-        `)
-        .bind(date, `-${TRACK_DEDUP_RETENTION_DAYS} days`);
+        `,
+    )
+    .bind(date, `-${TRACK_DEDUP_RETENTION_DAYS} days`);
 
-    const [dedupResult] = await db.batch([dedupStmt, dailyStmt, totalStmt, cleanupStmt]);
-    const changes = dedupResult?.meta?.changes;
-    return typeof changes === "number" ? changes > 0 : true;
+  const [dedupResult] = await db.batch([
+    dedupStmt,
+    dailyStmt,
+    totalStmt,
+    cleanupStmt,
+  ]);
+  const changes = dedupResult?.meta?.changes;
+  return typeof changes === "number" ? changes > 0 : true;
 }
 
 async function hashString(value: string): Promise<string> {
-    const data = new TextEncoder().encode(value);
-    const digest = await crypto.subtle.digest("SHA-256", data);
-    return Array.from(new Uint8Array(digest))
-        .map((byte) => byte.toString(16).padStart(2, "0"))
-        .join("");
+  const data = new TextEncoder().encode(value);
+  const digest = await crypto.subtle.digest("SHA-256", data);
+  return Array.from(new Uint8Array(digest))
+    .map((byte) => byte.toString(16).padStart(2, "0"))
+    .join("");
 }
 
 async function getPaperPublicStats(
-    db: ReturnType<typeof drizzle>,
-    paperId: string,
+  db: ReturnType<typeof drizzle>,
+  paperId: string,
 ): Promise<{ views: number; downloads: number }> {
-    const row = await db
-        .select({
-            views: paperStatsTotal.totalViews,
-            downloads: paperStatsTotal.totalDownloads,
-        })
-        .from(paperStatsTotal)
-        .where(eq(paperStatsTotal.paperId, paperId))
-        .get();
-    return {
-        views: row?.views ?? 0,
-        downloads: row?.downloads ?? 0,
-    };
+  const row = await db
+    .select({
+      views: paperStatsTotal.totalViews,
+      downloads: paperStatsTotal.totalDownloads,
+    })
+    .from(paperStatsTotal)
+    .where(eq(paperStatsTotal.paperId, paperId))
+    .get();
+  return {
+    views: row?.views ?? 0,
+    downloads: row?.downloads ?? 0,
+  };
 }
 
 function sanitizeFilename(filename: string): string {
-    const basename = filename.split(/[\\/]/).pop() ?? "";
-    const cleaned = basename
-        .replace(/\.{2,}/g, ".")
-        .replace(/[^A-Za-z0-9._-]/g, "_")
-        .replace(/_+/g, "_")
-        .replace(/^\.+/, "")
-        .slice(0, 120);
-    return cleaned || `file-${crypto.randomUUID()}`;
+  const basename = filename.split(/[\\/]/).pop() ?? "";
+  const cleaned = basename
+    .replace(/\.{2,}/g, ".")
+    .replace(/[^A-Za-z0-9._-]/g, "_")
+    .replace(/_+/g, "_")
+    .replace(/^\.+/, "")
+    .slice(0, 120);
+  return cleaned || `file-${crypto.randomUUID()}`;
 }
 
 function isValidUrlScheme(urlStr: string): boolean {
-    try {
-        const url = new URL(urlStr);
-        return ["http:", "https:"].includes(url.protocol);
-    } catch {
-        return false;
-    }
+  try {
+    const url = new URL(urlStr);
+    return ["http:", "https:"].includes(url.protocol);
+  } catch {
+    return false;
+  }
 }
-
 
 // In-memory token cache to prevent repeated JWT verifications for the same token
 // within the same worker isolate. Maps token -> { payload: { sub: string }, expiresAt: number }
-const tokenCache = new Map<string, { payload: { sub: string }; expiresAt: number }>();
-const inFlightVerifications = new Map<string, Promise<{ sub: string; exp?: number }>>();
+const tokenCache = new Map<
+  string,
+  { payload: { sub: string }; expiresAt: number }
+>();
+const inFlightVerifications = new Map<
+  string,
+  Promise<{ sub: string; exp?: number }>
+>();
 const MAX_CACHE_SIZE = 1000;
 const TOKEN_CACHE_MAX_AGE_MS = 60 * 1000;
 
 function purgeExpiredTokenCache(now: number): void {
-    for (const [cachedToken, entry] of tokenCache.entries()) {
-        if (entry.expiresAt <= now) {
-            tokenCache.delete(cachedToken);
-        }
+  for (const [cachedToken, entry] of tokenCache.entries()) {
+    if (entry.expiresAt <= now) {
+      tokenCache.delete(cachedToken);
     }
+  }
 }
 
 async function authorizePaperAccess(
-    c: Context<{ Bindings: Env; Variables: Variables }>,
-    db: ReturnType<typeof drizzle>,
-    paper: { visibility: string; id: string },
-): Promise<{ ok: true; user?: { sub: string } } | { ok: false; status: ContentfulStatusCode; error: string }> {
-    if (paper.visibility === "public") return { ok: true };
+  c: Context<{ Bindings: Env; Variables: Variables }>,
+  db: ReturnType<typeof drizzle>,
+  paper: { visibility: string; id: string },
+): Promise<
+  | { ok: true; user?: { sub: string } }
+  | { ok: false; status: ContentfulStatusCode; error: string }
+> {
+  if (paper.visibility === "public") return { ok: true };
 
-    const authHeader = c.req.header("Authorization");
-    const rawToken = authHeader?.startsWith("Bearer ") ? authHeader.slice(7) : null;
-    if (!rawToken) {
-        return { ok: false, status: 401, error: "Unauthorized" };
+  const authHeader = c.req.header("Authorization");
+  const rawToken = authHeader?.startsWith("Bearer ")
+    ? authHeader.slice(7)
+    : null;
+  if (!rawToken) {
+    return { ok: false, status: 401, error: "Unauthorized" };
+  }
+
+  const token = `${c.env.JWT_SECRET}:${rawToken}`;
+  let user: { sub: string };
+  const now = Date.now();
+  const cached = tokenCache.get(token);
+
+  if (cached && cached.expiresAt > now) {
+    user = cached.payload;
+  } else {
+    if (cached) {
+      tokenCache.delete(token);
     }
 
-    const token = `${c.env.JWT_SECRET}:${rawToken}`;
-    let user: { sub: string };
-    const now = Date.now();
-    const cached = tokenCache.get(token);
+    let verifyPromise = inFlightVerifications.get(token);
+    if (!verifyPromise) {
+      verifyPromise = (async () => {
+        const { verify } = await import("hono/jwt");
+        const verified = (await verify(
+          rawToken,
+          c.env.JWT_SECRET,
+          "HS256",
+        )) as { sub: string; exp?: number };
 
-    if (cached && cached.expiresAt > now) {
-        user = cached.payload;
-    } else {
-        if (cached) {
-            tokenCache.delete(token);
+        const postVerifyNow = Date.now();
+        if (tokenCache.size >= MAX_CACHE_SIZE) {
+          purgeExpiredTokenCache(postVerifyNow);
+          if (tokenCache.size >= MAX_CACHE_SIZE) {
+            tokenCache.delete(tokenCache.keys().next().value!);
+          }
         }
+        const jwtExpiresAt = verified.exp
+          ? verified.exp * 1000
+          : postVerifyNow + TOKEN_CACHE_MAX_AGE_MS;
+        const expiresAt = Math.min(
+          jwtExpiresAt,
+          postVerifyNow + TOKEN_CACHE_MAX_AGE_MS,
+        );
+        tokenCache.set(token, { payload: { sub: verified.sub }, expiresAt });
+        return verified;
+      })();
 
-        let verifyPromise = inFlightVerifications.get(token);
-        if (!verifyPromise) {
-            verifyPromise = (async () => {
-                const { verify } = await import("hono/jwt");
-                const verified = (await verify(rawToken, c.env.JWT_SECRET, "HS256")) as { sub: string; exp?: number };
-
-                const postVerifyNow = Date.now();
-                if (tokenCache.size >= MAX_CACHE_SIZE) {
-                    purgeExpiredTokenCache(postVerifyNow);
-                    if (tokenCache.size >= MAX_CACHE_SIZE) {
-                        tokenCache.delete(tokenCache.keys().next().value!);
-                    }
-                }
-                const jwtExpiresAt = verified.exp ? verified.exp * 1000 : postVerifyNow + TOKEN_CACHE_MAX_AGE_MS;
-                const expiresAt = Math.min(jwtExpiresAt, postVerifyNow + TOKEN_CACHE_MAX_AGE_MS);
-                tokenCache.set(token, { payload: { sub: verified.sub }, expiresAt });
-                return verified;
-            })();
-
-            inFlightVerifications.set(token, verifyPromise);
-        }
-
-        try {
-            user = await verifyPromise;
-        } catch {
-            return { ok: false, status: 401, error: "Invalid token" };
-        } finally {
-            inFlightVerifications.delete(token);
-        }
+      inFlightVerifications.set(token, verifyPromise);
     }
 
-    // Authors always have access
-    const isAuthor = await db
-        .select()
-        .from(paperAuthors)
-        .where(
-            and(
-                eq(paperAuthors.paperId, paper.id),
-                eq(paperAuthors.userId, user.sub),
-            ),
-        )
-        .get();
-    if (isAuthor) return { ok: true, user };
-
-    if (paper.visibility === "private") {
-        return { ok: false, status: 403, error: "Forbidden" };
+    try {
+      user = await verifyPromise;
+    } catch {
+      return { ok: false, status: 401, error: "Invalid token" };
+    } finally {
+      inFlightVerifications.delete(token);
     }
+  }
 
-    if (paper.visibility === "org_only") {
-        const isMemberOfPaperOrg = await db
-            .select({ id: orgMembers.userId })
-            .from(orgMembers)
-            .innerJoin(paperOrgs, eq(orgMembers.orgId, paperOrgs.orgId))
-            .where(
-                and(
-                    eq(paperOrgs.paperId, paper.id),
-                    eq(orgMembers.userId, user.sub),
-                ),
-            )
-            .get();
+  // Authors always have access
+  const isAuthor = await db
+    .select()
+    .from(paperAuthors)
+    .where(
+      and(
+        eq(paperAuthors.paperId, paper.id),
+        eq(paperAuthors.userId, user.sub),
+      ),
+    )
+    .get();
+  if (isAuthor) return { ok: true, user };
 
-        if (!isMemberOfPaperOrg) {
-            return { ok: false, status: 403, error: "Forbidden" };
-        }
-    } else if (paper.visibility !== "public") {
-        return { ok: false, status: 403, error: "Forbidden" };
+  if (paper.visibility === "private") {
+    return { ok: false, status: 403, error: "Forbidden" };
+  }
+
+  if (paper.visibility === "org_only") {
+    const isMemberOfPaperOrg = await db
+      .select({ id: orgMembers.userId })
+      .from(orgMembers)
+      .innerJoin(paperOrgs, eq(orgMembers.orgId, paperOrgs.orgId))
+      .where(
+        and(eq(paperOrgs.paperId, paper.id), eq(orgMembers.userId, user.sub)),
+      )
+      .get();
+
+    if (!isMemberOfPaperOrg) {
+      return { ok: false, status: 403, error: "Forbidden" };
     }
+  } else if (paper.visibility !== "public") {
+    return { ok: false, status: 403, error: "Forbidden" };
+  }
 
-    return { ok: true, user };
+  return { ok: true, user };
 }
 
 async function isPaperAuthor(
-    db: ReturnType<typeof drizzle>,
-    paperId: string,
-    userId: string,
+  db: ReturnType<typeof drizzle>,
+  paperId: string,
+  userId: string,
 ): Promise<boolean> {
-    const author = await db
-        .select({ userId: paperAuthors.userId })
-        .from(paperAuthors)
-        .where(
-            and(
-                eq(paperAuthors.paperId, paperId),
-                eq(paperAuthors.userId, userId),
-            ),
-        )
-        .get();
+  const author = await db
+    .select({ userId: paperAuthors.userId })
+    .from(paperAuthors)
+    .where(
+      and(eq(paperAuthors.paperId, paperId), eq(paperAuthors.userId, userId)),
+    )
+    .get();
 
-    return !!author;
+  return !!author;
 }
 
 async function generateSignedPreviewUrl(
-    bucket: Env["BUCKET"],
-    objectKey: string,
+  bucket: Env["BUCKET"],
+  objectKey: string,
 ): Promise<string | null> {
-    const bucketLike = bucket as unknown as {
-        createSignedUrl?: (key: string, options?: { expiresIn?: number }) => Promise<string>;
-        presign?: (key: string, options?: { expiresIn?: number }) => Promise<string>;
-    };
+  const bucketLike = bucket as unknown as {
+    createSignedUrl?: (
+      key: string,
+      options?: { expiresIn?: number },
+    ) => Promise<string>;
+    presign?: (
+      key: string,
+      options?: { expiresIn?: number },
+    ) => Promise<string>;
+  };
 
-    try {
-        if (typeof bucketLike.createSignedUrl === "function") {
-            return await bucketLike.createSignedUrl(objectKey, { expiresIn: 300 });
-        }
-
-        if (typeof bucketLike.presign === "function") {
-            return await bucketLike.presign(objectKey, { expiresIn: 300 });
-        }
-    } catch {
-        return null;
+  try {
+    if (typeof bucketLike.createSignedUrl === "function") {
+      return await bucketLike.createSignedUrl(objectKey, { expiresIn: 300 });
     }
 
+    if (typeof bucketLike.presign === "function") {
+      return await bucketLike.presign(objectKey, { expiresIn: 300 });
+    }
+  } catch {
     return null;
-}
+  }
 
+  return null;
+}
 
 type ParsedMetadata = {
-    title: string;
-    abstract: string | null;
-    visibility: "public" | "org_only" | "private";
-    showViewCount: boolean;
-    language: string | null;
-    externalUrl: string | null;
-    doi: string | null;
-    venue: string | null;
-    venueType: VenueType | null;
-    year: number | null;
-    category: CategoryType | null;
-    tags: string | null;
-    orgId?: string;
+  title: string;
+  abstract: string | null;
+  visibility: "public" | "org_only" | "private";
+  showViewCount: boolean;
+  language: string | null;
+  externalUrl: string | null;
+  doi: string | null;
+  venue: string | null;
+  venueType: VenueType | null;
+  year: number | null;
+  category: CategoryType | null;
+  tags: string | null;
+  orgId?: string;
 };
 
-function parseAndValidateMetadata(c: Context, metadataStr: string): { errorResponse?: Response; data?: ParsedMetadata } {
-    let meta: Record<string, unknown>;
-    try {
-        meta = JSON.parse(metadataStr);
-    } catch {
-        return { errorResponse: c.json({ error: "Invalid metadata JSON" }, 400) };
-    }
+function parseAndValidateMetadata(
+  c: Context,
+  metadataStr: string,
+): { errorResponse?: Response; data?: ParsedMetadata } {
+  let meta: Record<string, unknown>;
+  try {
+    meta = JSON.parse(metadataStr);
+  } catch {
+    return { errorResponse: c.json({ error: "Invalid metadata JSON" }, 400) };
+  }
 
-    const title = meta.title as string | undefined;
-    if (
-        !title ||
-        typeof title !== "string" ||
-        title.trim().length === 0 ||
-        title.trim().length > MAX_TITLE_LENGTH
-    )
-        return { errorResponse: c.json({ error: `title is required (1-${MAX_TITLE_LENGTH} chars)` }, 400) };
-
-    const vis = (meta.visibility as string) || "private";
-    if (!VALID_VISIBILITY.includes(vis))
-        return { errorResponse: c.json({ error: "Invalid visibility" }, 400) };
-
-    const venueType = (meta.venueType as string | null | undefined) ?? null;
-    if (venueType !== null && !(VALID_VENUE_TYPES as readonly string[]).includes(venueType))
-        return { errorResponse: c.json({ error: "Invalid venueType" }, 400) };
-
-    const category = (meta.category as string | null | undefined) ?? null;
-    if (category !== null && !(VALID_CATEGORIES as readonly string[]).includes(category))
-        return { errorResponse: c.json({ error: "Invalid category" }, 400) };
-
-    const externalUrl = (meta.externalUrl as string) || null;
-    if (externalUrl && !isValidUrlScheme(externalUrl)) {
-        return { errorResponse: c.json({ error: "Invalid externalUrl scheme (only http/https allowed)" }, 400) };
-    }
-
-    if (
-        meta.showViewCount !== undefined
-        && typeof meta.showViewCount !== "boolean"
-    ) {
-        return { errorResponse: c.json({ error: "showViewCount must be a boolean" }, 400) };
-    }
-
-    const orgId = meta.orgId as string | undefined;
-    if (vis === "org_only" && !orgId) {
-        return { errorResponse: c.json({ error: "orgId is required for org_only visibility" }, 400) };
-    }
-
+  const title = meta.title as string | undefined;
+  if (
+    !title ||
+    typeof title !== "string" ||
+    title.trim().length === 0 ||
+    title.trim().length > MAX_TITLE_LENGTH
+  )
     return {
-        data: {
-            title: title.trim(),
-            abstract: (meta.abstract as string) || null,
-            visibility: vis as "public" | "org_only" | "private",
-            showViewCount: Boolean(meta.showViewCount),
-            language: (meta.language as string) || null,
-            externalUrl,
-            doi: (meta.doi as string) || null,
-            venue: (meta.venue as string) || null,
-            venueType: venueType as VenueType | null,
-            year: meta.year ? Number(meta.year) : null,
-            category: category as CategoryType | null,
-            tags: meta.tags ? JSON.stringify(meta.tags) : null,
-            orgId,
-        }
+      errorResponse: c.json(
+        { error: `title is required (1-${MAX_TITLE_LENGTH} chars)` },
+        400,
+      ),
     };
+
+  const vis = (meta.visibility as string) || "private";
+  if (!VALID_VISIBILITY.includes(vis))
+    return { errorResponse: c.json({ error: "Invalid visibility" }, 400) };
+
+  const venueType = (meta.venueType as string | null | undefined) ?? null;
+  if (
+    venueType !== null &&
+    !(VALID_VENUE_TYPES as readonly string[]).includes(venueType)
+  )
+    return { errorResponse: c.json({ error: "Invalid venueType" }, 400) };
+
+  const category = (meta.category as string | null | undefined) ?? null;
+  if (
+    category !== null &&
+    !(VALID_CATEGORIES as readonly string[]).includes(category)
+  )
+    return { errorResponse: c.json({ error: "Invalid category" }, 400) };
+
+  const externalUrl = (meta.externalUrl as string) || null;
+  if (externalUrl && !isValidUrlScheme(externalUrl)) {
+    return {
+      errorResponse: c.json(
+        { error: "Invalid externalUrl scheme (only http/https allowed)" },
+        400,
+      ),
+    };
+  }
+
+  if (
+    meta.showViewCount !== undefined &&
+    typeof meta.showViewCount !== "boolean"
+  ) {
+    return {
+      errorResponse: c.json({ error: "showViewCount must be a boolean" }, 400),
+    };
+  }
+
+  const orgId = meta.orgId as string | undefined;
+  if (vis === "org_only" && !orgId) {
+    return {
+      errorResponse: c.json(
+        { error: "orgId is required for org_only visibility" },
+        400,
+      ),
+    };
+  }
+
+  return {
+    data: {
+      title: title.trim(),
+      abstract: (meta.abstract as string) || null,
+      visibility: vis as "public" | "org_only" | "private",
+      showViewCount: Boolean(meta.showViewCount),
+      language: (meta.language as string) || null,
+      externalUrl,
+      doi: (meta.doi as string) || null,
+      venue: (meta.venue as string) || null,
+      venueType: venueType as VenueType | null,
+      year: meta.year ? Number(meta.year) : null,
+      category: category as CategoryType | null,
+      tags: meta.tags ? JSON.stringify(meta.tags) : null,
+      orgId,
+    },
+  };
 }
 
-
 type UploadEntry = {
-    file: File;
-    fileType: "paper" | "slides" | "poster" | "supplementary";
-    safeFilename: string;
-    r2Key: string;
+  file: File;
+  fileType: "paper" | "slides" | "poster" | "supplementary";
+  safeFilename: string;
+  r2Key: string;
 };
 
-async function prepareUploadEntries(c: Context, body: Record<string, string | File | (string | File)[]>, paperId: string): Promise<{ errorResponse?: Response; uploads?: UploadEntry[] }> {
-    const uploads: UploadEntry[] = [];
+async function prepareUploadEntries(
+  c: Context,
+  body: Record<string, string | File | (string | File)[]>,
+  paperId: string,
+): Promise<{ errorResponse?: Response; uploads?: UploadEntry[] }> {
+  const uploads: UploadEntry[] = [];
 
-    // Validate all file entries before any upload or DB mutation.
-    for (let i = 0; body[`files_${i}`]; i++) {
-        const fileCandidate = body[`files_${i}`];
+  // Validate all file entries before any upload or DB mutation.
+  for (let i = 0; body[`files_${i}`]; i++) {
+    const fileCandidate = body[`files_${i}`];
 
-        if (typeof fileCandidate === "string" || Array.isArray(fileCandidate)) {
-            console.error(`Field files_${i} is not a single file`);
-            return { errorResponse: c.json({ error: `Field files_${i} is not a valid file` }, 400) };
-        }
-
-        const file = fileCandidate as File;
-        if (!(file instanceof File) && typeof (file as any).slice !== "function") {
-            console.error(`Field files_${i} is not a valid File/Blob`);
-            return { errorResponse: c.json({ error: `Field files_${i} is not a valid file` }, 400) };
-        }
-
-        if (file.size > MAX_FILE_SIZE)
-            return { errorResponse: c.json(
-                { error: `File ${file.name} exceeds 50 MB limit` },
-                400,
-            ) };
-        if (!ALLOWED_MIME_TYPES.includes(file.type))
-            return { errorResponse: c.json(
-                {
-                    error: `File ${file.name} has unsupported type: ${file.type || "unknown"}`,
-                },
-                400,
-            ) };
-
-        const isValidContent = await validateMagicNumbers(file, file.type);
-        if (!isValidContent) {
-            console.error(`Magic number validation failed for file ${file.name} (declared: ${file.type})`);
-            return { errorResponse: c.json(
-                { error: `File ${file.name} does not match expected format for ${file.type}` },
-                400,
-            ) };
-        }
-
-        const ft = (body[`file_types_${i}`] as string) || "paper";
-        if (!VALID_FILE_TYPES.includes(ft))
-            return { errorResponse: c.json({ error: `Invalid file_type: ${ft}` }, 400) };
-
-        const safeFilename = sanitizeFilename(file.name);
-        const uniqueFilename = `${crypto.randomUUID()}-${safeFilename}`;
-
-        uploads.push({
-            file,
-            fileType: ft as UploadEntry["fileType"],
-            safeFilename,
-            r2Key: `papers/${paperId}/${ft}/${uniqueFilename}`,
-        });
+    if (typeof fileCandidate === "string" || Array.isArray(fileCandidate)) {
+      console.error(`Field files_${i} is not a single file`);
+      return {
+        errorResponse: c.json(
+          { error: `Field files_${i} is not a valid file` },
+          400,
+        ),
+      };
     }
 
-    if (uploads.length === 0) {
-        return { errorResponse: c.json({ error: "At least one file is required" }, 400) };
+    const file = fileCandidate as File;
+    if (!(file instanceof File) && typeof (file as any).slice !== "function") {
+      console.error(`Field files_${i} is not a valid File/Blob`);
+      return {
+        errorResponse: c.json(
+          { error: `Field files_${i} is not a valid file` },
+          400,
+        ),
+      };
     }
 
-    return { uploads };
+    if (file.size > MAX_FILE_SIZE)
+      return {
+        errorResponse: c.json(
+          { error: `File ${file.name} exceeds 50 MB limit` },
+          400,
+        ),
+      };
+    if (!ALLOWED_MIME_TYPES.includes(file.type))
+      return {
+        errorResponse: c.json(
+          {
+            error: `File ${file.name} has unsupported type: ${file.type || "unknown"}`,
+          },
+          400,
+        ),
+      };
+
+    const isValidContent = await validateMagicNumbers(file, file.type);
+    if (!isValidContent) {
+      console.error(
+        `Magic number validation failed for file ${file.name} (declared: ${file.type})`,
+      );
+      return {
+        errorResponse: c.json(
+          {
+            error: `File ${file.name} does not match expected format for ${file.type}`,
+          },
+          400,
+        ),
+      };
+    }
+
+    const ft = (body[`file_types_${i}`] as string) || "paper";
+    if (!VALID_FILE_TYPES.includes(ft))
+      return {
+        errorResponse: c.json({ error: `Invalid file_type: ${ft}` }, 400),
+      };
+
+    const safeFilename = sanitizeFilename(file.name);
+    const uniqueFilename = `${crypto.randomUUID()}-${safeFilename}`;
+
+    uploads.push({
+      file,
+      fileType: ft as UploadEntry["fileType"],
+      safeFilename,
+      r2Key: `papers/${paperId}/${ft}/${uniqueFilename}`,
+    });
+  }
+
+  if (uploads.length === 0) {
+    return {
+      errorResponse: c.json({ error: "At least one file is required" }, 400),
+    };
+  }
+
+  return { uploads };
 }
 
 // POST /api/papers — create paper + upload files
 papersRoute.post("/", authMiddleware, async (c) => {
-    const body = await c.req.parseBody({ all: true });
+  const body = await c.req.parseBody({ all: true });
 
-    const metadataStr = body["metadata"];
-    if (typeof metadataStr !== "string")
-        return c.json({ error: "metadata field is required" }, 400);
+  const metadataStr = body["metadata"];
+  if (typeof metadataStr !== "string")
+    return c.json({ error: "metadata field is required" }, 400);
 
-    const { errorResponse, data: meta } = parseAndValidateMetadata(c, metadataStr);
-    if (errorResponse) return errorResponse;
-    if (!meta) return c.json({ error: "Unexpected parsing error" }, 500); // Should not happen based on helper logic
+  const { errorResponse, data: meta } = parseAndValidateMetadata(
+    c,
+    metadataStr,
+  );
+  if (errorResponse) return errorResponse;
+  if (!meta) return c.json({ error: "Unexpected parsing error" }, 500); // Should not happen based on helper logic
 
-    const paperId = crypto.randomUUID();
-    const userId = c.get("user").sub;
+  const paperId = crypto.randomUUID();
+  const userId = c.get("user").sub;
 
-    const db = drizzle(c.env.DB);
-    await enableForeignKeys(db);
+  const db = drizzle(c.env.DB);
+  await enableForeignKeys(db);
+
+  if (meta.visibility === "org_only" && meta.orgId) {
+    const membership = await db
+      .select({ orgId: orgMembers.orgId })
+      .from(orgMembers)
+      .where(
+        and(eq(orgMembers.orgId, meta.orgId), eq(orgMembers.userId, userId)),
+      )
+      .get();
+    if (!membership) {
+      console.error(
+        `Membership check failed for userId: ${userId}, orgId: ${meta.orgId}`,
+      );
+      return c.json({ error: "Invalid orgId or not a member" }, 403);
+    }
+  }
+
+  const { errorResponse: uploadError, uploads } = await prepareUploadEntries(
+    c,
+    body,
+    paperId,
+  );
+  if (uploadError) return uploadError;
+  if (!uploads)
+    return c.json({ error: "Unexpected upload processing error" }, 500); // Should not happen based on helper logic
+
+  const paperValues: typeof papers.$inferInsert = {
+    id: paperId,
+    title: meta.title,
+    abstract: meta.abstract,
+    visibility: meta.visibility,
+    showViewCount: meta.showViewCount,
+    language: meta.language,
+    externalUrl: meta.externalUrl,
+    doi: meta.doi,
+    venue: meta.venue,
+    venueType: meta.venueType,
+    year: meta.year,
+    category: meta.category,
+    tags: meta.tags,
+  };
+
+  const uploadedKeys: string[] = [];
+  try {
+    const errors: unknown[] = [];
+    const results = await pMap(
+      uploads,
+      async (entry) => {
+        try {
+          await c.env.BUCKET.put(entry.r2Key, entry.file.stream() as any, {
+            httpMetadata: { contentType: entry.file.type },
+          });
+          return { r2Key: entry.r2Key, error: null };
+        } catch (e) {
+          return { r2Key: null, error: e };
+        }
+      },
+      { concurrency: MAX_CONCURRENT_UPLOADS },
+    );
+
+    for (const res of results) {
+      if (res.error) errors.push(res.error);
+      else if (res.r2Key) uploadedKeys.push(res.r2Key);
+    }
+
+    if (errors.length > 0) {
+      console.error("File upload errors:", {
+        errors: errors.map((e) => (e instanceof Error ? e.message : String(e))),
+      });
+      throw errors[0] ?? new Error("An unknown upload error occurred.");
+    }
+
+    await db.insert(papers).values(paperValues);
+
+    await db.insert(paperAuthors).values({ paperId, userId, role: "uploader" });
 
     if (meta.visibility === "org_only" && meta.orgId) {
-        const membership = await db
-            .select({ orgId: orgMembers.orgId })
-            .from(orgMembers)
-            .where(
-                and(
-                    eq(orgMembers.orgId, meta.orgId),
-                    eq(orgMembers.userId, userId),
-                ),
-            )
-            .get();
-        if (!membership) {
-            console.error(`Membership check failed for userId: ${userId}, orgId: ${meta.orgId}`);
-            return c.json({ error: "Invalid orgId or not a member" }, 403);
-        }
+      await db.insert(paperOrgs).values({ paperId, orgId: meta.orgId });
     }
 
-    const { errorResponse: uploadError, uploads } = await prepareUploadEntries(c, body, paperId);
-    if (uploadError) return uploadError;
-    if (!uploads) return c.json({ error: "Unexpected upload processing error" }, 500); // Should not happen based on helper logic
+    await db.insert(paperFiles).values(
+      uploads.map((entry) => ({
+        id: crypto.randomUUID(),
+        paperId,
+        r2Key: entry.r2Key,
+        fileType: entry.fileType,
+        filename: entry.safeFilename,
+        sizeBytes: entry.file.size,
+        mimeType: entry.file.type || null,
+        ...touchUpdatedAt(),
+      })),
+    );
+  } catch (error) {
+    await deleteKeysInBatches(c.env.BUCKET, uploadedKeys, (info) => {
+      // Ignore cleanup errors during rollback after a later failure.
+      console.error(
+        "Cleanup error (non-fatal, rollback continues):",
+        info.error,
+      );
+    });
+    await db.delete(papers).where(eq(papers.id, paperId));
+    throw error;
+  }
 
-    const paperValues: typeof papers.$inferInsert = {
-        id: paperId,
-        title: meta.title,
-        abstract: meta.abstract,
-        visibility: meta.visibility,
-        showViewCount: meta.showViewCount,
-        language: meta.language,
-        externalUrl: meta.externalUrl,
-        doi: meta.doi,
-        venue: meta.venue,
-        venueType: meta.venueType,
-        year: meta.year,
-        category: meta.category,
-        tags: meta.tags,
-    };
-
-    const uploadedKeys: string[] = [];
-    try {
-        const errors: unknown[] = [];
-        const results = await pMap(
-            uploads,
-            async (entry) => {
-                try {
-                    await c.env.BUCKET.put(entry.r2Key, entry.file.stream() as any, {
-                        httpMetadata: { contentType: entry.file.type },
-                    });
-                    return { r2Key: entry.r2Key, error: null };
-                } catch (e) {
-                    return { r2Key: null, error: e };
-                }
-            },
-            { concurrency: MAX_CONCURRENT_UPLOADS }
-        );
-
-        for (const res of results) {
-            if (res.error) errors.push(res.error);
-            else if (res.r2Key) uploadedKeys.push(res.r2Key);
-        }
-
-        if (errors.length > 0) {
-            console.error("File upload errors:", {
-                errors: errors.map((e) => (e instanceof Error ? e.message : String(e))),
-            });
-            throw errors[0] ?? new Error("An unknown upload error occurred.");
-        }
-
-        await db.insert(papers).values(paperValues);
-
-        await db
-            .insert(paperAuthors)
-            .values({ paperId, userId, role: "uploader" });
-
-        if (meta.visibility === "org_only" && meta.orgId) {
-            await db.insert(paperOrgs).values({ paperId, orgId: meta.orgId });
-        }
-
-        await db.insert(paperFiles).values(
-            uploads.map((entry) => ({
-                id: crypto.randomUUID(),
-                paperId,
-                r2Key: entry.r2Key,
-                fileType: entry.fileType,
-                filename: entry.safeFilename,
-                sizeBytes: entry.file.size,
-                mimeType: entry.file.type || null,
-                ...touchUpdatedAt(),
-            })),
-        );
-    } catch (error) {
-        await deleteKeysInBatches(c.env.BUCKET, uploadedKeys, (info) => {
-            // Ignore cleanup errors during rollback after a later failure.
-            console.error("Cleanup error (non-fatal, rollback continues):", info.error);
-        });
-        await db.delete(papers).where(eq(papers.id, paperId));
-        throw error;
-    }
-
-    return c.json({ paper: { id: paperId } }, 201);
+  return c.json({ paper: { id: paperId } }, 201);
 });
 
 // GET /api/papers — my papers list
 papersRoute.get("/", authMiddleware, async (c) => {
-    const db = drizzle(c.env.DB);
-    const userId = c.get("user").sub;
+  const db = drizzle(c.env.DB);
+  const userId = c.get("user").sub;
 
-    const rows = await db
-        .select({ paper: papers })
-        .from(papers)
-        .innerJoin(
-            paperAuthors,
-            and(
-                eq(paperAuthors.paperId, papers.id),
-                eq(paperAuthors.userId, userId),
-            ),
-        )
-        .all();
+  const rows = await db
+    .select({ paper: papers })
+    .from(papers)
+    .innerJoin(
+      paperAuthors,
+      and(eq(paperAuthors.paperId, papers.id), eq(paperAuthors.userId, userId)),
+    )
+    .all();
 
-    return c.json({ papers: rows.map((r) => r.paper) });
+  return c.json({ papers: rows.map((r) => r.paper) });
 });
 
 // GET /api/papers/:id — paper detail
 papersRoute.get("/:id", async (c) => {
-    const paperId = c.req.param("id");
-    const db = drizzle(c.env.DB);
+  const paperId = c.req.param("id");
+  const db = drizzle(c.env.DB);
 
-    const paper = await db
-        .select()
-        .from(papers)
-        .where(eq(papers.id, paperId))
-        .get();
-    if (!paper) return c.json({ error: "Not found" }, 404);
+  const paper = await db
+    .select()
+    .from(papers)
+    .where(eq(papers.id, paperId))
+    .get();
+  if (!paper) return c.json({ error: "Not found" }, 404);
 
-    const access = await authorizePaperAccess(c, db, paper);
-    if (!access.ok) {
-        return c.json({ error: access.error }, access.status);
-    }
+  const access = await authorizePaperAccess(c, db, paper);
+  if (!access.ok) {
+    return c.json({ error: access.error }, access.status);
+  }
 
-    const [rawFiles, authors] = (await db.batch([
-        db
-            .select()
-            .from(paperFiles)
-            .where(eq(paperFiles.paperId, paperId)),
-        db
-            .select({
-                userId: paperAuthors.userId,
-                role: paperAuthors.role,
-                name: users.name,
-                displayName: users.displayName,
-                avatarUrl: users.avatarUrl,
-            })
-            .from(paperAuthors)
-            .innerJoin(users, eq(paperAuthors.userId, users.id))
-            .where(eq(paperAuthors.paperId, paperId)),
-    ])) as [
-            (typeof paperFiles.$inferSelect)[],
-            { userId: string; role: string; name: string | null; displayName: string | null; avatarUrl: string | null }[]
-        ];
+  const [rawFiles, authors] = (await db.batch([
+    db.select().from(paperFiles).where(eq(paperFiles.paperId, paperId)),
+    db
+      .select({
+        userId: paperAuthors.userId,
+        role: paperAuthors.role,
+        name: users.name,
+        displayName: users.displayName,
+        avatarUrl: users.avatarUrl,
+      })
+      .from(paperAuthors)
+      .innerJoin(users, eq(paperAuthors.userId, users.id))
+      .where(eq(paperAuthors.paperId, paperId)),
+  ])) as [
+    (typeof paperFiles.$inferSelect)[],
+    {
+      userId: string;
+      role: string;
+      name: string | null;
+      displayName: string | null;
+      avatarUrl: string | null;
+    }[],
+  ];
 
-    const files = rawFiles.map((file) => ({
-        ...file,
-        downloadUrl: `/api/papers/${paperId}/files/${file.id}/download`,
-    }));
-    const publicStats = paper.showViewCount
-        ? await getPaperPublicStats(db, paperId)
-        : null;
+  const files = rawFiles.map((file) => ({
+    ...file,
+    downloadUrl: `/api/papers/${paperId}/files/${file.id}/download`,
+  }));
+  const publicStats = paper.showViewCount
+    ? await getPaperPublicStats(db, paperId)
+    : null;
 
-    return c.json({
-        paper: {
-            id: paper.id,
-            title: paper.title,
-            abstract: paper.abstract,
-            description: paper.description,
-            descriptionUpdatedAt: toIsoUtc(paper.descriptionUpdatedAt),
-            visibility: paper.visibility,
-            showViewCount: paper.showViewCount,
-            publicViewCount: publicStats?.views ?? null,
-            publicDownloadCount: publicStats?.downloads ?? null,
-            language: paper.language,
-            externalUrl: paper.externalUrl,
-            doi: paper.doi,
-            venue: paper.venue,
-            venueType: paper.venueType,
-            year: paper.year,
-            category: paper.category,
-            tags: paper.tags,
-            createdAt: paper.createdAt,
-            updatedAt: paper.updatedAt,
-        },
-        files,
-        authors,
-    });
+  return c.json({
+    paper: {
+      id: paper.id,
+      title: paper.title,
+      abstract: paper.abstract,
+      description: paper.description,
+      descriptionUpdatedAt: toIsoUtc(paper.descriptionUpdatedAt),
+      visibility: paper.visibility,
+      showViewCount: paper.showViewCount,
+      publicViewCount: publicStats?.views ?? null,
+      publicDownloadCount: publicStats?.downloads ?? null,
+      language: paper.language,
+      externalUrl: paper.externalUrl,
+      doi: paper.doi,
+      venue: paper.venue,
+      venueType: paper.venueType,
+      year: paper.year,
+      category: paper.category,
+      tags: paper.tags,
+      createdAt: paper.createdAt,
+      updatedAt: paper.updatedAt,
+    },
+    files,
+    authors,
+  });
 });
 
 // GET /api/papers/:id/cite — generate citation text
 papersRoute.get("/:id/cite", async (c) => {
-    const paperId = c.req.param("id");
-    const formatRaw = c.req.query("format") ?? "bibtex";
-    const format = isCitationFormat(formatRaw) ? formatRaw : "bibtex";
-    const db = drizzle(c.env.DB);
+  const paperId = c.req.param("id");
+  const formatRaw = c.req.query("format") ?? "bibtex";
+  const format = isCitationFormat(formatRaw) ? formatRaw : "bibtex";
+  const db = drizzle(c.env.DB);
 
-    const paper = await db
-        .select()
-        .from(papers)
-        .where(eq(papers.id, paperId))
-        .get();
-    if (!paper) return c.json({ error: "Not found" }, 404);
+  const paper = await db
+    .select()
+    .from(papers)
+    .where(eq(papers.id, paperId))
+    .get();
+  if (!paper) return c.json({ error: "Not found" }, 404);
 
-    const access = await authorizePaperAccess(c, db, paper);
-    if (!access.ok) {
-        return c.json({ error: access.error }, access.status);
-    }
+  const access = await authorizePaperAccess(c, db, paper);
+  if (!access.ok) {
+    return c.json({ error: access.error }, access.status);
+  }
 
-    const authors = await db
-        .select({
-            name: users.name,
-            displayName: users.displayName,
-        })
-        .from(paperAuthors)
-        .innerJoin(users, eq(paperAuthors.userId, users.id))
-        .where(eq(paperAuthors.paperId, paperId))
-        .all();
+  const authors = await db
+    .select({
+      name: users.name,
+      displayName: users.displayName,
+    })
+    .from(paperAuthors)
+    .innerJoin(users, eq(paperAuthors.userId, users.id))
+    .where(eq(paperAuthors.paperId, paperId))
+    .all();
 
-    const citation = buildCitation(
-        {
-            id: paper.id,
-            title: paper.title,
-            venue: paper.venue,
-            venueType: paper.venueType,
-            year: paper.year,
-            category: paper.category,
-            doi: paper.doi,
-            externalUrl: paper.externalUrl,
-        },
-        authors,
-        format,
-        c.env.FRONTEND_URL,
-    );
+  const citation = buildCitation(
+    {
+      id: paper.id,
+      title: paper.title,
+      venue: paper.venue,
+      venueType: paper.venueType,
+      year: paper.year,
+      category: paper.category,
+      doi: paper.doi,
+      externalUrl: paper.externalUrl,
+    },
+    authors,
+    format,
+    c.env.FRONTEND_URL,
+  );
 
-    return c.json(citation);
+  return c.json(citation);
 });
 
 // POST /api/papers/:id/track — record daily stats events
 papersRoute.post("/:id/track", async (c) => {
-    const paperId = c.req.param("id");
-    const db = drizzle(c.env.DB);
-    await enableForeignKeys(db);
+  const paperId = c.req.param("id");
+  const db = drizzle(c.env.DB);
+  await enableForeignKeys(db);
 
-    let body: unknown;
-    try {
-        body = await c.req.json();
-    } catch {
-        return c.json({ error: "Invalid JSON body" }, 400);
-    }
-    if (!body || typeof body !== "object" || Array.isArray(body)) {
-        return c.json({ error: "Invalid JSON body" }, 400);
-    }
-    const payload = body as { event?: unknown; referrer?: unknown };
-    if (!isTrackEvent(payload.event)) {
-        return c.json({ error: "event must be one of view, download, preview" }, 400);
-    }
-
-    const paper = await db
-        .select({ id: papers.id, visibility: papers.visibility })
-        .from(papers)
-        .where(eq(papers.id, paperId))
-        .get();
-    if (!paper) return c.json({ error: "Not found" }, 404);
-
-    const access = await authorizePaperAccess(c, db, paper);
-    if (!access.ok) {
-        return c.json({ error: access.error }, access.status);
-    }
-
-    if (isBotUserAgent(c.req.header("User-Agent"))) {
-        return new Response(null, { status: 204 });
-    }
-
-    const referrer = normalizeReferrer(payload.referrer);
-    const date = formatDateKey(new Date());
-    const sessionHash = await buildTrackSessionHash(c, date, paperId);
-
-    await runInBackground(
-        c,
-        recordTrackEvent({
-            db: c.env.DB,
-            paperId,
-            event: payload.event,
-            date,
-            sessionHash,
-            referrer,
-        }).catch((error) => {
-            console.error("Failed to record paper track event", {
-                paperId,
-                event: payload.event,
-                error: error instanceof Error ? error.message : String(error),
-            });
-        }),
+  let body: unknown;
+  try {
+    body = await c.req.json();
+  } catch {
+    return c.json({ error: "Invalid JSON body" }, 400);
+  }
+  if (!body || typeof body !== "object" || Array.isArray(body)) {
+    return c.json({ error: "Invalid JSON body" }, 400);
+  }
+  const payload = body as { event?: unknown; referrer?: unknown };
+  if (!isTrackEvent(payload.event)) {
+    return c.json(
+      { error: "event must be one of view, download, preview" },
+      400,
     );
+  }
 
+  const paper = await db
+    .select({ id: papers.id, visibility: papers.visibility })
+    .from(papers)
+    .where(eq(papers.id, paperId))
+    .get();
+  if (!paper) return c.json({ error: "Not found" }, 404);
+
+  const access = await authorizePaperAccess(c, db, paper);
+  if (!access.ok) {
+    return c.json({ error: access.error }, access.status);
+  }
+
+  if (isBotUserAgent(c.req.header("User-Agent"))) {
     return new Response(null, { status: 204 });
+  }
+
+  const referrer = normalizeReferrer(payload.referrer);
+  const date = formatDateKey(new Date());
+  const sessionHash = await buildTrackSessionHash(c, date, paperId);
+
+  await runInBackground(
+    c,
+    recordTrackEvent({
+      db: c.env.DB,
+      paperId,
+      event: payload.event,
+      date,
+      sessionHash,
+      referrer,
+    }).catch((error) => {
+      console.error("Failed to record paper track event", {
+        paperId,
+        event: payload.event,
+        error: error instanceof Error ? error.message : String(error),
+      });
+    }),
+  );
+
+  return new Response(null, { status: 204 });
 });
 
 // GET /api/papers/:id/stats — author-only paper statistics
 papersRoute.get("/:id/stats", authMiddleware, async (c) => {
-    const paperId = c.req.param("id");
-    const userId = c.get("user").sub;
-    const db = drizzle(c.env.DB);
-    const days = parseTrackDays(c.req.query("days"));
-    if (days === null) {
-        return c.json({ error: "days must be one of 7, 30, 90, 365" }, 400);
-    }
+  const paperId = c.req.param("id");
+  const userId = c.get("user").sub;
+  const db = drizzle(c.env.DB);
+  const days = parseTrackDays(c.req.query("days"));
+  if (days === null) {
+    return c.json({ error: "days must be one of 7, 30, 90, 365" }, 400);
+  }
 
-    const paper = await db
-        .select({ id: papers.id })
-        .from(papers)
-        .where(eq(papers.id, paperId))
-        .get();
-    if (!paper) return c.json({ error: "Not found" }, 404);
+  const paper = await db
+    .select({ id: papers.id })
+    .from(papers)
+    .where(eq(papers.id, paperId))
+    .get();
+  if (!paper) return c.json({ error: "Not found" }, 404);
 
-    const author = await isPaperAuthor(db, paperId, userId);
-    if (!author) return c.json({ error: "Forbidden" }, 403);
+  const author = await isPaperAuthor(db, paperId, userId);
+  if (!author) return c.json({ error: "Forbidden" }, 403);
 
-    const dateRange = getDateRange(days);
-    const sinceDate = dateRange[0];
+  const dateRange = getDateRange(days);
+  const sinceDate = dateRange[0];
 
-    const [totalRow, dailyRows] = await Promise.all([
-        db
-            .select({
-                views: paperStatsTotal.totalViews,
-                downloads: paperStatsTotal.totalDownloads,
-                previews: paperStatsTotal.totalPreviews,
-            })
-            .from(paperStatsTotal)
-            .where(eq(paperStatsTotal.paperId, paperId))
-            .get(),
-        db
-            .select({
-                date: paperStatsDaily.date,
-                views: paperStatsDaily.views,
-                downloads: paperStatsDaily.downloads,
-                previews: paperStatsDaily.previews,
-            })
-            .from(paperStatsDaily)
-            .where(
-                and(
-                    eq(paperStatsDaily.paperId, paperId),
-                    gte(paperStatsDaily.date, sinceDate),
-                ),
-            )
-            .all(),
-    ]);
+  const [totalRow, dailyRows] = await Promise.all([
+    db
+      .select({
+        views: paperStatsTotal.totalViews,
+        downloads: paperStatsTotal.totalDownloads,
+        previews: paperStatsTotal.totalPreviews,
+      })
+      .from(paperStatsTotal)
+      .where(eq(paperStatsTotal.paperId, paperId))
+      .get(),
+    db
+      .select({
+        date: paperStatsDaily.date,
+        views: paperStatsDaily.views,
+        downloads: paperStatsDaily.downloads,
+        previews: paperStatsDaily.previews,
+      })
+      .from(paperStatsDaily)
+      .where(
+        and(
+          eq(paperStatsDaily.paperId, paperId),
+          gte(paperStatsDaily.date, sinceDate),
+        ),
+      )
+      .all(),
+  ]);
 
-    const dailyMap = new Map(
-        dailyRows.map((row) => [row.date, row]),
-    );
-    const daily = dateRange.map((date) => {
-        const row = dailyMap.get(date);
-        return {
-            date,
-            views: row?.views ?? 0,
-            downloads: row?.downloads ?? 0,
-            previews: row?.previews ?? 0,
-        };
-    });
+  const dailyMap = new Map(dailyRows.map((row) => [row.date, row]));
+  const daily = dateRange.map((date) => {
+    const row = dailyMap.get(date);
+    return {
+      date,
+      views: row?.views ?? 0,
+      downloads: row?.downloads ?? 0,
+      previews: row?.previews ?? 0,
+    };
+  });
 
-    return c.json({
-        total: {
-            views: totalRow?.views ?? 0,
-            downloads: totalRow?.downloads ?? 0,
-            previews: totalRow?.previews ?? 0,
-        },
-        daily,
-        days,
-    });
+  return c.json({
+    total: {
+      views: totalRow?.views ?? 0,
+      downloads: totalRow?.downloads ?? 0,
+      previews: totalRow?.previews ?? 0,
+    },
+    daily,
+    days,
+  });
 });
 
 // GET /api/papers/:id/files/:fileId/download — download file
 papersRoute.get("/:id/files/:fileId/download", async (c) => {
-    const paperId = c.req.param("id");
-    const fileId = c.req.param("fileId");
-    const db = drizzle(c.env.DB);
+  const paperId = c.req.param("id");
+  const fileId = c.req.param("fileId");
+  const db = drizzle(c.env.DB);
 
-    const paper = await db
-        .select()
-        .from(papers)
-        .where(eq(papers.id, paperId))
-        .get();
-    if (!paper) return c.json({ error: "Not found" }, 404);
+  const paper = await db
+    .select()
+    .from(papers)
+    .where(eq(papers.id, paperId))
+    .get();
+  if (!paper) return c.json({ error: "Not found" }, 404);
 
-    const access = await authorizePaperAccess(c, db, paper);
-    if (!access.ok) {
-        return c.json({ error: access.error }, access.status);
-    }
+  const access = await authorizePaperAccess(c, db, paper);
+  if (!access.ok) {
+    return c.json({ error: access.error }, access.status);
+  }
 
-    const file = await db
-        .select()
-        .from(paperFiles)
-        .where(and(eq(paperFiles.id, fileId), eq(paperFiles.paperId, paperId)))
-        .get();
-    if (!file) return c.json({ error: "File not found" }, 404);
+  const file = await db
+    .select()
+    .from(paperFiles)
+    .where(and(eq(paperFiles.id, fileId), eq(paperFiles.paperId, paperId)))
+    .get();
+  if (!file) return c.json({ error: "File not found" }, 404);
 
-    const object = await c.env.BUCKET.get(file.r2Key);
-    if (!object) return c.json({ error: "File not found in storage" }, 404);
+  const object = await c.env.BUCKET.get(file.r2Key);
+  if (!object) return c.json({ error: "File not found in storage" }, 404);
 
-    const headers: Record<string, string> = {
-        "Content-Type": object.httpMetadata?.contentType || "application/octet-stream",
-        "Content-Disposition": `attachment; filename="${encodeURIComponent(file.filename)}"`,
-    };
-    if (paper.visibility === "public") {
-        headers["Cache-Control"] = "public, max-age=3600";
-    } else {
-        headers["Cache-Control"] = "private, no-store";
-        headers["Pragma"] = "no-cache";
-        headers["Vary"] = "Authorization";
-    }
-    if (object.size) {
-        headers["Content-Length"] = object.size.toString();
-    }
+  const headers: Record<string, string> = {
+    "Content-Type":
+      object.httpMetadata?.contentType || "application/octet-stream",
+    "Content-Disposition": `attachment; filename="${encodeURIComponent(file.filename)}"`,
+  };
+  if (paper.visibility === "public") {
+    headers["Cache-Control"] = "public, max-age=3600";
+  } else {
+    headers["Cache-Control"] = "private, no-store";
+    headers["Pragma"] = "no-cache";
+    headers["Vary"] = "Authorization";
+  }
+  if (object.size) {
+    headers["Content-Length"] = object.size.toString();
+  }
 
-    return new Response(object.body as ReadableStream, { headers });
+  return new Response(object.body as ReadableStream, { headers });
 });
 
 // GET /api/papers/:id/files/:fileId/preview — preview URL metadata for inline rendering
 papersRoute.get("/:id/files/:fileId/preview", async (c) => {
-    const paperId = c.req.param("id");
-    const fileId = c.req.param("fileId");
-    const db = drizzle(c.env.DB);
+  const paperId = c.req.param("id");
+  const fileId = c.req.param("fileId");
+  const db = drizzle(c.env.DB);
 
-    const paper = await db
-        .select()
-        .from(papers)
-        .where(eq(papers.id, paperId))
-        .get();
-    if (!paper) return c.json({ error: "Not found" }, 404);
+  const paper = await db
+    .select()
+    .from(papers)
+    .where(eq(papers.id, paperId))
+    .get();
+  if (!paper) return c.json({ error: "Not found" }, 404);
 
-    const access = await authorizePaperAccess(c, db, paper);
-    if (!access.ok) {
-        return c.json({ error: access.error }, access.status);
-    }
+  const access = await authorizePaperAccess(c, db, paper);
+  if (!access.ok) {
+    return c.json({ error: access.error }, access.status);
+  }
 
-    const file = await db
-        .select()
-        .from(paperFiles)
-        .where(and(eq(paperFiles.id, fileId), eq(paperFiles.paperId, paperId)))
-        .get();
-    if (!file) return c.json({ error: "File not found" }, 404);
+  const file = await db
+    .select()
+    .from(paperFiles)
+    .where(and(eq(paperFiles.id, fileId), eq(paperFiles.paperId, paperId)))
+    .get();
+  if (!file) return c.json({ error: "File not found" }, 404);
 
-    const signedUrl = await generateSignedPreviewUrl(c.env.BUCKET, file.r2Key);
-    const streamUrl = `/api/papers/${paperId}/files/${fileId}/stream`;
+  const signedUrl = await generateSignedPreviewUrl(c.env.BUCKET, file.r2Key);
+  const streamUrl = `/api/papers/${paperId}/files/${fileId}/stream`;
 
-    return c.json({
-        url: signedUrl ?? streamUrl,
-        mimeType: file.mimeType || "application/octet-stream",
-        filename: file.filename,
-    });
+  return c.json({
+    url: signedUrl ?? streamUrl,
+    mimeType: file.mimeType || "application/octet-stream",
+    filename: file.filename,
+  });
 });
 
 // GET /api/papers/:id/files/:fileId/stream — inline object stream fallback for preview
 papersRoute.get("/:id/files/:fileId/stream", async (c) => {
-    const paperId = c.req.param("id");
-    const fileId = c.req.param("fileId");
-    const db = drizzle(c.env.DB);
+  const paperId = c.req.param("id");
+  const fileId = c.req.param("fileId");
+  const db = drizzle(c.env.DB);
 
-    const paper = await db
-        .select()
-        .from(papers)
-        .where(eq(papers.id, paperId))
-        .get();
-    if (!paper) return c.json({ error: "Not found" }, 404);
+  const paper = await db
+    .select()
+    .from(papers)
+    .where(eq(papers.id, paperId))
+    .get();
+  if (!paper) return c.json({ error: "Not found" }, 404);
 
-    const access = await authorizePaperAccess(c, db, paper);
-    if (!access.ok) {
-        return c.json({ error: access.error }, access.status);
-    }
+  const access = await authorizePaperAccess(c, db, paper);
+  if (!access.ok) {
+    return c.json({ error: access.error }, access.status);
+  }
 
-    const file = await db
-        .select()
-        .from(paperFiles)
-        .where(and(eq(paperFiles.id, fileId), eq(paperFiles.paperId, paperId)))
-        .get();
-    if (!file) return c.json({ error: "File not found" }, 404);
+  const file = await db
+    .select()
+    .from(paperFiles)
+    .where(and(eq(paperFiles.id, fileId), eq(paperFiles.paperId, paperId)))
+    .get();
+  if (!file) return c.json({ error: "File not found" }, 404);
 
-    const object = await c.env.BUCKET.get(file.r2Key);
-    if (!object) return c.json({ error: "File not found in storage" }, 404);
+  const object = await c.env.BUCKET.get(file.r2Key);
+  if (!object) return c.json({ error: "File not found in storage" }, 404);
 
-    const headers: Record<string, string> = {
-        "Content-Type": object.httpMetadata?.contentType || file.mimeType || "application/octet-stream",
-        "Content-Disposition": `inline; filename="${encodeURIComponent(file.filename)}"`,
-    };
+  const headers: Record<string, string> = {
+    "Content-Type":
+      object.httpMetadata?.contentType ||
+      file.mimeType ||
+      "application/octet-stream",
+    "Content-Disposition": `inline; filename="${encodeURIComponent(file.filename)}"`,
+  };
 
-    if (paper.visibility === "public") {
-        headers["Cache-Control"] = "public, max-age=300";
-    } else {
-        headers["Cache-Control"] = "private, no-store";
-        headers["Pragma"] = "no-cache";
-        headers["Vary"] = "Authorization";
-    }
+  if (paper.visibility === "public") {
+    headers["Cache-Control"] = "public, max-age=300";
+  } else {
+    headers["Cache-Control"] = "private, no-store";
+    headers["Pragma"] = "no-cache";
+    headers["Vary"] = "Authorization";
+  }
 
-    if (object.size) {
-        headers["Content-Length"] = object.size.toString();
-    }
+  if (object.size) {
+    headers["Content-Length"] = object.size.toString();
+  }
 
-    return new Response(object.body as ReadableStream, { headers });
+  return new Response(object.body as ReadableStream, { headers });
 });
 
 // POST /api/papers/:id/invites — send coauthor invite
 papersRoute.post("/:id/invites", authMiddleware, async (c) => {
-    const paperId = c.req.param("id");
-    let body: { inviteeId?: unknown; inviteeEmail?: unknown };
-    try {
-        body = await c.req.json();
-    } catch {
-        return c.json({ error: "Invalid JSON body" }, 400);
-    }
+  const paperId = c.req.param("id");
+  let body: { inviteeId?: unknown; inviteeEmail?: unknown };
+  try {
+    body = await c.req.json();
+  } catch {
+    return c.json({ error: "Invalid JSON body" }, 400);
+  }
 
-    const inviteeId =
-        typeof body.inviteeId === "string" && body.inviteeId.trim().length > 0
-            ? body.inviteeId.trim()
-            : null;
-    const inviteeEmail =
-        typeof body.inviteeEmail === "string" &&
-            body.inviteeEmail.trim().length > 0
-            ? body.inviteeEmail.trim().toLowerCase()
-            : null;
+  const inviteeId =
+    typeof body.inviteeId === "string" && body.inviteeId.trim().length > 0
+      ? body.inviteeId.trim()
+      : null;
+  const inviteeEmail =
+    typeof body.inviteeEmail === "string" && body.inviteeEmail.trim().length > 0
+      ? body.inviteeEmail.trim().toLowerCase()
+      : null;
 
-    if (!inviteeId && !inviteeEmail) {
-        return c.json({ error: "inviteeId or inviteeEmail is required" }, 400);
-    }
+  if (!inviteeId && !inviteeEmail) {
+    return c.json({ error: "inviteeId or inviteeEmail is required" }, 400);
+  }
 
-    const db = drizzle(c.env.DB);
-    await enableForeignKeys(db);
-    const userId = c.get("user").sub;
+  const db = drizzle(c.env.DB);
+  await enableForeignKeys(db);
+  const userId = c.get("user").sub;
 
-    const isUploader = await db
-        .select()
-        .from(paperAuthors)
-        .where(
-            and(
-                eq(paperAuthors.paperId, paperId),
-                eq(paperAuthors.userId, userId),
-                eq(paperAuthors.role, "uploader"),
-            ),
-        )
-        .get();
-    if (!isUploader)
-        return c.json({ error: "Only uploaders can invite" }, 403);
+  const isUploader = await db
+    .select()
+    .from(paperAuthors)
+    .where(
+      and(
+        eq(paperAuthors.paperId, paperId),
+        eq(paperAuthors.userId, userId),
+        eq(paperAuthors.role, "uploader"),
+      ),
+    )
+    .get();
+  if (!isUploader) return c.json({ error: "Only uploaders can invite" }, 403);
 
-    if (inviteeId === userId) {
+  if (inviteeId === userId) {
+    return c.json({ error: "Cannot invite yourself" }, 400);
+  }
+
+  let resolvedInviteeId: string | null = inviteeId;
+  let resolvedInviteeEmail: string | null = inviteeEmail;
+
+  if (!resolvedInviteeId && resolvedInviteeEmail) {
+    const matchedUser = await db
+      .select({ id: users.id })
+      .from(users)
+      .where(eq(users.email, resolvedInviteeEmail))
+      .get();
+    if (matchedUser) {
+      if (matchedUser.id === userId) {
         return c.json({ error: "Cannot invite yourself" }, 400);
+      }
+      resolvedInviteeId = matchedUser.id;
+      resolvedInviteeEmail = null;
     }
+  }
 
-    let resolvedInviteeId: string | null = inviteeId;
-    let resolvedInviteeEmail: string | null = inviteeEmail;
+  if (resolvedInviteeId) {
+    const alreadyAuthor = await db
+      .select()
+      .from(paperAuthors)
+      .where(
+        and(
+          eq(paperAuthors.paperId, paperId),
+          eq(paperAuthors.userId, resolvedInviteeId),
+        ),
+      )
+      .get();
+    if (alreadyAuthor)
+      return c.json({ error: "User is already an author" }, 409);
 
-    if (!resolvedInviteeId && resolvedInviteeEmail) {
-        const matchedUser = await db
-            .select({ id: users.id })
-            .from(users)
-            .where(eq(users.email, resolvedInviteeEmail))
-            .get();
-        if (matchedUser) {
-            if (matchedUser.id === userId) {
-                return c.json({ error: "Cannot invite yourself" }, 400);
-            }
-            resolvedInviteeId = matchedUser.id;
-            resolvedInviteeEmail = null;
-        }
-    }
+    const invitee = await db
+      .select({ id: users.id })
+      .from(users)
+      .where(eq(users.id, resolvedInviteeId))
+      .get();
+    if (!invitee) return c.json({ error: "User not found" }, 404);
+  }
 
-    if (resolvedInviteeId) {
-        const alreadyAuthor = await db
-            .select()
-            .from(paperAuthors)
-            .where(
-                and(
-                    eq(paperAuthors.paperId, paperId),
-                    eq(paperAuthors.userId, resolvedInviteeId),
-                ),
-            )
-            .get();
-        if (alreadyAuthor)
-            return c.json({ error: "User is already an author" }, 409);
+  try {
+    await db.insert(coauthorInvites).values({
+      id: crypto.randomUUID(),
+      paperId,
+      inviterId: userId,
+      inviteeId: resolvedInviteeId,
+      inviteeEmail: resolvedInviteeEmail,
+      ...touchUpdatedAt(),
+    });
+  } catch (e: unknown) {
+    const msg = e instanceof Error ? e.message : "";
+    if (msg.includes("UNIQUE"))
+      return c.json({ error: "Invite already sent" }, 409);
+    throw e;
+  }
 
-        const invitee = await db
-            .select({ id: users.id })
-            .from(users)
-            .where(eq(users.id, resolvedInviteeId))
-            .get();
-        if (!invitee) return c.json({ error: "User not found" }, 404);
-    }
-
-    try {
-        await db.insert(coauthorInvites).values({
-            id: crypto.randomUUID(),
-            paperId,
-            inviterId: userId,
-            inviteeId: resolvedInviteeId,
-            inviteeEmail: resolvedInviteeEmail,
-            ...touchUpdatedAt(),
-        });
-    } catch (e: unknown) {
-        const msg = e instanceof Error ? e.message : "";
-        if (msg.includes("UNIQUE"))
-            return c.json({ error: "Invite already sent" }, 409);
-        throw e;
-    }
-
-    return c.json({ ok: true }, 201);
+  return c.json({ ok: true }, 201);
 });
 
 // GET /api/papers/:id/invites — list invites for a paper
 papersRoute.get("/:id/invites", authMiddleware, async (c) => {
-    const paperId = c.req.param("id");
-    const db = drizzle(c.env.DB);
-    const userId = c.get("user").sub;
+  const paperId = c.req.param("id");
+  const db = drizzle(c.env.DB);
+  const userId = c.get("user").sub;
 
-    const isUploader = await db
-        .select()
-        .from(paperAuthors)
-        .where(
-            and(
-                eq(paperAuthors.paperId, paperId),
-                eq(paperAuthors.userId, userId),
-                eq(paperAuthors.role, "uploader"),
-            ),
-        )
-        .get();
-    if (!isUploader) return c.json({ error: "Forbidden" }, 403);
+  const isUploader = await db
+    .select()
+    .from(paperAuthors)
+    .where(
+      and(
+        eq(paperAuthors.paperId, paperId),
+        eq(paperAuthors.userId, userId),
+        eq(paperAuthors.role, "uploader"),
+      ),
+    )
+    .get();
+  if (!isUploader) return c.json({ error: "Forbidden" }, 403);
 
-    const inviteRows = await db
-        .select({
-            coauthorInvites: coauthorInvites,
-            users: {
-                id: users.id,
-                name: users.name,
-                displayName: users.displayName,
-            }
-        })
-        .from(coauthorInvites)
-        .leftJoin(users, eq(coauthorInvites.inviteeId, users.id))
-        .where(eq(coauthorInvites.paperId, paperId))
-        .all();
+  const inviteRows = await db
+    .select({
+      coauthorInvites: coauthorInvites,
+      users: {
+        id: users.id,
+        name: users.name,
+        displayName: users.displayName,
+      },
+    })
+    .from(coauthorInvites)
+    .leftJoin(users, eq(coauthorInvites.inviteeId, users.id))
+    .where(eq(coauthorInvites.paperId, paperId))
+    .all();
 
-    const enriched = inviteRows.map((row) => {
-        const inv = row.coauthorInvites;
-        const invitee = row.users && row.users.id ? row.users : null;
-        return {
-            ...inv,
-            inviteeName: invitee
-                ? invitee.displayName || invitee.name
-                : inv.inviteeEmail,
-        };
-    });
+  const enriched = inviteRows.map((row) => {
+    const inv = row.coauthorInvites;
+    const invitee = row.users && row.users.id ? row.users : null;
+    return {
+      ...inv,
+      inviteeName: invitee
+        ? invitee.displayName || invitee.name
+        : inv.inviteeEmail,
+    };
+  });
 
-    return c.json({ invites: enriched });
+  return c.json({ invites: enriched });
 });
 
 // DELETE /api/papers/:id — delete paper owned by uploader
 papersRoute.delete("/:id", authMiddleware, async (c) => {
-    const paperId = c.req.param("id");
-    const userId = c.get("user").sub;
-    const db = drizzle(c.env.DB);
-    await enableForeignKeys(db);
+  const paperId = c.req.param("id");
+  const userId = c.get("user").sub;
+  const db = drizzle(c.env.DB);
+  await enableForeignKeys(db);
 
-    const isUploader = await db
-        .select()
-        .from(paperAuthors)
-        .where(
-            and(
-                eq(paperAuthors.paperId, paperId),
-                eq(paperAuthors.userId, userId),
-                eq(paperAuthors.role, "uploader"),
-            ),
-        )
-        .get();
-    if (!isUploader) return c.json({ error: "Forbidden" }, 403);
+  const isUploader = await db
+    .select()
+    .from(paperAuthors)
+    .where(
+      and(
+        eq(paperAuthors.paperId, paperId),
+        eq(paperAuthors.userId, userId),
+        eq(paperAuthors.role, "uploader"),
+      ),
+    )
+    .get();
+  if (!isUploader) return c.json({ error: "Forbidden" }, 403);
 
-    const files = await db
-        .select({ r2Key: paperFiles.r2Key })
-        .from(paperFiles)
-        .where(eq(paperFiles.paperId, paperId))
-        .all();
+  const files = await db
+    .select({ r2Key: paperFiles.r2Key })
+    .from(paperFiles)
+    .where(eq(paperFiles.paperId, paperId))
+    .all();
 
-    const keys = files.map((f) => f.r2Key);
-    await deleteKeysInBatches(c.env.BUCKET, keys);
-    await db.delete(papers).where(eq(papers.id, paperId));
+  const keys = files.map((f) => f.r2Key);
+  await deleteKeysInBatches(c.env.BUCKET, keys);
+  await db.delete(papers).where(eq(papers.id, paperId));
 
-    return c.json({ ok: true });
+  return c.json({ ok: true });
 });
 
 // PUT /api/papers/:id/description — update paper description
 papersRoute.put("/:id/description", authMiddleware, async (c) => {
-    const paperId = c.req.param("id");
-    const userId = c.get("user").sub;
-    let parsedBody: unknown;
-    try {
-        parsedBody = await c.req.json();
-    } catch {
-        return c.json({ error: "Invalid JSON body" }, 400);
-    }
-    if (!parsedBody || typeof parsedBody !== "object" || Array.isArray(parsedBody)) {
-        return c.json({ error: "Invalid JSON body" }, 400);
-    }
-    const body = parsedBody as Record<string, unknown>;
+  const paperId = c.req.param("id");
+  const userId = c.get("user").sub;
+  let parsedBody: unknown;
+  try {
+    parsedBody = await c.req.json();
+  } catch {
+    return c.json({ error: "Invalid JSON body" }, 400);
+  }
+  if (
+    !parsedBody ||
+    typeof parsedBody !== "object" ||
+    Array.isArray(parsedBody)
+  ) {
+    return c.json({ error: "Invalid JSON body" }, 400);
+  }
+  const body = parsedBody as Record<string, unknown>;
 
-    if (!("description" in body)) {
-        return c.json({ error: "description is required" }, 400);
-    }
-    if (!(typeof body.description === "string" || body.description === null)) {
-        return c.json({ error: "description must be a string or null" }, 400);
-    }
+  if (!("description" in body)) {
+    return c.json({ error: "description is required" }, 400);
+  }
+  if (!(typeof body.description === "string" || body.description === null)) {
+    return c.json({ error: "description must be a string or null" }, 400);
+  }
 
-    const normalizedDescription = typeof body.description === "string"
-        ? body.description.split("\0").join("").trim()
-        : null;
-    if (normalizedDescription && normalizedDescription.length > MAX_DESCRIPTION_LENGTH) {
-        return c.json({ error: `description must be ${MAX_DESCRIPTION_LENGTH} chars or less` }, 400);
-    }
+  const normalizedDescription =
+    typeof body.description === "string"
+      ? body.description.split("\0").join("").trim()
+      : null;
+  if (
+    normalizedDescription &&
+    normalizedDescription.length > MAX_DESCRIPTION_LENGTH
+  ) {
+    return c.json(
+      { error: `description must be ${MAX_DESCRIPTION_LENGTH} chars or less` },
+      400,
+    );
+  }
 
-    const db = drizzle(c.env.DB);
-    await enableForeignKeys(db);
+  const db = drizzle(c.env.DB);
+  await enableForeignKeys(db);
 
-    const paper = await db
-        .select({ id: papers.id })
-        .from(papers)
-        .where(eq(papers.id, paperId))
-        .get();
-    if (!paper) return c.json({ error: "Not found" }, 404);
+  const paper = await db
+    .select({ id: papers.id })
+    .from(papers)
+    .where(eq(papers.id, paperId))
+    .get();
+  if (!paper) return c.json({ error: "Not found" }, 404);
 
-    const author = await db
-        .select({ userId: paperAuthors.userId })
-        .from(paperAuthors)
-        .where(
-            and(
-                eq(paperAuthors.paperId, paperId),
-                eq(paperAuthors.userId, userId),
-            ),
-        )
-        .get();
-    if (!author) return c.json({ error: "Forbidden" }, 403);
+  const author = await db
+    .select({ userId: paperAuthors.userId })
+    .from(paperAuthors)
+    .where(
+      and(eq(paperAuthors.paperId, paperId), eq(paperAuthors.userId, userId)),
+    )
+    .get();
+  if (!author) return c.json({ error: "Forbidden" }, 403);
 
-    const descriptionUpdatedAt = normalizedDescription ? sql`(datetime('now'))` : null;
-    await db.update(papers).set({
-        description: normalizedDescription,
-        descriptionUpdatedAt,
-        ...touchUpdatedAt(),
-    }).where(eq(papers.id, paperId));
+  const descriptionUpdatedAt = normalizedDescription
+    ? sql`(datetime('now'))`
+    : null;
+  await db
+    .update(papers)
+    .set({
+      description: normalizedDescription,
+      descriptionUpdatedAt,
+      ...touchUpdatedAt(),
+    })
+    .where(eq(papers.id, paperId));
 
-    const updatedPaper = await db
-        .select({
-            id: papers.id,
-            description: papers.description,
-            descriptionUpdatedAt: papers.descriptionUpdatedAt,
-        })
-        .from(papers)
-        .where(eq(papers.id, paperId))
-        .get();
-    if (!updatedPaper) return c.json({ error: "Not found" }, 404);
+  const updatedPaper = await db
+    .select({
+      id: papers.id,
+      description: papers.description,
+      descriptionUpdatedAt: papers.descriptionUpdatedAt,
+    })
+    .from(papers)
+    .where(eq(papers.id, paperId))
+    .get();
+  if (!updatedPaper) return c.json({ error: "Not found" }, 404);
 
-    const normalizedDescriptionUpdatedAt = toIsoUtc(updatedPaper.descriptionUpdatedAt);
+  const normalizedDescriptionUpdatedAt = toIsoUtc(
+    updatedPaper.descriptionUpdatedAt,
+  );
 
-    return c.json({
-        id: updatedPaper.id,
-        description: updatedPaper.description,
-        descriptionUpdatedAt: normalizedDescriptionUpdatedAt,
-        // Backward compatibility for existing clients expecting snake_case.
-        description_updated_at: normalizedDescriptionUpdatedAt,
-    });
+  return c.json({
+    id: updatedPaper.id,
+    description: updatedPaper.description,
+    descriptionUpdatedAt: normalizedDescriptionUpdatedAt,
+    // Backward compatibility for existing clients expecting snake_case.
+    description_updated_at: normalizedDescriptionUpdatedAt,
+  });
 });
 
 // PATCH /api/papers/:id — edit paper metadata
 papersRoute.patch("/:id", authMiddleware, async (c) => {
-    const paperId = c.req.param("id");
-    const userId = c.get("user").sub;
-    let parsedBody: unknown;
-    try {
-        parsedBody = await c.req.json();
-    } catch {
-        return c.json({ error: "Invalid JSON body" }, 400);
+  const paperId = c.req.param("id");
+  const userId = c.get("user").sub;
+  let parsedBody: unknown;
+  try {
+    parsedBody = await c.req.json();
+  } catch {
+    return c.json({ error: "Invalid JSON body" }, 400);
+  }
+  if (
+    !parsedBody ||
+    typeof parsedBody !== "object" ||
+    Array.isArray(parsedBody)
+  ) {
+    return c.json({ error: "Invalid JSON body" }, 400);
+  }
+  const body = parsedBody as Record<string, unknown>;
+
+  const db = drizzle(c.env.DB);
+  await enableForeignKeys(db);
+
+  const paper = await db
+    .select({ id: papers.id, visibility: papers.visibility })
+    .from(papers)
+    .where(eq(papers.id, paperId))
+    .get();
+  if (!paper) return c.json({ error: "Not found" }, 404);
+
+  const isAuthor = await db
+    .select()
+    .from(paperAuthors)
+    .where(
+      and(eq(paperAuthors.paperId, paperId), eq(paperAuthors.userId, userId)),
+    )
+    .get();
+  if (!isAuthor) return c.json({ error: "Forbidden" }, 403);
+
+  const updates: Record<string, any> = { ...touchUpdatedAt() };
+  let hasRealUpdates = false;
+
+  if ("title" in body) {
+    if (typeof body.title !== "string") {
+      return c.json({ error: "title must be a string" }, 400);
     }
-    if (!parsedBody || typeof parsedBody !== "object" || Array.isArray(parsedBody)) {
-        return c.json({ error: "Invalid JSON body" }, 400);
+    const trimmedTitle = body.title.trim();
+    if (trimmedTitle.length === 0 || trimmedTitle.length > MAX_TITLE_LENGTH) {
+      return c.json(
+        { error: `title is required (1-${MAX_TITLE_LENGTH} chars)` },
+        400,
+      );
     }
-    const body = parsedBody as Record<string, unknown>;
-
-    const db = drizzle(c.env.DB);
-    await enableForeignKeys(db);
-
-    const paper = await db
-        .select({ id: papers.id, visibility: papers.visibility })
-        .from(papers)
-        .where(eq(papers.id, paperId))
-        .get();
-    if (!paper) return c.json({ error: "Not found" }, 404);
-
-    const isAuthor = await db
-        .select()
-        .from(paperAuthors)
-        .where(
-            and(
-                eq(paperAuthors.paperId, paperId),
-                eq(paperAuthors.userId, userId)
-            )
-        )
-        .get();
-    if (!isAuthor) return c.json({ error: "Forbidden" }, 403);
-
-    const updates: Record<string, any> = { ...touchUpdatedAt() };
-    let hasRealUpdates = false;
-
-    if ("title" in body) {
-        if (typeof body.title !== "string") {
-            return c.json({ error: "title must be a string" }, 400);
-        }
-        const trimmedTitle = body.title.trim();
-        if (trimmedTitle.length === 0 || trimmedTitle.length > MAX_TITLE_LENGTH) {
-            return c.json({ error: `title is required (1-${MAX_TITLE_LENGTH} chars)` }, 400);
-        }
-        updates.title = trimmedTitle;
-        hasRealUpdates = true;
+    updates.title = trimmedTitle;
+    hasRealUpdates = true;
+  }
+  if ("abstract" in body) {
+    if (!(typeof body.abstract === "string" || body.abstract === null)) {
+      return c.json({ error: "abstract must be a string or null" }, 400);
     }
-    if ("abstract" in body) {
-        if (!(typeof body.abstract === "string" || body.abstract === null)) {
-            return c.json({ error: "abstract must be a string or null" }, 400);
-        }
-        const abstract = typeof body.abstract === "string" ? body.abstract.trim() : null;
-        if (abstract && abstract.length > MAX_ABSTRACT_LENGTH) {
-            return c.json({ error: `abstract must be ${MAX_ABSTRACT_LENGTH} chars or less` }, 400);
-        }
-        updates.abstract = abstract || null;
-        hasRealUpdates = true;
+    const abstract =
+      typeof body.abstract === "string" ? body.abstract.trim() : null;
+    if (abstract && abstract.length > MAX_ABSTRACT_LENGTH) {
+      return c.json(
+        { error: `abstract must be ${MAX_ABSTRACT_LENGTH} chars or less` },
+        400,
+      );
     }
-    if ("visibility" in body) {
-        if (typeof body.visibility !== "string" || !VALID_VISIBILITY.includes(body.visibility)) {
-            return c.json({ error: "Invalid visibility" }, 400);
+    updates.abstract = abstract || null;
+    hasRealUpdates = true;
+  }
+  if ("visibility" in body) {
+    if (
+      typeof body.visibility !== "string" ||
+      !VALID_VISIBILITY.includes(body.visibility)
+    ) {
+      return c.json({ error: "Invalid visibility" }, 400);
+    }
+    if (body.visibility === "org_only" && paper.visibility !== "org_only") {
+      return c.json(
+        {
+          error:
+            "Changing visibility to org_only is not supported in edit flow",
+        },
+        400,
+      );
+    }
+    updates.visibility = body.visibility;
+    hasRealUpdates = true;
+  }
+  if ("showViewCount" in body) {
+    if (typeof body.showViewCount !== "boolean") {
+      return c.json({ error: "showViewCount must be a boolean" }, 400);
+    }
+    updates.showViewCount = body.showViewCount;
+    hasRealUpdates = true;
+  }
+  if ("language" in body) {
+    if (!(typeof body.language === "string" || body.language === null)) {
+      return c.json({ error: "language must be a string or null" }, 400);
+    }
+    const language =
+      typeof body.language === "string" ? body.language.trim() : null;
+    if (language && language.length > MAX_LANGUAGE_LENGTH) {
+      return c.json(
+        { error: `language must be ${MAX_LANGUAGE_LENGTH} chars or less` },
+        400,
+      );
+    }
+    updates.language = language || null;
+    hasRealUpdates = true;
+  }
+  if ("externalUrl" in body) {
+    if (!(typeof body.externalUrl === "string" || body.externalUrl === null)) {
+      return c.json({ error: "externalUrl must be a string or null" }, 400);
+    }
+    const externalUrl =
+      typeof body.externalUrl === "string" ? body.externalUrl.trim() : null;
+    if (externalUrl && externalUrl.length > MAX_EXTERNAL_URL_LENGTH) {
+      return c.json(
+        {
+          error: `externalUrl must be ${MAX_EXTERNAL_URL_LENGTH} chars or less`,
+        },
+        400,
+      );
+    }
+    if (externalUrl && !isValidUrlScheme(externalUrl)) {
+      return c.json(
+        { error: "Invalid externalUrl scheme (only http/https allowed)" },
+        400,
+      );
+    }
+    updates.externalUrl = externalUrl || null;
+    hasRealUpdates = true;
+  }
+  if ("doi" in body) {
+    if (!(typeof body.doi === "string" || body.doi === null)) {
+      return c.json({ error: "doi must be a string or null" }, 400);
+    }
+    const doi = typeof body.doi === "string" ? body.doi.trim() : null;
+    if (doi && doi.length > MAX_DOI_LENGTH) {
+      return c.json(
+        { error: `doi must be ${MAX_DOI_LENGTH} chars or less` },
+        400,
+      );
+    }
+    updates.doi = doi || null;
+    hasRealUpdates = true;
+  }
+  if ("venue" in body) {
+    if (!(typeof body.venue === "string" || body.venue === null)) {
+      return c.json({ error: "venue must be a string or null" }, 400);
+    }
+    const venue = typeof body.venue === "string" ? body.venue.trim() : null;
+    if (venue && venue.length > MAX_VENUE_LENGTH) {
+      return c.json(
+        { error: `venue must be ${MAX_VENUE_LENGTH} chars or less` },
+        400,
+      );
+    }
+    updates.venue = venue || null;
+    hasRealUpdates = true;
+  }
+  if ("venueType" in body) {
+    if (!(typeof body.venueType === "string" || body.venueType === null)) {
+      return c.json({ error: "venueType must be a string or null" }, 400);
+    }
+    if (
+      body.venueType &&
+      !(VALID_VENUE_TYPES as readonly string[]).includes(body.venueType)
+    )
+      return c.json({ error: "Invalid venueType" }, 400);
+    updates.venueType = body.venueType || null;
+    hasRealUpdates = true;
+  }
+  if ("year" in body) {
+    if (
+      !(typeof body.year === "number" || body.year === null) ||
+      Number.isNaN(body.year)
+    ) {
+      return c.json({ error: "year must be a number or null" }, 400);
+    }
+    updates.year = body.year;
+    hasRealUpdates = true;
+  }
+  if ("category" in body) {
+    if (!(typeof body.category === "string" || body.category === null)) {
+      return c.json({ error: "category must be a string or null" }, 400);
+    }
+    if (
+      body.category &&
+      !(VALID_CATEGORIES as readonly string[]).includes(body.category)
+    )
+      return c.json({ error: "Invalid category" }, 400);
+    updates.category = body.category || null;
+    hasRealUpdates = true;
+  }
+  if ("tags" in body) {
+    if (Array.isArray(body.tags)) {
+      const tags = body.tags;
+      const len = tags.length;
+      let hasChanges = false;
+      let validCount = 0;
+
+      // Fast pass to check if the array is already perfectly clean
+      for (let i = 0; i < len; i++) {
+        const tag = tags[i];
+        if (typeof tag !== "string") {
+          return c.json({ error: "tags must contain only strings" }, 400);
         }
-        if (body.visibility === "org_only" && paper.visibility !== "org_only") {
+        const tagLen = tag.length;
+        if (tagLen === 0) {
+          hasChanges = true;
+          continue;
+        }
+        // Check if string has leading or trailing space characters that require trimming
+        if (tag.charCodeAt(0) <= 32 || tag.charCodeAt(tagLen - 1) <= 32) {
+          hasChanges = true;
+          continue;
+        }
+        // Check if string requires lowercase conversion
+        if (tag !== tag.toLowerCase()) {
+          hasChanges = true;
+          continue;
+        }
+        if (tagLen > MAX_TAG_LENGTH) {
+          return c.json(
+            { error: `tags must be ${MAX_TAG_LENGTH} chars or less` },
+            400,
+          );
+        }
+        // Check for duplicates
+        for (let j = 0; j < i; j++) {
+          if (tags[j] === tag) {
+            hasChanges = true;
+            break;
+          }
+        }
+        validCount++;
+      }
+
+      if (!hasChanges) {
+        updates.tags = validCount > 0 ? JSON.stringify(tags) : null;
+      } else {
+        // Fallback path: allocate new array and trim
+        const normalizedTags: string[] = [];
+        for (let i = 0; i < len; i++) {
+          const tag = tags[i].trim().toLowerCase();
+          if (tag.length === 0) continue;
+          if (tag.length > MAX_TAG_LENGTH) {
             return c.json(
-                { error: "Changing visibility to org_only is not supported in edit flow" },
-                400,
+              { error: `tags must be ${MAX_TAG_LENGTH} chars or less` },
+              400,
             );
+          }
+          normalizedTags.push(tag);
         }
-        updates.visibility = body.visibility;
-        hasRealUpdates = true;
+        const uniqueTags = [...new Set(normalizedTags)];
+        updates.tags =
+          uniqueTags.length > 0 ? JSON.stringify(uniqueTags) : null;
+      }
+    } else if (body.tags === null) {
+      updates.tags = null;
+    } else {
+      return c.json({ error: "tags must be an array or null" }, 400);
     }
-    if ("showViewCount" in body) {
-        if (typeof body.showViewCount !== "boolean") {
-            return c.json({ error: "showViewCount must be a boolean" }, 400);
-        }
-        updates.showViewCount = body.showViewCount;
-        hasRealUpdates = true;
-    }
-    if ("language" in body) {
-        if (!(typeof body.language === "string" || body.language === null)) {
-            return c.json({ error: "language must be a string or null" }, 400);
-        }
-        const language = typeof body.language === "string" ? body.language.trim() : null;
-        if (language && language.length > MAX_LANGUAGE_LENGTH) {
-            return c.json({ error: `language must be ${MAX_LANGUAGE_LENGTH} chars or less` }, 400);
-        }
-        updates.language = language || null;
-        hasRealUpdates = true;
-    }
-    if ("externalUrl" in body) {
-        if (!(typeof body.externalUrl === "string" || body.externalUrl === null)) {
-            return c.json({ error: "externalUrl must be a string or null" }, 400);
-        }
-        const externalUrl = typeof body.externalUrl === "string" ? body.externalUrl.trim() : null;
-        if (externalUrl && externalUrl.length > MAX_EXTERNAL_URL_LENGTH) {
-            return c.json({ error: `externalUrl must be ${MAX_EXTERNAL_URL_LENGTH} chars or less` }, 400);
-        }
-        if (externalUrl && !isValidUrlScheme(externalUrl)) {
-            return c.json({ error: "Invalid externalUrl scheme (only http/https allowed)" }, 400);
-        }
-        updates.externalUrl = externalUrl || null;
-        hasRealUpdates = true;
-    }
-    if ("doi" in body) {
-        if (!(typeof body.doi === "string" || body.doi === null)) {
-            return c.json({ error: "doi must be a string or null" }, 400);
-        }
-        const doi = typeof body.doi === "string" ? body.doi.trim() : null;
-        if (doi && doi.length > MAX_DOI_LENGTH) {
-            return c.json({ error: `doi must be ${MAX_DOI_LENGTH} chars or less` }, 400);
-        }
-        updates.doi = doi || null;
-        hasRealUpdates = true;
-    }
-    if ("venue" in body) {
-        if (!(typeof body.venue === "string" || body.venue === null)) {
-            return c.json({ error: "venue must be a string or null" }, 400);
-        }
-        const venue = typeof body.venue === "string" ? body.venue.trim() : null;
-        if (venue && venue.length > MAX_VENUE_LENGTH) {
-            return c.json({ error: `venue must be ${MAX_VENUE_LENGTH} chars or less` }, 400);
-        }
-        updates.venue = venue || null;
-        hasRealUpdates = true;
-    }
-    if ("venueType" in body) {
-        if (!(typeof body.venueType === "string" || body.venueType === null)) {
-            return c.json({ error: "venueType must be a string or null" }, 400);
-        }
-        if (body.venueType && !(VALID_VENUE_TYPES as readonly string[]).includes(body.venueType)) return c.json({ error: "Invalid venueType" }, 400);
-        updates.venueType = body.venueType || null;
-        hasRealUpdates = true;
-    }
-    if ("year" in body) {
-        if (!(typeof body.year === "number" || body.year === null) || Number.isNaN(body.year)) {
-            return c.json({ error: "year must be a number or null" }, 400);
-        }
-        updates.year = body.year;
-        hasRealUpdates = true;
-    }
-    if ("category" in body) {
-        if (!(typeof body.category === "string" || body.category === null)) {
-            return c.json({ error: "category must be a string or null" }, 400);
-        }
-        if (body.category && !(VALID_CATEGORIES as readonly string[]).includes(body.category)) return c.json({ error: "Invalid category" }, 400);
-        updates.category = body.category || null;
-        hasRealUpdates = true;
-    }
-    if ("tags" in body) {
-        if (Array.isArray(body.tags)) {
-            const tags = body.tags;
-            const len = tags.length;
-            let hasChanges = false;
-            let validCount = 0;
+    hasRealUpdates = true;
+  }
+  if (!hasRealUpdates) {
+    return c.json({ error: "No valid fields to update" }, 400);
+  }
 
-            // Fast pass to check if the array is already perfectly clean
-            for (let i = 0; i < len; i++) {
-                const tag = tags[i];
-                if (typeof tag !== "string") {
-                    return c.json({ error: "tags must contain only strings" }, 400);
-                }
-                const tagLen = tag.length;
-                if (tagLen === 0) {
-                    hasChanges = true;
-                    continue;
-                }
-                // Check if string has leading or trailing space characters that require trimming
-                if (tag.charCodeAt(0) <= 32 || tag.charCodeAt(tagLen - 1) <= 32) {
-                    hasChanges = true;
-                    continue;
-                }
-                // Check if string requires lowercase conversion
-                if (tag !== tag.toLowerCase()) {
-                    hasChanges = true;
-                    continue;
-                }
-                if (tagLen > MAX_TAG_LENGTH) {
-                    return c.json({ error: `tags must be ${MAX_TAG_LENGTH} chars or less` }, 400);
-                }
-                // Check for duplicates
-                for (let j = 0; j < i; j++) {
-                    if (tags[j] === tag) {
-                        hasChanges = true;
-                        break;
-                    }
-                }
-                validCount++;
-            }
-
-            if (!hasChanges) {
-                updates.tags = validCount > 0 ? JSON.stringify(tags) : null;
-            } else {
-                // Fallback path: allocate new array and trim
-                const normalizedTags: string[] = [];
-                for (let i = 0; i < len; i++) {
-                    const tag = tags[i].trim().toLowerCase();
-                    if (tag.length === 0) continue;
-                    if (tag.length > MAX_TAG_LENGTH) {
-                        return c.json({ error: `tags must be ${MAX_TAG_LENGTH} chars or less` }, 400);
-                    }
-                    normalizedTags.push(tag);
-                }
-                const uniqueTags = [...new Set(normalizedTags)];
-                updates.tags = uniqueTags.length > 0 ? JSON.stringify(uniqueTags) : null;
-            }
-        } else if (body.tags === null) {
-            updates.tags = null;
-        } else {
-            return c.json({ error: "tags must be an array or null" }, 400);
-        }
-        hasRealUpdates = true;
-    }
-    if (!hasRealUpdates) {
-        return c.json({ error: "No valid fields to update" }, 400);
-    }
-
-    await db.update(papers).set(updates).where(eq(papers.id, paperId));
-    return c.json({ ok: true });
+  await db.update(papers).set(updates).where(eq(papers.id, paperId));
+  return c.json({ ok: true });
 });
 
 export default papersRoute;

--- a/apps/api/src/routes/tags.ts
+++ b/apps/api/src/routes/tags.ts
@@ -1,10 +1,7 @@
 import { Hono } from "hono";
 import { drizzle } from "drizzle-orm/d1";
 import { and, eq } from "drizzle-orm";
-import {
-    orgMembers,
-    orgs,
-} from "../db/schema";
+import { orgMembers, orgs } from "../db/schema";
 import type { Env, Variables } from "../types";
 import { authMiddleware } from "../middleware/auth";
 
@@ -21,37 +18,37 @@ const SAFE_TAG_ARRAY_SQL = `
 `;
 const TRIMMED_TAG_SQL = "TRIM(json_each.value)";
 
-
 // GET /api/tags/suggest?q=...&orgSlug=...
 tagsRoute.get("/suggest", authMiddleware, async (c) => {
-    const db = drizzle(c.env.DB);
-    const userId = c.get("user").sub;
-    const query = (c.req.query("q") ?? "").trim();
-    const orgSlug = (c.req.query("orgSlug") ?? "").trim().toLowerCase();
-    const normalizedQuery = query.toLowerCase().replace(/([%_\\])/g, '\\$1');
+  const db = drizzle(c.env.DB);
+  const userId = c.get("user").sub;
+  const query = (c.req.query("q") ?? "").trim();
+  const orgSlug = (c.req.query("orgSlug") ?? "").trim().toLowerCase();
+  const normalizedQuery = query.toLowerCase().replace(/([%_\\])/g, "\\$1");
 
-    if (query.length < TAG_SUGGEST_MIN_QUERY_LENGTH) {
-        return c.json({ tags: [] });
-    }
+  if (query.length < TAG_SUGGEST_MIN_QUERY_LENGTH) {
+    return c.json({ tags: [] });
+  }
 
-    let tags: string[] = [];
+  let tags: string[] = [];
 
-    if (orgSlug) {
-        const org = await db
-            .select({ id: orgs.id })
-            .from(orgs)
-            .where(eq(orgs.slug, orgSlug))
-            .get();
-        if (!org) return c.json({ error: "Org not found" }, 404);
+  if (orgSlug) {
+    const org = await db
+      .select({ id: orgs.id })
+      .from(orgs)
+      .where(eq(orgs.slug, orgSlug))
+      .get();
+    if (!org) return c.json({ error: "Org not found" }, 404);
 
-        const membership = await db
-            .select({ userId: orgMembers.userId })
-            .from(orgMembers)
-            .where(and(eq(orgMembers.orgId, org.id), eq(orgMembers.userId, userId)))
-            .get();
-        if (!membership) return c.json({ error: "Forbidden" }, 403);
+    const membership = await db
+      .select({ userId: orgMembers.userId })
+      .from(orgMembers)
+      .where(and(eq(orgMembers.orgId, org.id), eq(orgMembers.userId, userId)))
+      .get();
+    if (!membership) return c.json({ error: "Forbidden" }, 403);
 
-        const result = await c.env.DB.prepare(`
+    const result = await c.env.DB.prepare(
+      `
             SELECT
                 ${TRIMMED_TAG_SQL} as tag,
                 COUNT(*) as count
@@ -71,10 +68,14 @@ tagsRoute.get("/suggest", authMiddleware, async (c) => {
             GROUP BY ${TRIMMED_TAG_SQL}
             ORDER BY count DESC, tag ASC
             LIMIT ?4
-        `).bind(userId, org.id, normalizedQuery || "", TAG_SUGGEST_LIMIT).all();
-        tags = (result.results || []).map((r: any) => r.tag);
-    } else {
-        const result = await c.env.DB.prepare(`
+        `,
+    )
+      .bind(userId, org.id, normalizedQuery || "", TAG_SUGGEST_LIMIT)
+      .all();
+    tags = (result.results || []).map((r: any) => r.tag);
+  } else {
+    const result = await c.env.DB.prepare(
+      `
             SELECT
                 ${TRIMMED_TAG_SQL} as tag,
                 COUNT(*) as count
@@ -88,11 +89,14 @@ tagsRoute.get("/suggest", authMiddleware, async (c) => {
             GROUP BY ${TRIMMED_TAG_SQL}
             ORDER BY count DESC, tag ASC
             LIMIT ?3
-        `).bind(userId, normalizedQuery || "", TAG_SUGGEST_LIMIT).all();
-        tags = (result.results || []).map((r: any) => r.tag);
-    }
+        `,
+    )
+      .bind(userId, normalizedQuery || "", TAG_SUGGEST_LIMIT)
+      .all();
+    tags = (result.results || []).map((r: any) => r.tag);
+  }
 
-    return c.json({ tags });
+  return c.json({ tags });
 });
 
 export default tagsRoute;

--- a/apps/api/src/routes/test-auth.ts
+++ b/apps/api/src/routes/test-auth.ts
@@ -3,136 +3,136 @@ import { sign } from "hono/jwt";
 import { drizzle } from "drizzle-orm/d1";
 import { eq } from "drizzle-orm";
 import { timingSafeEqual } from "hono/utils/buffer";
-import { users, orgs, orgMembers, enableForeignKeys, touchUpdatedAt } from "../db/schema";
+import {
+  users,
+  orgs,
+  orgMembers,
+  enableForeignKeys,
+  touchUpdatedAt,
+} from "../db/schema";
 import type { Env, Variables } from "../types";
 
 const testAuth = new Hono<{ Bindings: Env; Variables: Variables }>();
 const JWT_EXPIRY_SECONDS = 7 * 24 * 60 * 60;
 
 testAuth.use("*", async (c, next) => {
-    if (c.env.ENABLE_TEST_AUTH !== "true" || !c.env.TEST_AUTH_SECRET) {
-        return c.json({ error: "Not Found" }, 404);
-    }
+  if (c.env.ENABLE_TEST_AUTH !== "true" || !c.env.TEST_AUTH_SECRET) {
+    return c.json({ error: "Not Found" }, 404);
+  }
 
+  const testSecret = c.req.header("x-test-auth-secret");
+  const providedTestSecret = typeof testSecret === "string" ? testSecret : "";
+  const expectedTestSecret = c.env.TEST_AUTH_SECRET;
 
-    const testSecret = c.req.header("x-test-auth-secret");
-    const providedTestSecret = typeof testSecret === "string" ? testSecret : "";
-    const expectedTestSecret = c.env.TEST_AUTH_SECRET;
+  if (!(await timingSafeEqual(providedTestSecret, expectedTestSecret))) {
+    return c.json({ error: "Unauthorized (E2E)" }, 401);
+  }
 
-    if (!(await timingSafeEqual(providedTestSecret, expectedTestSecret))) {
-        return c.json({ error: "Unauthorized (E2E)" }, 401);
-    }
-
-    await next();
+  await next();
 });
 
 // POST /api/test-auth/test-token — only for E2E testing
 testAuth.post("/test-token", async (c) => {
-
-
-    let body: { sub: string; githubId: string; name: string };
-    try {
-        const raw = await c.req.json();
-        if (
-            !raw ||
-            typeof raw.sub !== "string" ||
-            typeof raw.githubId !== "string" ||
-            typeof raw.name !== "string"
-        ) {
-            return c.json({ error: "Invalid request body" }, 400);
-        }
-        body = raw;
-    } catch {
-        return c.json({ error: "Invalid JSON" }, 400);
+  let body: { sub: string; githubId: string; name: string };
+  try {
+    const raw = await c.req.json();
+    if (
+      !raw ||
+      typeof raw.sub !== "string" ||
+      typeof raw.githubId !== "string" ||
+      typeof raw.name !== "string"
+    ) {
+      return c.json({ error: "Invalid request body" }, 400);
     }
+    body = raw;
+  } catch {
+    return c.json({ error: "Invalid JSON" }, 400);
+  }
 
-    const db = drizzle(c.env.DB);
-    await enableForeignKeys(db);
+  const db = drizzle(c.env.DB);
+  await enableForeignKeys(db);
 
-    // Upsert user
-    await db
-        .insert(users)
-        .values({
-            id: body.sub,
-            githubId: body.githubId,
-            name: body.name,
-            avatarUrl: null,
-            email: null,
-            ...touchUpdatedAt(),
-        })
-        .onConflictDoUpdate({
-            target: users.githubId,
-            set: {
-                name: body.name,
-                ...touchUpdatedAt(),
-            },
-        });
+  // Upsert user
+  await db
+    .insert(users)
+    .values({
+      id: body.sub,
+      githubId: body.githubId,
+      name: body.name,
+      avatarUrl: null,
+      email: null,
+      ...touchUpdatedAt(),
+    })
+    .onConflictDoUpdate({
+      target: users.githubId,
+      set: {
+        name: body.name,
+        ...touchUpdatedAt(),
+      },
+    });
 
-    // Fetch the actual persisted user ID (in case of conflict on githubId)
-    const persistedUser = await db
-        .select({ id: users.id })
-        .from(users)
-        .where(eq(users.githubId, body.githubId))
-        .get();
+  // Fetch the actual persisted user ID (in case of conflict on githubId)
+  const persistedUser = await db
+    .select({ id: users.id })
+    .from(users)
+    .where(eq(users.githubId, body.githubId))
+    .get();
 
-    if (!persistedUser) {
-        return c.json({ error: "Failed to persist user" }, 500);
-    }
+  if (!persistedUser) {
+    return c.json({ error: "Failed to persist user" }, 500);
+  }
 
-    const now = Math.floor(Date.now() / 1000);
-    const jwt = await sign(
-        {
-            sub: persistedUser.id,
-            githubId: body.githubId,
-            name: body.name,
-            iat: now,
-            exp: now + JWT_EXPIRY_SECONDS,
-        },
-        c.env.JWT_SECRET,
-        "HS256",
-    );
+  const now = Math.floor(Date.now() / 1000);
+  const jwt = await sign(
+    {
+      sub: persistedUser.id,
+      githubId: body.githubId,
+      name: body.name,
+      iat: now,
+      exp: now + JWT_EXPIRY_SECONDS,
+    },
+    c.env.JWT_SECRET,
+    "HS256",
+  );
 
-    return c.json({ token: jwt });
+  return c.json({ token: jwt });
 });
 
 // POST /api/test-auth/test-org — only for E2E testing
 testAuth.post("/test-org", async (c) => {
+  let body: { userId?: string; orgId?: string };
+  try {
+    body = await c.req.json();
+  } catch {
+    return c.json({ error: "Invalid JSON" }, 400);
+  }
+  if (!body.userId || !body.orgId) {
+    return c.json({ error: "userId and orgId are required" }, 400);
+  }
 
+  const db = drizzle(c.env.DB);
+  await enableForeignKeys(db);
 
-    let body: { userId?: string; orgId?: string };
-    try {
-        body = await c.req.json();
-    } catch {
-        return c.json({ error: "Invalid JSON" }, 400);
-    }
-    if (!body.userId || !body.orgId) {
-        return c.json({ error: "userId and orgId are required" }, 400);
-    }
+  await db
+    .insert(orgs)
+    .values({
+      id: body.orgId,
+      slug: `test-org-${crypto.randomUUID().slice(0, 8)}`,
+      name: "Test Org",
+      ...touchUpdatedAt(),
+    })
+    .onConflictDoNothing({ target: orgs.id });
 
-    const db = drizzle(c.env.DB);
-    await enableForeignKeys(db);
+  await db
+    .insert(orgMembers)
+    .values({
+      orgId: body.orgId,
+      userId: body.userId,
+      role: "member",
+    })
+    .onConflictDoNothing();
 
-    await db
-        .insert(orgs)
-        .values({
-            id: body.orgId,
-            slug: `test-org-${crypto.randomUUID().slice(0, 8)}`,
-            name: "Test Org",
-            ...touchUpdatedAt(),
-        })
-        .onConflictDoNothing({ target: orgs.id });
-
-    await db
-        .insert(orgMembers)
-        .values({
-            orgId: body.orgId,
-            userId: body.userId,
-            role: "member",
-        })
-        .onConflictDoNothing();
-
-    return c.json({ ok: true });
+  return c.json({ ok: true });
 });
-
 
 export default testAuth;

--- a/apps/api/src/routes/users.ts
+++ b/apps/api/src/routes/users.ts
@@ -136,7 +136,7 @@ usersRoute.get("/search", authMiddleware, async (c) => {
       and(
         or(
           sql`${users.name} LIKE ${searchPattern} ESCAPE '\\' COLLATE NOCASE`,
-          sql`${users.githubId} LIKE ${searchPattern} ESCAPE '\\' COLLATE NOCASE`
+          sql`${users.githubId} LIKE ${searchPattern} ESCAPE '\\' COLLATE NOCASE`,
         ),
         ne(users.id, currentUserId),
       ),

--- a/apps/api/src/test/helpers.ts
+++ b/apps/api/src/test/helpers.ts
@@ -5,161 +5,171 @@ import type app from "../index";
 const DEFAULT_SECRET = "test-jwt-secret";
 
 export type TestEnv = {
-    DB: unknown;
-    BUCKET: {
-        put: (key: string, value: unknown) => Promise<void>;
-        delete: (key: string) => Promise<void>;
-        get: (key: string) => Promise<{ key: string; value: unknown } | null>;
-    };
-    GITHUB_CLIENT_ID: string;
-    GITHUB_CLIENT_SECRET: string;
-    JWT_SECRET: string;
-    FRONTEND_URL: string;
-    ALLOWED_ORIGINS?: string;
-    ENABLE_TEST_AUTH?: string;
-    TEST_AUTH_SECRET?: string;
+  DB: unknown;
+  BUCKET: {
+    put: (key: string, value: unknown) => Promise<void>;
+    delete: (key: string) => Promise<void>;
+    get: (key: string) => Promise<{ key: string; value: unknown } | null>;
+  };
+  GITHUB_CLIENT_ID: string;
+  GITHUB_CLIENT_SECRET: string;
+  JWT_SECRET: string;
+  FRONTEND_URL: string;
+  ALLOWED_ORIGINS?: string;
+  ENABLE_TEST_AUTH?: string;
+  TEST_AUTH_SECRET?: string;
 };
 
 export async function createTestApp(): Promise<typeof app> {
-    const mod = await import("../index");
-    return mod.default;
+  const mod = await import("../index");
+  return mod.default;
 }
 
-export async function createTestJWT(payload: Record<string, unknown>): Promise<string> {
-    const now = Math.floor(Date.now() / 1000);
-    return sign(
-        {
-            ...payload,
-            iat: now,
-            exp: now + 3600
-        },
-        DEFAULT_SECRET,
-        "HS256"
-    );
+export async function createTestJWT(
+  payload: Record<string, unknown>,
+): Promise<string> {
+  const now = Math.floor(Date.now() / 1000);
+  return sign(
+    {
+      ...payload,
+      iat: now,
+      exp: now + 3600,
+    },
+    DEFAULT_SECRET,
+    "HS256",
+  );
 }
 
-export async function createExpiredJWT(payload: Record<string, unknown>): Promise<string> {
-    const now = Math.floor(Date.now() / 1000);
-    return sign(
-        {
-            ...payload,
-            iat: now - 7200,
-            exp: now - 3600
-        },
-        DEFAULT_SECRET,
-        "HS256"
-    );
+export async function createExpiredJWT(
+  payload: Record<string, unknown>,
+): Promise<string> {
+  const now = Math.floor(Date.now() / 1000);
+  return sign(
+    {
+      ...payload,
+      iat: now - 7200,
+      exp: now - 3600,
+    },
+    DEFAULT_SECRET,
+    "HS256",
+  );
 }
 
-export function makeQuery(
-    { getResult = null, allResult = [] }: { getResult?: unknown; allResult?: unknown[] } = {},
-) {
-    return {
-        from() {
-            return this;
-        },
-        where() {
-            return this;
-        },
-        innerJoin() {
-            return this;
-        },
-        leftJoin() {
-            return this;
-        },
-        limit() {
-            return this;
-        },
-        groupBy() {
-            return this;
-        },
-        orderBy() {
-            return this;
-        },
-        offset() {
-            return this;
-        },
-        get: async () => getResult,
-        all: async () => allResult,
-    };
+export function makeQuery({
+  getResult = null,
+  allResult = [],
+}: { getResult?: unknown; allResult?: unknown[] } = {}) {
+  return {
+    from() {
+      return this;
+    },
+    where() {
+      return this;
+    },
+    innerJoin() {
+      return this;
+    },
+    leftJoin() {
+      return this;
+    },
+    limit() {
+      return this;
+    },
+    groupBy() {
+      return this;
+    },
+    orderBy() {
+      return this;
+    },
+    offset() {
+      return this;
+    },
+    get: async () => getResult,
+    all: async () => allResult,
+  };
 }
 
 export type MockDbResponse = {
-    getResult?: unknown;
-    allResult?: unknown[];
+  getResult?: unknown;
+  allResult?: unknown[];
 };
 
 export function createMockDb(overrides: Record<string, any> = {}) {
-    return {
-        run: vi.fn(async () => undefined),
-        select: vi.fn(() => makeQuery()),
-        insert: vi.fn(() => ({ values: vi.fn(async () => undefined) })),
-        update: vi.fn(() => ({
-            set: vi.fn(() => ({ where: vi.fn(async () => ({ meta: { changes: 1 } })) })),
-        })),
-        delete: vi.fn(() => ({
-            where: vi.fn(async () => ({ meta: { changes: 1 } })),
-        })),
-        batch: vi.fn(async (queries) =>
-            Promise.all(queries.map((query: any) => (query.all ? query.all() : query))),
-        ),
-        ...overrides,
-    };
+  return {
+    run: vi.fn(async () => undefined),
+    select: vi.fn(() => makeQuery()),
+    insert: vi.fn(() => ({ values: vi.fn(async () => undefined) })),
+    update: vi.fn(() => ({
+      set: vi.fn(() => ({
+        where: vi.fn(async () => ({ meta: { changes: 1 } })),
+      })),
+    })),
+    delete: vi.fn(() => ({
+      where: vi.fn(async () => ({ meta: { changes: 1 } })),
+    })),
+    batch: vi.fn(async (queries) =>
+      Promise.all(
+        queries.map((query: any) => (query.all ? query.all() : query)),
+      ),
+    ),
+    ...overrides,
+  };
 }
 
-
 export function createMockD1Binding() {
-    const all = vi.fn(async () => ({ results: [] }));
-    const first = vi.fn(async () => null);
-    const run = vi.fn(async () => all());
-    const statement = { run, all, first };
+  const all = vi.fn(async () => ({ results: [] }));
+  const first = vi.fn(async () => null);
+  const run = vi.fn(async () => all());
+  const statement = { run, all, first };
 
-    return {
-        prepare: vi.fn(() => ({
-            ...statement,
-            bind: vi.fn(() => statement),
-        })),
-    };
+  return {
+    prepare: vi.fn(() => ({
+      ...statement,
+      bind: vi.fn(() => statement),
+    })),
+  };
 }
 
 export function queueSelectResponses(
-    mockDb: { select: unknown },
-    responses: MockDbResponse[],
+  mockDb: { select: unknown },
+  responses: MockDbResponse[],
 ) {
-    let index = 0;
-    (mockDb as { select: ReturnType<typeof vi.fn> }).select = vi.fn(() => {
-        const response = responses[index++];
-        if (!response) {
-            throw new Error(`queueSelectResponses: unexpected mockDb.select() call #${index}`);
-        }
-        return makeQuery(response);
-    });
+  let index = 0;
+  (mockDb as { select: ReturnType<typeof vi.fn> }).select = vi.fn(() => {
+    const response = responses[index++];
+    if (!response) {
+      throw new Error(
+        `queueSelectResponses: unexpected mockDb.select() call #${index}`,
+      );
+    }
+    return makeQuery(response);
+  });
 }
 
 export function createMockR2() {
-    const store = new Map<string, unknown>();
-    return {
-        put: async (key: string, value: unknown) => {
-            store.set(key, value);
-        },
-        delete: async (key: string) => {
-            store.delete(key);
-        },
-        get: async (key: string) => {
-            if (!store.has(key)) return null;
-            return { key, value: store.get(key) };
-        }
-    };
+  const store = new Map<string, unknown>();
+  return {
+    put: async (key: string, value: unknown) => {
+      store.set(key, value);
+    },
+    delete: async (key: string) => {
+      store.delete(key);
+    },
+    get: async (key: string) => {
+      if (!store.has(key)) return null;
+      return { key, value: store.get(key) };
+    },
+  };
 }
 
 export function createTestEnv(overrides: Partial<TestEnv> = {}): TestEnv {
-    return {
-        DB: {},
-        BUCKET: createMockR2(),
-        GITHUB_CLIENT_ID: "test-client-id",
-        GITHUB_CLIENT_SECRET: "test-client-secret",
-        JWT_SECRET: DEFAULT_SECRET,
-        FRONTEND_URL: "http://localhost:3000",
-        ...overrides
-    };
+  return {
+    DB: {},
+    BUCKET: createMockR2(),
+    GITHUB_CLIENT_ID: "test-client-id",
+    GITHUB_CLIENT_SECRET: "test-client-secret",
+    JWT_SECRET: DEFAULT_SECRET,
+    FRONTEND_URL: "http://localhost:3000",
+    ...overrides,
+  };
 }

--- a/apps/api/src/types.ts
+++ b/apps/api/src/types.ts
@@ -1,24 +1,24 @@
 import type { D1Database, R2Bucket } from "@cloudflare/workers-types";
 
 export type Env = {
-    DB: D1Database;
-    BUCKET: R2Bucket;
-    GITHUB_CLIENT_ID: string;
-    GITHUB_CLIENT_SECRET: string;
-    JWT_SECRET: string;
-    FRONTEND_URL: string;
-    ALLOWED_ORIGINS?: string;
-    ENABLE_TEST_AUTH?: string;
-    TEST_AUTH_SECRET?: string;
+  DB: D1Database;
+  BUCKET: R2Bucket;
+  GITHUB_CLIENT_ID: string;
+  GITHUB_CLIENT_SECRET: string;
+  JWT_SECRET: string;
+  FRONTEND_URL: string;
+  ALLOWED_ORIGINS?: string;
+  ENABLE_TEST_AUTH?: string;
+  TEST_AUTH_SECRET?: string;
 };
 
 export type JwtPayload = {
-    sub: string;
-    githubId: string;
-    name: string;
-    exp: number;
+  sub: string;
+  githubId: string;
+  name: string;
+  exp: number;
 };
 
 export type Variables = {
-    user: JwtPayload;
+  user: JwtPayload;
 };

--- a/apps/api/src/utils/__tests__/badge.bench.ts
+++ b/apps/api/src/utils/__tests__/badge.bench.ts
@@ -3,11 +3,19 @@ import { buildBadgeSvg, estimateTextWidth } from "../badge";
 import { benchmarkOptions } from "./bench-utils";
 
 describe("badge benchmark", () => {
-    bench("buildBadgeSvg", () => {
-        buildBadgeSvg("📄 OpenShelf", "Balance Boundary Explorer (2026)", "4c1");
-    }, benchmarkOptions);
+  bench(
+    "buildBadgeSvg",
+    () => {
+      buildBadgeSvg("📄 OpenShelf", "Balance Boundary Explorer (2026)", "4c1");
+    },
+    benchmarkOptions,
+  );
 
-    bench("estimateTextWidth", () => {
-        estimateTextWidth("Balance Boundary Explorer (2026) 📄 OpenShelf 👍");
-    }, benchmarkOptions);
+  bench(
+    "estimateTextWidth",
+    () => {
+      estimateTextWidth("Balance Boundary Explorer (2026) 📄 OpenShelf 👍");
+    },
+    benchmarkOptions,
+  );
 });

--- a/apps/api/src/utils/__tests__/badge.test.ts
+++ b/apps/api/src/utils/__tests__/badge.test.ts
@@ -1,225 +1,231 @@
 import { describe, expect, it } from "vitest";
 import {
-    escapeXml,
-    normalizeBadgeStyle,
-    normalizeBadgeLabel,
-    normalizeBadgeColor,
-    truncateBadgeText,
-    estimateTextWidth,
-    buildBadgeMessage,
-    buildLeftText,
-    buildBadgeSvg,
-    buildShieldsEndpointPayload,
-    buildNotFoundBadge,
-    createEtag,
+  escapeXml,
+  normalizeBadgeStyle,
+  normalizeBadgeLabel,
+  normalizeBadgeColor,
+  truncateBadgeText,
+  estimateTextWidth,
+  buildBadgeMessage,
+  buildLeftText,
+  buildBadgeSvg,
+  buildShieldsEndpointPayload,
+  buildNotFoundBadge,
+  createEtag,
 } from "../badge";
 
 describe("badge utils", () => {
-    describe("escapeXml", () => {
-        it("escapes special characters", () => {
-            expect(escapeXml('a & b < c > d " e \' f')).toBe(
-                "a &amp; b &lt; c &gt; d &quot; e &#39; f",
-            );
-        });
-        it("handles empty strings", () => {
-            expect(escapeXml("")).toBe("");
-        });
-        it("handles strings without special characters", () => {
-            expect(escapeXml("hello world")).toBe("hello world");
-        });
+  describe("escapeXml", () => {
+    it("escapes special characters", () => {
+      expect(escapeXml("a & b < c > d \" e ' f")).toBe(
+        "a &amp; b &lt; c &gt; d &quot; e &#39; f",
+      );
     });
-
-    describe("normalizeBadgeStyle", () => {
-        it("returns compact for compact input", () => {
-            expect(normalizeBadgeStyle("compact")).toBe("compact");
-        });
-        it("returns default for other string inputs", () => {
-            expect(normalizeBadgeStyle("flat")).toBe("default");
-            expect(normalizeBadgeStyle("")).toBe("default");
-        });
-        it("returns default for null/undefined", () => {
-            expect(normalizeBadgeStyle(null)).toBe("default");
-            expect(normalizeBadgeStyle(undefined)).toBe("default");
-        });
+    it("handles empty strings", () => {
+      expect(escapeXml("")).toBe("");
     });
-
-    describe("normalizeBadgeLabel", () => {
-        it("returns the label trimmed and whitespace-normalized", () => {
-            expect(normalizeBadgeLabel("  hello   world  ")).toBe("hello world");
-        });
-        it("returns default label for empty, null, or undefined", () => {
-            expect(normalizeBadgeLabel("")).toBe("OpenShelf");
-            expect(normalizeBadgeLabel("   ")).toBe("OpenShelf");
-            expect(normalizeBadgeLabel(null)).toBe("OpenShelf");
-            expect(normalizeBadgeLabel(undefined)).toBe("OpenShelf");
-        });
-        it("truncates long labels", () => {
-            const longLabel = "this is a very long label that exceeds the limit";
-            const normalized = normalizeBadgeLabel(longLabel);
-            expect(normalized.length).toBeLessThanOrEqual(24);
-            expect(normalized.endsWith("…")).toBe(true);
-        });
+    it("handles strings without special characters", () => {
+      expect(escapeXml("hello world")).toBe("hello world");
     });
+  });
 
-    describe("normalizeBadgeColor", () => {
-        it("returns lowercase standard hex colors without #", () => {
-            expect(normalizeBadgeColor("FF0000")).toBe("ff0000");
-            expect(normalizeBadgeColor("#00FF00")).toBe("00ff00");
-            expect(normalizeBadgeColor("123")).toBe("123");
-        });
-        it("returns lowercase named colors", () => {
-            expect(normalizeBadgeColor("Red")).toBe("red");
-            expect(normalizeBadgeColor("blue")).toBe("blue");
-        });
-        it("returns default color for invalid, empty, null, or undefined", () => {
-            expect(normalizeBadgeColor("invalid color!")).toBe("4c1");
-            expect(normalizeBadgeColor("")).toBe("4c1");
-            expect(normalizeBadgeColor(null)).toBe("4c1");
-            expect(normalizeBadgeColor(undefined)).toBe("4c1");
-        });
+  describe("normalizeBadgeStyle", () => {
+    it("returns compact for compact input", () => {
+      expect(normalizeBadgeStyle("compact")).toBe("compact");
     });
-
-    describe("truncateBadgeText", () => {
-        it("does not truncate if within max length", () => {
-            expect(truncateBadgeText("hello", 10)).toBe("hello");
-            expect(truncateBadgeText("hello", 5)).toBe("hello");
-        });
-        it("truncates and adds ellipsis if exceeding max length", () => {
-            expect(truncateBadgeText("hello world", 8)).toBe("hello w…");
-        });
-        it("handles max length <= 1", () => {
-            expect(truncateBadgeText("hello", 1)).toBe("…");
-            expect(truncateBadgeText("hello", 0)).toBe("…");
-        });
-        it("normalizes whitespace before truncating", () => {
-            expect(truncateBadgeText("hello   world", 8)).toBe("hello w…");
-        });
+    it("returns default for other string inputs", () => {
+      expect(normalizeBadgeStyle("flat")).toBe("default");
+      expect(normalizeBadgeStyle("")).toBe("default");
     });
-
-    describe("estimateTextWidth", () => {
-        it("estimates width for basic alphanumeric characters", () => {
-            expect(estimateTextWidth("a")).toBe(6);
-            expect(estimateTextWidth("A")).toBe(7);
-            expect(estimateTextWidth("1")).toBe(6);
-        });
-        it("estimates width for wide characters", () => {
-            expect(estimateTextWidth("あ")).toBe(11);
-        });
-        it("estimates width for emojis", () => {
-            expect(estimateTextWidth("😀")).toBe(12);
-        });
-        it("estimates width for other characters (e.g., symbols, spaces)", () => {
-            expect(estimateTextWidth(" ")).toBe(5);
-            expect(estimateTextWidth("-")).toBe(5);
-        });
-        it("estimates total width", () => {
-            expect(estimateTextWidth("aA1 あ😀 ")).toBe(52);
-        });
+    it("returns default for null/undefined", () => {
+      expect(normalizeBadgeStyle(null)).toBe("default");
+      expect(normalizeBadgeStyle(undefined)).toBe("default");
     });
+  });
 
-    describe("buildBadgeMessage", () => {
-        it("returns 'Paper' for compact style", () => {
-            expect(buildBadgeMessage("Some Title", 2024, "compact")).toBe("Paper");
-        });
-        it("includes title and year for default style", () => {
-            expect(buildBadgeMessage("Some Title", 2024, "default")).toBe("Some Title (2024)");
-        });
-        it("omits year if null", () => {
-            expect(buildBadgeMessage("Some Title", null, "default")).toBe("Some Title");
-        });
-        it("omits year if year is 0", () => {
-            expect(buildBadgeMessage("Some Title", 0, "default")).toBe("Some Title");
-        });
-        it("truncates long titles with year", () => {
-            const title = "This is a very long title that should definitely be truncated";
-            const message = buildBadgeMessage(title, 2024, "default");
-            expect(message).toContain("… (2024)");
-            expect(message.length).toBeLessThanOrEqual(35 + 7); // 35 for title + 7 for " (2024)"
-        });
-        it("truncates long titles without year", () => {
-            const title = "This is a very long title that should definitely be truncated because it is long";
-            const message = buildBadgeMessage(title, null, "default");
-            expect(message).toContain("…");
-            expect(message.length).toBeLessThanOrEqual(38);
-        });
-        it("returns 'Paper' if result is empty", () => {
-            expect(buildBadgeMessage("   ", null, "default")).toBe("Paper");
-        });
+  describe("normalizeBadgeLabel", () => {
+    it("returns the label trimmed and whitespace-normalized", () => {
+      expect(normalizeBadgeLabel("  hello   world  ")).toBe("hello world");
     });
-
-    describe("buildLeftText", () => {
-        it("prepends document emoji", () => {
-            expect(buildLeftText("Label")).toBe("📄 Label");
-        });
+    it("returns default label for empty, null, or undefined", () => {
+      expect(normalizeBadgeLabel("")).toBe("OpenShelf");
+      expect(normalizeBadgeLabel("   ")).toBe("OpenShelf");
+      expect(normalizeBadgeLabel(null)).toBe("OpenShelf");
+      expect(normalizeBadgeLabel(undefined)).toBe("OpenShelf");
     });
-
-    describe("buildBadgeSvg", () => {
-        it("generates a valid SVG string", () => {
-            const svg = buildBadgeSvg("left", "right", "ff0000");
-            expect(svg).toContain("<svg");
-            expect(svg).toContain("</svg>");
-            expect(svg).toContain("left");
-            expect(svg).toContain("right");
-            expect(svg).toContain("#ff0000"); // color is transformed to hex
-        });
-        it("handles empty inputs by using defaults", () => {
-            const svg = buildBadgeSvg("", "", "");
-            expect(svg).toContain("📄 OpenShelf");
-            expect(svg).toContain("Paper");
-            expect(svg).toContain("#4c1");
-        });
-        it("handles named colors", () => {
-            const svg = buildBadgeSvg("left", "right", "red");
-            expect(svg).toContain(`fill="red"`);
-        });
+    it("truncates long labels", () => {
+      const longLabel = "this is a very long label that exceeds the limit";
+      const normalized = normalizeBadgeLabel(longLabel);
+      expect(normalized.length).toBeLessThanOrEqual(24);
+      expect(normalized.endsWith("…")).toBe(true);
     });
+  });
 
-    describe("buildShieldsEndpointPayload", () => {
-        it("returns a Shields.io compatible payload", () => {
-            const payload = buildShieldsEndpointPayload("left", "right", "ff0000");
-            expect(payload).toEqual({
-                schemaVersion: 1,
-                label: "left",
-                message: "right",
-                color: "ff0000",
-            });
-        });
+  describe("normalizeBadgeColor", () => {
+    it("returns lowercase standard hex colors without #", () => {
+      expect(normalizeBadgeColor("FF0000")).toBe("ff0000");
+      expect(normalizeBadgeColor("#00FF00")).toBe("00ff00");
+      expect(normalizeBadgeColor("123")).toBe("123");
     });
-
-    describe("buildNotFoundBadge", () => {
-        it("returns SVG and JSON for not found badge", () => {
-        // NOTE: color and style options are intentionally ignored by buildNotFoundBadge.
-        // It always uses the default NOT_FOUND_COLOR (#9f9f9f) and default style layout.
-
-            const result = buildNotFoundBadge({
-                style: "default",
-                label: "MyLabel",
-                color: "123",
-            });
-            expect(result.svg).toContain("📄 MyLabel");
-            expect(result.svg).toContain("not found");
-            expect(result.svg).toContain("#9f9f9f");
-
-            expect(result.json).toEqual({
-                schemaVersion: 1,
-                label: "📄 MyLabel",
-                message: "not found",
-                color: "9f9f9f",
-            });
-        });
+    it("returns lowercase named colors", () => {
+      expect(normalizeBadgeColor("Red")).toBe("red");
+      expect(normalizeBadgeColor("blue")).toBe("blue");
     });
-
-    describe("createEtag", () => {
-        it("generates a stable 16-character hex string enclosed in quotes", () => {
-            const etag1 = createEtag("hello world");
-            const etag2 = createEtag("hello world");
-            expect(etag1).toBe(etag2);
-            expect(etag1).toMatch(/^"[0-9a-f]{16}"$/);
-        });
-        it("generates different hashes for different inputs", () => {
-            const etag1 = createEtag("hello world");
-            const etag2 = createEtag("hello world!");
-            expect(etag1).not.toBe(etag2);
-        });
+    it("returns default color for invalid, empty, null, or undefined", () => {
+      expect(normalizeBadgeColor("invalid color!")).toBe("4c1");
+      expect(normalizeBadgeColor("")).toBe("4c1");
+      expect(normalizeBadgeColor(null)).toBe("4c1");
+      expect(normalizeBadgeColor(undefined)).toBe("4c1");
     });
+  });
+
+  describe("truncateBadgeText", () => {
+    it("does not truncate if within max length", () => {
+      expect(truncateBadgeText("hello", 10)).toBe("hello");
+      expect(truncateBadgeText("hello", 5)).toBe("hello");
+    });
+    it("truncates and adds ellipsis if exceeding max length", () => {
+      expect(truncateBadgeText("hello world", 8)).toBe("hello w…");
+    });
+    it("handles max length <= 1", () => {
+      expect(truncateBadgeText("hello", 1)).toBe("…");
+      expect(truncateBadgeText("hello", 0)).toBe("…");
+    });
+    it("normalizes whitespace before truncating", () => {
+      expect(truncateBadgeText("hello   world", 8)).toBe("hello w…");
+    });
+  });
+
+  describe("estimateTextWidth", () => {
+    it("estimates width for basic alphanumeric characters", () => {
+      expect(estimateTextWidth("a")).toBe(6);
+      expect(estimateTextWidth("A")).toBe(7);
+      expect(estimateTextWidth("1")).toBe(6);
+    });
+    it("estimates width for wide characters", () => {
+      expect(estimateTextWidth("あ")).toBe(11);
+    });
+    it("estimates width for emojis", () => {
+      expect(estimateTextWidth("😀")).toBe(12);
+    });
+    it("estimates width for other characters (e.g., symbols, spaces)", () => {
+      expect(estimateTextWidth(" ")).toBe(5);
+      expect(estimateTextWidth("-")).toBe(5);
+    });
+    it("estimates total width", () => {
+      expect(estimateTextWidth("aA1 あ😀 ")).toBe(52);
+    });
+  });
+
+  describe("buildBadgeMessage", () => {
+    it("returns 'Paper' for compact style", () => {
+      expect(buildBadgeMessage("Some Title", 2024, "compact")).toBe("Paper");
+    });
+    it("includes title and year for default style", () => {
+      expect(buildBadgeMessage("Some Title", 2024, "default")).toBe(
+        "Some Title (2024)",
+      );
+    });
+    it("omits year if null", () => {
+      expect(buildBadgeMessage("Some Title", null, "default")).toBe(
+        "Some Title",
+      );
+    });
+    it("omits year if year is 0", () => {
+      expect(buildBadgeMessage("Some Title", 0, "default")).toBe("Some Title");
+    });
+    it("truncates long titles with year", () => {
+      const title =
+        "This is a very long title that should definitely be truncated";
+      const message = buildBadgeMessage(title, 2024, "default");
+      expect(message).toContain("… (2024)");
+      expect(message.length).toBeLessThanOrEqual(35 + 7); // 35 for title + 7 for " (2024)"
+    });
+    it("truncates long titles without year", () => {
+      const title =
+        "This is a very long title that should definitely be truncated because it is long";
+      const message = buildBadgeMessage(title, null, "default");
+      expect(message).toContain("…");
+      expect(message.length).toBeLessThanOrEqual(38);
+    });
+    it("returns 'Paper' if result is empty", () => {
+      expect(buildBadgeMessage("   ", null, "default")).toBe("Paper");
+    });
+  });
+
+  describe("buildLeftText", () => {
+    it("prepends document emoji", () => {
+      expect(buildLeftText("Label")).toBe("📄 Label");
+    });
+  });
+
+  describe("buildBadgeSvg", () => {
+    it("generates a valid SVG string", () => {
+      const svg = buildBadgeSvg("left", "right", "ff0000");
+      expect(svg).toContain("<svg");
+      expect(svg).toContain("</svg>");
+      expect(svg).toContain("left");
+      expect(svg).toContain("right");
+      expect(svg).toContain("#ff0000"); // color is transformed to hex
+    });
+    it("handles empty inputs by using defaults", () => {
+      const svg = buildBadgeSvg("", "", "");
+      expect(svg).toContain("📄 OpenShelf");
+      expect(svg).toContain("Paper");
+      expect(svg).toContain("#4c1");
+    });
+    it("handles named colors", () => {
+      const svg = buildBadgeSvg("left", "right", "red");
+      expect(svg).toContain(`fill="red"`);
+    });
+  });
+
+  describe("buildShieldsEndpointPayload", () => {
+    it("returns a Shields.io compatible payload", () => {
+      const payload = buildShieldsEndpointPayload("left", "right", "ff0000");
+      expect(payload).toEqual({
+        schemaVersion: 1,
+        label: "left",
+        message: "right",
+        color: "ff0000",
+      });
+    });
+  });
+
+  describe("buildNotFoundBadge", () => {
+    it("returns SVG and JSON for not found badge", () => {
+      // NOTE: color and style options are intentionally ignored by buildNotFoundBadge.
+      // It always uses the default NOT_FOUND_COLOR (#9f9f9f) and default style layout.
+
+      const result = buildNotFoundBadge({
+        style: "default",
+        label: "MyLabel",
+        color: "123",
+      });
+      expect(result.svg).toContain("📄 MyLabel");
+      expect(result.svg).toContain("not found");
+      expect(result.svg).toContain("#9f9f9f");
+
+      expect(result.json).toEqual({
+        schemaVersion: 1,
+        label: "📄 MyLabel",
+        message: "not found",
+        color: "9f9f9f",
+      });
+    });
+  });
+
+  describe("createEtag", () => {
+    it("generates a stable 16-character hex string enclosed in quotes", () => {
+      const etag1 = createEtag("hello world");
+      const etag2 = createEtag("hello world");
+      expect(etag1).toBe(etag2);
+      expect(etag1).toMatch(/^"[0-9a-f]{16}"$/);
+    });
+    it("generates different hashes for different inputs", () => {
+      const etag1 = createEtag("hello world");
+      const etag2 = createEtag("hello world!");
+      expect(etag1).not.toBe(etag2);
+    });
+  });
 });

--- a/apps/api/src/utils/__tests__/bench-utils.ts
+++ b/apps/api/src/utils/__tests__/bench-utils.ts
@@ -1,6 +1,6 @@
 export const benchmarkOptions = {
-    time: 2000,
-    warmupTime: 500,
-    iterations: 25,
-    warmupIterations: 10,
+  time: 2000,
+  warmupTime: 500,
+  iterations: 25,
+  warmupIterations: 10,
 };

--- a/apps/api/src/utils/__tests__/citation.bench.ts
+++ b/apps/api/src/utils/__tests__/citation.bench.ts
@@ -3,45 +3,69 @@ import { buildCitation } from "../citation";
 import { benchmarkOptions } from "./bench-utils";
 
 describe("citation benchmark", () => {
-    const paperBase = {
-        id: "paper-1",
-        title: "Balance Boundary Explorer",
-        venue: "ASE",
-        venueType: "conference" as const,
-        year: 2026,
-        category: "other" as const,
-        doi: "10.1145/xxxxxxx.xxxxxxx",
-        externalUrl: null,
-    };
+  const paperBase = {
+    id: "paper-1",
+    title: "Balance Boundary Explorer",
+    venue: "ASE",
+    venueType: "conference" as const,
+    year: 2026,
+    category: "other" as const,
+    doi: "10.1145/xxxxxxx.xxxxxxx",
+    externalUrl: null,
+  };
 
-    const authors = [
-        { name: "hiroki", displayName: "Hiroki Mukai" },
-        { name: "kato", displayName: "Yusaku Kato" },
-    ];
+  const authors = [
+    { name: "hiroki", displayName: "Hiroki Mukai" },
+    { name: "kato", displayName: "Yusaku Kato" },
+  ];
 
-    const frontendUrl = "https://openshelf.example";
+  const frontendUrl = "https://openshelf.example";
 
-    bench("buildCitation bibtex", () => {
-        buildCitation(paperBase, authors, "bibtex", frontendUrl);
-    }, benchmarkOptions);
+  bench(
+    "buildCitation bibtex",
+    () => {
+      buildCitation(paperBase, authors, "bibtex", frontendUrl);
+    },
+    benchmarkOptions,
+  );
 
-    bench("buildCitation biblatex", () => {
-        buildCitation(paperBase, authors, "biblatex", frontendUrl);
-    }, benchmarkOptions);
+  bench(
+    "buildCitation biblatex",
+    () => {
+      buildCitation(paperBase, authors, "biblatex", frontendUrl);
+    },
+    benchmarkOptions,
+  );
 
-    bench("buildCitation apa", () => {
-        buildCitation(paperBase, authors, "apa", frontendUrl);
-    }, benchmarkOptions);
+  bench(
+    "buildCitation apa",
+    () => {
+      buildCitation(paperBase, authors, "apa", frontendUrl);
+    },
+    benchmarkOptions,
+  );
 
-    bench("buildCitation ieee", () => {
-        buildCitation(paperBase, authors, "ieee", frontendUrl);
-    }, benchmarkOptions);
+  bench(
+    "buildCitation ieee",
+    () => {
+      buildCitation(paperBase, authors, "ieee", frontendUrl);
+    },
+    benchmarkOptions,
+  );
 
-    bench("buildCitation mla", () => {
-        buildCitation(paperBase, authors, "mla", frontendUrl);
-    }, benchmarkOptions);
+  bench(
+    "buildCitation mla",
+    () => {
+      buildCitation(paperBase, authors, "mla", frontendUrl);
+    },
+    benchmarkOptions,
+  );
 
-    bench("buildCitation plain", () => {
-        buildCitation(paperBase, authors, "plain", frontendUrl);
-    }, benchmarkOptions);
+  bench(
+    "buildCitation plain",
+    () => {
+      buildCitation(paperBase, authors, "plain", frontendUrl);
+    },
+    benchmarkOptions,
+  );
 });

--- a/apps/api/src/utils/__tests__/citation.test.ts
+++ b/apps/api/src/utils/__tests__/citation.test.ts
@@ -2,171 +2,206 @@ import { describe, expect, it } from "vitest";
 import { buildCitation } from "../citation";
 
 describe("buildCitation", () => {
-    const paperBase = {
-        id: "paper-1",
-        title: "Balance Boundary Explorer",
-        venue: "ASE",
-        venueType: "conference" as const,
-        year: 2026,
-        category: "other" as const,
-        doi: null,
-        externalUrl: null,
-    };
+  const paperBase = {
+    id: "paper-1",
+    title: "Balance Boundary Explorer",
+    venue: "ASE",
+    venueType: "conference" as const,
+    year: 2026,
+    category: "other" as const,
+    doi: null,
+    externalUrl: null,
+  };
 
-    it("generates bibtex with key and fallback url when doi is missing", () => {
-        const result = buildCitation(
-            paperBase,
-            [
-                { name: "hiroki", displayName: "Hiroki Mukai" },
-                { name: "kato", displayName: "Yusaku Kato" },
-            ],
-            "bibtex",
-            "https://openshelf.example",
-        );
+  it("generates bibtex with key and fallback url when doi is missing", () => {
+    const result = buildCitation(
+      paperBase,
+      [
+        { name: "hiroki", displayName: "Hiroki Mukai" },
+        { name: "kato", displayName: "Yusaku Kato" },
+      ],
+      "bibtex",
+      "https://openshelf.example",
+    );
 
-        expect(result.format).toBe("bibtex");
-        expect(result.key).toBe("mukai2026balance");
-        expect(result.citation).toContain("@inproceedings{mukai2026balance");
-        expect(result.citation).toContain("author = {Hiroki Mukai and Yusaku Kato}");
-        expect(result.citation).toContain("url = {https://openshelf.example/papers/paper-1}");
+    expect(result.format).toBe("bibtex");
+    expect(result.key).toBe("mukai2026balance");
+    expect(result.citation).toContain("@inproceedings{mukai2026balance");
+    expect(result.citation).toContain(
+      "author = {Hiroki Mukai and Yusaku Kato}",
+    );
+    expect(result.citation).toContain(
+      "url = {https://openshelf.example/papers/paper-1}",
+    );
+  });
+
+  describe("when doi exists", () => {
+    const paperWithDoi = { ...paperBase, doi: "10.1145/xxxxxxx.xxxxxxx" };
+    const authors = [{ name: "hiroki", displayName: "Hiroki Mukai" }];
+
+    it("uses doi for bibtex and omits url", () => {
+      const bibtex = buildCitation(
+        paperWithDoi,
+        authors,
+        "bibtex",
+        "https://openshelf.example",
+      );
+      expect(bibtex.citation).toContain("doi = {10.1145/xxxxxxx.xxxxxxx}");
+      expect(bibtex.citation).not.toContain("url = {");
     });
 
-    describe("when doi exists", () => {
-        const paperWithDoi = { ...paperBase, doi: "10.1145/xxxxxxx.xxxxxxx" };
-        const authors = [{ name: "hiroki", displayName: "Hiroki Mukai" }];
-
-        it("uses doi for bibtex and omits url", () => {
-            const bibtex = buildCitation(paperWithDoi, authors, "bibtex", "https://openshelf.example");
-            expect(bibtex.citation).toContain("doi = {10.1145/xxxxxxx.xxxxxxx}");
-            expect(bibtex.citation).not.toContain("url = {");
-        });
-
-        it("uses doi url for plain format", () => {
-            const plain = buildCitation(paperWithDoi, authors, "plain", "https://openshelf.example");
-            expect(plain.citation).toContain("https://doi.org/10.1145/xxxxxxx.xxxxxxx");
-        });
-
-        it("uses doi url for apa format", () => {
-            const apa = buildCitation(paperWithDoi, authors, "apa", "https://openshelf.example");
-            expect(apa.citation).toContain("https://doi.org/10.1145/xxxxxxx.xxxxxxx");
-        });
-
-        it("uses doi prefix for ieee format", () => {
-            const ieee = buildCitation(paperWithDoi, authors, "ieee", "https://openshelf.example");
-            expect(ieee.citation).toContain("doi: 10.1145/xxxxxxx.xxxxxxx");
-        });
-
-        it("uses doi prefix for mla format", () => {
-            const mla = buildCitation(paperWithDoi, authors, "mla", "https://openshelf.example");
-            expect(mla.citation).toContain("doi:10.1145/xxxxxxx.xxxxxxx");
-        });
+    it("uses doi url for plain format", () => {
+      const plain = buildCitation(
+        paperWithDoi,
+        authors,
+        "plain",
+        "https://openshelf.example",
+      );
+      expect(plain.citation).toContain(
+        "https://doi.org/10.1145/xxxxxxx.xxxxxxx",
+      );
     });
 
-    it("supports plain format output", () => {
-        const result = buildCitation(
-            paperBase,
-            [{ name: "hiroki", displayName: "向井 宏樹" }],
-            "plain",
-            "https://openshelf.example",
-        );
-
-        expect(result.format).toBe("plain");
-        expect(result.key).toBeNull();
-        expect(result.citation).toContain("向井 宏樹");
-        expect(result.citation).toContain("Balance Boundary Explorer");
+    it("uses doi url for apa format", () => {
+      const apa = buildCitation(
+        paperWithDoi,
+        authors,
+        "apa",
+        "https://openshelf.example",
+      );
+      expect(apa.citation).toContain("https://doi.org/10.1145/xxxxxxx.xxxxxxx");
     });
 
-    it("maps category and venue type to expected bibtex entry type", () => {
-        const bachelor = buildCitation(
-            { ...paperBase, category: "thesis_bachelor", venueType: null },
-            [{ name: "a", displayName: "Alice" }],
-            "bibtex",
-            "https://openshelf.example",
-        );
-        const master = buildCitation(
-            { ...paperBase, category: "thesis_master", venueType: null },
-            [{ name: "a", displayName: "Alice" }],
-            "bibtex",
-            "https://openshelf.example",
-        );
-        const journal = buildCitation(
-            { ...paperBase, category: "other", venueType: "journal", venue: "JSS" },
-            [{ name: "a", displayName: "Alice" }],
-            "bibtex",
-            "https://openshelf.example",
-        );
-        const report = buildCitation(
-            { ...paperBase, category: "report", venueType: null, venue: null },
-            [{ name: "a", displayName: "Alice" }],
-            "bibtex",
-            "https://openshelf.example",
-        );
-
-        expect(bachelor.citation).toContain("@misc{");
-        expect(master.citation).toContain("@mastersthesis{");
-        expect(journal.citation).toContain("@article{");
-        expect(report.citation).toContain("@techreport{");
+    it("uses doi prefix for ieee format", () => {
+      const ieee = buildCitation(
+        paperWithDoi,
+        authors,
+        "ieee",
+        "https://openshelf.example",
+      );
+      expect(ieee.citation).toContain("doi: 10.1145/xxxxxxx.xxxxxxx");
     });
 
-    it("emits biblatex-specific thesis entry metadata for thesis_master", () => {
-        const result = buildCitation(
-            { ...paperBase, category: "thesis_master", venueType: null, venue: null },
-            [{ name: "hiroki", displayName: "Hiroki Mukai" }],
-            "biblatex",
-            "https://openshelf.example",
-        );
-
-        expect(result.citation).toContain("@thesis{");
-        expect(result.citation).toContain("type = {Master's thesis}");
+    it("uses doi prefix for mla format", () => {
+      const mla = buildCitation(
+        paperWithDoi,
+        authors,
+        "mla",
+        "https://openshelf.example",
+      );
+      expect(mla.citation).toContain("doi:10.1145/xxxxxxx.xxxxxxx");
     });
+  });
 
-    it("formats APA output with surname-initial style", () => {
-        const result = buildCitation(
-            paperBase,
-            [
-                { name: "hiroki", displayName: "Hiroki Mukai" },
-                { name: "kato", displayName: "Yusaku Kato" },
-            ],
-            "apa",
-            "https://openshelf.example",
-        );
+  it("supports plain format output", () => {
+    const result = buildCitation(
+      paperBase,
+      [{ name: "hiroki", displayName: "向井 宏樹" }],
+      "plain",
+      "https://openshelf.example",
+    );
 
-        expect(result.citation).toContain("Mukai, H.");
-        expect(result.citation).toContain("Kato, Y.");
-        expect(result.citation).toContain("(2026).");
-    });
+    expect(result.format).toBe("plain");
+    expect(result.key).toBeNull();
+    expect(result.citation).toContain("向井 宏樹");
+    expect(result.citation).toContain("Balance Boundary Explorer");
+  });
 
-    it("formats IEEE output correctly", () => {
-        const result = buildCitation(
-            paperBase,
-            [
-                { name: "hiroki", displayName: "Hiroki Mukai" },
-                { name: "kato", displayName: "Yusaku Kato" },
-            ],
-            "ieee",
-            "https://openshelf.example",
-        );
+  it("maps category and venue type to expected bibtex entry type", () => {
+    const bachelor = buildCitation(
+      { ...paperBase, category: "thesis_bachelor", venueType: null },
+      [{ name: "a", displayName: "Alice" }],
+      "bibtex",
+      "https://openshelf.example",
+    );
+    const master = buildCitation(
+      { ...paperBase, category: "thesis_master", venueType: null },
+      [{ name: "a", displayName: "Alice" }],
+      "bibtex",
+      "https://openshelf.example",
+    );
+    const journal = buildCitation(
+      { ...paperBase, category: "other", venueType: "journal", venue: "JSS" },
+      [{ name: "a", displayName: "Alice" }],
+      "bibtex",
+      "https://openshelf.example",
+    );
+    const report = buildCitation(
+      { ...paperBase, category: "report", venueType: null, venue: null },
+      [{ name: "a", displayName: "Alice" }],
+      "bibtex",
+      "https://openshelf.example",
+    );
 
-        expect(result.format).toBe("ieee");
-        expect(result.key).toBeNull();
-        expect(result.citation).toContain("Hiroki Mukai, Yusaku Kato");
-        expect(result.citation).toContain('"Balance Boundary Explorer", ASE, 2026, https://openshelf.example/papers/paper-1.');
-    });
+    expect(bachelor.citation).toContain("@misc{");
+    expect(master.citation).toContain("@mastersthesis{");
+    expect(journal.citation).toContain("@article{");
+    expect(report.citation).toContain("@techreport{");
+  });
 
-    it("formats MLA output correctly", () => {
-        const result = buildCitation(
-            paperBase,
-            [
-                { name: "hiroki", displayName: "Hiroki Mukai" },
-                { name: "kato", displayName: "Yusaku Kato" },
-            ],
-            "mla",
-            "https://openshelf.example",
-        );
+  it("emits biblatex-specific thesis entry metadata for thesis_master", () => {
+    const result = buildCitation(
+      { ...paperBase, category: "thesis_master", venueType: null, venue: null },
+      [{ name: "hiroki", displayName: "Hiroki Mukai" }],
+      "biblatex",
+      "https://openshelf.example",
+    );
 
-        expect(result.format).toBe("mla");
-        expect(result.key).toBeNull();
-        expect(result.citation).toContain("Hiroki Mukai, Yusaku Kato.");
-        expect(result.citation).toContain('"Balance Boundary Explorer", ASE, 2026. https://openshelf.example/papers/paper-1.');
-    });
+    expect(result.citation).toContain("@thesis{");
+    expect(result.citation).toContain("type = {Master's thesis}");
+  });
+
+  it("formats APA output with surname-initial style", () => {
+    const result = buildCitation(
+      paperBase,
+      [
+        { name: "hiroki", displayName: "Hiroki Mukai" },
+        { name: "kato", displayName: "Yusaku Kato" },
+      ],
+      "apa",
+      "https://openshelf.example",
+    );
+
+    expect(result.citation).toContain("Mukai, H.");
+    expect(result.citation).toContain("Kato, Y.");
+    expect(result.citation).toContain("(2026).");
+  });
+
+  it("formats IEEE output correctly", () => {
+    const result = buildCitation(
+      paperBase,
+      [
+        { name: "hiroki", displayName: "Hiroki Mukai" },
+        { name: "kato", displayName: "Yusaku Kato" },
+      ],
+      "ieee",
+      "https://openshelf.example",
+    );
+
+    expect(result.format).toBe("ieee");
+    expect(result.key).toBeNull();
+    expect(result.citation).toContain("Hiroki Mukai, Yusaku Kato");
+    expect(result.citation).toContain(
+      '"Balance Boundary Explorer", ASE, 2026, https://openshelf.example/papers/paper-1.',
+    );
+  });
+
+  it("formats MLA output correctly", () => {
+    const result = buildCitation(
+      paperBase,
+      [
+        { name: "hiroki", displayName: "Hiroki Mukai" },
+        { name: "kato", displayName: "Yusaku Kato" },
+      ],
+      "mla",
+      "https://openshelf.example",
+    );
+
+    expect(result.format).toBe("mla");
+    expect(result.key).toBeNull();
+    expect(result.citation).toContain("Hiroki Mukai, Yusaku Kato.");
+    expect(result.citation).toContain(
+      '"Balance Boundary Explorer", ASE, 2026. https://openshelf.example/papers/paper-1.',
+    );
+  });
 });

--- a/apps/api/src/utils/__tests__/file.bench.ts
+++ b/apps/api/src/utils/__tests__/file.bench.ts
@@ -3,18 +3,30 @@ import { validateMagicNumbers } from "../file";
 import { benchmarkOptions } from "./bench-utils";
 
 describe("file extensions benchmark", () => {
-    // Create dummy File objects once so the benchmark measures validation only.
-    const pdfMagic = new Uint8Array([0x25, 0x50, 0x44, 0x46, 0x2d]);
-    const pdfFile = new File([pdfMagic], "sample.pdf", { type: "application/pdf" });
+  // Create dummy File objects once so the benchmark measures validation only.
+  const pdfMagic = new Uint8Array([0x25, 0x50, 0x44, 0x46, 0x2d]);
+  const pdfFile = new File([pdfMagic], "sample.pdf", {
+    type: "application/pdf",
+  });
 
-    bench("validateMagicNumbers pdf", async () => {
-        await validateMagicNumbers(pdfFile, "application/pdf");
-    }, benchmarkOptions);
+  bench(
+    "validateMagicNumbers pdf",
+    async () => {
+      await validateMagicNumbers(pdfFile, "application/pdf");
+    },
+    benchmarkOptions,
+  );
 
-    const pngMagic = new Uint8Array([0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a]);
-    const pngFile = new File([pngMagic], "image.png", { type: "image/png" });
+  const pngMagic = new Uint8Array([
+    0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a,
+  ]);
+  const pngFile = new File([pngMagic], "image.png", { type: "image/png" });
 
-    bench("validateMagicNumbers png", async () => {
-        await validateMagicNumbers(pngFile, "image/png");
-    }, benchmarkOptions);
+  bench(
+    "validateMagicNumbers png",
+    async () => {
+      await validateMagicNumbers(pngFile, "image/png");
+    },
+    benchmarkOptions,
+  );
 });

--- a/apps/api/src/utils/__tests__/file.test.ts
+++ b/apps/api/src/utils/__tests__/file.test.ts
@@ -224,7 +224,7 @@ describe("validateMagicNumbers", () => {
     ).resolves.toBe(false);
   });
 
-it("returns false when File.slice throws RangeError", async () => {
+  it("returns false when File.slice throws RangeError", async () => {
     const errorFile = {
       slice: () => ({
         arrayBuffer: async () => {
@@ -235,10 +235,12 @@ it("returns false when File.slice throws RangeError", async () => {
       type: "application/pdf",
     } as unknown as File;
 
-    await expect(validateMagicNumbers(errorFile, "application/pdf")).resolves.toBe(false);
+    await expect(
+      validateMagicNumbers(errorFile, "application/pdf"),
+    ).resolves.toBe(false);
   });
 
-it("returns false when File.slice throws TypeError", async () => {
+  it("returns false when File.slice throws TypeError", async () => {
     const errorFile = {
       slice: () => ({
         arrayBuffer: async () => {
@@ -249,10 +251,12 @@ it("returns false when File.slice throws TypeError", async () => {
       type: "application/pdf",
     } as unknown as File;
 
-    await expect(validateMagicNumbers(errorFile, "application/pdf")).resolves.toBe(false);
+    await expect(
+      validateMagicNumbers(errorFile, "application/pdf"),
+    ).resolves.toBe(false);
   });
 
-it("returns false when File.slice throws DOMException with InvalidStateError", async () => {
+  it("returns false when File.slice throws DOMException with InvalidStateError", async () => {
     const errorFile = {
       slice: () => ({
         arrayBuffer: async () => {
@@ -263,10 +267,12 @@ it("returns false when File.slice throws DOMException with InvalidStateError", a
       type: "application/pdf",
     } as unknown as File;
 
-    await expect(validateMagicNumbers(errorFile, "application/pdf")).resolves.toBe(false);
+    await expect(
+      validateMagicNumbers(errorFile, "application/pdf"),
+    ).resolves.toBe(false);
   });
 
-it("throws the error when File.slice throws an unexpected error", async () => {
+  it("throws the error when File.slice throws an unexpected error", async () => {
     const customError = new Error("Unexpected error");
     const errorFile = {
       slice: () => ({
@@ -278,7 +284,9 @@ it("throws the error when File.slice throws an unexpected error", async () => {
       type: "application/pdf",
     } as unknown as File;
 
-    await expect(validateMagicNumbers(errorFile, "application/pdf")).rejects.toThrow("Unexpected error");
+    await expect(
+      validateMagicNumbers(errorFile, "application/pdf"),
+    ).rejects.toThrow("Unexpected error");
   });
 
   it("throws the error when File.slice throws DOMException with AbortError", async () => {
@@ -293,6 +301,8 @@ it("throws the error when File.slice throws an unexpected error", async () => {
       type: "application/pdf",
     } as unknown as File;
 
-    await expect(validateMagicNumbers(errorFile, "application/pdf")).rejects.toThrow(customError);
+    await expect(
+      validateMagicNumbers(errorFile, "application/pdf"),
+    ).rejects.toThrow(customError);
   });
 });

--- a/apps/api/src/utils/__tests__/origin.bench.ts
+++ b/apps/api/src/utils/__tests__/origin.bench.ts
@@ -3,17 +3,33 @@ import { isAllowedOrigin } from "../origin";
 import { benchmarkOptions } from "./bench-utils";
 
 describe("origin benchmark", () => {
-    const allowedOrigins = [
+  const allowedOrigins = [
+    "https://openshelf.example",
+    "https://*.openshelf.example",
+    "http://localhost:3000",
+  ];
+
+  bench(
+    "isAllowedOrigin exact match",
+    () => {
+      isAllowedOrigin(
         "https://openshelf.example",
-        "https://*.openshelf.example",
-        "http://localhost:3000",
-    ];
+        "https://openshelf.example",
+        allowedOrigins,
+      );
+    },
+    benchmarkOptions,
+  );
 
-    bench("isAllowedOrigin exact match", () => {
-        isAllowedOrigin("https://openshelf.example", "https://openshelf.example", allowedOrigins);
-    }, benchmarkOptions);
-
-    bench("isAllowedOrigin wildcard match", () => {
-        isAllowedOrigin("https://app.openshelf.example", "https://openshelf.example", allowedOrigins);
-    }, benchmarkOptions);
+  bench(
+    "isAllowedOrigin wildcard match",
+    () => {
+      isAllowedOrigin(
+        "https://app.openshelf.example",
+        "https://openshelf.example",
+        allowedOrigins,
+      );
+    },
+    benchmarkOptions,
+  );
 });

--- a/apps/api/src/utils/__tests__/origin.test.ts
+++ b/apps/api/src/utils/__tests__/origin.test.ts
@@ -1,97 +1,154 @@
 import { describe, expect, it } from "vitest";
-import { isAllowedOrigin, matchesOriginPattern, normalizeOrigin } from "../origin";
+import {
+  isAllowedOrigin,
+  matchesOriginPattern,
+  normalizeOrigin,
+} from "../origin";
 
 describe("origin utils", () => {
-    it("allows request when origin matches the normalized frontend origin", () => {
-        const origin = normalizeOrigin("https://frontend.example.com/")!;
+  it("allows request when origin matches the normalized frontend origin", () => {
+    const origin = normalizeOrigin("https://frontend.example.com/")!;
 
-        expect(
-            isAllowedOrigin(
-                origin,
-                "https://frontend.example.com",
-                ["https://app.example.com"],
-                { allowWildcard: false },
-            ),
-        ).toBe(true);
+    expect(
+      isAllowedOrigin(
+        origin,
+        "https://frontend.example.com",
+        ["https://app.example.com"],
+        { allowWildcard: false },
+      ),
+    ).toBe(true);
+  });
+
+  describe("matchesOriginPattern", () => {
+    // Construct pattern with dots using string join to bypass CodeQL literal string analysis
+    const p = (...parts: string[]) => parts.join(".");
+
+    it("returns true for global wildcard", () => {
+      expect(matchesOriginPattern("https://example.com", "*")).toBe(true);
     });
 
-    describe("matchesOriginPattern", () => {
-        // Construct pattern with dots using string join to bypass CodeQL literal string analysis
-        const p = (...parts: string[]) => parts.join(".");
-
-        it("returns true for global wildcard", () => {
-            expect(matchesOriginPattern("https://example.com", "*")).toBe(true);
-        });
-
-        it("returns true for exact matches without wildcard", () => {
-            expect(matchesOriginPattern("https://example.com", p("https://example", "com"))).toBe(true);
-            expect(matchesOriginPattern("https://example.com", p("https://other", "com"))).toBe(false);
-        });
-
-        it("matches single subdomain wildcard", () => {
-            const pattern = p("https://*", "example", "com");
-            expect(matchesOriginPattern("https://app.example.com", pattern)).toBe(true);
-            expect(matchesOriginPattern("https://api.example.com", pattern)).toBe(true);
-            expect(matchesOriginPattern("https://abc-123.example.com", pattern)).toBe(true);
-        });
-
-        it("does not match across multiple subdomain levels with single wildcard", () => {
-            const pattern = p("https://*", "example", "com");
-            expect(matchesOriginPattern("https://sub.app.example.com", pattern)).toBe(false);
-            expect(matchesOriginPattern("https://example.com", pattern)).toBe(false);
-        });
-
-        it("matches multiple wildcards", () => {
-            const pattern = p("https://*", "*", "example", "com");
-            expect(matchesOriginPattern("https://app.dev.example.com", pattern)).toBe(true);
-            expect(matchesOriginPattern("https://api.staging.example.com", pattern)).toBe(true);
-        });
-
-        it("escapes special regex characters in pattern", () => {
-            // The pattern has dots which should be treated literally, not as any character regex
-            expect(matchesOriginPattern("https://exampleXcom", p("https://*", "example", "com"))).toBe(false);
-            expect(matchesOriginPattern("https://app.example.com", p("https://app", "example", "com"))).toBe(true);
-        });
-
-        it("handles patterns with other special characters", () => {
-            expect(matchesOriginPattern("https://a+b.example.com", p("https://a+b", "example", "com"))).toBe(true);
-            expect(matchesOriginPattern("https://a(b).example.com", p("https://a(b)", "example", "com"))).toBe(true);
-        });
+    it("returns true for exact matches without wildcard", () => {
+      expect(
+        matchesOriginPattern(
+          "https://example.com",
+          p("https://example", "com"),
+        ),
+      ).toBe(true);
+      expect(
+        matchesOriginPattern("https://example.com", p("https://other", "com")),
+      ).toBe(false);
     });
 
-    it("normalizes exact origins before comparison", () => {
-        const origin = normalizeOrigin("https://app.example.com")!;
-        const frontendOrigin = normalizeOrigin("https://frontend.example.com")!;
-        const allowedOrigins = ["https://app.example.com/", "https://other.example.com"];
-
-        expect(isAllowedOrigin(origin, frontendOrigin, allowedOrigins)).toBe(true);
+    it("matches single subdomain wildcard", () => {
+      const pattern = p("https://*", "example", "com");
+      expect(matchesOriginPattern("https://app.example.com", pattern)).toBe(
+        true,
+      );
+      expect(matchesOriginPattern("https://api.example.com", pattern)).toBe(
+        true,
+      );
+      expect(matchesOriginPattern("https://abc-123.example.com", pattern)).toBe(
+        true,
+      );
     });
 
-    it("rejects wildcard allowlist for CSRF checks", () => {
-        const origin = normalizeOrigin("https://evil.example.com")!;
-        const frontendOrigin = normalizeOrigin("https://frontend.example.com")!;
-
-        expect(isAllowedOrigin(origin, frontendOrigin, ["*"], { allowWildcard: false })).toBe(false);
-        expect(isAllowedOrigin(origin, frontendOrigin, ["*"], { allowWildcard: true })).toBe(true);
+    it("does not match across multiple subdomain levels with single wildcard", () => {
+      const pattern = p("https://*", "example", "com");
+      expect(matchesOriginPattern("https://sub.app.example.com", pattern)).toBe(
+        false,
+      );
+      expect(matchesOriginPattern("https://example.com", pattern)).toBe(false);
     });
 
-    it("rejects wildcard subdomain patterns for CSRF checks", () => {
-        const origin = normalizeOrigin("https://app.example.com")!;
-        const frontendOrigin = normalizeOrigin("https://frontend.example.com")!;
-
-        expect(isAllowedOrigin(origin, frontendOrigin, ["https://*.example.com"], { allowWildcard: false })).toBe(false);
-        expect(isAllowedOrigin(origin, frontendOrigin, ["https://*.example.com"], { allowWildcard: true })).toBe(true);
+    it("matches multiple wildcards", () => {
+      const pattern = p("https://*", "*", "example", "com");
+      expect(matchesOriginPattern("https://app.dev.example.com", pattern)).toBe(
+        true,
+      );
+      expect(
+        matchesOriginPattern("https://api.staging.example.com", pattern),
+      ).toBe(true);
     });
 
-    it("does not let wildcard cross host boundary", () => {
-        expect(
-            isAllowedOrigin(
-                "https://evil.com/?.example.com",
-                normalizeOrigin("https://frontend.example.com"),
-                ["https://*.example.com"],
-                { allowWildcard: true },
-            ),
-        ).toBe(false);
+    it("escapes special regex characters in pattern", () => {
+      // The pattern has dots which should be treated literally, not as any character regex
+      expect(
+        matchesOriginPattern(
+          "https://exampleXcom",
+          p("https://*", "example", "com"),
+        ),
+      ).toBe(false);
+      expect(
+        matchesOriginPattern(
+          "https://app.example.com",
+          p("https://app", "example", "com"),
+        ),
+      ).toBe(true);
     });
 
+    it("handles patterns with other special characters", () => {
+      expect(
+        matchesOriginPattern(
+          "https://a+b.example.com",
+          p("https://a+b", "example", "com"),
+        ),
+      ).toBe(true);
+      expect(
+        matchesOriginPattern(
+          "https://a(b).example.com",
+          p("https://a(b)", "example", "com"),
+        ),
+      ).toBe(true);
+    });
+  });
+
+  it("normalizes exact origins before comparison", () => {
+    const origin = normalizeOrigin("https://app.example.com")!;
+    const frontendOrigin = normalizeOrigin("https://frontend.example.com")!;
+    const allowedOrigins = [
+      "https://app.example.com/",
+      "https://other.example.com",
+    ];
+
+    expect(isAllowedOrigin(origin, frontendOrigin, allowedOrigins)).toBe(true);
+  });
+
+  it("rejects wildcard allowlist for CSRF checks", () => {
+    const origin = normalizeOrigin("https://evil.example.com")!;
+    const frontendOrigin = normalizeOrigin("https://frontend.example.com")!;
+
+    expect(
+      isAllowedOrigin(origin, frontendOrigin, ["*"], { allowWildcard: false }),
+    ).toBe(false);
+    expect(
+      isAllowedOrigin(origin, frontendOrigin, ["*"], { allowWildcard: true }),
+    ).toBe(true);
+  });
+
+  it("rejects wildcard subdomain patterns for CSRF checks", () => {
+    const origin = normalizeOrigin("https://app.example.com")!;
+    const frontendOrigin = normalizeOrigin("https://frontend.example.com")!;
+
+    expect(
+      isAllowedOrigin(origin, frontendOrigin, ["https://*.example.com"], {
+        allowWildcard: false,
+      }),
+    ).toBe(false);
+    expect(
+      isAllowedOrigin(origin, frontendOrigin, ["https://*.example.com"], {
+        allowWildcard: true,
+      }),
+    ).toBe(true);
+  });
+
+  it("does not let wildcard cross host boundary", () => {
+    expect(
+      isAllowedOrigin(
+        "https://evil.com/?.example.com",
+        normalizeOrigin("https://frontend.example.com"),
+        ["https://*.example.com"],
+        { allowWildcard: true },
+      ),
+    ).toBe(false);
+  });
 });

--- a/apps/api/src/utils/__tests__/tags.bench.ts
+++ b/apps/api/src/utils/__tests__/tags.bench.ts
@@ -3,19 +3,35 @@ import { parseStoredTags } from "../tags";
 import { benchmarkOptions } from "./bench-utils";
 
 describe("tags benchmark", () => {
-    bench("parseStoredTags with valid JSON array", () => {
-        parseStoredTags('["tag1", "tag2", "tag3"]');
-    }, benchmarkOptions);
+  bench(
+    "parseStoredTags with valid JSON array",
+    () => {
+      parseStoredTags('["tag1", "tag2", "tag3"]');
+    },
+    benchmarkOptions,
+  );
 
-    bench("parseStoredTags with empty string", () => {
-        parseStoredTags("");
-    }, benchmarkOptions);
+  bench(
+    "parseStoredTags with empty string",
+    () => {
+      parseStoredTags("");
+    },
+    benchmarkOptions,
+  );
 
-    bench("parseStoredTags with null", () => {
-        parseStoredTags(null);
-    }, benchmarkOptions);
+  bench(
+    "parseStoredTags with null",
+    () => {
+      parseStoredTags(null);
+    },
+    benchmarkOptions,
+  );
 
-    bench("parseStoredTags with invalid JSON", () => {
-        parseStoredTags('["tag1", "tag2", "tag3"');
-    }, benchmarkOptions);
+  bench(
+    "parseStoredTags with invalid JSON",
+    () => {
+      parseStoredTags('["tag1", "tag2", "tag3"');
+    },
+    benchmarkOptions,
+  );
 });

--- a/apps/api/src/utils/__tests__/tags.test.ts
+++ b/apps/api/src/utils/__tests__/tags.test.ts
@@ -2,62 +2,62 @@ import { describe, expect, it } from "vitest";
 import { parseStoredTags } from "../tags";
 
 describe("parseStoredTags", () => {
-    it("returns an empty array for null input", () => {
-        expect(parseStoredTags(null)).toEqual([]);
-    });
+  it("returns an empty array for null input", () => {
+    expect(parseStoredTags(null)).toEqual([]);
+  });
 
-    it("returns an empty array for an empty string", () => {
-        expect(parseStoredTags("")).toEqual([]);
-    });
+  it("returns an empty array for an empty string", () => {
+    expect(parseStoredTags("")).toEqual([]);
+  });
 
-    it("returns an empty array for an empty JSON array", () => {
-        expect(parseStoredTags("[]")).toEqual([]);
-    });
+  it("returns an empty array for an empty JSON array", () => {
+    expect(parseStoredTags("[]")).toEqual([]);
+  });
 
-    it("parses a valid JSON array of strings", () => {
-        expect(parseStoredTags('["tag1", "tag2", "tag3"]')).toEqual([
-            "tag1",
-            "tag2",
-            "tag3",
-        ]);
-    });
+  it("parses a valid JSON array of strings", () => {
+    expect(parseStoredTags('["tag1", "tag2", "tag3"]')).toEqual([
+      "tag1",
+      "tag2",
+      "tag3",
+    ]);
+  });
 
-    it("trims whitespace from tags", () => {
-        expect(parseStoredTags('[" tag1 ", "tag2  ", "  tag3"]')).toEqual([
-            "tag1",
-            "tag2",
-            "tag3",
-        ]);
-    });
+  it("trims whitespace from tags", () => {
+    expect(parseStoredTags('[" tag1 ", "tag2  ", "  tag3"]')).toEqual([
+      "tag1",
+      "tag2",
+      "tag3",
+    ]);
+  });
 
-    it("filters out empty tags after trimming", () => {
-        expect(parseStoredTags('["tag1", "", "  ", "tag2"]')).toEqual([
-            "tag1",
-            "tag2",
-        ]);
-    });
+  it("filters out empty tags after trimming", () => {
+    expect(parseStoredTags('["tag1", "", "  ", "tag2"]')).toEqual([
+      "tag1",
+      "tag2",
+    ]);
+  });
 
-    it("filters out non-string items", () => {
-        expect(parseStoredTags('["tag1", 42, null, {}, "tag2"]')).toEqual([
-            "tag1",
-            "tag2",
-        ]);
-    });
+  it("filters out non-string items", () => {
+    expect(parseStoredTags('["tag1", 42, null, {}, "tag2"]')).toEqual([
+      "tag1",
+      "tag2",
+    ]);
+  });
 
-    it("returns an empty array if the parsed JSON is an object", () => {
-        expect(parseStoredTags('{"tag": "value"}')).toEqual([]);
-    });
+  it("returns an empty array if the parsed JSON is an object", () => {
+    expect(parseStoredTags('{"tag": "value"}')).toEqual([]);
+  });
 
-    it("returns an empty array if the parsed JSON is a string", () => {
-        expect(parseStoredTags('"just a string"')).toEqual([]);
-    });
+  it("returns an empty array if the parsed JSON is a string", () => {
+    expect(parseStoredTags('"just a string"')).toEqual([]);
+  });
 
-    it("returns an empty array if the parsed JSON is a number", () => {
-        expect(parseStoredTags("42")).toEqual([]);
-    });
+  it("returns an empty array if the parsed JSON is a number", () => {
+    expect(parseStoredTags("42")).toEqual([]);
+  });
 
-    it("returns an empty array and catches errors for invalid JSON", () => {
-        expect(parseStoredTags("invalid-json")).toEqual([]);
-        expect(parseStoredTags('["unclosed", "array"')).toEqual([]);
-    });
+  it("returns an empty array and catches errors for invalid JSON", () => {
+    expect(parseStoredTags("invalid-json")).toEqual([]);
+    expect(parseStoredTags('["unclosed", "array"')).toEqual([]);
+  });
 });

--- a/apps/api/src/utils/badge.ts
+++ b/apps/api/src/utils/badge.ts
@@ -1,16 +1,16 @@
 export type BadgeStyle = "default" | "compact";
 
 export type BadgeOptions = {
-    style: BadgeStyle;
-    label: string;
-    color: string;
+  style: BadgeStyle;
+  label: string;
+  color: string;
 };
 
 export type ShieldsEndpointResponse = {
-    schemaVersion: 1;
-    label: string;
-    message: string;
-    color: string;
+  schemaVersion: 1;
+  label: string;
+  message: string;
+  color: string;
 };
 
 const DEFAULT_LABEL = "OpenShelf";
@@ -24,160 +24,162 @@ const MAX_TITLE_LENGTH_WITH_YEAR = 35;
 const MAX_TITLE_LENGTH_WITHOUT_YEAR = 38;
 
 export const BADGE_CACHE_CONTROL =
-    "public, max-age=86400, stale-while-revalidate=3600";
+  "public, max-age=86400, stale-while-revalidate=3600";
 
 const WIDE_CHAR_REGEX =
-    /[\u1100-\u115F\u2329\u232A\u2E80-\uA4CF\uAC00-\uD7A3\uF900-\uFAFF\uFE10-\uFE19\uFE30-\uFE6F\uFF00-\uFF60\uFFE0-\uFFE6]/;
+  /[\u1100-\u115F\u2329\u232A\u2E80-\uA4CF\uAC00-\uD7A3\uF900-\uFAFF\uFE10-\uFE19\uFE30-\uFE6F\uFF00-\uFF60\uFFE0-\uFFE6]/;
 const EMOJI_REGEX = /[\u{1F300}-\u{1FAFF}\u{2600}-\u{27BF}]/u;
 
 function toSafeText(value: string): string {
-    return value.replace(/\s+/g, " ").trim();
+  return value.replace(/\s+/g, " ").trim();
 }
 
 function toSvgColor(color: string): string {
-    return /^[0-9a-f]{3,8}$/i.test(color) ? `#${color}` : color;
+  return /^[0-9a-f]{3,8}$/i.test(color) ? `#${color}` : color;
 }
 
 export function escapeXml(value: string): string {
-    return value
-        .replaceAll("&", "&amp;")
-        .replaceAll("<", "&lt;")
-        .replaceAll(">", "&gt;")
-        .replaceAll('"', "&quot;")
-        .replaceAll("'", "&#39;");
+  return value
+    .replaceAll("&", "&amp;")
+    .replaceAll("<", "&lt;")
+    .replaceAll(">", "&gt;")
+    .replaceAll('"', "&quot;")
+    .replaceAll("'", "&#39;");
 }
 
-export function normalizeBadgeStyle(value: string | null | undefined): BadgeStyle {
-    return value === "compact" ? "compact" : "default";
+export function normalizeBadgeStyle(
+  value: string | null | undefined,
+): BadgeStyle {
+  return value === "compact" ? "compact" : "default";
 }
 
 export function normalizeBadgeLabel(value: string | null | undefined): string {
-    const normalized = toSafeText(value ?? "");
-    if (!normalized) return DEFAULT_LABEL;
-    return truncateBadgeText(normalized, MAX_LABEL_LENGTH);
+  const normalized = toSafeText(value ?? "");
+  if (!normalized) return DEFAULT_LABEL;
+  return truncateBadgeText(normalized, MAX_LABEL_LENGTH);
 }
 
 export function normalizeBadgeColor(value: string | null | undefined): string {
-    const normalized = toSafeText(value ?? "").replace(/^#/, "");
-    if (!normalized) return DEFAULT_COLOR;
-    if (/^[0-9a-f]{3,8}$/i.test(normalized)) return normalized.toLowerCase();
-    if (/^[a-z]+$/i.test(normalized)) return normalized.toLowerCase();
-    return DEFAULT_COLOR;
+  const normalized = toSafeText(value ?? "").replace(/^#/, "");
+  if (!normalized) return DEFAULT_COLOR;
+  if (/^[0-9a-f]{3,8}$/i.test(normalized)) return normalized.toLowerCase();
+  if (/^[a-z]+$/i.test(normalized)) return normalized.toLowerCase();
+  return DEFAULT_COLOR;
 }
 
 export function truncateBadgeText(value: string, maxLength: number): string {
-    const chars = [...toSafeText(value)];
-    if (chars.length <= maxLength) return chars.join("");
-    if (maxLength <= 1) return "…";
-    return `${chars.slice(0, maxLength - 1).join("")}…`;
+  const chars = [...toSafeText(value)];
+  if (chars.length <= maxLength) return chars.join("");
+  if (maxLength <= 1) return "…";
+  return `${chars.slice(0, maxLength - 1).join("")}…`;
 }
 
 export function estimateTextWidth(text: string): number {
-    let width = 0;
-    for (const ch of text) {
-        if (EMOJI_REGEX.test(ch)) {
-            width += 12;
-            continue;
-        }
-
-        if (WIDE_CHAR_REGEX.test(ch)) {
-            width += 11;
-            continue;
-        }
-
-        if (/[A-Z]/.test(ch)) {
-            width += 7;
-            continue;
-        }
-
-        if (/[a-z0-9]/.test(ch)) {
-            width += 6;
-            continue;
-        }
-
-        width += 5;
+  let width = 0;
+  for (const ch of text) {
+    if (EMOJI_REGEX.test(ch)) {
+      width += 12;
+      continue;
     }
 
-    return width;
+    if (WIDE_CHAR_REGEX.test(ch)) {
+      width += 11;
+      continue;
+    }
+
+    if (/[A-Z]/.test(ch)) {
+      width += 7;
+      continue;
+    }
+
+    if (/[a-z0-9]/.test(ch)) {
+      width += 6;
+      continue;
+    }
+
+    width += 5;
+  }
+
+  return width;
 }
 
 export function buildBadgeMessage(
-    title: string,
-    year: number | null,
-    style: BadgeStyle,
+  title: string,
+  year: number | null,
+  style: BadgeStyle,
 ): string {
-    if (style === "compact") return "Paper";
-    const yearSuffix = year ? ` (${year})` : "";
-    const maxTitleLength = year
-        ? MAX_TITLE_LENGTH_WITH_YEAR
-        : MAX_TITLE_LENGTH_WITHOUT_YEAR;
-    const shortTitle = truncateBadgeText(title, maxTitleLength);
-    const result = `${shortTitle}${yearSuffix}`.trim();
-    return result || "Paper";
+  if (style === "compact") return "Paper";
+  const yearSuffix = year ? ` (${year})` : "";
+  const maxTitleLength = year
+    ? MAX_TITLE_LENGTH_WITH_YEAR
+    : MAX_TITLE_LENGTH_WITHOUT_YEAR;
+  const shortTitle = truncateBadgeText(title, maxTitleLength);
+  const result = `${shortTitle}${yearSuffix}`.trim();
+  return result || "Paper";
 }
 
 export function buildLeftText(label: string): string {
-    return `📄 ${label}`;
+  return `📄 ${label}`;
 }
 
 export function buildBadgeSvg(
-    leftTextRaw: string,
-    rightTextRaw: string,
-    rightColorRaw: string,
+  leftTextRaw: string,
+  rightTextRaw: string,
+  rightColorRaw: string,
 ): string {
-    const leftText = toSafeText(leftTextRaw) || buildLeftText(DEFAULT_LABEL);
-    const rightText = toSafeText(rightTextRaw) || "Paper";
-    const rightColor = toSvgColor(rightColorRaw || DEFAULT_COLOR);
+  const leftText = toSafeText(leftTextRaw) || buildLeftText(DEFAULT_LABEL);
+  const rightText = toSafeText(rightTextRaw) || "Paper";
+  const rightColor = toSvgColor(rightColorRaw || DEFAULT_COLOR);
 
-    const leftWidth = Math.max(
-        MIN_SEGMENT_WIDTH,
-        Math.ceil(estimateTextWidth(leftText) + BADGE_PADDING_X * 2),
-    );
-    const rightWidth = Math.max(
-        MIN_SEGMENT_WIDTH,
-        Math.ceil(estimateTextWidth(rightText) + BADGE_PADDING_X * 2),
-    );
-    const totalWidth = leftWidth + rightWidth;
+  const leftWidth = Math.max(
+    MIN_SEGMENT_WIDTH,
+    Math.ceil(estimateTextWidth(leftText) + BADGE_PADDING_X * 2),
+  );
+  const rightWidth = Math.max(
+    MIN_SEGMENT_WIDTH,
+    Math.ceil(estimateTextWidth(rightText) + BADGE_PADDING_X * 2),
+  );
+  const totalWidth = leftWidth + rightWidth;
 
-    const leftCenter = Math.round(leftWidth / 2);
-    const rightCenter = leftWidth + Math.round(rightWidth / 2);
-    const ariaLabel = `${leftText}: ${rightText}`;
+  const leftCenter = Math.round(leftWidth / 2);
+  const rightCenter = leftWidth + Math.round(rightWidth / 2);
+  const ariaLabel = `${leftText}: ${rightText}`;
 
-    return `<svg xmlns="http://www.w3.org/2000/svg" width="${totalWidth}" height="${BADGE_HEIGHT}" role="img" aria-label="${escapeXml(ariaLabel)}"><linearGradient id="s" x2="0" y2="100%"><stop offset="0" stop-color="#fff" stop-opacity=".7"/><stop offset=".1" stop-color="#aaa" stop-opacity=".1"/><stop offset=".9" stop-color="#000" stop-opacity=".3"/><stop offset="1" stop-color="#000" stop-opacity=".5"/></linearGradient><mask id="m"><rect width="${totalWidth}" height="${BADGE_HEIGHT}" rx="3" fill="#fff"/></mask><g mask="url(#m)"><rect width="${leftWidth}" height="${BADGE_HEIGHT}" fill="#555"/><rect x="${leftWidth}" width="${rightWidth}" height="${BADGE_HEIGHT}" fill="${escapeXml(rightColor)}"/><rect width="${totalWidth}" height="${BADGE_HEIGHT}" fill="url(#s)"/></g><g fill="#fff" text-anchor="middle" font-family="Verdana,Geneva,DejaVu Sans,sans-serif" font-size="11"><text x="${leftCenter}" y="15" fill="#010101" fill-opacity=".3">${escapeXml(leftText)}</text><text x="${leftCenter}" y="14">${escapeXml(leftText)}</text><text x="${rightCenter}" y="15" fill="#010101" fill-opacity=".3">${escapeXml(rightText)}</text><text x="${rightCenter}" y="14">${escapeXml(rightText)}</text></g></svg>`;
+  return `<svg xmlns="http://www.w3.org/2000/svg" width="${totalWidth}" height="${BADGE_HEIGHT}" role="img" aria-label="${escapeXml(ariaLabel)}"><linearGradient id="s" x2="0" y2="100%"><stop offset="0" stop-color="#fff" stop-opacity=".7"/><stop offset=".1" stop-color="#aaa" stop-opacity=".1"/><stop offset=".9" stop-color="#000" stop-opacity=".3"/><stop offset="1" stop-color="#000" stop-opacity=".5"/></linearGradient><mask id="m"><rect width="${totalWidth}" height="${BADGE_HEIGHT}" rx="3" fill="#fff"/></mask><g mask="url(#m)"><rect width="${leftWidth}" height="${BADGE_HEIGHT}" fill="#555"/><rect x="${leftWidth}" width="${rightWidth}" height="${BADGE_HEIGHT}" fill="${escapeXml(rightColor)}"/><rect width="${totalWidth}" height="${BADGE_HEIGHT}" fill="url(#s)"/></g><g fill="#fff" text-anchor="middle" font-family="Verdana,Geneva,DejaVu Sans,sans-serif" font-size="11"><text x="${leftCenter}" y="15" fill="#010101" fill-opacity=".3">${escapeXml(leftText)}</text><text x="${leftCenter}" y="14">${escapeXml(leftText)}</text><text x="${rightCenter}" y="15" fill="#010101" fill-opacity=".3">${escapeXml(rightText)}</text><text x="${rightCenter}" y="14">${escapeXml(rightText)}</text></g></svg>`;
 }
 
 export function buildShieldsEndpointPayload(
-    leftText: string,
-    rightText: string,
-    color: string,
+  leftText: string,
+  rightText: string,
+  color: string,
 ): ShieldsEndpointResponse {
-    return {
-        schemaVersion: 1,
-        label: leftText,
-        message: rightText,
-        color,
-    };
+  return {
+    schemaVersion: 1,
+    label: leftText,
+    message: rightText,
+    color,
+  };
 }
 
 export function buildNotFoundBadge(options: BadgeOptions): {
-    svg: string;
-    json: ShieldsEndpointResponse;
+  svg: string;
+  json: ShieldsEndpointResponse;
 } {
-    const leftText = buildLeftText(options.label);
-    const rightText = "not found";
-    return {
-        svg: buildBadgeSvg(leftText, rightText, NOT_FOUND_COLOR),
-        json: buildShieldsEndpointPayload(leftText, rightText, NOT_FOUND_COLOR),
-    };
+  const leftText = buildLeftText(options.label);
+  const rightText = "not found";
+  return {
+    svg: buildBadgeSvg(leftText, rightText, NOT_FOUND_COLOR),
+    json: buildShieldsEndpointPayload(leftText, rightText, NOT_FOUND_COLOR),
+  };
 }
 
 export function createEtag(value: string): string {
-    let hash = 0xcbf29ce484222325n;
-    const fnvPrime = 0x100000001b3n;
-    const mask64 = 0xffffffffffffffffn;
-    for (const ch of value) {
-        hash ^= BigInt(ch.codePointAt(0) ?? 0);
-        hash = (hash * fnvPrime) & mask64;
-    }
-    return `"${hash.toString(16).padStart(16, "0")}"`;
+  let hash = 0xcbf29ce484222325n;
+  const fnvPrime = 0x100000001b3n;
+  const mask64 = 0xffffffffffffffffn;
+  for (const ch of value) {
+    hash ^= BigInt(ch.codePointAt(0) ?? 0);
+    hash = (hash * fnvPrime) & mask64;
+  }
+  return `"${hash.toString(16).padStart(16, "0")}"`;
 }

--- a/apps/api/src/utils/citation.ts
+++ b/apps/api/src/utils/citation.ts
@@ -1,256 +1,286 @@
 import type { CategoryType, VenueType } from "../db/schema";
 
 export type CitationFormat =
-    | "bibtex"
-    | "biblatex"
-    | "apa"
-    | "ieee"
-    | "mla"
-    | "plain";
+  | "bibtex"
+  | "biblatex"
+  | "apa"
+  | "ieee"
+  | "mla"
+  | "plain";
 
 type CitationPaper = {
-    id: string;
-    title: string;
-    venue: string | null;
-    venueType: VenueType | null;
-    year: number | null;
-    category: CategoryType | null;
-    doi: string | null;
-    externalUrl: string | null;
+  id: string;
+  title: string;
+  venue: string | null;
+  venueType: VenueType | null;
+  year: number | null;
+  category: CategoryType | null;
+  doi: string | null;
+  externalUrl: string | null;
 };
 
 type CitationAuthor = {
-    name: string | null;
-    displayName: string | null;
+  name: string | null;
+  displayName: string | null;
 };
 
 const STOP_WORDS = new Set([
-    "a",
-    "an",
-    "the",
-    "of",
-    "on",
-    "in",
-    "for",
-    "to",
-    "and",
-    "with",
-    "by",
+  "a",
+  "an",
+  "the",
+  "of",
+  "on",
+  "in",
+  "for",
+  "to",
+  "and",
+  "with",
+  "by",
 ]);
 
 function normalizeAscii(value: string): string {
-    return value
-        .normalize("NFKD")
-        .replace(/[\u0300-\u036f]/g, "")
-        .replace(/[^a-zA-Z0-9\s]/g, " ")
-        .trim()
-        .toLowerCase();
+  return value
+    .normalize("NFKD")
+    .replace(/[\u0300-\u036f]/g, "")
+    .replace(/[^a-zA-Z0-9\s]/g, " ")
+    .trim()
+    .toLowerCase();
 }
 
 function escapeBibValue(value: string): string {
-    return value
-        .replace(/\\/g, "\\\\")
-        .replace(/{/g, "\\{")
-        .replace(/}/g, "\\}");
+  return value.replace(/\\/g, "\\\\").replace(/{/g, "\\{").replace(/}/g, "\\}");
 }
 
 function pickAuthorLabel(author: CitationAuthor): string {
-    return author.displayName?.trim() || author.name?.trim() || "Unknown Author";
+  return author.displayName?.trim() || author.name?.trim() || "Unknown Author";
 }
 
 function pickSurname(author: CitationAuthor): string {
-    const ascii = normalizeAscii(pickAuthorLabel(author));
-    const tokens = ascii.split(/\s+/).filter(Boolean);
-    return tokens[tokens.length - 1] || "author";
+  const ascii = normalizeAscii(pickAuthorLabel(author));
+  const tokens = ascii.split(/\s+/).filter(Boolean);
+  return tokens[tokens.length - 1] || "author";
 }
 
 function pickTitleKeyWord(title: string): string {
-    const tokens = normalizeAscii(title).split(/\s+/).filter(Boolean);
-    return tokens.find((token) => !STOP_WORDS.has(token)) || tokens[0] || "paper";
+  const tokens = normalizeAscii(title).split(/\s+/).filter(Boolean);
+  return tokens.find((token) => !STOP_WORDS.has(token)) || tokens[0] || "paper";
 }
 
-function pickEntryType(paper: CitationPaper): "mastersthesis" | "inproceedings" | "article" | "techreport" | "misc" {
-    if (paper.category === "thesis_bachelor") return "misc";
-    if (paper.category === "thesis_master") return "mastersthesis";
-    if (paper.category === "report") return "techreport";
-    if (paper.venueType === "conference" || paper.venueType === "workshop") return "inproceedings";
-    if (paper.venueType === "journal") return "article";
-    return "misc";
+function pickEntryType(
+  paper: CitationPaper,
+): "mastersthesis" | "inproceedings" | "article" | "techreport" | "misc" {
+  if (paper.category === "thesis_bachelor") return "misc";
+  if (paper.category === "thesis_master") return "mastersthesis";
+  if (paper.category === "report") return "techreport";
+  if (paper.venueType === "conference" || paper.venueType === "workshop")
+    return "inproceedings";
+  if (paper.venueType === "journal") return "article";
+  return "misc";
 }
 
 function buildPaperUrl(frontendUrl: string, paper: CitationPaper): string {
-    if (paper.externalUrl && /^https?:\/\//i.test(paper.externalUrl)) {
-        return paper.externalUrl;
-    }
-    const base = frontendUrl.replace(/\/+$/, "");
-    return `${base}/papers/${paper.id}`;
+  if (paper.externalUrl && /^https?:\/\//i.test(paper.externalUrl)) {
+    return paper.externalUrl;
+  }
+  const base = frontendUrl.replace(/\/+$/, "");
+  return `${base}/papers/${paper.id}`;
 }
 
-
 function toApaAuthorName(author: CitationAuthor): string {
-    const label = pickAuthorLabel(author).trim();
-    const parts = label.split(/\s+/).filter(Boolean);
-    if (parts.length <= 1) return label;
+  const label = pickAuthorLabel(author).trim();
+  const parts = label.split(/\s+/).filter(Boolean);
+  if (parts.length <= 1) return label;
 
-    const familyName = parts[parts.length - 1];
-    const initials = parts
-        .slice(0, -1)
-        .map((part) => part.charAt(0).toUpperCase())
-        .filter(Boolean)
-        .join(". ");
+  const familyName = parts[parts.length - 1];
+  const initials = parts
+    .slice(0, -1)
+    .map((part) => part.charAt(0).toUpperCase())
+    .filter(Boolean)
+    .join(". ");
 
-    return initials ? `${familyName}, ${initials}.` : familyName;
+  return initials ? `${familyName}, ${initials}.` : familyName;
 }
 
 function toBibLaTeXEntryTypeAndFields(
-    entryType: ReturnType<typeof pickEntryType>,
+  entryType: ReturnType<typeof pickEntryType>,
 ): { entryType: string; extraFields: Array<[string, string]> } {
-    if (entryType === "mastersthesis") {
-        return {
-            entryType: "thesis",
-            extraFields: [["type", "Master's thesis"]],
-        };
-    }
+  if (entryType === "mastersthesis") {
+    return {
+      entryType: "thesis",
+      extraFields: [["type", "Master's thesis"]],
+    };
+  }
 
-    return { entryType, extraFields: [] };
+  return { entryType, extraFields: [] };
 }
 
 function buildBibTexBody(
-    entryType: string,
-    key: string,
-    paper: CitationPaper,
-    authors: CitationAuthor[],
-    frontendUrl: string,
-    extraFields: Array<[string, string]> = [],
+  entryType: string,
+  key: string,
+  paper: CitationPaper,
+  authors: CitationAuthor[],
+  frontendUrl: string,
+  extraFields: Array<[string, string]> = [],
 ): string {
-    const fields: Array<[string, string]> = [
-        ["author", authors.map((author) => pickAuthorLabel(author)).join(" and ")],
-        ["title", paper.title],
-    ];
+  const fields: Array<[string, string]> = [
+    ["author", authors.map((author) => pickAuthorLabel(author)).join(" and ")],
+    ["title", paper.title],
+  ];
 
-    if (paper.venue) {
-        fields.push([
-            entryType === "article" ? "journal" : "booktitle",
-            paper.venue,
-        ]);
-    }
-    if (paper.year) {
-        fields.push(["year", String(paper.year)]);
-    }
-    if (paper.doi) {
-        fields.push(["doi", paper.doi]);
-    } else {
-        fields.push(["url", buildPaperUrl(frontendUrl, paper)]);
-    }
+  if (paper.venue) {
+    fields.push([
+      entryType === "article" ? "journal" : "booktitle",
+      paper.venue,
+    ]);
+  }
+  if (paper.year) {
+    fields.push(["year", String(paper.year)]);
+  }
+  if (paper.doi) {
+    fields.push(["doi", paper.doi]);
+  } else {
+    fields.push(["url", buildPaperUrl(frontendUrl, paper)]);
+  }
 
-    fields.push(...extraFields);
+  fields.push(...extraFields);
 
-    const body = fields
-        .map(([name, value]) => `  ${name} = {${escapeBibValue(value)}}`)
-        .join(",\n");
+  const body = fields
+    .map(([name, value]) => `  ${name} = {${escapeBibValue(value)}}`)
+    .join(",\n");
 
-    return `@${entryType}{${key},\n${body}\n}`;
+  return `@${entryType}{${key},\n${body}\n}`;
 }
 
 function buildPlainText(
-    paper: CitationPaper,
-    authors: CitationAuthor[],
-    frontendUrl: string,
+  paper: CitationPaper,
+  authors: CitationAuthor[],
+  frontendUrl: string,
 ): string {
-    const authorText = authors.map((author) => pickAuthorLabel(author)).join(", ");
-    const yearText = paper.year ? `(${paper.year})` : "(n.d.)";
-    const venueText = paper.venue ? ` ${paper.venue}.` : "";
-    const locator = paper.doi ? ` https://doi.org/${paper.doi}` : ` ${buildPaperUrl(frontendUrl, paper)}`;
-    return `${authorText}. ${yearText}. ${paper.title}.${venueText}${locator}`;
+  const authorText = authors
+    .map((author) => pickAuthorLabel(author))
+    .join(", ");
+  const yearText = paper.year ? `(${paper.year})` : "(n.d.)";
+  const venueText = paper.venue ? ` ${paper.venue}.` : "";
+  const locator = paper.doi
+    ? ` https://doi.org/${paper.doi}`
+    : ` ${buildPaperUrl(frontendUrl, paper)}`;
+  return `${authorText}. ${yearText}. ${paper.title}.${venueText}${locator}`;
 }
 
 function buildApaText(
-    paper: CitationPaper,
-    authors: CitationAuthor[],
-    frontendUrl: string,
+  paper: CitationPaper,
+  authors: CitationAuthor[],
+  frontendUrl: string,
 ): string {
-    const authorText = authors.map((author) => toApaAuthorName(author)).join(", ");
-    const yearText = paper.year ? `(${paper.year}).` : "(n.d.).";
-    const venueText = paper.venue ? ` ${paper.venue}.` : "";
-    const locator = paper.doi
-        ? ` https://doi.org/${paper.doi}`
-        : ` ${buildPaperUrl(frontendUrl, paper)}`;
-    return `${authorText} ${yearText} ${paper.title}.${venueText}${locator}`;
+  const authorText = authors
+    .map((author) => toApaAuthorName(author))
+    .join(", ");
+  const yearText = paper.year ? `(${paper.year}).` : "(n.d.).";
+  const venueText = paper.venue ? ` ${paper.venue}.` : "";
+  const locator = paper.doi
+    ? ` https://doi.org/${paper.doi}`
+    : ` ${buildPaperUrl(frontendUrl, paper)}`;
+  return `${authorText} ${yearText} ${paper.title}.${venueText}${locator}`;
 }
 
 function buildIeeeText(
-    paper: CitationPaper,
-    authors: CitationAuthor[],
-    frontendUrl: string,
+  paper: CitationPaper,
+  authors: CitationAuthor[],
+  frontendUrl: string,
 ): string {
-    const authorText = authors.map((author) => pickAuthorLabel(author)).join(", ");
-    const yearText = paper.year ? String(paper.year) : "n.d.";
-    const venueText = paper.venue ? `, ${paper.venue}` : "";
-    const locator = paper.doi ? `, doi: ${paper.doi}` : `, ${buildPaperUrl(frontendUrl, paper)}`;
-    return `${authorText}, "${paper.title}"${venueText}, ${yearText}${locator}.`;
+  const authorText = authors
+    .map((author) => pickAuthorLabel(author))
+    .join(", ");
+  const yearText = paper.year ? String(paper.year) : "n.d.";
+  const venueText = paper.venue ? `, ${paper.venue}` : "";
+  const locator = paper.doi
+    ? `, doi: ${paper.doi}`
+    : `, ${buildPaperUrl(frontendUrl, paper)}`;
+  return `${authorText}, "${paper.title}"${venueText}, ${yearText}${locator}.`;
 }
 
 function buildMlaText(
-    paper: CitationPaper,
-    authors: CitationAuthor[],
-    frontendUrl: string,
+  paper: CitationPaper,
+  authors: CitationAuthor[],
+  frontendUrl: string,
 ): string {
-    const authorText = authors.map((author) => pickAuthorLabel(author)).join(", ");
-    const venueText = paper.venue ? `, ${paper.venue}` : "";
-    const yearText = paper.year ? `, ${paper.year}` : "";
-    const locator = paper.doi ? `. doi:${paper.doi}.` : `. ${buildPaperUrl(frontendUrl, paper)}.`;
-    return `${authorText}. "${paper.title}"${venueText}${yearText}${locator}`;
+  const authorText = authors
+    .map((author) => pickAuthorLabel(author))
+    .join(", ");
+  const venueText = paper.venue ? `, ${paper.venue}` : "";
+  const yearText = paper.year ? `, ${paper.year}` : "";
+  const locator = paper.doi
+    ? `. doi:${paper.doi}.`
+    : `. ${buildPaperUrl(frontendUrl, paper)}.`;
+  return `${authorText}. "${paper.title}"${venueText}${yearText}${locator}`;
 }
 
 export function buildCitation(
-    paper: CitationPaper,
-    authors: CitationAuthor[],
-    format: CitationFormat,
-    frontendUrl: string,
+  paper: CitationPaper,
+  authors: CitationAuthor[],
+  format: CitationFormat,
+  frontendUrl: string,
 ): { format: CitationFormat; citation: string; key: string | null } {
-    const firstAuthor = authors[0] ?? { name: null, displayName: null };
-    const key = `${pickSurname(firstAuthor)}${paper.year ?? "noyear"}${pickTitleKeyWord(paper.title)}`;
-    const entryType = pickEntryType(paper);
+  const firstAuthor = authors[0] ?? { name: null, displayName: null };
+  const key = `${pickSurname(firstAuthor)}${paper.year ?? "noyear"}${pickTitleKeyWord(paper.title)}`;
+  const entryType = pickEntryType(paper);
 
-    if (format === "bibtex") {
-        return {
-            format,
-            citation: buildBibTexBody(entryType, key, paper, authors, frontendUrl),
-            key,
-        };
-    }
+  if (format === "bibtex") {
+    return {
+      format,
+      citation: buildBibTexBody(entryType, key, paper, authors, frontendUrl),
+      key,
+    };
+  }
 
-    if (format === "biblatex") {
-        const { entryType: bibLatexType, extraFields } = toBibLaTeXEntryTypeAndFields(entryType);
-        return {
-            format,
-            citation: buildBibTexBody(
-                bibLatexType,
-                key,
-                paper,
-                authors,
-                frontendUrl,
-                extraFields,
-            ),
-            key,
-        };
-    }
+  if (format === "biblatex") {
+    const { entryType: bibLatexType, extraFields } =
+      toBibLaTeXEntryTypeAndFields(entryType);
+    return {
+      format,
+      citation: buildBibTexBody(
+        bibLatexType,
+        key,
+        paper,
+        authors,
+        frontendUrl,
+        extraFields,
+      ),
+      key,
+    };
+  }
 
-    if (format === "plain") {
-        return { format, citation: buildPlainText(paper, authors, frontendUrl), key: null };
-    }
+  if (format === "plain") {
+    return {
+      format,
+      citation: buildPlainText(paper, authors, frontendUrl),
+      key: null,
+    };
+  }
 
-    if (format === "apa") {
-        return { format, citation: buildApaText(paper, authors, frontendUrl), key: null };
-    }
+  if (format === "apa") {
+    return {
+      format,
+      citation: buildApaText(paper, authors, frontendUrl),
+      key: null,
+    };
+  }
 
-    if (format === "ieee") {
-        return { format, citation: buildIeeeText(paper, authors, frontendUrl), key: null };
-    }
+  if (format === "ieee") {
+    return {
+      format,
+      citation: buildIeeeText(paper, authors, frontendUrl),
+      key: null,
+    };
+  }
 
-    return { format, citation: buildMlaText(paper, authors, frontendUrl), key: null };
+  return {
+    format,
+    citation: buildMlaText(paper, authors, frontendUrl),
+    key: null,
+  };
 }
 
 export function isCitationFormat(value: string): value is CitationFormat {
-    return ["bibtex", "biblatex", "apa", "ieee", "mla", "plain"].includes(value);
+  return ["bibtex", "biblatex", "apa", "ieee", "mla", "plain"].includes(value);
 }

--- a/apps/api/src/utils/origin.ts
+++ b/apps/api/src/utils/origin.ts
@@ -1,23 +1,23 @@
 export function normalizeOrigin(value: string | undefined): string | null {
-    if (!value) return null;
+  if (!value) return null;
+  try {
+    return new URL(value).origin;
+  } catch {
     try {
-        return new URL(value).origin;
+      return new URL(decodeURIComponent(value)).origin;
     } catch {
-        try {
-            return new URL(decodeURIComponent(value)).origin;
-        } catch {
-            return null;
-        }
+      return null;
     }
+  }
 }
 
 export function parseOriginList(value: string | undefined): string[] {
-    return value
-        ? value
-            .split(",")
-            .map((origin) => origin.trim())
-            .filter(Boolean)
-        : [];
+  return value
+    ? value
+        .split(",")
+        .map((origin) => origin.trim())
+        .filter(Boolean)
+    : [];
 }
 
 /**
@@ -26,53 +26,58 @@ export function parseOriginList(value: string | undefined): string[] {
  * They do not match dots (`.`), so a wildcard only matches a single subdomain segment.
  */
 export function matchesOriginPattern(origin: string, pattern: string): boolean {
-    if (pattern === "*") return true;
-    if (!pattern.includes("*")) return origin === pattern;
+  if (pattern === "*") return true;
+  if (!pattern.includes("*")) return origin === pattern;
 
-    const parts = pattern.split("*");
-    const escapedParts = parts.map((part) => part.replace(/[|\\{}()[\]^$+?.]/g, "\\$&"));
-    const regexSource = `^${escapedParts.join("[a-zA-Z0-9-]+")}$`;
+  const parts = pattern.split("*");
+  const escapedParts = parts.map((part) =>
+    part.replace(/[|\\{}()[\]^$+?.]/g, "\\$&"),
+  );
+  const regexSource = `^${escapedParts.join("[a-zA-Z0-9-]+")}$`;
 
-    return new RegExp(regexSource).test(origin);
+  return new RegExp(regexSource).test(origin);
 }
 
 export function isAllowedOrigin(
-    origin: string | null | undefined,
-    frontendOrigin: string | null,
-    allowedOrigins: string[],
-    options: { allowWildcard?: boolean } = {},
+  origin: string | null | undefined,
+  frontendOrigin: string | null,
+  allowedOrigins: string[],
+  options: { allowWildcard?: boolean } = {},
 ): boolean {
-    if (!origin) return false;
-    if (frontendOrigin && origin === frontendOrigin) return true;
-    const normalizedFrontendOrigin = frontendOrigin ? normalizeOrigin(frontendOrigin) : null;
-    if (normalizedFrontendOrigin && origin === normalizedFrontendOrigin) return true;
+  if (!origin) return false;
+  if (frontendOrigin && origin === frontendOrigin) return true;
+  const normalizedFrontendOrigin = frontendOrigin
+    ? normalizeOrigin(frontendOrigin)
+    : null;
+  if (normalizedFrontendOrigin && origin === normalizedFrontendOrigin)
+    return true;
 
-    const allowWildcard = options.allowWildcard ?? true;
+  const allowWildcard = options.allowWildcard ?? true;
 
-    return allowedOrigins.some((allowedOrigin) => {
-        if (allowedOrigin.includes("*")) {
-            return allowWildcard && matchesOriginPattern(origin, allowedOrigin);
-        }
+  return allowedOrigins.some((allowedOrigin) => {
+    if (allowedOrigin.includes("*")) {
+      return allowWildcard && matchesOriginPattern(origin, allowedOrigin);
+    }
 
-        if (origin === allowedOrigin) return true;
-        const normalizedAllowedOrigin = normalizeOrigin(allowedOrigin);
-        return normalizedAllowedOrigin ? origin === normalizedAllowedOrigin : false;
-    });
+    if (origin === allowedOrigin) return true;
+    const normalizedAllowedOrigin = normalizeOrigin(allowedOrigin);
+    return normalizedAllowedOrigin ? origin === normalizedAllowedOrigin : false;
+  });
 }
 
 export function resolveAllowedOrigin(
-    candidates: Array<string | undefined>,
-    frontendUrl: string,
-    allowedOrigins: string[],
-    options: { allowWildcard?: boolean } = {},
+  candidates: Array<string | undefined>,
+  frontendUrl: string,
+  allowedOrigins: string[],
+  options: { allowWildcard?: boolean } = {},
 ): string {
-    const frontendOrigin = normalizeOrigin(frontendUrl);
-    for (const candidate of candidates) {
-        const normalized = normalizeOrigin(candidate);
-        if (isAllowedOrigin(normalized, frontendOrigin, allowedOrigins, options)) {
-            return normalized as string;
-        }
+  const frontendOrigin = normalizeOrigin(frontendUrl);
+  for (const candidate of candidates) {
+    const normalized = normalizeOrigin(candidate);
+    if (isAllowedOrigin(normalized, frontendOrigin, allowedOrigins, options)) {
+      return normalized as string;
     }
+  }
 
-    return frontendOrigin ?? frontendUrl;
+  return frontendOrigin ?? frontendUrl;
 }

--- a/apps/api/src/utils/tags.ts
+++ b/apps/api/src/utils/tags.ts
@@ -1,13 +1,13 @@
 export function parseStoredTags(rawTags: string | null): string[] {
-    if (!rawTags) return [];
-    try {
-        const parsed = JSON.parse(rawTags);
-        if (!Array.isArray(parsed)) return [];
-        return parsed
-            .filter((tag): tag is string => typeof tag === "string")
-            .map((tag) => tag.trim())
-            .filter((tag) => tag.length > 0);
-    } catch {
-        return [];
-    }
+  if (!rawTags) return [];
+  try {
+    const parsed = JSON.parse(rawTags);
+    if (!Array.isArray(parsed)) return [];
+    return parsed
+      .filter((tag): tag is string => typeof tag === "string")
+      .map((tag) => tag.trim())
+      .filter((tag) => tag.length > 0);
+  } catch {
+    return [];
+  }
 }

--- a/apps/web/src/app/__tests__/auth-callback.test.tsx
+++ b/apps/web/src/app/__tests__/auth-callback.test.tsx
@@ -15,25 +15,12 @@ describe("AuthCallback", () => {
 
   beforeEach(() => {
     replace.mockReset();
-    localStorage.clear();
-    window.location.hash = "";
   });
 
-  it("stores the token from the hash fragment", async () => {
-    window.location.hash = "#token=test-token";
-
+  it("redirects to home", async () => {
     render(<AuthCallback />);
 
     expect(screen.getByText("ログイン中...")).toBeInTheDocument();
-
-    await waitFor(() => {
-      expect(localStorage.getItem("auth_token")).toBe("test-token");
-      expect(replace).toHaveBeenCalledWith("/");
-    });
-  });
-
-  it("redirects even when no token is present", async () => {
-    render(<AuthCallback />);
 
     await waitFor(() => {
       expect(replace).toHaveBeenCalledWith("/");

--- a/apps/web/src/app/__tests__/collections-new.test.tsx
+++ b/apps/web/src/app/__tests__/collections-new.test.tsx
@@ -205,14 +205,18 @@ describe("NewCollectionPage", () => {
       target: { value: "bad--slug" },
     });
 
-    expect(await screen.findByText("※ 3-40文字, 英小文字/数字/ハイフン")).toBeInTheDocument();
+    expect(
+      await screen.findByText("※ 3-40文字, 英小文字/数字/ハイフン"),
+    ).toBeInTheDocument();
     expect(screen.getByRole("button", { name: "作成" })).toBeDisabled();
   });
 
   it("shows API error when create fails", async () => {
     vi.mocked(apiFetch).mockImplementation(async (url, init) => {
       if (url === "/api/users/user-1/collections") {
-        return new Response(JSON.stringify({ collections: [] }), { status: 200 });
+        return new Response(JSON.stringify({ collections: [] }), {
+          status: 200,
+        });
       }
       if (url === "/api/collections" && init?.method === "POST") {
         return new Response(JSON.stringify({ error: "already exists" }), {
@@ -228,7 +232,9 @@ describe("NewCollectionPage", () => {
       target: { value: "Lab Picks" },
     });
 
-    await waitFor(() => expect(screen.getByText("✓ 使用可能")).toBeInTheDocument());
+    await waitFor(() =>
+      expect(screen.getByText("✓ 使用可能")).toBeInTheDocument(),
+    );
     fireEvent.click(screen.getByRole("button", { name: "作成" }));
 
     expect(await screen.findByText("already exists")).toBeInTheDocument();

--- a/apps/web/src/app/__tests__/orgs-new.test.tsx
+++ b/apps/web/src/app/__tests__/orgs-new.test.tsx
@@ -115,7 +115,9 @@ describe("NewOrgPage", () => {
         return new Response("{}", { status: 404 });
       }
       if (url === "/api/orgs" && init?.method === "POST") {
-        return new Response(JSON.stringify({ error: "slug taken" }), { status: 409 });
+        return new Response(JSON.stringify({ error: "slug taken" }), {
+          status: 409,
+        });
       }
       throw new Error(`Unexpected request: ${String(url)}`);
     });

--- a/apps/web/src/app/auth/callback/page.tsx
+++ b/apps/web/src/app/auth/callback/page.tsx
@@ -6,12 +6,6 @@ import { useRouter } from "next/navigation";
 export default function AuthCallback() {
   const router = useRouter();
   useEffect(() => {
-    const hash = window.location.hash.substring(1);
-    const params = new URLSearchParams(hash);
-    const token = params.get("token");
-    if (token) {
-      localStorage.setItem("auth_token", token);
-    }
     router.replace("/");
   }, [router]);
   return <p>ログイン中...</p>;

--- a/apps/web/src/components/__tests__/auth-provider.test.tsx
+++ b/apps/web/src/components/__tests__/auth-provider.test.tsx
@@ -39,12 +39,10 @@ describe("AuthProvider", () => {
   });
 
   beforeEach(() => {
-    localStorage.clear();
     vi.clearAllMocks();
   });
 
-  it("sets user when token exists and /api/auth/me succeeds", async () => {
-    localStorage.setItem("auth_token", "token-1");
+  it("sets user when /api/auth/me succeeds", async () => {
     vi.mocked(apiFetch).mockResolvedValue(
       new Response(
         JSON.stringify({
@@ -72,21 +70,7 @@ describe("AuthProvider", () => {
     });
   });
 
-  it("keeps user null when token does not exist", async () => {
-    render(
-      <AuthProvider>
-        <Consumer />
-      </AuthProvider>,
-    );
-
-    await waitFor(() => {
-      expect(screen.getByTestId("loading").textContent).toBe("false");
-      expect(screen.getByTestId("user").textContent).toBe("null");
-    });
-  });
-
-  it("logout clears localStorage token and sets user null", async () => {
-    localStorage.setItem("auth_token", "token-1");
+  it("logout calls /api/auth/logout and sets user null", async () => {
     vi.mocked(apiFetch).mockResolvedValue(
       new Response(
         JSON.stringify({
@@ -112,11 +96,17 @@ describe("AuthProvider", () => {
     await waitFor(() => {
       expect(screen.getByTestId("user").textContent).toBe("Alice");
     });
+
+    vi.mocked(apiFetch).mockResolvedValueOnce(
+      new Response(JSON.stringify({ ok: true }), { status: 200 }),
+    );
 
     fireEvent.click(screen.getByRole("button", { name: "logout" }));
 
     await waitFor(() => {
-      expect(localStorage.getItem("auth_token")).toBeNull();
+      expect(apiFetch).toHaveBeenCalledWith("/api/auth/logout", {
+        method: "POST",
+      });
       expect(screen.getByTestId("user").textContent).toBe("null");
     });
   });
@@ -130,7 +120,6 @@ describe("AuthProvider", () => {
   });
 
   it("keeps user null when /api/auth/me responds with non-ok", async () => {
-    localStorage.setItem("auth_token", "token-1");
     vi.mocked(apiFetch).mockResolvedValue(new Response("{}", { status: 401 }));
 
     render(
@@ -146,7 +135,6 @@ describe("AuthProvider", () => {
   });
 
   it("keeps user null when /api/auth/me throws", async () => {
-    localStorage.setItem("auth_token", "token-1");
     vi.mocked(apiFetch).mockRejectedValue(new Error("network error"));
 
     render(
@@ -163,7 +151,9 @@ describe("AuthProvider", () => {
 
   it("login logs an error and does not navigate when NEXT_PUBLIC_API_URL is missing", async () => {
     vi.stubEnv("NEXT_PUBLIC_API_URL", "");
-    const errorSpy = vi.spyOn(console, "error").mockImplementation(() => undefined);
+    const errorSpy = vi
+      .spyOn(console, "error")
+      .mockImplementation(() => undefined);
     const originalLocation = window.location;
 
     try {
@@ -191,9 +181,10 @@ describe("AuthProvider", () => {
   });
 
   it("refresh re-fetches user data", async () => {
-    localStorage.setItem("auth_token", "token-1");
     vi.mocked(apiFetch)
-      .mockResolvedValueOnce(new Response(JSON.stringify({ user: null }), { status: 401 }))
+      .mockResolvedValueOnce(
+        new Response(JSON.stringify({ user: null }), { status: 401 }),
+      )
       .mockResolvedValueOnce(
         new Response(
           JSON.stringify({

--- a/apps/web/src/components/auth-provider.tsx
+++ b/apps/web/src/components/auth-provider.tsx
@@ -38,12 +38,6 @@ export function AuthProvider({ children }: { children: React.ReactNode }) {
 
   const fetchUser = useCallback(async () => {
     try {
-      const token = localStorage.getItem("auth_token");
-      if (!token) {
-        setUser(null);
-        setLoading(false);
-        return;
-      }
       const res = await apiFetch("/api/auth/me");
       if (res.ok) {
         const data = await res.json();
@@ -75,7 +69,11 @@ export function AuthProvider({ children }: { children: React.ReactNode }) {
   }, []);
 
   const logout = useCallback(async () => {
-    localStorage.removeItem("auth_token");
+    try {
+      await apiFetch("/api/auth/logout", { method: "POST" });
+    } catch (e) {
+      console.error("Logout failed", e);
+    }
     setUser(null);
   }, []);
 

--- a/apps/web/src/lib/__tests__/api.test.ts
+++ b/apps/web/src/lib/__tests__/api.test.ts
@@ -1,24 +1,12 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
-import { apiFetch, authHeaders } from "../api";
+import { apiFetch } from "../api";
 
 describe("api helpers", () => {
   beforeEach(() => {
-    localStorage.clear();
     vi.restoreAllMocks();
   });
 
-  it("authHeaders returns Authorization header when token exists", () => {
-    localStorage.setItem("auth_token", "abc123");
-
-    expect(authHeaders()).toEqual({ Authorization: "Bearer abc123" });
-  });
-
-  it("authHeaders returns empty object when token does not exist", () => {
-    expect(authHeaders()).toEqual({});
-  });
-
-  it("apiFetch calls API_BASE + path with Authorization header", async () => {
-    localStorage.setItem("auth_token", "token-x");
+  it("apiFetch calls API_BASE + path with credentials include", async () => {
     const fetchMock = vi
       .spyOn(globalThis, "fetch")
       .mockResolvedValue(new Response(null, { status: 200 }));
@@ -28,8 +16,6 @@ describe("api helpers", () => {
     expect(fetchMock).toHaveBeenCalledTimes(1);
     const [url, init] = fetchMock.mock.calls[0];
     expect(url).toBe("/api/auth/me");
-    expect((init?.headers as Record<string, string>).Authorization).toBe(
-      "Bearer token-x",
-    );
+    expect(init?.credentials).toBe("include");
   });
 });

--- a/apps/web/src/lib/api.ts
+++ b/apps/web/src/lib/api.ts
@@ -1,17 +1,11 @@
 const API_BASE = process.env.NEXT_PUBLIC_API_URL ?? "";
 
-export function authHeaders(): HeadersInit {
-  const token =
-    typeof window !== "undefined" ? localStorage.getItem("auth_token") : null;
-  return token ? { Authorization: `Bearer ${token}` } : {};
-}
-
 export async function apiFetch(
   path: string,
   init?: RequestInit,
 ): Promise<Response> {
   return fetch(`${API_BASE}${path}`, {
     ...init,
-    headers: { ...authHeaders(), ...init?.headers },
+    credentials: init?.credentials ?? "include",
   });
 }


### PR DESCRIPTION
🎯 **What:**
Changed the authentication flow to store the JWT inside an HttpOnly `auth_token` cookie rather than persisting it in `localStorage`.

⚠️ **Risk:**
Storing the JWT in `localStorage` leaves the token vulnerable to Cross-Site Scripting (XSS) attacks. If an attacker injects malicious scripts into the frontend application, they could easily read the `auth_token` from `localStorage` and use it to impersonate the user.

🛡️ **Solution:**
- Updated the backend `/api/auth/github/callback` to set the `auth_token` inside an HttpOnly and secure cookie.
- Modified the authentication middleware (`authMiddleware`) to fall back to the `auth_token` cookie if the `Authorization` header is not present.
- Updated `/api/auth/logout` to clear the `auth_token` cookie upon logout.
- Removed `localStorage.setItem` from the frontend callback route.
- Updated `apiFetch` in `apps/web/src/lib/api.ts` to use `credentials: "include"` instead of reading from `localStorage` and injecting the token into headers.
- Adapted `AuthProvider` to rely fully on the backend session by calling the `/api/auth/me` and `/api/auth/logout` endpoints.

---
*PR created automatically by Jules for task [14824296781014644015](https://jules.google.com/task/14824296781014644015) started by @is0692vs*

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

JWT の保存場所を `localStorage` から HttpOnly Cookie に移行することで XSS によるトークン窃取リスクを排除します。バックエンドのコールバックで Cookie を発行し、`authMiddleware` がヘッダーと Cookie の両方を受け入れるよう拡張、フロントエンドは `credentials: "include"` で通信する構成に変わります。

- **バックエンド**: `/api/auth/github/callback` が HttpOnly Cookie を発行、`authMiddleware` が Bearer → Cookie のフォールバックを実装、`/api/auth/logout` が Cookie を削除するよう更新。
- **フロントエンド**: コールバックページから `localStorage.setItem` を除去、`apiFetch` は `credentials: "include"` を使用、`AuthProvider` はサーバーの `/api/auth/me` / `/api/auth/logout` に完全委譲する形に刷新。
</details>

<details open><summary><h3>Confidence Score: 3/5</h3></summary>

Cookie ベース認証への移行の方向性は正しいが、`secure` フラグの算出方法の不整合、Cookie `domain` の設定ミス、`sameSite: Lax` とクロスオリジン fetch の非互換という複数の問題が重なっており、本番環境での正常動作が難しい状態。

OAuth コールバックで発行する `auth_token` Cookie の `secure` フラグをフロントエンド URL のプロトコルから導出する不整合（同ファイル内の他 Cookie は API リクエスト URL から正しく取得）に加え、既存スレッドで指摘されたドメイン設定ミスおよび `sameSite: Lax` とクロスオリジン fetch の非互換が重複しており、複数の実装上の問題が未解決のままマージされると本番で認証が全断するリスクがある。

apps/api/src/routes/auth.ts の Cookie 発行ロジック（`secure` フラグ・`domain` 属性・`sameSite` 設定・ログアウト時の `deleteCookie`）を重点的に確認してください。
</details>

<details open><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| apps/api/src/routes/auth.ts | GitHub OAuth コールバックで JWT を HttpOnly Cookie として発行するよう変更。`secure` フラグをフロントエンド URL のプロトコルから導出している不整合あり。 |
| apps/api/src/middleware/auth.ts | 認証ミドルウェアを Bearer ヘッダー優先、なければ `auth_token` Cookie にフォールバックするよう拡張。ロジックは正確で既存テストでカバー済み。 |
| apps/web/src/lib/api.ts | `authHeaders()` を削除し、`credentials: include` を付与するシンプルな実装に変更。 |
| apps/web/src/components/auth-provider.tsx | localStorage 依存を除去し、`/api/auth/me` と `/api/auth/logout` エンドポイントに委譲する形に刷新。 |
| apps/web/src/app/auth/callback/page.tsx | ハッシュから JWT を読み取って localStorage に保存していたコードを削除。リダイレクトのみの実装になった。 |
| apps/api/src/index.ts | CSRF ミドルウェアが Bearer トークンをバイパス、Cookie 認証リクエストは Origin/Referer チェックを経由する既存構造。本 PR での変更はトレーリングカンマ修正のみ。 |

</details>

</details>

<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant Browser
    participant Frontend as Next.js Frontend
    participant API as Hono API
    participant GitHub as GitHub OAuth

    Browser->>Frontend: ログインボタンクリック
    Frontend->>API: GET /api/auth/github
    API->>API: state + nonce を DB 保存
    API-->>Browser: 302 + nonce Cookie (HttpOnly)
    Browser->>GitHub: OAuth 認可ページ
    GitHub-->>Browser: 302 callback へリダイレクト
    Browser->>API: GET /api/auth/github/callback
    API->>GitHub: code をトークンに交換
    GitHub-->>API: access token
    API->>GitHub: ユーザー情報取得
    GitHub-->>API: user payload
    API->>API: ユーザー upsert + JWT 生成
    API-->>Browser: 302 + auth_token Cookie (HttpOnly)
    Browser->>Frontend: /auth/callback ページ
    Frontend->>API: GET /api/auth/me (credentials include)
    API->>API: authMiddleware: Cookie から JWT を検証
    API-->>Frontend: ユーザー情報
    Frontend-->>Browser: ログイン完了

    Browser->>Frontend: ログアウト操作
    Frontend->>API: POST /api/auth/logout
    API-->>Browser: Cookie 削除 + ok
    Frontend->>Frontend: setUser(null)
```

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 1 code review issue. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 1
apps/api/src/routes/auth.ts:245-246
`isSecure` をフロントエンド URL のプロトコルから導出していますが、同ファイル内の OAuth フロー Cookie（44・51行目）と同様に **API サーバーのリクエスト URL** から取得するのが正しい実装です。API が HTTP でフロントエンドが HTTPS の場合、`secure: true` の Cookie がブラウザから API に送られず全認証リクエストが 401 になります。

```suggestion
  const frontendUrlObj = new URL(frontendUrl);
  const isSecure = new URL(c.req.url).protocol === "https:";
```

`````

</details>

<sub>Reviews (2): Last reviewed commit: ["🔒 Fix: Migrate JWT from LocalStorage to..."](https://github.com/hiroki-org/openshelf/commit/47361f1ca7490976c6c24c2a1c3a966c0a0091fa) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=31466089)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->