### PR TITLE
🧪 テスト改善: 一般的なDBエラーのテスト名の統一

### DIFF
--- a/apps/api/src/routes/__tests__/papers.test.ts
+++ b/apps/api/src/routes/__tests__/papers.test.ts
@@ -2142,7 +2142,7 @@ describe("papers routes", () => {
             expect(data.error).toBe("Invite already sent");
         });
 
-        it("POST /api/papers/:id/invites returns 500 for non-UNIQUE database errors", async () => {
+        it("propagates general db insert errors", async () => {
             const token = await createTestJWT({ sub: "user-uploader", githubId: "123", name: "Uploader" });
             setupInviteChecks();
 


### PR DESCRIPTION
🎯 **What:** 招待送信時の一般的なデータベースエラーに対するテストの名称をプロジェクトの規約に合わせて修正しました。

📊 **Coverage:** `apps/api/src/routes/__tests__/papers.test.ts` の `POST /api/papers/:id/invites returns 500 for non-UNIQUE database errors` テストを `propagates general db insert errors` に変更し、想定外のエラーがHonoのグローバルハンドラーによって適切に500エラーとして処理されることを再確認しました。

✨ **Result:** 規約に沿ったテスト名に変更されたことで、今後のテストの可読性と一貫性が向上しました。

---
*PR created automatically by Jules for task [13218502411295728563](https://jules.google.com/task/13218502411295728563) started by @is0692vs*

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

テストファイル `apps/api/src/routes/__tests__/papers.test.ts` において、招待送信時の一般的なDBエラーに対するテスト名を、プロジェクト規約に沿った形式へ変更した単純なリネームPRです。

- `POST /api/papers/:id/invites returns 500 for non-UNIQUE database errors` → `propagates general db insert errors` へテスト名を変更。テストロジック・アサーション・モック設定に一切の変更はなく、命名の統一のみが目的です。
</details>

<details open><summary><h3>Confidence Score: 5/5</h3></summary>

テスト名の変更のみであり、ロジック・アサーション・モックに一切の影響はありません。

変更はテスト名1行のリネームに限定されており、テスト本体のセットアップ・モック・アサーションはすべて変更前と同一です。動作への影響がないため安全にマージできます。

特に注意が必要なファイルはありません。
</details>

<details open><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| apps/api/src/routes/__tests__/papers.test.ts | テスト名を規約に合わせてリネームのみ。テストロジック・モック・アサーションに変更なし。 |

</details>

</details>

<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant Test as テスト
    participant App as Hono App
    participant DB as DB (Mock)
    participant Handler as Global Error Handler

    Test->>App: POST /api/papers/:id/invites
    App->>DB: insert().values()
    DB-->>App: throw new Error("Some other DB Error")
    App->>Handler: 未処理エラーを伝播
    Handler-->>Test: HTTP 500
```

<sub>Reviews (1): Last reviewed commit: ["🧪 Added test for unexpected database er..."](https://github.com/hiroki-org/openshelf/commit/248039d45a7d487552b4f55f5b1fdb4c46e98a83) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=31480443)</sub>

<!-- /greptile_comment -->