### PR TITLE
🧹 [Code Health] Remove 'any' casting in role inclusion checks in orgs route

### DIFF
--- a/apps/api/src/routes/orgs.ts
+++ b/apps/api/src/routes/orgs.ts
@@ -144,7 +144,7 @@ async function requireOrgAdmin(
   userId: string,
 ) {
   const membership = await getOrgMembership(db, orgId, userId);
-  if (!membership || !ADMIN_LIKE_ROLES.includes(membership.role as any)) {
+  if (!membership || !(ADMIN_LIKE_ROLES as readonly string[]).includes(membership.role)) {
     return { ok: false as const, error: "Forbidden: admin access required" };
   }
   return { ok: true as const, membership };
@@ -534,7 +534,7 @@ orgsRoute.post("/:slug/members", authMiddleware, async (c) => {
   const targetUserId = targetUserIdResult.value as string;
 
   const rawRole = payload.role ?? "member";
-  if (!MEMBER_ROLES.includes(rawRole as any)) {
+  if (!(MEMBER_ROLES as readonly unknown[]).includes(rawRole)) {
     return c.json({ error: "role must be 'admin' or 'member'" }, 400);
   }
   const role = rawRole as "admin" | "member";
@@ -609,7 +609,7 @@ orgsRoute.patch("/:slug/members/:userId", authMiddleware, async (c) => {
   }
 
   const rawRole = payload.role;
-  if (!MEMBER_ROLES.includes(rawRole as any)) {
+  if (!(MEMBER_ROLES as readonly unknown[]).includes(rawRole)) {
     return c.json({ error: "role must be 'admin' or 'member'" }, 400);
   }
   const newRole = rawRole as "admin" | "member";
@@ -617,7 +617,7 @@ orgsRoute.patch("/:slug/members/:userId", authMiddleware, async (c) => {
   // Prevent demoting the last admin purely via atomic update check
   if (
     newRole === "member" &&
-    ADMIN_LIKE_ROLES.includes(membership.role as any)
+    (ADMIN_LIKE_ROLES as readonly string[]).includes(membership.role)
   ) {
     const result = await db
       .update(orgMembers)
@@ -672,7 +672,7 @@ orgsRoute.delete("/:slug/members/:userId", authMiddleware, async (c) => {
   }
 
   // Prevent removing the last admin purely via atomic delete check
-  if (ADMIN_LIKE_ROLES.includes(membership.role as any)) {
+  if ((ADMIN_LIKE_ROLES as readonly string[]).includes(membership.role)) {
     const result = await db
       .delete(orgMembers)
       .where(


### PR DESCRIPTION
## 🧹 Code Health Improvement

🎯 **What:** Removed instances of `includes(x as any)` when checking `MEMBER_ROLES` and `ADMIN_LIKE_ROLES` in `apps/api/src/routes/orgs.ts`. Replaced them with type-safe assertions like `!(MEMBER_ROLES as readonly unknown[]).includes(rawRole)` and `!(ADMIN_LIKE_ROLES as readonly string[]).includes(membership.role)`.

💡 **Why:** Using `as any` defeats the purpose of TypeScript's type checking. By correctly casting the array to `readonly unknown[]` or `readonly string[]` (since `.includes` on a `const` array of strings expects a string argument matching its specific type union in older TS, or we can broaden the array type), we can safely pass `unknown` or `string` to `.includes()` without bypassing type safety completely. This prevents accidental introduction of bugs if the underlying types change and improves code maintainability.

✅ **Verification:** Verified by running `bun x tsc --noEmit` in `apps/api` and confirming no type errors were introduced. Also ran `bun x eslint` and the full test suites for both `apps/api` and `apps/web` to ensure no functional regressions were introduced.

✨ **Result:** Improved type safety and cleaner code in the organizations API routes.

---
*PR created automatically by Jules for task [9649602087841108907](https://jules.google.com/task/9649602087841108907) started by @is0692vs*

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

org ルートにおける `MEMBER_ROLES` および `ADMIN_LIKE_ROLES` の `.includes()` 呼び出しで使用していた `as any` キャストを、文脈に応じた `readonly unknown[]` / `readonly string[]` キャストに置き換えた型安全性の改善です。

- `rawRole`（型：`unknown`）を渡す箇所では `MEMBER_ROLES as readonly unknown[]` を使用し、`membership.role`（型：`string`）を渡す箇所では `ADMIN_LIKE_ROLES as readonly string[]` を使用しており、それぞれの引数の型に合わせた一貫した選択が行われています。
- チェック通過後の `rawRole as "admin" | "member"` という型アサーションは今回の変更では残っており、型述語関数を導入することでこれも解消できます（提案コメント参照）。
</details>


<details open><summary><h3>Confidence Score: 4/5</h3></summary>

ロジックに変更はなく、型キャスト戦略のみの変更のためマージは安全です。

変更内容は `as any` を文脈に応じた `readonly unknown[]` / `readonly string[]` キャストへ置き換えたのみで、実行時の動作は同一です。チェック後の `rawRole as "admin" | "member"` アサーションが残っており、型述語関数を導入することで完全に解消できます。

apps/api/src/routes/orgs.ts — 型述語関数の導入を検討する価値があります。
</details>


<details open><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| apps/api/src/routes/orgs.ts | `as any` を `readonly unknown[]` / `readonly string[]` キャストに置き換えた型安全性改善。ロジックに変更なし。チェック後の `rawRole as "admin" | "member"` アサーションが残るため、型述語関数を導入するとより完全な型絞り込みが得られる。 |

</details>


</details>


<!-- greptile_failed_comments -->
<details open><summary><h3>Comments Outside Diff (1)</h3></summary>

1. `apps/api/src/routes/orgs.ts`, line 87 ([link](https://github.com/hiroki-org/openshelf/blob/f2a630ba756063ef15919832513b26b56233ec60/apps/api/src/routes/orgs.ts#L87)) 

   <a href="#"><img alt="P2" src="https://greptile-static-assets.s3.amazonaws.com/badges/p2.svg?v=7" align="top"></a> `MEMBER_ROLES` の型は `readonly ["admin", "member"]` ですが、`rawRole` の型は `unknown` なので `readonly unknown[]` にキャストするのは理にかなっています。ただし、このアプローチではチェック後も TypeScript は `rawRole` の型を絞り込めないため、結局 `rawRole as "admin" | "member"` という型アサーションが残ります。型述語関数を使うことで、`.includes()` チェックと型絞り込みを同時に実現でき、後続の `as` キャストが不要になります。

   

   <details><summary>Prompt To Fix With AI</summary>

   `````markdown
   This is a comment left during a code review.
   Path: apps/api/src/routes/orgs.ts
   Line: 87

   Comment:
   `MEMBER_ROLES` の型は `readonly ["admin", "member"]` ですが、`rawRole` の型は `unknown` なので `readonly unknown[]` にキャストするのは理にかなっています。ただし、このアプローチではチェック後も TypeScript は `rawRole` の型を絞り込めないため、結局 `rawRole as "admin" | "member"` という型アサーションが残ります。型述語関数を使うことで、`.includes()` チェックと型絞り込みを同時に実現でき、後続の `as` キャストが不要になります。

   

   How can I resolve this? If you propose a fix, please make it concise.
   `````
   </details>

</details>

<!-- /greptile_failed_comments -->

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 1 code review issue. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 1
apps/api/src/routes/orgs.ts:87
`MEMBER_ROLES` の型は `readonly ["admin", "member"]` ですが、`rawRole` の型は `unknown` なので `readonly unknown[]` にキャストするのは理にかなっています。ただし、このアプローチではチェック後も TypeScript は `rawRole` の型を絞り込めないため、結局 `rawRole as "admin" | "member"` という型アサーションが残ります。型述語関数を使うことで、`.includes()` チェックと型絞り込みを同時に実現でき、後続の `as` キャストが不要になります。

```suggestion
const MEMBER_ROLES = ["admin", "member"] as const;

function isMemberRole(value: unknown): value is "admin" | "member" {
  return (MEMBER_ROLES as readonly unknown[]).includes(value);
}
```


`````

</details>

<sub>Reviews (1): Last reviewed commit: ["🧹 \[Code Health\] Remove &#39;any&#39; casting in..."](https://github.com/hiroki-org/openshelf/commit/f2a630ba756063ef15919832513b26b56233ec60) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=31473967)</sub>

<!-- /greptile_comment -->