### PR TITLE
🧪 Update unexpected db error test for paper invites

### DIFF
--- a/apps/api/src/routes/__tests__/papers.test.ts
+++ b/apps/api/src/routes/__tests__/papers.test.ts
@@ -3183,8 +3183,8 @@ describe("papers routes", () => {
       expect(data.error).toBe("Invite already sent");
     });
 
-    it("POST /api/papers/:id/invites returns 500 for unexpected db errors", async () => {
-      const consoleSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+    it("propagates general db insert errors", async () => {
+      vi.spyOn(console, "error").mockImplementation(() => {});
       try {
         const token = await createTestJWT({
           sub: "user-uploader",
@@ -3203,7 +3203,7 @@ describe("papers routes", () => {
 
         expect(res.status).toBe(500);
       } finally {
-        consoleSpy.mockRestore();
+        vi.mocked(console.error).mockRestore();
       }
     });
   });

--- a/apps/api/src/routes/__tests__/papers.test.ts
+++ b/apps/api/src/routes/__tests__/papers.test.ts
@@ -3183,8 +3183,8 @@ describe("papers routes", () => {
       expect(data.error).toBe("Invite already sent");
     });
 
-    it("propagates general db insert errors", async () => {
-      vi.spyOn(console, "error").mockImplementation(() => {});
+    it("POST /api/papers/:id/invites returns 500 for unexpected db errors", async () => {
+      const consoleSpy = vi.spyOn(console, "error").mockImplementation(() => {});
       try {
         const token = await createTestJWT({
           sub: "user-uploader",
@@ -3203,7 +3203,7 @@ describe("papers routes", () => {
 
         expect(res.status).toBe(500);
       } finally {
-        vi.mocked(console.error).mockRestore();
+        consoleSpy.mockRestore();
       }
     });
   });

--- a/apps/api/src/routes/__tests__/papers.test.ts
+++ b/apps/api/src/routes/__tests__/papers.test.ts
@@ -2161,13 +2161,11 @@ describe("papers routes", () => {
     });
     const set = vi.fn().mockReturnThis();
     const where = vi.fn().mockReturnThis();
-    mockDb.select = vi
-      .fn()
-      .mockImplementation(() =>
-        makeQuery({
-          getResult: { paperId: "paper-1", userId: "user-1", role: "uploader" },
-        }),
-      );
+    mockDb.select = vi.fn().mockImplementation(() =>
+      makeQuery({
+        getResult: { paperId: "paper-1", userId: "user-1", role: "uploader" },
+      }),
+    );
     mockDb.update = vi.fn().mockImplementation(() => ({ set, where }) as any);
 
     const app = await createTestApp();
@@ -2211,13 +2209,11 @@ describe("papers routes", () => {
       githubId: "123",
       name: "Uploader",
     });
-    mockDb.select = vi
-      .fn()
-      .mockImplementation(() =>
-        makeQuery({
-          getResult: { paperId: "paper-1", userId: "user-1", role: "uploader" },
-        }),
-      );
+    mockDb.select = vi.fn().mockImplementation(() =>
+      makeQuery({
+        getResult: { paperId: "paper-1", userId: "user-1", role: "uploader" },
+      }),
+    );
 
     const app = await createTestApp();
     const env = createTestEnv();
@@ -2371,13 +2367,11 @@ describe("papers routes", () => {
     });
     const set = vi.fn().mockReturnThis();
     const where = vi.fn().mockReturnThis();
-    mockDb.select = vi
-      .fn()
-      .mockImplementation(() =>
-        makeQuery({
-          getResult: { paperId: "paper-1", userId: "user-1", role: "uploader" },
-        }),
-      );
+    mockDb.select = vi.fn().mockImplementation(() =>
+      makeQuery({
+        getResult: { paperId: "paper-1", userId: "user-1", role: "uploader" },
+      }),
+    );
     mockDb.update = vi.fn().mockImplementation(() => ({ set, where }) as any);
 
     const app = await createTestApp();
@@ -2423,13 +2417,11 @@ describe("papers routes", () => {
     });
     const set = vi.fn().mockReturnThis();
     const where = vi.fn().mockReturnThis();
-    mockDb.select = vi
-      .fn()
-      .mockImplementation(() =>
-        makeQuery({
-          getResult: { paperId: "paper-1", userId: "user-1", role: "uploader" },
-        }),
-      );
+    mockDb.select = vi.fn().mockImplementation(() =>
+      makeQuery({
+        getResult: { paperId: "paper-1", userId: "user-1", role: "uploader" },
+      }),
+    );
     mockDb.update = vi.fn().mockImplementation(() => ({ set, where }) as any);
 
     const app = await createTestApp();
@@ -2465,13 +2457,11 @@ describe("papers routes", () => {
     });
     const set = vi.fn().mockReturnThis();
     const where = vi.fn().mockReturnThis();
-    mockDb.select = vi
-      .fn()
-      .mockImplementation(() =>
-        makeQuery({
-          getResult: { paperId: "paper-1", userId: "user-1", role: "uploader" },
-        }),
-      );
+    mockDb.select = vi.fn().mockImplementation(() =>
+      makeQuery({
+        getResult: { paperId: "paper-1", userId: "user-1", role: "uploader" },
+      }),
+    );
     mockDb.update = vi.fn().mockImplementation(() => ({ set, where }) as any);
 
     const app = await createTestApp();
@@ -2505,13 +2495,11 @@ describe("papers routes", () => {
       githubId: "123",
       name: "Uploader",
     });
-    mockDb.select = vi
-      .fn()
-      .mockImplementation(() =>
-        makeQuery({
-          getResult: { paperId: "paper-1", userId: "user-1", role: "uploader" },
-        }),
-      );
+    mockDb.select = vi.fn().mockImplementation(() =>
+      makeQuery({
+        getResult: { paperId: "paper-1", userId: "user-1", role: "uploader" },
+      }),
+    );
 
     const app = await createTestApp();
     const env = createTestEnv();
@@ -2541,13 +2529,11 @@ describe("papers routes", () => {
     });
     const set = vi.fn().mockReturnThis();
     const where = vi.fn().mockReturnThis();
-    mockDb.select = vi
-      .fn()
-      .mockImplementation(() =>
-        makeQuery({
-          getResult: { paperId: "paper-1", userId: "user-1", role: "uploader" },
-        }),
-      );
+    mockDb.select = vi.fn().mockImplementation(() =>
+      makeQuery({
+        getResult: { paperId: "paper-1", userId: "user-1", role: "uploader" },
+      }),
+    );
     mockDb.update = vi.fn().mockImplementation(() => ({ set, where }) as any);
 
     const app = await createTestApp();
@@ -2583,13 +2569,11 @@ describe("papers routes", () => {
     });
     const set = vi.fn().mockReturnThis();
     const where = vi.fn().mockReturnThis();
-    mockDb.select = vi
-      .fn()
-      .mockImplementation(() =>
-        makeQuery({
-          getResult: { paperId: "paper-1", userId: "user-1", role: "uploader" },
-        }),
-      );
+    mockDb.select = vi.fn().mockImplementation(() =>
+      makeQuery({
+        getResult: { paperId: "paper-1", userId: "user-1", role: "uploader" },
+      }),
+    );
     mockDb.update = vi.fn().mockImplementation(() => ({ set, where }) as any);
 
     const app = await createTestApp();
@@ -2627,13 +2611,11 @@ describe("papers routes", () => {
     });
     const set = vi.fn().mockReturnThis();
     const where = vi.fn().mockReturnThis();
-    mockDb.select = vi
-      .fn()
-      .mockImplementation(() =>
-        makeQuery({
-          getResult: { paperId: "paper-1", userId: "user-1", role: "uploader" },
-        }),
-      );
+    mockDb.select = vi.fn().mockImplementation(() =>
+      makeQuery({
+        getResult: { paperId: "paper-1", userId: "user-1", role: "uploader" },
+      }),
+    );
     mockDb.update = vi.fn().mockImplementation(() => ({ set, where }) as any);
 
     const app = await createTestApp();
@@ -2669,13 +2651,11 @@ describe("papers routes", () => {
     });
     const set = vi.fn().mockReturnThis();
     const where = vi.fn().mockReturnThis();
-    mockDb.select = vi
-      .fn()
-      .mockImplementation(() =>
-        makeQuery({
-          getResult: { paperId: "paper-1", userId: "user-1", role: "uploader" },
-        }),
-      );
+    mockDb.select = vi.fn().mockImplementation(() =>
+      makeQuery({
+        getResult: { paperId: "paper-1", userId: "user-1", role: "uploader" },
+      }),
+    );
     mockDb.update = vi.fn().mockImplementation(() => ({ set, where }) as any);
 
     const app = await createTestApp();
@@ -2711,13 +2691,11 @@ describe("papers routes", () => {
     });
     const set = vi.fn().mockReturnThis();
     const where = vi.fn().mockReturnThis();
-    mockDb.select = vi
-      .fn()
-      .mockImplementation(() =>
-        makeQuery({
-          getResult: { paperId: "paper-1", userId: "user-1", role: "uploader" },
-        }),
-      );
+    mockDb.select = vi.fn().mockImplementation(() =>
+      makeQuery({
+        getResult: { paperId: "paper-1", userId: "user-1", role: "uploader" },
+      }),
+    );
     mockDb.update = vi.fn().mockImplementation(() => ({ set, where }) as any);
 
     const app = await createTestApp();
@@ -2761,13 +2739,11 @@ describe("papers routes", () => {
       githubId: "123",
       name: "Uploader",
     });
-    mockDb.select = vi
-      .fn()
-      .mockImplementation(() =>
-        makeQuery({
-          getResult: { paperId: "paper-1", userId: "user-1", role: "uploader" },
-        }),
-      );
+    mockDb.select = vi.fn().mockImplementation(() =>
+      makeQuery({
+        getResult: { paperId: "paper-1", userId: "user-1", role: "uploader" },
+      }),
+    );
 
     const app = await createTestApp();
     const env = createTestEnv();
@@ -2921,13 +2897,11 @@ describe("papers routes", () => {
     });
     const set = vi.fn().mockReturnThis();
     const where = vi.fn().mockReturnThis();
-    mockDb.select = vi
-      .fn()
-      .mockImplementation(() =>
-        makeQuery({
-          getResult: { paperId: "paper-1", userId: "user-1", role: "uploader" },
-        }),
-      );
+    mockDb.select = vi.fn().mockImplementation(() =>
+      makeQuery({
+        getResult: { paperId: "paper-1", userId: "user-1", role: "uploader" },
+      }),
+    );
     mockDb.update = vi.fn().mockImplementation(() => ({ set, where }) as any);
 
     const app = await createTestApp();
@@ -2966,13 +2940,11 @@ describe("papers routes", () => {
   });
 
   it("GET /api/papers/:id returns 401 for private paper without Bearer token", async () => {
-    mockDb.select = vi
-      .fn()
-      .mockImplementationOnce(() =>
-        makeQuery({
-          getResult: { id: "paper-1", title: "P1", visibility: "private" },
-        }),
-      );
+    mockDb.select = vi.fn().mockImplementationOnce(() =>
+      makeQuery({
+        getResult: { id: "paper-1", title: "P1", visibility: "private" },
+      }),
+    );
 
     const app = await createTestApp();
     const env = createTestEnv();
@@ -3211,23 +3183,28 @@ describe("papers routes", () => {
       expect(data.error).toBe("Invite already sent");
     });
 
-    it("POST /api/papers/:id/invites returns 500 for non-UNIQUE database errors", async () => {
-      const token = await createTestJWT({
-        sub: "user-uploader",
-        githubId: "123",
-        name: "Uploader",
-      });
-      setupInviteChecks();
+    it("propagates general db insert errors", async () => {
+      vi.spyOn(console, "error").mockImplementation(() => {});
+      try {
+        const token = await createTestJWT({
+          sub: "user-uploader",
+          githubId: "123",
+          name: "Uploader",
+        });
+        setupInviteChecks();
 
-      mockDb.insert = vi.fn().mockReturnValue({
-        values: vi.fn().mockRejectedValue(new Error("Some other DB Error")),
-      });
+        mockDb.insert = vi.fn().mockReturnValue({
+          values: vi.fn().mockRejectedValue(new Error("Some other DB Error")),
+        });
 
-      const app = await createTestApp();
-      const env = createTestEnv();
-      const res = await sendInviteRequest(token, app, env);
+        const app = await createTestApp();
+        const env = createTestEnv();
+        const res = await sendInviteRequest(token, app, env);
 
-      expect(res.status).toBe(500);
+        expect(res.status).toBe(500);
+      } finally {
+        vi.mocked(console.error).mockRestore();
+      }
     });
   });
 });


### PR DESCRIPTION
🎯 **What:** Improved the testing gap addressed for testing unexpected db errors when sending invites by silencing expected errors from polluting the test console logs and renaming the test suite. 📊 **Coverage:** Now clearly tests that non-UNIQUE database errors on invite creations propagate and correctly return 500 status code. ✨ **Result:** Prevents test suite pollution and improves readability for errors testing.

---
*PR created automatically by Jules for task [8580236804888129971](https://jules.google.com/task/8580236804888129971) started by @is0692vs*

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

このPRはテストファイルのみを変更しており、`papers.test.ts` 内の `mockDb.select` モック呼び出しの書式を統一的にリフォーマットしています。また、予期しない DB エラーが 500 を返すことを検証するテストに `vi.spyOn(console, "error")` + `try/finally` を追加し、テスト実行中の `console.error` 出力を抑制しています。

- 複数箇所の `vi.fn().mockImplementation(() => ...)` チェーンのフォーマットを統一（ロジック変更なし）
- invite DB エラーテストを `try/finally` で囲み、`console.error` をモックして予期されたエラーログがコンソールを汚染しないよう改善
- テスト名を \"POST /api/papers/:id/invites returns 500 for non-UNIQUE database errors\" から \"propagates general db insert errors\" に短縮
</details>

<details open><summary><h3>Confidence Score: 4/5</h3></summary>

テストのみの変更であり、プロダクションコードへの影響はない。安全にマージできる。

変更はすべてテストファイル内に留まり、プロダクションロジックへの影響はない。`console.error` の抑制と `try/finally` によるクリーンアップは意図通りに機能しており、spy 参照の扱い方と短縮されたテスト名にわずかな改善余地がある程度。

特に注意が必要なファイルはないが、`papers.test.ts` の新しいテストブロックにおける spy のリストアパターンを確認することを推奨。
</details>

<details open><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| apps/api/src/routes/__tests__/papers.test.ts | テストコードのみの変更。`mockDb.select` モックの書式を統一的にリフォーマットし、invite の予期せぬ DB エラーテストを `try/finally` で `console.error` を一時的に抑制する形式に更新。テスト名の変更および spy 参照の扱い方に軽微な改善余地あり。 |

</details>

</details>

<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A["POST /api/papers/:id/invites"] --> B{isUploader?}
    B -- No --> C[403 Forbidden]
    B -- Yes --> D{alreadyAuthor?}
    D -- Yes --> E[409 Conflict]
    D -- No --> F{inviteeExists?}
    F -- No --> G[404 Not Found]
    F -- Yes --> H[db.insert invite]
    H -- UNIQUE constraint error --> I[409 'Invite already sent']
    H -- Other DB error --> J["console.error (now silenced in test)"]
    J --> K[500 Internal Server Error]
    H -- Success --> L[200 OK]
```

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 2 code review issues. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 2
apps/api/src/routes/__tests__/papers.test.ts:3186
**テスト名から期待する HTTP ステータスコードが失われている**

元のテスト名 "POST /api/papers/:id/invites returns 500 for non-UNIQUE database errors" には、対象ルート・期待するステータスコード (500) の両方が含まれていました。新しい名前 "propagates general db insert errors" はより簡潔ですが、HTTP 500 を返すことという重要な検証内容が名前から読み取れなくなっています。テスト結果一覧を見たとき、このテストが何を保証しているか即座に判断しにくくなります。`"POST /api/papers/:id/invites returns 500 for unexpected db errors"` のように HTTP ステータスコードを含む名前にすることを検討してください。

### Issue 2 of 2
apps/api/src/routes/__tests__/papers.test.ts:3186-3208
**spy の参照を保持しないまま `finally` 内で `vi.mocked()` を使ってリストアしている**

`vi.spyOn()` は spy オブジェクトへの参照を返しますが、その参照を変数に保存せずに `finally` 内で `vi.mocked(console.error).mockRestore()` を呼んでいます。`vi.spyOn` の呼び出しが何らかの理由で失敗した場合、`vi.mocked(console.error)` は未モックの関数を参照し `mockRestore()` は何もしません。`spyOn` の戻り値を変数に受け取ってから `finally` でリストアする書き方のほうが明示的かつ安全です。

```suggestion
    it("propagates general db insert errors", async () => {
      const consoleSpy = vi.spyOn(console, "error").mockImplementation(() => {});
      try {
        const token = await createTestJWT({
          sub: "user-uploader",
          githubId: "123",
          name: "Uploader",
        });
        setupInviteChecks();

        mockDb.insert = vi.fn().mockReturnValue({
          values: vi.fn().mockRejectedValue(new Error("Some other DB Error")),
        });

        const app = await createTestApp();
        const env = createTestEnv();
        const res = await sendInviteRequest(token, app, env);

        expect(res.status).toBe(500);
      } finally {
        consoleSpy.mockRestore();
      }
    });
```

`````

</details>

<sub>Reviews (1): Last reviewed commit: ["🧪 Update unexpected db error test for p..."](https://github.com/hiroki-org/openshelf/commit/decd6e85883a1e13f557aeebc6ae6fc72254f037) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=31527270)</sub>

> Greptile also left **2 inline comments** on this PR.

<!-- /greptile_comment -->