### PR TITLE
🧹 [code health improvement] Refactor role validation using type guards in orgs.ts

### DIFF
--- a/apps/api/src/routes/orgs.ts
+++ b/apps/api/src/routes/orgs.ts
@@ -90,7 +90,22 @@ const escapeLikeLiteral = (str: string) => {
   return str.replace(/[\\%_]/g, "\\$&");
 };
 
+type MemberRole = (typeof MEMBER_ROLES)[number];
+function isMemberRole(role: unknown): role is MemberRole {
+  return (
+    typeof role === "string" &&
+    (MEMBER_ROLES as readonly string[]).includes(role)
+  );
+}
+
 const ADMIN_LIKE_ROLES = ["admin", "owner"] as const;
+type AdminLikeRole = (typeof ADMIN_LIKE_ROLES)[number];
+function isAdminLikeRole(role: unknown): role is AdminLikeRole {
+  return (
+    typeof role === "string" &&
+    (ADMIN_LIKE_ROLES as readonly string[]).includes(role)
+  );
+}
 
 // ─── Validation helpers ─────────────────────────────────────────
 const SLUG_RE = /^[a-z0-9][a-z0-9-]*[a-z0-9]$|^[a-z0-9]$/;
@@ -144,7 +159,7 @@ async function requireOrgAdmin(
   userId: string,
 ) {
   const membership = await getOrgMembership(db, orgId, userId);
-  if (!membership || !ADMIN_LIKE_ROLES.includes(membership.role as any)) {
+  if (!membership || !isAdminLikeRole(membership.role)) {
     return { ok: false as const, error: "Forbidden: admin access required" };
   }
   return { ok: true as const, membership };
@@ -534,7 +549,7 @@ orgsRoute.post("/:slug/members", authMiddleware, async (c) => {
   const targetUserId = targetUserIdResult.value as string;
 
   const rawRole = payload.role ?? "member";
-  if (!MEMBER_ROLES.includes(rawRole as any)) {
+  if (!isMemberRole(rawRole)) {
     return c.json({ error: "role must be 'admin' or 'member'" }, 400);
   }
   const role = rawRole as "admin" | "member";
@@ -571,7 +586,10 @@ orgsRoute.post("/:slug/members", authMiddleware, async (c) => {
 // PATCH /api/orgs/:slug/members/:userId — change role
 orgsRoute.patch("/:slug/members/:userId", authMiddleware, async (c) => {
   const slug = c.req.param("slug");
-  const targetUserIdResult = normalizeBoundedId(c.req.param("userId"), "userId");
+  const targetUserIdResult = normalizeBoundedId(
+    c.req.param("userId"),
+    "userId",
+  );
   if (targetUserIdResult.error) {
     return c.json({ error: targetUserIdResult.error }, 400);
   }
@@ -609,16 +627,13 @@ orgsRoute.patch("/:slug/members/:userId", authMiddleware, async (c) => {
   }
 
   const rawRole = payload.role;
-  if (!MEMBER_ROLES.includes(rawRole as any)) {
+  if (!isMemberRole(rawRole)) {
     return c.json({ error: "role must be 'admin' or 'member'" }, 400);
   }
   const newRole = rawRole as "admin" | "member";
 
   // Prevent demoting the last admin purely via atomic update check
-  if (
-    newRole === "member" &&
-    ADMIN_LIKE_ROLES.includes(membership.role as any)
-  ) {
+  if (newRole === "member" && isAdminLikeRole(membership.role)) {
     const result = await db
       .update(orgMembers)
       .set({ role: newRole })
@@ -649,7 +664,10 @@ orgsRoute.patch("/:slug/members/:userId", authMiddleware, async (c) => {
 // DELETE /api/orgs/:slug/members/:userId — remove member
 orgsRoute.delete("/:slug/members/:userId", authMiddleware, async (c) => {
   const slug = c.req.param("slug");
-  const targetUserIdResult = normalizeBoundedId(c.req.param("userId"), "userId");
+  const targetUserIdResult = normalizeBoundedId(
+    c.req.param("userId"),
+    "userId",
+  );
   if (targetUserIdResult.error) {
     return c.json({ error: targetUserIdResult.error }, 400);
   }
@@ -672,7 +690,7 @@ orgsRoute.delete("/:slug/members/:userId", authMiddleware, async (c) => {
   }
 
   // Prevent removing the last admin purely via atomic delete check
-  if (ADMIN_LIKE_ROLES.includes(membership.role as any)) {
+  if (isAdminLikeRole(membership.role)) {
     const result = await db
       .delete(orgMembers)
       .where(
@@ -1014,9 +1032,7 @@ orgsRoute.post("/:slug/papers", authMiddleware, async (c) => {
   const existing = await db
     .select()
     .from(paperOrgs)
-    .where(
-      and(eq(paperOrgs.paperId, paperId), eq(paperOrgs.orgId, org.id)),
-    )
+    .where(and(eq(paperOrgs.paperId, paperId), eq(paperOrgs.orgId, org.id)))
     .get();
   if (existing)
     return c.json({ error: "Paper is already associated with this org" }, 409);


### PR DESCRIPTION
🎯 **What:** Replaced `as any` type casting with proper type guards `isMemberRole` and `isAdminLikeRole` for role validation in `apps/api/src/routes/orgs.ts`.

💡 **Why:** Using `as any` defeats TypeScript's safety guarantees and makes the code harder to reason about and maintain. Introducing specific type guards enhances code health by explicitly validating that unknown inputs map to the expected narrow types (`MemberRole`, `AdminLikeRole`) before checking array inclusion, improving both type safety and runtime safety.

✅ **Verification:** 
- The full test suites for `apps/api` and `apps/web` were run and passed successfully.
- Code was formatted.
- `bun run typecheck` passed cleanly across workspaces.

✨ **Result:** Improved maintainability and type safety in the organization role management endpoints without altering any runtime behavior.

---
*PR created automatically by Jules for task [16503400927389878814](https://jules.google.com/task/16503400927389878814) started by @is0692vs*

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

`apps/api/src/routes/orgs.ts` にて、ロール検証の `as any` 型アサーションを `isMemberRole` / `isAdminLikeRole` という2つの型ガードに置き換えるリファクタリングです。型ガード自体は正しく実装されており、ランタイムの動作変更はありません。

- `isMemberRole` と `isAdminLikeRole` を新たに追加し、4箇所の `as any` アサーションをすべてガード関数に統一した。
- ガード通過後の `const role = rawRole as "admin" | "member"` が2箇所残っており、型ガードによる絞り込みで既に不要になっている（P2 提案あり）。
- フォーマット調整として `normalizeBoundedId` 呼び出しと `.where(and(...))` の引数改行も含まれている。
</details>

<details open><summary><h3>Confidence Score: 4/5</h3></summary>

ロール検証ロジックの変更はすべて等価であり、マージしても安全です。

型ガードの実装・配置・使用箇所はいずれも正しく、ランタイム動作の変化はありません。ガード通過後に `as "admin" | "member"` が残っている点は、型安全性向上というPRの目標を完全に達成しきれていない軽微な不整合ですが、バグや安全上の問題ではありません。

apps/api/src/routes/orgs.ts の553行目・633行目付近の残余アサーション
</details>

<details open><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| apps/api/src/routes/orgs.ts | `as any` を `isMemberRole` / `isAdminLikeRole` の型ガードに置き換えた。型ガード自体は正しく実装されているが、ガード通過後も `as "admin" | "member"` の冗長なアサーションが2箇所残っている。 |

</details>

</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 2 code review issues. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 2
apps/api/src/routes/orgs.ts:551-555
`isMemberRole` ガードが通過した後、TypeScript は `rawRole` の型を既に `MemberRole`（= `"admin" | "member"`）に絞り込んでいます。そのため `as "admin" | "member"` の型アサーションは冗長です。`as any` を排除することがこのPRの目的であるなら、この残余アサーションも合わせて除去すると一貫性が高まります。

```suggestion
  const rawRole = payload.role ?? "member";
  if (!isMemberRole(rawRole)) {
    return c.json({ error: "role must be 'admin' or 'member'" }, 400);
  }
  const role = rawRole;
```

### Issue 2 of 2
apps/api/src/routes/orgs.ts:629-633
PATCH ハンドラでも同様に、`isMemberRole` によって `rawRole` が `MemberRole` に絞り込まれた後も `as "admin" | "member"` を使っています。ガードが意図通りに機能しているため、このアサーションは不要です。

```suggestion
  const rawRole = payload.role;
  if (!isMemberRole(rawRole)) {
    return c.json({ error: "role must be 'admin' or 'member'" }, 400);
  }
  const newRole = rawRole;
```

`````

</details>

<sub>Reviews (1): Last reviewed commit: ["🧹 refactor: replace &#39;as any&#39; with type ..."](https://github.com/hiroki-org/openshelf/commit/01a6d3d36a2be17c585e694fb6acdb9a2e78e529) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=31473767)</sub>

> Greptile also left **2 inline comments** on this PR.

<!-- /greptile_comment -->