### PR TITLE
🧹 Refactor: Extract click-outside logic into custom hook

### DIFF
--- a/apps/web/src/app/__tests__/collections-new.test.tsx
+++ b/apps/web/src/app/__tests__/collections-new.test.tsx
@@ -205,14 +205,18 @@ describe("NewCollectionPage", () => {
       target: { value: "bad--slug" },
     });
 
-    expect(await screen.findByText("※ 3-40文字, 英小文字/数字/ハイフン")).toBeInTheDocument();
+    expect(
+      await screen.findByText("※ 3-40文字, 英小文字/数字/ハイフン"),
+    ).toBeInTheDocument();
     expect(screen.getByRole("button", { name: "作成" })).toBeDisabled();
   });
 
   it("shows API error when create fails", async () => {
     vi.mocked(apiFetch).mockImplementation(async (url, init) => {
       if (url === "/api/users/user-1/collections") {
-        return new Response(JSON.stringify({ collections: [] }), { status: 200 });
+        return new Response(JSON.stringify({ collections: [] }), {
+          status: 200,
+        });
       }
       if (url === "/api/collections" && init?.method === "POST") {
         return new Response(JSON.stringify({ error: "already exists" }), {
@@ -228,7 +232,9 @@ describe("NewCollectionPage", () => {
       target: { value: "Lab Picks" },
     });
 
-    await waitFor(() => expect(screen.getByText("✓ 使用可能")).toBeInTheDocument());
+    await waitFor(() =>
+      expect(screen.getByText("✓ 使用可能")).toBeInTheDocument(),
+    );
     fireEvent.click(screen.getByRole("button", { name: "作成" }));
 
     expect(await screen.findByText("already exists")).toBeInTheDocument();

--- a/apps/web/src/app/__tests__/orgs-new.test.tsx
+++ b/apps/web/src/app/__tests__/orgs-new.test.tsx
@@ -115,7 +115,9 @@ describe("NewOrgPage", () => {
         return new Response("{}", { status: 404 });
       }
       if (url === "/api/orgs" && init?.method === "POST") {
-        return new Response(JSON.stringify({ error: "slug taken" }), { status: 409 });
+        return new Response(JSON.stringify({ error: "slug taken" }), {
+          status: 409,
+        });
       }
       throw new Error(`Unexpected request: ${String(url)}`);
     });

--- a/apps/web/src/app/papers/[id]/cite-button.tsx
+++ b/apps/web/src/app/papers/[id]/cite-button.tsx
@@ -3,7 +3,8 @@
 import { toast } from "@/components/toast";
 import { apiFetch } from "@/lib/api";
 import { safePath } from "@/lib/sanitization";
-import { useEffect, useRef, useState } from "react";
+import { useRef, useState } from "react";
+import { useClickOutside } from "@/hooks/use-click-outside";
 
 type CitationFormat = "bibtex" | "biblatex" | "apa" | "ieee" | "mla" | "plain";
 
@@ -27,33 +28,7 @@ export function CiteButton({ paperId }: CiteButtonProps) {
   );
   const containerRef = useRef<HTMLDivElement | null>(null);
 
-  useEffect(() => {
-    if (!open) return;
-
-    const handlePointerDown = (event: PointerEvent) => {
-      const target = event.target;
-      if (
-        target instanceof Node &&
-        containerRef.current &&
-        !containerRef.current.contains(target)
-      ) {
-        setOpen(false);
-      }
-    };
-
-    const handleEscape = (event: KeyboardEvent) => {
-      if (event.key === "Escape") {
-        setOpen(false);
-      }
-    };
-
-    document.addEventListener("pointerdown", handlePointerDown);
-    document.addEventListener("keydown", handleEscape);
-    return () => {
-      document.removeEventListener("pointerdown", handlePointerDown);
-      document.removeEventListener("keydown", handleEscape);
-    };
-  }, [open]);
+  useClickOutside(containerRef, () => setOpen(false), open);
 
   const handleCopy = async (format: CitationFormat) => {
     setLoadingFormat(format);

--- a/apps/web/src/components/__tests__/auth-provider.test.tsx
+++ b/apps/web/src/components/__tests__/auth-provider.test.tsx
@@ -163,7 +163,9 @@ describe("AuthProvider", () => {
 
   it("login logs an error and does not navigate when NEXT_PUBLIC_API_URL is missing", async () => {
     vi.stubEnv("NEXT_PUBLIC_API_URL", "");
-    const errorSpy = vi.spyOn(console, "error").mockImplementation(() => undefined);
+    const errorSpy = vi
+      .spyOn(console, "error")
+      .mockImplementation(() => undefined);
     const originalLocation = window.location;
 
     try {
@@ -193,7 +195,9 @@ describe("AuthProvider", () => {
   it("refresh re-fetches user data", async () => {
     localStorage.setItem("auth_token", "token-1");
     vi.mocked(apiFetch)
-      .mockResolvedValueOnce(new Response(JSON.stringify({ user: null }), { status: 401 }))
+      .mockResolvedValueOnce(
+        new Response(JSON.stringify({ user: null }), { status: 401 }),
+      )
       .mockResolvedValueOnce(
         new Response(
           JSON.stringify({

--- a/apps/web/src/components/feed-button.tsx
+++ b/apps/web/src/components/feed-button.tsx
@@ -2,6 +2,7 @@
 
 import { toast } from "@/components/toast";
 import { useEffect, useRef, useState } from "react";
+import { useClickOutside } from "@/hooks/use-click-outside";
 
 type FeedButtonProps = {
   url: string;
@@ -18,6 +19,15 @@ export function FeedButton({
   const containerRef = useRef<HTMLDivElement>(null);
   const triggerRef = useRef<HTMLButtonElement>(null);
   const dialogRef = useRef<HTMLDivElement>(null);
+
+  useClickOutside(
+    containerRef,
+    () => {
+      setOpen(false);
+      triggerRef.current?.focus();
+    },
+    open,
+  );
 
   useEffect(() => {
     if (!open) return;
@@ -36,14 +46,6 @@ export function FeedButton({
 
     const firstFocusable = getFocusableElements()[0];
     (firstFocusable ?? dialogRef.current)?.focus();
-
-    const handlePointerDown = (event: PointerEvent) => {
-      const target = event.target;
-      if (target instanceof Node && !containerRef.current?.contains(target)) {
-        setOpen(false);
-        triggerRef.current?.focus();
-      }
-    };
 
     const handleKeyDown = (event: KeyboardEvent) => {
       if (event.key === "Escape") {
@@ -81,11 +83,9 @@ export function FeedButton({
       }
     };
 
-    document.addEventListener("pointerdown", handlePointerDown);
     document.addEventListener("keydown", handleKeyDown);
 
     return () => {
-      document.removeEventListener("pointerdown", handlePointerDown);
       document.removeEventListener("keydown", handleKeyDown);
     };
   }, [open]);

--- a/apps/web/src/hooks/use-click-outside.ts
+++ b/apps/web/src/hooks/use-click-outside.ts
@@ -1,0 +1,35 @@
+import { RefObject, useEffect } from "react";
+
+export function useClickOutside(
+  ref: RefObject<HTMLElement | null>,
+  handler: () => void,
+  active: boolean = true,
+) {
+  useEffect(() => {
+    if (!active) return;
+
+    const handlePointerDown = (event: PointerEvent) => {
+      const target = event.target;
+      if (
+        target instanceof Node &&
+        ref.current &&
+        !ref.current.contains(target)
+      ) {
+        handler();
+      }
+    };
+
+    const handleEscape = (event: KeyboardEvent) => {
+      if (event.key === "Escape") {
+        handler();
+      }
+    };
+
+    document.addEventListener("pointerdown", handlePointerDown);
+    document.addEventListener("keydown", handleEscape);
+    return () => {
+      document.removeEventListener("pointerdown", handlePointerDown);
+      document.removeEventListener("keydown", handleEscape);
+    };
+  }, [ref, handler, active]);
+}


### PR DESCRIPTION
🎯 **What:** Extracted the click-outside and Escape key dismissal logic from `CiteButton` and `FeedButton` into a new, reusable `useClickOutside` hook.
💡 **Why:** This reduces code duplication, shortens the overly long `CiteButton` function, and improves overall code readability and maintainability.
✅ **Verification:** Ran the full test suite (`bun x vitest run apps/web/` and `bun x vitest run apps/api/`) to ensure no regressions were introduced. Formatted code with `prettier`.
✨ **Result:** Both components now cleanly use the `useClickOutside` hook without any loss of functionality.

---
*PR created automatically by Jules for task [11641971017958570916](https://jules.google.com/task/11641971017958570916) started by @is0692vs*

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

クリック外クリックと Escape キーによる dismissal ロジックを `CiteButton` と `FeedButton` から抽出し、再利用可能な `useClickOutside` フックに集約したリファクタリング PR です。テストファイル 3 件は Prettier によるフォーマット調整のみです。

- `CiteButton` は元の `useEffect` を完全に削除して `useClickOutside` に正しく移行できています。
- `FeedButton` では `handlePointerDown` の移行は成功していますが、残存する `handleKeyDown` が引き続き Escape を処理しており、`useClickOutside` との二重処理が発生しています。
- `useClickOutside` フックの依存配列に毎レンダーで新参照が生成されるインライン関数 `handler` が含まれているため、`active` が `true` の間、再レンダーのたびにイベントリスナーの付け外しが繰り返されます。
</details>


<details open><summary><h3>Confidence Score: 3/5</h3></summary>

`FeedButton` の Escape 二重処理を修正してからマージすることを推奨します。

`FeedButton` では `useClickOutside` と残存する `handleKeyDown` の両方が Escape を処理しており、ロジックの責務が重複しています。現時点では React のバッチ処理により目立った動作の変化はないものの、将来の変更でサイレントなバグを引き起こしうる状態です。また `useClickOutside` の依存配列設計により、コンポーネントが開いている間は再レンダーのたびに不要なリスナーの付け外しが発生します。`CiteButton` の移行は正しく完了しており、テストの変更もフォーマットのみです。

`apps/web/src/components/feed-button.tsx` と `apps/web/src/hooks/use-click-outside.ts` に注目してください。
</details>


<details open><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| apps/web/src/hooks/use-click-outside.ts | 新規カスタムフック。クリック外・Escape キーの dismissal ロジックを集約しているが、`handler` を依存配列に含めているためレンダーごとにリスナーの付け外しが発生する。 |
| apps/web/src/components/feed-button.tsx | `useClickOutside` を導入したが、残存する `handleKeyDown` が Escape を二重処理している。`pointerdown` 処理は正しく移行済み。 |
| apps/web/src/app/papers/[id]/cite-button.tsx | `useClickOutside` への移行は正しく完了。元の `useEffect` が丸ごと削除されており、重複処理なし。 |
| apps/web/src/app/__tests__/collections-new.test.tsx | Prettier によるフォーマット調整のみ。ロジック変更なし。 |
| apps/web/src/app/__tests__/orgs-new.test.tsx | Prettier によるフォーマット調整のみ。ロジック変更なし。 |
| apps/web/src/components/__tests__/auth-provider.test.tsx | Prettier によるフォーマット調整のみ。ロジック変更なし。 |

</details>


</details>


<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant User
    participant Document
    participant useClickOutside
    participant FeedButton_handleKeyDown

    User->>Document: "Escape キー押下 (FeedButton open=true)"
    Document->>useClickOutside: keydown イベント
    useClickOutside->>FeedButton: handler() → setOpen(false) + triggerRef.focus()
    Document->>FeedButton_handleKeyDown: keydown イベント
    FeedButton_handleKeyDown->>FeedButton: setOpen(false) ← 重複 (no-op)
    FeedButton_handleKeyDown->>FeedButton: triggerRef.focus() ← 重複 (no-op)

    User->>Document: コンポーネント外クリック (pointerdown)
    Document->>useClickOutside: pointerdown イベント
    useClickOutside->>FeedButton: handler() → setOpen(false) + triggerRef.focus()
```

<!-- greptile_failed_comments -->
<details open><summary><h3>Comments Outside Diff (1)</h3></summary>

1. `apps/web/src/components/feed-button.tsx`, line 50-55 ([link](https://github.com/hiroki-org/openshelf/blob/a5d7f211d8877bf8f594f311b6b7d90c95d651fd/apps/web/src/components/feed-button.tsx#L50-L55)) 

   <a href="#"><img alt="P1" src="https://greptile-static-assets.s3.amazonaws.com/badges/p1.svg?v=7" align="top"></a> **FeedButton の Escape キー二重処理**

   `useClickOutside` フックは内部の `handleEscape` リスナーで Escape キーを処理し、`() => { setOpen(false); triggerRef.current?.focus(); }` を呼びます。一方、残っている `handleKeyDown`（50〜55行目）でも Escape を処理し `setOpen(false)` と `triggerRef.current?.focus()` を実行します。`open` が `true` のとき、Escape キー押下でハンドラーが **2回** 実行される状態になっています。`handlePointerDown` を `useClickOutside` に移行した際に、`handleKeyDown` から Escape ブランチを削除し忘れたものと思われます。React の state バッチング処理により現時点では目立ったユーザー影響はありませんが、イベントリスナーの責務が重複しており、将来的なバグの温床になります。

   <details><summary>Prompt To Fix With AI</summary>

   `````markdown
   This is a comment left during a code review.
   Path: apps/web/src/components/feed-button.tsx
   Line: 50-55

   Comment:
   **FeedButton の Escape キー二重処理**

   `useClickOutside` フックは内部の `handleEscape` リスナーで Escape キーを処理し、`() => { setOpen(false); triggerRef.current?.focus(); }` を呼びます。一方、残っている `handleKeyDown`（50〜55行目）でも Escape を処理し `setOpen(false)` と `triggerRef.current?.focus()` を実行します。`open` が `true` のとき、Escape キー押下でハンドラーが **2回** 実行される状態になっています。`handlePointerDown` を `useClickOutside` に移行した際に、`handleKeyDown` から Escape ブランチを削除し忘れたものと思われます。React の state バッチング処理により現時点では目立ったユーザー影響はありませんが、イベントリスナーの責務が重複しており、将来的なバグの温床になります。

   How can I resolve this? If you propose a fix, please make it concise.
   `````
   </details>

</details>

<!-- /greptile_failed_comments -->

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 2 code review issues. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 2
apps/web/src/components/feed-button.tsx:50-55
**FeedButton の Escape キー二重処理**

`useClickOutside` フックは内部の `handleEscape` リスナーで Escape キーを処理し、`() => { setOpen(false); triggerRef.current?.focus(); }` を呼びます。一方、残っている `handleKeyDown`（50〜55行目）でも Escape を処理し `setOpen(false)` と `triggerRef.current?.focus()` を実行します。`open` が `true` のとき、Escape キー押下でハンドラーが **2回** 実行される状態になっています。`handlePointerDown` を `useClickOutside` に移行した際に、`handleKeyDown` から Escape ブランチを削除し忘れたものと思われます。React の state バッチング処理により現時点では目立ったユーザー影響はありませんが、イベントリスナーの責務が重複しており、将来的なバグの温床になります。

### Issue 2 of 2
apps/web/src/hooks/use-click-outside.ts:1-35
**`handler` が依存配列に含まれることでエフェクトが毎レンダーで再実行される**

`handler` は `CiteButton`・`FeedButton` どちらもインラインアロー関数として渡されているため、レンダーごとに新しい参照が生成されます。`active` が `true` のとき、再レンダーのたびにクリーンアップ（リスナー解除）→再セットアップ（リスナー登録）のサイクルが発生し、不要な DOM 操作が繰り返されます。ハンドラーを ref に格納する「callback ref パターン」を用いると、参照の安定性を保ちながら常に最新のハンドラーを呼び出せます。

```suggestion
import { RefObject, useEffect, useRef } from "react";

export function useClickOutside(
  ref: RefObject<HTMLElement | null>,
  handler: () => void,
  active: boolean = true,
) {
  const handlerRef = useRef(handler);
  handlerRef.current = handler;

  useEffect(() => {
    if (!active) return;

    const handlePointerDown = (event: PointerEvent) => {
      const target = event.target;
      if (
        target instanceof Node &&
        ref.current &&
        !ref.current.contains(target)
      ) {
        handlerRef.current();
      }
    };

    const handleEscape = (event: KeyboardEvent) => {
      if (event.key === "Escape") {
        handlerRef.current();
      }
    };

    document.addEventListener("pointerdown", handlePointerDown);
    document.addEventListener("keydown", handleEscape);
    return () => {
      document.removeEventListener("pointerdown", handlePointerDown);
      document.removeEventListener("keydown", handleEscape);
    };
  }, [ref, active]);
}
```


`````

</details>

<sub>Reviews (1): Last reviewed commit: ["refactor: extract click-outside logic in..."](https://github.com/hiroki-org/openshelf/commit/a5d7f211d8877bf8f594f311b6b7d90c95d651fd) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=31479471)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->