### PR TITLE
🧪 Update POST /api/papers/:id/invites db error test to match propagation conventions

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -12,3 +12,9 @@
 **Vulnerability:** A wildcard in the `ALLOWED_ORIGINS` configuration allows the CORS and OAuth flow to accept any client-provided origin, leading to a bypass in origin verification and an open redirect where tokens can be stolen.
 **Learning:** Utilities that resolve or validate origins against a configurable list should explicitly reject wildcard patterns in sensitive flows such as OAuth redirects or CORS responses, ensuring wildcards only apply when strictly intended by the configuration.
 **Prevention:** Pass `{ allowWildcard: false }` to the `isAllowedOrigin` helper in all places where sensitive token delivery relies on frontend URLs.
+## 2026-05-10 - Propagate DB Errors Test Fix
+**Learning:** When asserting that generic errors are propagated to top-level error handlers in Hono tests with , simply verify the final response status (e.g. 500) rather than attempting to catch a thrown error since the framework captures and wraps them into a 500 Response.
+**Action:** Changed the test name from '... returns 500 ...' to 'propagates general db insert errors ...' to clarify the intent.
+## 2025-02-14 - Propagate DB Errors Test Fix
+**Learning:** When asserting that generic errors are propagated to top-level error handlers in Hono tests with app.request, simply verify the final response status (e.g. 500) rather than attempting to catch a thrown error since the framework captures and wraps them into a 500 Response.
+**Action:** Changed the test name from "... returns 500 ..." to "propagates general db insert errors ..." to clarify the intent.

--- a/apps/api/src/routes/__tests__/papers.test.ts
+++ b/apps/api/src/routes/__tests__/papers.test.ts
@@ -2142,7 +2142,7 @@ describe("papers routes", () => {
             expect(data.error).toBe("Invite already sent");
         });
 
-        it("POST /api/papers/:id/invites returns 500 for non-UNIQUE database errors", async () => {
+        it("propagates general db insert errors for POST /api/papers/:id/invites", async () => {
             const token = await createTestJWT({ sub: "user-uploader", githubId: "123", name: "Uploader" });
             setupInviteChecks();
 
@@ -2153,6 +2153,9 @@ describe("papers routes", () => {
             const app = await createTestApp();
             const env = createTestEnv();
             const res = await sendInviteRequest(token, app, env);
+
+            // The default Hono error handler will catch the thrown error and return a 500 status.
+            // We verify we reached that 500 status.
 
             expect(res.status).toBe(500);
         });


### PR DESCRIPTION
🎯 **What:** The testing gap addressed
The test for `POST /api/papers/:id/invites` throwing a non-UNIQUE database error was correctly reaching the 500 status block handled by Hono's top-level error handler, but its name did not align with the established testing convention in the file for these types of generic error propagations.

📊 **Coverage:** What scenarios are now tested
The unexpected database error test was updated to use the standard "propagates general db [operation] errors" naming convention, and comments were added clarifying that generic errors bubble up to Hono's default error handler and resolve with a 500 status.

✨ **Result:** The improvement in test coverage
Tests passing with clearer documentation of the framework's default error handling behavior and consistent naming.

---
*PR created automatically by Jules for task [15265478134591462798](https://jules.google.com/task/15265478134591462798) started by @is0692vs*

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

このPRは `POST /api/papers/:id/invites` の汎用DBエラーテストの名称を、ファイル内で確立されている `"propagates general db [operation] errors"` 規約に合わせてリネームし、Honoのデフォルトエラーハンドラに関するコメントを追加するものです。テストロジック自体への変更はありません。

- `papers.test.ts`: テスト名を `"propagates general db insert errors for POST /api/papers/:id/invites"` にリネームし、500レスポンスがHonoのデフォルトエラーハンドラ経由で返ることを説明するコメントを追加。
- `.jules/sentinel.md`: 今回の変更に関する学習エントリを追記したが、同内容のエントリが2026-05-10と2025-02-14の2つの日付で重複して追加されており、かつ2026-05-10のエントリに `app.request` が欠落した不完全な記述が含まれている。
</details>

<details open><summary><h3>Confidence Score: 3/5</h3></summary>

テストコード自体の変更は安全だが、sentinel.md の不完全・重複エントリはそのままマージすると誤情報として蓄積される。

`papers.test.ts` の変更はテスト名のリネームとコメント追加のみで、ロジックへの影響はない。一方 `.jules/sentinel.md` には2026-05-10と2025-02-14の同内容エントリが二重追加されており、2026-05-10のエントリでは `app.request` が欠落した不完全な文章が含まれている。このままマージされると誤情報が知識ベースに蓄積されるため、修正が必要。

.jules/sentinel.md — 重複・不完全なエントリの修正が必要
</details>

<details open><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| .jules/sentinel.md | 同一内容の学習エントリが2026-05-10・2025-02-14の2つの異なる日付で重複追加されており、かつ2026-05-10のエントリでは「app.request」が欠落した不完全な文が含まれている |
| apps/api/src/routes/__tests__/papers.test.ts | テスト名を「propagates general db insert errors」規約に合わせてリネームし、Honoのデフォルトエラーハンドラに関するコメントを追加。テストロジック自体に変更はなく安全 |

</details>

</details>

<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant Test as テストコード
    participant Route as POST /api/papers/:id/invites
    participant DB as mockDb.insert
    participant Hono as Honoエラーハンドラ

    Test->>Route: リクエスト送信
    Route->>DB: insert().values()
    DB-->>Route: Error("Some other DB Error") をスロー
    Route-->>Hono: エラーをバブルアップ
    Hono-->>Test: 500 Response
    Note over Test: expect(res.status).toBe(500) ✅
```

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 1 code review issue. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 1
.jules/sentinel.md:15-20
**sentinel.md に重複・不完全なエントリが追加されています**

2026-05-10 と 2025-02-14 の2つのエントリが同時に追加されていますが、内容がほぼ同一です。また、2026-05-10 のエントリは「`in Hono tests with ,`」と記述が途切れており、本来「`with app.request,`」とすべき部分が欠落しています。同じ学習内容を異なる日付で二重登録するのは誤りであり、どちらのエントリが正規のものか不明瞭です。

`````

</details>

<sub>Reviews (1): Last reviewed commit: ["🧪 Update papers test to match general d..."](https://github.com/hiroki-org/openshelf/commit/35126e39990bb67781cc13e4cdf1a80ac6e983a4) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=31480321)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->