### PR TITLE
🧹 Code Health: remove 'any' type casting in orgs role checks

### DIFF
--- a/apps/api/src/routes/orgs.ts
+++ b/apps/api/src/routes/orgs.ts
@@ -92,6 +92,14 @@ const escapeLikeLiteral = (str: string) => {
 
 const ADMIN_LIKE_ROLES = ["admin", "owner"] as const;
 
+function isMemberRole(role: unknown): role is "admin" | "member" {
+  return (MEMBER_ROLES as readonly unknown[]).includes(role);
+}
+
+function isAdminLikeRole(role: unknown): role is "admin" | "owner" {
+  return (ADMIN_LIKE_ROLES as readonly unknown[]).includes(role);
+}
+
 // ─── Validation helpers ─────────────────────────────────────────
 const SLUG_RE = /^[a-z0-9][a-z0-9-]*[a-z0-9]$|^[a-z0-9]$/;
 
@@ -144,7 +152,7 @@ async function requireOrgAdmin(
   userId: string,
 ) {
   const membership = await getOrgMembership(db, orgId, userId);
-  if (!membership || !ADMIN_LIKE_ROLES.includes(membership.role as any)) {
+  if (!membership || !isAdminLikeRole(membership.role)) {
     return { ok: false as const, error: "Forbidden: admin access required" };
   }
   return { ok: true as const, membership };
@@ -534,10 +542,10 @@ orgsRoute.post("/:slug/members", authMiddleware, async (c) => {
   const targetUserId = targetUserIdResult.value as string;
 
   const rawRole = payload.role ?? "member";
-  if (!MEMBER_ROLES.includes(rawRole as any)) {
+  if (!isMemberRole(rawRole)) {
     return c.json({ error: "role must be 'admin' or 'member'" }, 400);
   }
-  const role = rawRole as "admin" | "member";
+  const role = rawRole;
 
   // Check user exists
   const targetUser = await db
@@ -571,7 +579,10 @@ orgsRoute.post("/:slug/members", authMiddleware, async (c) => {
 // PATCH /api/orgs/:slug/members/:userId — change role
 orgsRoute.patch("/:slug/members/:userId", authMiddleware, async (c) => {
   const slug = c.req.param("slug");
-  const targetUserIdResult = normalizeBoundedId(c.req.param("userId"), "userId");
+  const targetUserIdResult = normalizeBoundedId(
+    c.req.param("userId"),
+    "userId",
+  );
   if (targetUserIdResult.error) {
     return c.json({ error: targetUserIdResult.error }, 400);
   }
@@ -609,16 +620,13 @@ orgsRoute.patch("/:slug/members/:userId", authMiddleware, async (c) => {
   }
 
   const rawRole = payload.role;
-  if (!MEMBER_ROLES.includes(rawRole as any)) {
+  if (!isMemberRole(rawRole)) {
     return c.json({ error: "role must be 'admin' or 'member'" }, 400);
   }
-  const newRole = rawRole as "admin" | "member";
+  const newRole = rawRole;
 
   // Prevent demoting the last admin purely via atomic update check
-  if (
-    newRole === "member" &&
-    ADMIN_LIKE_ROLES.includes(membership.role as any)
-  ) {
+  if (newRole === "member" && isAdminLikeRole(membership.role)) {
     const result = await db
       .update(orgMembers)
       .set({ role: newRole })
@@ -649,7 +657,10 @@ orgsRoute.patch("/:slug/members/:userId", authMiddleware, async (c) => {
 // DELETE /api/orgs/:slug/members/:userId — remove member
 orgsRoute.delete("/:slug/members/:userId", authMiddleware, async (c) => {
   const slug = c.req.param("slug");
-  const targetUserIdResult = normalizeBoundedId(c.req.param("userId"), "userId");
+  const targetUserIdResult = normalizeBoundedId(
+    c.req.param("userId"),
+    "userId",
+  );
   if (targetUserIdResult.error) {
     return c.json({ error: targetUserIdResult.error }, 400);
   }
@@ -672,7 +683,7 @@ orgsRoute.delete("/:slug/members/:userId", authMiddleware, async (c) => {
   }
 
   // Prevent removing the last admin purely via atomic delete check
-  if (ADMIN_LIKE_ROLES.includes(membership.role as any)) {
+  if (isAdminLikeRole(membership.role)) {
     const result = await db
       .delete(orgMembers)
       .where(
@@ -1014,9 +1025,7 @@ orgsRoute.post("/:slug/papers", authMiddleware, async (c) => {
   const existing = await db
     .select()
     .from(paperOrgs)
-    .where(
-      and(eq(paperOrgs.paperId, paperId), eq(paperOrgs.orgId, org.id)),
-    )
+    .where(and(eq(paperOrgs.paperId, paperId), eq(paperOrgs.orgId, org.id)))
     .get();
   if (existing)
     return c.json({ error: "Paper is already associated with this org" }, 409);

--- a/apps/api/src/routes/orgs.ts
+++ b/apps/api/src/routes/orgs.ts
@@ -92,11 +92,11 @@ const escapeLikeLiteral = (str: string) => {
 
 const ADMIN_LIKE_ROLES = ["admin", "owner"] as const;
 
-function isMemberRole(role: unknown): role is "admin" | "member" {
+function isMemberRole(role: unknown): role is (typeof MEMBER_ROLES)[number] {
   return (MEMBER_ROLES as readonly unknown[]).includes(role);
 }
 
-function isAdminLikeRole(role: unknown): role is "admin" | "owner" {
+function isAdminLikeRole(role: unknown): role is (typeof ADMIN_LIKE_ROLES)[number] {
   return (ADMIN_LIKE_ROLES as readonly unknown[]).includes(role);
 }
 


### PR DESCRIPTION
🎯 **What:** Replaced `as any` casting for `MEMBER_ROLES` and `ADMIN_LIKE_ROLES` checks in `apps/api/src/routes/orgs.ts` with proper type guard functions (`isMemberRole` and `isAdminLikeRole`).

💡 **Why:** Using `any` bypasses TypeScript's type checking, making it easier to introduce bugs. Using proper type guards ensures we maintain type safety when checking if arbitrary user inputs correspond to valid roles. It also cleans up the variable assignments where `rawRole as "admin" | "member"` was unnecessarily done after type narrowing.

✅ **Verification:** Verified via `bun run lint` and running the full Vitest suite to ensure no regressions were introduced.

✨ **Result:** Improved type safety and cleaner, more readable code without changing the existing logic.

---
*PR created automatically by Jules for task [13393869615607683364](https://jules.google.com/task/13393869615607683364) started by @is0692vs*

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

`apps/api/src/routes/orgs.ts` における `as any` キャストを、専用の型ガード関数（`isMemberRole`・`isAdminLikeRole`）に置き換えた型安全性改善 PR です。実行時の動作変更は一切なく、型チェックの強化とコードの可読性向上が目的です。

- `isMemberRole(role: unknown): role is \"admin\" | \"member\"` と `isAdminLikeRole(role: unknown): role is \"admin\" | \"owner\"` を追加し、`MEMBER_ROLES.includes(rawRole as any)` の呼び出しをすべて置換。
- 型ガード後の型ナローイングにより `rawRole as \"admin\" | \"member\"` という余分なキャストが不要になり、削除されている。
- `normalizeBoundedId` 呼び出しや `and(...)` 呼び出しのフォーマット調整も含まれるが、動作に影響しない。
</details>

<details open><summary><h3>Confidence Score: 5/5</h3></summary>

マージ安全。実行時ロジックに変更はなく、型安全性の改善のみ。

`as any` を型ガード関数へ置き換えるリファクタリングのみで、ルーティングロジック・DB アクセス・エラーレスポンスに一切変更がない。型ガードの実装は TypeScript の標準的な回避策として正しく、返り値の型アノテーションも定数配列の内容と一致している。

特に注意が必要なファイルはない。
</details>

<details open><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| apps/api/src/routes/orgs.ts | 型ガード関数 `isMemberRole` / `isAdminLikeRole` を導入し、`as any` キャストを排除。ロジックの変更はなく、型安全性のみ向上している。 |

</details>

</details>

<sub>Reviews (1): Last reviewed commit: ["🧹 fix: remove &#39;any&#39; type casting in org..."](https://github.com/hiroki-org/openshelf/commit/ec8a8107b6dc121975cef7a8085e5a9ca0ae5d7a) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=31474317)</sub>

<!-- /greptile_comment -->