### PR TITLE
🧹 [code health] Refactor TagAutocompleteInput by extracting useTagSuggestions hook

### DIFF
--- a/apps/web/src/components/tag-autocomplete-input.tsx
+++ b/apps/web/src/components/tag-autocomplete-input.tsx
@@ -115,15 +115,48 @@ function useTagSuggestions(value: string, orgSlug?: string) {
     };
   }, []);
 
+  const closeDropdown = () => {
+    setOpen(false);
+    setHighlightedIndex(-1);
+  };
+
+  const openDropdown = () => {
+    if (suggestions.length > 0) {
+      setOpen(true);
+    }
+  };
+
+  const scheduleBlurClose = () => {
+    if (blurTimeoutRef.current !== null) {
+      window.clearTimeout(blurTimeoutRef.current);
+    }
+    blurTimeoutRef.current = window.setTimeout(() => {
+      setOpen(false);
+    }, BLUR_DELAY_MS);
+  };
+
+  const moveHighlight = (direction: 1 | -1) => {
+    if (suggestions.length === 0) {
+      return;
+    }
+    setHighlightedIndex((prev) => {
+      if (direction === 1) {
+        return prev < suggestions.length - 1 ? prev + 1 : 0;
+      }
+      return prev > 0 ? prev - 1 : suggestions.length - 1;
+    });
+  };
+
   return {
     suggestions,
     highlightedIndex,
-    setHighlightedIndex,
     open,
-    setOpen,
     loading,
     committed,
-    blurTimeoutRef,
+    closeDropdown,
+    openDropdown,
+    scheduleBlurClose,
+    moveHighlight,
   };
 }
 
