### PR TITLE
🧹 [Code Health] test: fix visibility test missing branches

### DIFF
--- a/apps/api/src/routes/__tests__/collections.test.ts
+++ b/apps/api/src/routes/__tests__/collections.test.ts
@@ -319,8 +319,15 @@ describe("collections routes", () => {
       "http://localhost/api/collections",
       {
         method: "POST",
-        headers: { Authorization: `Bearer ${await createTestJWT({ sub: "user-1" })}` },
-        body: JSON.stringify({ name: "C1", slug: "col-1", owner_type: "user", visibility: "invalid_string" }),
+        headers: {
+          Authorization: `Bearer ${await createTestJWT({ sub: "user-1" })}`,
+        },
+        body: JSON.stringify({
+          name: "C1",
+          slug: "col-1",
+          owner_type: "user",
+          visibility: "invalid_string",
+        }),
       },
       env,
     );
@@ -1418,15 +1425,11 @@ describe("collections routes", () => {
       { allResult: [{ paperId: "p1" }, { paperId: "p2" }] },
     ]);
     mockDb.batch = vi.fn().mockResolvedValue([]);
-    mockDb.update = vi
-      .fn()
-      .mockImplementation(() => ({
-        set: vi
-          .fn()
-          .mockImplementation(() => ({
-            where: vi.fn().mockImplementation(() => "UPDATE_STATEMENT"),
-          })),
-      }));
+    mockDb.update = vi.fn().mockImplementation(() => ({
+      set: vi.fn().mockImplementation(() => ({
+        where: vi.fn().mockImplementation(() => "UPDATE_STATEMENT"),
+      })),
+    }));
     const app = await createTestApp();
     const env = createTestEnv();
     const res = await app.request(


### PR DESCRIPTION
🎯 **What:** Adds missing unit tests for invalid string visibilities.
💡 **Why:** To satisfy Codecov patch coverage limits broken by a previous refactor replacing 'any' casting with 'parseVisibility'.
✅ **Verification:** Validated tests locally.
✨ **Result:** Missing paths in POST/PATCH collections routes are now fully covered.

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

このPRは `parseVisibility` 関数の2つの未カバーブランチ（有効なVisibility文字列リストに含まれない文字列を渡した場合）に対してユニットテストを追加します。同時にテストファイル全体のインデントをタブ4スペースから2スペースに統一する大規模な整形も含まれます。

- **新規テスト2件の追加**: `POST /api/collections` と `PATCH /api/collections/:id` の両ルートに対し、`visibility` フィールドに無効な文字列（`\"invalid_string\"` / `\"invalid_string_vis\"`）を渡したとき 400 + `{ error: \"Invalid visibility\" }` が返ることを検証する。
- **インデント整形**: ファイル全体の4スペースインデントを2スペースに変換（機能変更なし）。
</details>

<details open><summary><h3>Confidence Score: 5/5</h3></summary>

テストのみの変更で、プロダクションコードへの影響はまったくない。安全にマージできる。

新規追加された2つのテストは、それぞれ `parseVisibility` の「型が文字列だが有効な値リストに含まれない」ブランチをカバーしており、ルート実装（POST: 244〜250行目、PATCH: 384〜390行目）の動作と正確に一致している。PATCHテストが `queueSelectResponses` でコレクション取得のモックを1件だけ積んでいる点も、PATCH ルートが先にコレクションを取得してから ownership チェック→JSON パース→visibility バリデーションの順で処理する実装と整合している。インデント整形はロジックを変更しない。

特に注意が必要なファイルはない。
</details>

<details open><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| apps/api/src/routes/__tests__/collections.test.ts | インデントを2スペースに統一し、`parseVisibility` の未カバーブランチ（無効な文字列）に対する2つの新規テストを追加。テストロジックは正確で、ルート実装の挙動と一致している。 |

</details>

</details>

<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[リクエスト受信] --> B{visibility が undefined?}
    B -- はい --> C[デフォルト: 'private']
    B -- いいえ --> D[parseVisibility呼び出し]
    D --> E{typeof value === 'string'?}
    E -- いいえ --> G[null を返す]
    E -- はい --> F{VALID_VISIBILITY に含まれる?}
    F -- いいえ --> G
    F -- はい --> H[Visibility 値を返す]
    G --> I[400 Invalid visibility]
    C --> J[処理続行]
    H --> J
```

<sub>Reviews (1): Last reviewed commit: ["test: add missing branches for invalid v..."](https://github.com/hiroki-org/openshelf/commit/63fa64391a4af9ce115d9a3008e5c017ca1e6dd4) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=31480161)</sub>

<!-- /greptile_comment -->