### PR TITLE
🧪 [testing improvement] コレクションへの論文追加時の予期せぬDBエラー伝播のテストを改善

### DIFF
--- a/apps/api/src/routes/__tests__/collections.test.ts
+++ b/apps/api/src/routes/__tests__/collections.test.ts
@@ -919,7 +919,7 @@ describe("collections routes", () => {
         expect(await res.json()).toEqual({ error: "Paper not found" });
     });
 
-    it("POST /api/collections/:id/papers ignores general db insert errors", async () => {
+    it("POST /api/collections/:id/papers propagates general db insert errors", async () => {
         queueSelectResponses([
             { getResult: { id: "c1", ownerType: "user", ownerId: "user-1" } },
             { getResult: { id: "p1" } },


### PR DESCRIPTION
🎯 **What:** `POST /api/collections/:id/papers` エンドポイントで、DBへの `insert` 時に一意制約エラー以外の予期せぬエラーが発生した場合、適切に500エラーとして伝播されることを確認するテストケースの要件に対応しました。

📊 **Coverage:** `collections.test.ts` の既存のテストを `propagates general db insert errors` と命名規則に沿って修正し、DB挿入時のモックエラーが確実に上位に伝播され500ステータスが返ることを網羅しています。

✨ **Result:** ルーティングでの例外ハンドリングが意図通りに動作していることを安全にテストでき、要件を正確に満たしました。

---
*PR created automatically by Jules for task [7875386824836424521](https://jules.google.com/task/7875386824836424521) started by @is0692vs*

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

テストケースの命名を修正するだけのシンプルな変更です。`POST /api/collections/:id/papers` エンドポイントでDB挿入時に予期せぬエラーが発生した場合のテストのタイトルが、実際の検証内容（500エラーの伝播確認）と一致するよう `"ignores"` から `"propagates"` へ変更されました。

- テスト本体のロジック・モック設定・アサーションには一切変更なし
- 旧テスト名 `"ignores general db insert errors"` は誤解を招く表現で（実際にはエラーを無視せず500として伝播させることを検証している）、今回の修正でその齟齬が解消された
</details>

<details open><summary><h3>Confidence Score: 5/5</h3></summary>

テスト名の修正のみであり、プロダクションコードへの影響はゼロです。安全にマージできます。

変更はテストケースの文字列1行のみです。旧テスト名 "ignores" は実際の振る舞いと真逆の印象を与えており、今回 "propagates" に修正されたことでテスト名とアサーション（500レスポンスの確認）が正確に対応するようになりました。テストロジック・モック・アサーションはすべて変更なしです。

特に注意が必要なファイルはありません。
</details>

<details open><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| apps/api/src/routes/__tests__/collections.test.ts | テスト名を "ignores general db insert errors" から "propagates general db insert errors" に変更。テスト本体の変更はなく、名前とテストの実際の検証内容（500レスポンスの確認）が一致するようになった。 |

</details>

</details>

<sub>Reviews (1): Last reviewed commit: ["🧪 \[testing improvement\] コレクションへの論文追加時の予..."](https://github.com/hiroki-org/openshelf/commit/fa26c80c15aa21baf5275dd862695d7d1f919bee) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=31476688)</sub>

<!-- /greptile_comment -->