@@ -138,19 +171,19 @@ export function TagAutocompleteInput({
   const {
     suggestions,
     highlightedIndex,
-    setHighlightedIndex,
     open,
-    setOpen,
     loading,
     committed,
-    blurTimeoutRef,
+    closeDropdown,
+    openDropdown,
+    scheduleBlurClose,
+    moveHighlight,
   } = useTagSuggestions(value, orgSlug);
 
   const applySuggestion = (suggestion: string) => {
     const next = [...committed, suggestion].join(", ");
     onChange(`${next}, `);
-    setOpen(false);
-    setHighlightedIndex(-1);
+    closeDropdown();
   };
 
   const listId = `${id}-suggestions`;
@@ -166,39 +199,24 @@ export function TagAutocompleteInput({
         type="text"
         value={value}
         onChange={(event) => onChange(event.target.value)}
-        onFocus={() => {
-          if (suggestions.length > 0) setOpen(true);
-        }}
-        onBlur={() => {
-          if (blurTimeoutRef.current !== null) {
-            window.clearTimeout(blurTimeoutRef.current);
-          }
-          blurTimeoutRef.current = window.setTimeout(
-            () => setOpen(false),
-            BLUR_DELAY_MS,
-          );
-        }}
+        onFocus={openDropdown}
+        onBlur={scheduleBlurClose}
         onKeyDown={(event) => {
           if (!open || suggestions.length === 0) return;
 
           if (event.key === "ArrowDown") {
             event.preventDefault();
-            setHighlightedIndex((prev) =>
-              prev < suggestions.length - 1 ? prev + 1 : 0,
-            );
+            moveHighlight(1);
             return;
           }
           if (event.key === "ArrowUp") {
             event.preventDefault();
-            setHighlightedIndex((prev) =>
-              prev > 0 ? prev - 1 : suggestions.length - 1,
-            );
+            moveHighlight(-1);
             return;
           }
           if (event.key === "Escape") {
             event.preventDefault();
-            setOpen(false);
-            setHighlightedIndex(-1);
+            closeDropdown();
             return;
           }
           if (

--- a/apps/web/src/components/tag-autocomplete-input.tsx
+++ b/apps/web/src/components/tag-autocomplete-input.tsx
@@ -33,14 +33,7 @@ function splitEditingState(value: string): {
   return { committed, currentRaw, currentTrimmed: currentRaw.trim() };
 }
 
-export function TagAutocompleteInput({
-  id,
-  value,
-  onChange,
-  placeholder,
-  orgSlug,
-  className,
-}: TagAutocompleteInputProps) {
+function useTagSuggestions(value: string, orgSlug?: string) {
   const [suggestions, setSuggestions] = useState<string[]>([]);
   const [highlightedIndex, setHighlightedIndex] = useState(-1);
   const [open, setOpen] = useState(false);
@@ -121,6 +114,37 @@ export function TagAutocompleteInput({
       }
     };
   }, []);
+
+  return {
+    suggestions,
+    highlightedIndex,
+    setHighlightedIndex,
+    open,
+    setOpen,
+    loading,
+    committed,
+    blurTimeoutRef,
+  };
+}
+
+export function TagAutocompleteInput({
+  id,
+  value,
+  onChange,
+  placeholder,
+  orgSlug,
+  className,
+}: TagAutocompleteInputProps) {
+  const {
+    suggestions,
+    highlightedIndex,
+    setHighlightedIndex,
+    open,
+    setOpen,
+    loading,
+    committed,
+    blurTimeoutRef,
+  } = useTagSuggestions(value, orgSlug);
 
   const applySuggestion = (suggestion: string) => {
     const next = [...committed, suggestion].join(", ");


### PR DESCRIPTION
🎯 **What:** Extracted state management, API data fetching, and event handler logic from `TagAutocompleteInput` into a new custom hook `useTagSuggestions` within the same file.

💡 **Why:** `TagAutocompleteInput` was becoming overly long and difficult to read. By extracting the complex logic into a dedicated hook, the component's main body is now focused on presentation and UI, improving separation of concerns, readability, and overall maintainability.

✅ **Verification:** 
- Formatted the code using Prettier.
- Verified that component-level tests (`TagAutocompleteInput.test.tsx`) pass successfully.
- Verified that the entire test suite across all workspaces (`apps/api` and `apps/web`) passes successfully, ensuring no regressions.

✨ **Result:** A more concise and maintainable `TagAutocompleteInput` component with a dedicated `useTagSuggestions` hook handling its complex logic.

---
*PR created automatically by Jules for task [2750329662066076375](https://jules.google.com/task/2750329662066076375) started by @is0692vs*

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

タグ補完ロジック（APIフェッチ・デバウンス・キャッシュ・ハイライト管理）を `TagAutocompleteInput` コンポーネントから `useTagSuggestions` カスタムフックに切り出したリファクタリングです。表示に関するコードと状態管理ロジックが分離され、可読性が向上しています。

- `useTagSuggestions` フックが `suggestions`・`highlightedIndex`・`open`・`loading`・`committed`・`blurTimeoutRef` をカプセル化し、コンポーネント本体がレンダリングに集中できる構成になった。
- 機能的な変更は一切なく、既存テストもすべてパスしているとのことで、リグレッションリスクは低い。
- `blurTimeoutRef` の所有管理とセッター関数の公開インターフェースに設計上の改善余地がある（詳細はインラインコメント参照）。
</details>


<details open><summary><h3>Confidence Score: 4/5</h3></summary>

純粋なリファクタリングで動作変更はなく、マージしても安全。

抽出されたロジックは元のコンポーネントと等価であり、APIフェッチや状態管理の挙動に変化はない。blurTimeoutRef の所有責務がフックとコンポーネントに分断されている点と、生のセッター関数が公開されている点は将来的な保守コストになりうるが、現時点で動作を壊すものではない。

apps/web/src/components/tag-autocomplete-input.tsx — blurTimeoutRef の扱いとセッター公開の設計を確認するとよい。
</details>


<details open><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| apps/web/src/components/tag-autocomplete-input.tsx | useTagSuggestions フックへのロジック抽出。APIフェッチ・キャッシュ・デバウンス・blur タイムアウト管理を分離。blurTimeoutRef の所有とミューテーションが hook と consumer に分断されている点と、内部 setter の公開が若干気になるが機能的な回帰はない。 |

</details>


</details>


<!-- greptile_failed_comments -->
<details open><summary><h3>Comments Outside Diff (1)</h3></summary>

1. `apps/web/src/components/tag-autocomplete-input.tsx`, line 42 ([link](https://github.com/hiroki-org/openshelf/blob/14ff9cff1758736acf1efbee808405a38c218823/apps/web/src/components/tag-autocomplete-input.tsx#L42)) 

   <a href="#"><img alt="P2" src="https://greptile-static-assets.s3.amazonaws.com/badges/p2.svg?v=7" align="top"></a> **blurTimeoutRef の責務が hook とコンポーネントに分断されている**

   `blurTimeoutRef` はフック内で生成・クリーンアップされていますが、実際にタイマーをセット（`window.setTimeout()`）する処理はコンポーネントの `onBlur` ハンドラ側にあります。フックの利用者がこの ref に書き込むことで暗黙的な契約が生まれ、将来の保守者がフック単体でロジックを追いにくくなります。`handleBlur` コールバックもフックから返すか、もしくは blur 処理全体をコンポーネント内で完結させるかのどちらかに統一すると、境界が明確になります。

   <details><summary>Prompt To Fix With AI</summary>

   `````markdown
   This is a comment left during a code review.
   Path: apps/web/src/components/tag-autocomplete-input.tsx
   Line: 42

   Comment:
   **blurTimeoutRef の責務が hook とコンポーネントに分断されている**

   `blurTimeoutRef` はフック内で生成・クリーンアップされていますが、実際にタイマーをセット（`window.setTimeout()`）する処理はコンポーネントの `onBlur` ハンドラ側にあります。フックの利用者がこの ref に書き込むことで暗黙的な契約が生まれ、将来の保守者がフック単体でロジックを追いにくくなります。`handleBlur` コールバックもフックから返すか、もしくは blur 処理全体をコンポーネント内で完結させるかのどちらかに統一すると、境界が明確になります。

   How can I resolve this? If you propose a fix, please make it concise.
   `````
   </details>

   Note: If this suggestion doesn't match your team's coding style, reply to this and let me know. I'll remember it for next time!

</details>

<!-- /greptile_failed_comments -->

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 2 code review issues. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 2
apps/web/src/components/tag-autocomplete-input.tsx:42
**blurTimeoutRef の責務が hook とコンポーネントに分断されている**

`blurTimeoutRef` はフック内で生成・クリーンアップされていますが、実際にタイマーをセット（`window.setTimeout()`）する処理はコンポーネントの `onBlur` ハンドラ側にあります。フックの利用者がこの ref に書き込むことで暗黙的な契約が生まれ、将来の保守者がフック単体でロジックを追いにくくなります。`handleBlur` コールバックもフックから返すか、もしくは blur 処理全体をコンポーネント内で完結させるかのどちらかに統一すると、境界が明確になります。

### Issue 2 of 2
apps/web/src/components/tag-autocomplete-input.tsx:118-127
**内部ステートセッターの直接公開**

`setHighlightedIndex` と `setOpen` という生のセッター関数がフックの公開 API として返されています。これらを外部から任意の値でよばれると、フック内部のデータ整合性が崩れる可能性があります（例: `open=true` のまま `suggestions` が空になるケース）。ユースケースに対応した意味のあるアクション（例: `closeDropdown()` や `navigateHighlight(direction)` のような関数）を返すと、インターフェースがよりカプセル化されます。


`````

</details>

<sub>Reviews (1): Last reviewed commit: ["refactor: extract useTagSuggestions hook..."](https://github.com/hiroki-org/openshelf/commit/14ff9cff1758736acf1efbee808405a38c218823) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=31479433)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->