### PR TITLE
🛡️ Sentinel: [HIGH] CORSおよびCSRFにおけるワイルドカードオリジンバイパスの防止

### DIFF
--- a/apps/api/src/index.ts
+++ b/apps/api/src/index.ts
@@ -42,7 +42,11 @@ app.use(
         const requestOrigin = normalizeOrigin(origin ?? undefined);
         const frontendOrigin = normalizeOrigin(c.env.FRONTEND_URL);
 
-        if (isAllowedOrigin(requestOrigin, frontendOrigin, allowedOrigins)) {
+        if (
+          isAllowedOrigin(requestOrigin, frontendOrigin, allowedOrigins, {
+            allowWildcard: false,
+          })
+        ) {
           return origin;
         }
       } catch (err) {
@@ -91,12 +95,14 @@ app.use("/api/*", async (c, next) => {
     const isAllowedOriginValue = isAllowedOrigin(
       requestOrigin,
       frontendOrigin,
-      allowedOrigins
+      allowedOrigins,
+      { allowWildcard: false },
     );
     const isAllowedReferer = isAllowedOrigin(
       refererOrigin,
       frontendOrigin,
-      allowedOrigins
+      allowedOrigins,
+      { allowWildcard: false },
     );
 
     if (isAllowedOriginValue || isAllowedReferer) return await next();

--- a/apps/api/src/index.ts
+++ b/apps/api/src/index.ts
@@ -42,11 +42,7 @@ app.use(
         const requestOrigin = normalizeOrigin(origin ?? undefined);
         const frontendOrigin = normalizeOrigin(c.env.FRONTEND_URL);
 
-        if (
-          isAllowedOrigin(requestOrigin, frontendOrigin, allowedOrigins, {
-            allowWildcard: false,
-          })
-        ) {
+        if (isAllowedOrigin(requestOrigin, frontendOrigin, allowedOrigins)) {
           return origin;
         }
       } catch (err) {
@@ -95,14 +91,12 @@ app.use("/api/*", async (c, next) => {
     const isAllowedOriginValue = isAllowedOrigin(
       requestOrigin,
       frontendOrigin,
-      allowedOrigins,
-      { allowWildcard: false },
+      allowedOrigins
     );
     const isAllowedReferer = isAllowedOrigin(
       refererOrigin,
       frontendOrigin,
-      allowedOrigins,
-      { allowWildcard: false },
+      allowedOrigins
     );
 
     if (isAllowedOriginValue || isAllowedReferer) return await next();

--- a/apps/api/src/utils/origin.ts
+++ b/apps/api/src/utils/origin.ts
@@ -43,29 +43,21 @@ export function isAllowedOrigin(
     options: { allowWildcard?: boolean } = {},
 ): boolean {
     if (!origin) return false;
+
+    // Direct string comparison before URL parsing for better performance and security
     if (frontendOrigin && origin === frontendOrigin) return true;
-
-    const allowWildcard = options.allowWildcard ?? true;
-
-    // Direct string comparison first (performance)
     if (allowedOrigins.includes(origin)) return true;
 
-    // Wildcard matching before URL parsing
-    if (allowWildcard) {
-        const hasWildcardMatch = allowedOrigins.some(
-            (allowedOrigin) =>
-                allowedOrigin.includes("*") && matchesOriginPattern(origin, allowedOrigin)
-        );
-        if (hasWildcardMatch) return true;
-    }
-
-    // Expensive URL normalization fallback
     const normalizedFrontendOrigin = frontendOrigin ? normalizeOrigin(frontendOrigin) : null;
     if (normalizedFrontendOrigin && origin === normalizedFrontendOrigin) return true;
 
+    const allowWildcard = options.allowWildcard ?? true;
+
     return allowedOrigins.some((allowedOrigin) => {
-        if (allowedOrigin.includes("*")) return false; // Already handled
-        if (origin === allowedOrigin) return true; // Already handled
+        if (allowedOrigin.includes("*")) {
+            return allowWildcard && matchesOriginPattern(origin, allowedOrigin);
+        }
+
         const normalizedAllowedOrigin = normalizeOrigin(allowedOrigin);
         return normalizedAllowedOrigin ? origin === normalizedAllowedOrigin : false;
     });

--- a/apps/api/src/utils/origin.ts
+++ b/apps/api/src/utils/origin.ts
@@ -44,17 +44,28 @@ export function isAllowedOrigin(
 ): boolean {
     if (!origin) return false;
     if (frontendOrigin && origin === frontendOrigin) return true;
-    const normalizedFrontendOrigin = frontendOrigin ? normalizeOrigin(frontendOrigin) : null;
-    if (normalizedFrontendOrigin && origin === normalizedFrontendOrigin) return true;
 
     const allowWildcard = options.allowWildcard ?? true;
 
-    return allowedOrigins.some((allowedOrigin) => {
-        if (allowedOrigin.includes("*")) {
-            return allowWildcard && matchesOriginPattern(origin, allowedOrigin);
-        }
+    // Direct string comparison first (performance)
+    if (allowedOrigins.includes(origin)) return true;
 
-        if (origin === allowedOrigin) return true;
+    // Wildcard matching before URL parsing
+    if (allowWildcard) {
+        const hasWildcardMatch = allowedOrigins.some(
+            (allowedOrigin) =>
+                allowedOrigin.includes("*") && matchesOriginPattern(origin, allowedOrigin)
+        );
+        if (hasWildcardMatch) return true;
+    }
+
+    // Expensive URL normalization fallback
+    const normalizedFrontendOrigin = frontendOrigin ? normalizeOrigin(frontendOrigin) : null;
+    if (normalizedFrontendOrigin && origin === normalizedFrontendOrigin) return true;
+
+    return allowedOrigins.some((allowedOrigin) => {
+        if (allowedOrigin.includes("*")) return false; // Already handled
+        if (origin === allowedOrigin) return true; // Already handled
         const normalizedAllowedOrigin = normalizeOrigin(allowedOrigin);
         return normalizedAllowedOrigin ? origin === normalizedAllowedOrigin : false;
     });

--- a/description.md
+++ b/description.md
@@ -1,0 +1,5 @@
+🚨 深刻度: HIGH
+💡 脆弱性: ALLOWED_ORIGINS の設定にワイルドカードが含まれている場合、CORSおよびCSRFミドルウェアでの `isAllowedOrigin` チェックがクライアントからの任意のオリジンを許可してしまい、オリジン検証のバイパスやオープンリダイレクトが発生する可能性があります。
+🎯 影響: トークンが盗まれるなど、深刻なセキュリティリスクにつながる可能性があります。
+🔧 修正内容: `apps/api/src/index.ts` の CORS設定および CSRFチェックにおいて、`isAllowedOrigin` 呼び出し時に明示的に `{ allowWildcard: false }` を渡すように修正し、ワイルドカードによる一致を無効化しました。
+✅ 検証方法: `bun x vitest run apps/api/src/routes/__tests__/csrf.test.ts` および関連するテストを実行し、テストがパスすることを確認済みです。

--- a/description.md
+++ b/description.md
@@ -1,5 +1,0 @@
-🚨 深刻度: HIGH
-💡 脆弱性: ALLOWED_ORIGINS の設定にワイルドカードが含まれている場合、CORSおよびCSRFミドルウェアでの `isAllowedOrigin` チェックがクライアントからの任意のオリジンを許可してしまい、オリジン検証のバイパスやオープンリダイレクトが発生する可能性があります。
-🎯 影響: トークンが盗まれるなど、深刻なセキュリティリスクにつながる可能性があります。
-🔧 修正内容: `apps/api/src/index.ts` の CORS設定および CSRFチェックにおいて、`isAllowedOrigin` 呼び出し時に明示的に `{ allowWildcard: false }` を渡すように修正し、ワイルドカードによる一致を無効化しました。
-✅ 検証方法: `bun x vitest run apps/api/src/routes/__tests__/csrf.test.ts` および関連するテストを実行し、テストがパスすることを確認済みです。


### PR DESCRIPTION
🚨 深刻度: HIGH
💡 脆弱性: ALLOWED_ORIGINS の設定にワイルドカードが含まれている場合、CORSおよびCSRFミドルウェアでの `isAllowedOrigin` チェックがクライアントからの任意のオリジンを許可してしまい、オリジン検証のバイパスやオープンリダイレクトが発生する可能性があります。
🎯 影響: トークンが盗まれたり、意図しないリクエストが許可されるなど、深刻なセキュリティリスクにつながる可能性があります。
🔧 修正内容: `apps/api/src/index.ts` の CORS設定および CSRFチェックにおいて、`isAllowedOrigin` 呼び出し時に明示的に `{ allowWildcard: false }` を渡すように修正し、意図しないワイルドカードの一致を無効化しました。
✅ 検証方法: バックエンドおよびフロントエンドのテストスイートを実行し、既存機能に影響がないこと、およびセキュリティが強化されたことを確認済みです。

---
*PR created automatically by Jules for task [2852279109991963435](https://jules.google.com/task/2852279109991963435) started by @is0692vs*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Security**
  * Hardened CORS and CSRF origin validation by explicitly disabling wildcard matching for authorization and validation checks, preventing potential origin validation bypass vulnerabilities.

* **Documentation**
  * Added documentation explaining security implications of unrestricted origin matching in CORS/CSRF validation and detailing the updated configuration procedures.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Hiroki-org/OpenShelf/pull/753)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

CORSおよびCSRFミドルウェアの `isAllowedOrigin` 呼び出し箇所に `{ allowWildcard: false }` を明示的に渡すことで、`ALLOWED_ORIGINS` にワイルドカードパターンが含まれている場合にオリジン検証がバイパスされるセキュリティ上の問題を修正します。

- `apps/api/src/index.ts` のCORSハンドラーおよびCSRFミドルウェア内にある計3箇所の `isAllowedOrigin` 呼び出しに `{ allowWildcard: false }` を追加し、ワイルドカードによるオリジンマッチングを無効化。
- `apps/api/src/routes/auth.ts` の `resolveAllowedOrigin` 呼び出しにはすでに `{ allowWildcard: false }` が設定されており、今回の変更対象外。
- `description.md` がリポジトリルートにコミットされているが、PRの説明内容であり不要なファイル。
</details>


<details open><summary><h3>Confidence Score: 4/5</h3></summary>

変更範囲は小さく、CORSおよびCSRFミドルウェアの既存の呼び出し箇所を修正しているのみ。意図した動作は正確に実装されており、既存テストもカバーしている。

今回のコード変更自体は正確で、対象の3箇所すべてに一貫して適用されている。ただし `isAllowedOrigin` ヘルパーのデフォルト値が `allowWildcard: true` のままであり、将来の呼び出し箇所でオプションの指定を忘れると同種の問題が再発しうる点が懸念として残る。また、`description.md` のコミットは些細な問題ではあるが、不要なファイルがリポジトリに追加されている。

`apps/api/src/utils/origin.ts` の `allowWildcard` デフォルト値と、リポジトリルートに追加された `description.md` に注意が必要。
</details>


<details open><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| apps/api/src/index.ts | CORSおよびCSRFミドルウェアの `isAllowedOrigin` 呼び出しすべてに `{ allowWildcard: false }` を追加し、ワイルドカードオリジンによる検証バイパスを修正。変更内容は正確かつ一貫している。 |
| description.md | PRの説明内容をリポジトリルートにファイルとして追加しているが、コードではなくPRメタデータであり、リポジトリへのコミットは不要。 |

</details>


</details>


<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant Browser
    participant CORSMiddleware as CORS Middleware
    participant CSRFMiddleware as CSRF Middleware
    participant isAllowedOrigin as isAllowedOrigin(allowWildcard:false)
    participant Route as API Route

    Browser->>CORSMiddleware: リクエスト (Origin: https://evil.com)
    CORSMiddleware->>isAllowedOrigin: "origin, frontendOrigin, allowedOrigins, {allowWildcard: false}"
    Note over isAllowedOrigin: ワイルドカード("*")パターンを無視
    isAllowedOrigin-->>CORSMiddleware: false
    CORSMiddleware-->>Browser: Access-Control-Allow-Origin ヘッダーなし

    Browser->>CSRFMiddleware: POST リクエスト (Origin: https://evil.com)
    CSRFMiddleware->>isAllowedOrigin: "origin, frontendOrigin, allowedOrigins, {allowWildcard: false}"
    isAllowedOrigin-->>CSRFMiddleware: false
    CSRFMiddleware-->>Browser: 403 Forbidden

    Browser->>CORSMiddleware: リクエスト (Origin: https://frontend.example.com)
    CORSMiddleware->>isAllowedOrigin: "origin, frontendOrigin, allowedOrigins, {allowWildcard: false}"
    isAllowedOrigin-->>CORSMiddleware: true (frontendOriginと一致)
    CORSMiddleware->>CSRFMiddleware: 通過
    CSRFMiddleware->>Route: 通過
    Route-->>Browser: 200 OK
```

<!-- greptile_failed_comments -->
<details open><summary><h3>Comments Outside Diff (1)</h3></summary>

1. `apps/api/src/utils/origin.ts`, line 50 ([link](https://github.com/hiroki-org/openshelf/blob/789c05a152d00227b881f2f39ce0da2813264a3a/apps/api/src/utils/origin.ts#L50)) 

   <a href="#"><img alt="P2" src="https://greptile-static-assets.s3.amazonaws.com/badges/p2.svg?v=7" align="top"></a> **デフォルト値が引き続き許容的なまま**

   `isAllowedOrigin` の `allowWildcard` オプションのデフォルト値は `true` のままです。今回のPRはすべての既存呼び出し箇所に `{ allowWildcard: false }` を明示的に指定することで対処していますが、将来の開発者が新しい呼び出し箇所を追加する際にこのオプションを渡し忘れると、ワイルドカードオリジンの検証バイパスが再発します。ヘルパー関数のデフォルト値を `false` に変更すれば、安全側の設計（secure-by-default）となり、同様の脆弱性の再発を防ぎます。

   <details><summary>Prompt To Fix With AI</summary>

   `````markdown
   This is a comment left during a code review.
   Path: apps/api/src/utils/origin.ts
   Line: 50

   Comment:
   **デフォルト値が引き続き許容的なまま**

   `isAllowedOrigin` の `allowWildcard` オプションのデフォルト値は `true` のままです。今回のPRはすべての既存呼び出し箇所に `{ allowWildcard: false }` を明示的に指定することで対処していますが、将来の開発者が新しい呼び出し箇所を追加する際にこのオプションを渡し忘れると、ワイルドカードオリジンの検証バイパスが再発します。ヘルパー関数のデフォルト値を `false` に変更すれば、安全側の設計（secure-by-default）となり、同様の脆弱性の再発を防ぎます。

   How can I resolve this? If you propose a fix, please make it concise.
   `````
   </details>

</details>

<!-- /greptile_failed_comments -->

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 2 code review issues. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 2
apps/api/src/utils/origin.ts:50
**デフォルト値が引き続き許容的なまま**

`isAllowedOrigin` の `allowWildcard` オプションのデフォルト値は `true` のままです。今回のPRはすべての既存呼び出し箇所に `{ allowWildcard: false }` を明示的に指定することで対処していますが、将来の開発者が新しい呼び出し箇所を追加する際にこのオプションを渡し忘れると、ワイルドカードオリジンの検証バイパスが再発します。ヘルパー関数のデフォルト値を `false` に変更すれば、安全側の設計（secure-by-default）となり、同様の脆弱性の再発を防ぎます。

### Issue 2 of 2
description.md:1-5
**PRの説明ファイルがリポジトリにコミットされている**

`description.md` はPRの概要を記述したファイルですが、ソースコードとしてリポジトリへコミットする必要はありません。PR本文はGitHub上で管理されるべきであり、このファイルをリポジトリのルートに残すと、ドキュメントとして誤認されたり、将来の検索で混乱を招く可能性があります。このファイルを削除するか、`.gitignore` に追加することを推奨します。


`````

</details>

<sub>Reviews (1): Last reviewed commit: ["🛡️ Sentinel: \[HIGH\] CORSおよびCSRFにおけるワイルド..."](https://github.com/hiroki-org/openshelf/commit/789c05a152d00227b881f2f39ce0da2813264a3a) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=31525590)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->