### PR TITLE
🧹 [Code Health] Replace 'as any' with type guards in orgs.ts

### DIFF
--- a/apps/api/src/routes/orgs.ts
+++ b/apps/api/src/routes/orgs.ts
@@ -86,11 +86,21 @@ function hasJwtSub(value: unknown): value is Pick<JwtPayload, "sub"> {
 
 const MEMBER_ROLES = ["admin", "member"] as const;
 
+function isMemberRole(role: unknown): role is (typeof MEMBER_ROLES)[number] {
+  return (MEMBER_ROLES as readonly unknown[]).includes(role);
+}
+
 const escapeLikeLiteral = (str: string) => {
   return str.replace(/[\\%_]/g, "\\$&");
 };
 
 const ADMIN_LIKE_ROLES = ["admin", "owner"] as const;
+
+function isAdminLikeRole(
+  role: unknown,
+): role is (typeof ADMIN_LIKE_ROLES)[number] {
+  return (ADMIN_LIKE_ROLES as readonly unknown[]).includes(role);
+}
 
 // ─── Validation helpers ─────────────────────────────────────────
 const SLUG_RE = /^[a-z0-9][a-z0-9-]*[a-z0-9]$|^[a-z0-9]$/;
@@ -144,7 +154,7 @@ async function requireOrgAdmin(
   userId: string,
 ) {
   const membership = await getOrgMembership(db, orgId, userId);
-  if (!membership || !ADMIN_LIKE_ROLES.includes(membership.role as any)) {
+  if (!membership || !isAdminLikeRole(membership.role)) {
     return { ok: false as const, error: "Forbidden: admin access required" };
   }
   return { ok: true as const, membership };
@@ -534,7 +544,7 @@ orgsRoute.post("/:slug/members", authMiddleware, async (c) => {
   const targetUserId = targetUserIdResult.value as string;
 
   const rawRole = payload.role ?? "member";
-  if (!MEMBER_ROLES.includes(rawRole as any)) {
+  if (!isMemberRole(rawRole)) {
     return c.json({ error: "role must be 'admin' or 'member'" }, 400);
   }
   const role = rawRole as "admin" | "member";
@@ -571,7 +581,10 @@ orgsRoute.post("/:slug/members", authMiddleware, async (c) => {
 // PATCH /api/orgs/:slug/members/:userId — change role
 orgsRoute.patch("/:slug/members/:userId", authMiddleware, async (c) => {
   const slug = c.req.param("slug");
-  const targetUserIdResult = normalizeBoundedId(c.req.param("userId"), "userId");
+  const targetUserIdResult = normalizeBoundedId(
+    c.req.param("userId"),
+    "userId",
+  );
   if (targetUserIdResult.error) {
     return c.json({ error: targetUserIdResult.error }, 400);
   }
@@ -609,16 +622,13 @@ orgsRoute.patch("/:slug/members/:userId", authMiddleware, async (c) => {
   }
 
   const rawRole = payload.role;
-  if (!MEMBER_ROLES.includes(rawRole as any)) {
+  if (!isMemberRole(rawRole)) {
     return c.json({ error: "role must be 'admin' or 'member'" }, 400);
   }
   const newRole = rawRole as "admin" | "member";
 
   // Prevent demoting the last admin purely via atomic update check
-  if (
-    newRole === "member" &&
-    ADMIN_LIKE_ROLES.includes(membership.role as any)
-  ) {
+  if (newRole === "member" && isAdminLikeRole(membership.role)) {
     const result = await db
       .update(orgMembers)
       .set({ role: newRole })
@@ -649,7 +659,10 @@ orgsRoute.patch("/:slug/members/:userId", authMiddleware, async (c) => {
 // DELETE /api/orgs/:slug/members/:userId — remove member
 orgsRoute.delete("/:slug/members/:userId", authMiddleware, async (c) => {
   const slug = c.req.param("slug");
-  const targetUserIdResult = normalizeBoundedId(c.req.param("userId"), "userId");
+  const targetUserIdResult = normalizeBoundedId(
+    c.req.param("userId"),
+    "userId",
+  );
   if (targetUserIdResult.error) {
     return c.json({ error: targetUserIdResult.error }, 400);
   }
@@ -672,7 +685,7 @@ orgsRoute.delete("/:slug/members/:userId", authMiddleware, async (c) => {
   }
 
   // Prevent removing the last admin purely via atomic delete check
-  if (ADMIN_LIKE_ROLES.includes(membership.role as any)) {
+  if (isAdminLikeRole(membership.role)) {
     const result = await db
       .delete(orgMembers)
       .where(
@@ -1014,9 +1027,7 @@ orgsRoute.post("/:slug/papers", authMiddleware, async (c) => {
   const existing = await db
     .select()
     .from(paperOrgs)
-    .where(
-      and(eq(paperOrgs.paperId, paperId), eq(paperOrgs.orgId, org.id)),
-    )
+    .where(and(eq(paperOrgs.paperId, paperId), eq(paperOrgs.orgId, org.id)))
     .get();
   if (existing)
     return c.json({ error: "Paper is already associated with this org" }, 409);


### PR DESCRIPTION
🎯 **What:** The code health issue addressed
Replaced the use of `.includes(... as any)` with proper type guards (`isMemberRole` and `isAdminLikeRole`) when validating user roles against `MEMBER_ROLES` and `ADMIN_LIKE_ROLES` in `apps/api/src/routes/orgs.ts`.

💡 **Why:** How this improves maintainability
Using `as any` bypasses TypeScript's type checking system and can hide potential errors if the types of the underlying lists or input variables change. By defining reusable, strongly-typed type guards (`isMemberRole(role: unknown): role is ...`), we rely on TypeScript's inference and type-narrowing features. This improves readability, provides better intellisense, and prevents potential bugs related to unchecked downcasting.

✅ **Verification:** How you confirmed the change is safe
Ran the full test suite (`bun x vitest run apps/api/` and `bun x vitest run apps/web/`). All 414 backend tests and 141 frontend tests passed successfully without regressions. Verified the type guards work by using static type inferences in the code. Formatted `orgs.ts` with Prettier.

✨ **Result:** The improvement achieved
Eliminated 5 instances of unsafe type casting (`as any`) for role checking, resulting in safer and cleaner TypeScript code in `apps/api/src/routes/orgs.ts`.

---
*PR created automatically by Jules for task [16589670378835033795](https://jules.google.com/task/16589670378835033795) started by @is0692vs*

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

このPR（`apps/api/src/routes/orgs.ts` の `as any` を型ガードに置き換え）のレビューを完了しました。2件のP2スタイル指摘（型ガード後の冗長な `as "admin" | "member"` キャスト）を行い、信頼スコア4/5でレビューを提出しました。
</details>

<details open><summary><h3>Confidence Score: 4/5</h3></summary>

ロール検証ロジックの動作は変わらず、型安全性の改善のみが目的であるためマージは安全です。

型ガード後に残る2箇所の冗長な `as "admin" | "member"` キャストは機能的な影響を持たないスタイル上の課題であり、ビジネスロジックや実行時挙動に変化はありません。

apps/api/src/routes/orgs.ts — 型ガード後に残る冗長なキャストの修正を検討してください。
</details>

<details open><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| apps/api/src/routes/orgs.ts | `as any` を型ガード（`isMemberRole`・`isAdminLikeRole`）に置き換え、型安全性を向上。型ガード後に残っている冗長な `as "admin" | "member"` キャストが2箇所存在するが機能的な問題はない。 |

</details>

</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 2 code review issues. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 2
apps/api/src/routes/orgs.ts:547-550
`isMemberRole` による型ガードが成功した後、TypeScript はすでに `rawRole` を `"admin" | "member"` に絞り込んでいるため、直後の `as "admin" | "member"` キャストは冗長です。型ガードを導入した本 PR の目的（`as` キャストの排除）を一貫させるためにも削除を検討してください。

```suggestion
  if (!isMemberRole(rawRole)) {
    return c.json({ error: "role must be 'admin' or 'member'" }, 400);
  }
  const role = rawRole;
```

### Issue 2 of 2
apps/api/src/routes/orgs.ts:625-628
こちらも同様に、`isMemberRole(rawRole)` が通過した後は `rawRole` が `"admin" | "member"` に型ナローイングされているため、`as "admin" | "member"` キャストは不要です。

```suggestion
  if (!isMemberRole(rawRole)) {
    return c.json({ error: "role must be 'admin' or 'member'" }, 400);
  }
  const newRole = rawRole;
```

`````

</details>

<sub>Reviews (1): Last reviewed commit: ["refactor(orgs): replace as any with type..."](https://github.com/hiroki-org/openshelf/commit/652f59fb9979e92ac23760367a4501b3f9067318) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=31473680)</sub>

> Greptile also left **2 inline comments** on this PR.

<!-- /greptile_comment -->