### PR TITLE
fix: override Next postcss vulnerability

### DIFF
--- a/apps/web/package-lock.json
+++ b/apps/web/package-lock.json
@@ -8337,7 +8337,7 @@
         "@swc/helpers": "0.5.15",
         "baseline-browser-mapping": "^2.9.19",
         "caniuse-lite": "^1.0.30001579",
-        "postcss": "8.4.31",
+        "postcss": "8.5.12",
         "styled-jsx": "5.1.6"
       },
       "bin": {
@@ -8381,9 +8381,9 @@
       }
     },
     "node_modules/next/node_modules/postcss": {
-      "version": "8.4.31",
-      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.4.31.tgz",
-      "integrity": "sha512-PS08Iboia9mts/2ygV3eLpY5ghnUcfLV/EXTOW1E2qYxJKGGBUtNjN76FYHnMs36RmARn41bC0AZmn+rR0OVpQ==",
+      "version": "8.5.12",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.12.tgz",
+      "integrity": "sha512-W62t/Se6rA0Az3DfCL0AqJwXuKwBeYg6nOaIgzP+xZ7N5BFCI7DYi1qs6ygUYT6rvfi6t9k65UMLJC+PHZpDAA==",
       "funding": [
         {
           "type": "opencollective",
@@ -8400,9 +8400,9 @@
       ],
       "license": "MIT",
       "dependencies": {
-        "nanoid": "^3.3.6",
-        "picocolors": "^1.0.0",
-        "source-map-js": "^1.0.2"
+        "nanoid": "^3.3.11",
+        "picocolors": "^1.1.1",
+        "source-map-js": "^1.2.1"
       },
       "engines": {
         "node": "^10 || ^12 || >=14"

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -42,5 +42,11 @@
     "typescript": "^6",
     "vitest": "^4.1.5"
   },
+  "overrides": {
+    "next": {
+      "postcss": "8.5.12"
+    },
+    "postcss": "$postcss"
+  },
   "license": "MIT"
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -9848,7 +9848,7 @@
         "@swc/helpers": "0.5.15",
         "baseline-browser-mapping": "^2.9.19",
         "caniuse-lite": "^1.0.30001579",
-        "postcss": "8.4.31",
+        "postcss": "8.5.12",
         "styled-jsx": "5.1.6"
       },
       "bin": {
@@ -9892,9 +9892,9 @@
       }
     },
     "node_modules/next/node_modules/postcss": {
-      "version": "8.4.31",
-      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.4.31.tgz",
-      "integrity": "sha512-PS08Iboia9mts/2ygV3eLpY5ghnUcfLV/EXTOW1E2qYxJKGGBUtNjN76FYHnMs36RmARn41bC0AZmn+rR0OVpQ==",
+      "version": "8.5.12",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.12.tgz",
+      "integrity": "sha512-W62t/Se6rA0Az3DfCL0AqJwXuKwBeYg6nOaIgzP+xZ7N5BFCI7DYi1qs6ygUYT6rvfi6t9k65UMLJC+PHZpDAA==",
       "funding": [
         {
           "type": "opencollective",
@@ -9911,9 +9911,9 @@
       ],
       "license": "MIT",
       "dependencies": {
-        "nanoid": "^3.3.6",
-        "picocolors": "^1.0.0",
-        "source-map-js": "^1.0.2"
+        "nanoid": "^3.3.11",
+        "picocolors": "^1.1.1",
+        "source-map-js": "^1.2.1"
       },
       "engines": {
         "node": "^10 || ^12 || >=14"

--- a/package.json
+++ b/package.json
@@ -44,9 +44,9 @@
     },
     "picomatch@^4.0.0": "^4.0.4",
     "next": {
-      "postcss": "^8.5.12"
+      "postcss": "8.5.12"
     },
-    "postcss": "^8.5.12"
+    "postcss": "$postcss"
   },
   "license": "MIT"
 }


### PR DESCRIPTION
## Summary
- override Next's nested postcss resolution to 8.5.12 in root and apps/web locks
- add apps/web override so standalone installs keep the same resolution
- clear the OSV GHSA-qx2v-qp2m-jg93 finding that blocks the staging->main release PR

## Verification
- npm audit --json (root): 0 vulnerabilities
- npm audit --json (apps/web): 0 vulnerabilities
- npm ci --dry-run
- npm run typecheck
- npm test
- npm run lint (existing warnings only)

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

Next.js が内包する postcss の脆弱性（GHSA-qx2v-qp2m-jg93）を解消するため、ルートおよび `apps/web` の両 `package.json` で `overrides` を整備し、両ロックファイルを 8.5.12 固定で再生成した PR です。

- ルート `package.json` の `overrides` で `next > postcss` を `^8.5.12` から厳密バージョン `8.5.12` に変更し、`postcss` トップレベルオーバーライドを `$postcss` エイリアス（devDependencies の `^8.5.12` を参照）へ統一。
- `apps/web/package.json` に同等の `overrides` ブロックを追加し、ワークスペースルートを経由しないスタンドアロン `npm install` でも同じ解決になるよう保証。
- 両ロックファイルの `node_modules/next/node_modules/postcss` エントリが 8.4.31 → 8.5.12 へ更新され、インテグリティハッシュが両ファイルで一致している。
</details>

<details open><summary><h3>Confidence Score: 5/5</h3></summary>

このPRはマージして安全です。変更範囲は依存関係のバージョン固定のみで、アプリケーションコードへの影響はありません。

変更はすべて `package.json` のオーバーライド設定とロックファイルの更新に限定されています。`next` 内の postcss を 8.4.31 から 8.5.12 へ固定することで脆弱性を解消しており、ルートと `apps/web` の両方が整合的に更新されています。`$postcss` エイリアスは npm overrides の正式な構文で、両パッケージの devDependencies に `postcss: "^8.5.12"` が存在するため正しく解決されます。

特に注意が必要なファイルはありません。
</details>

<details open><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| package.json | `overrides` の `next > postcss` を `^8.5.12` から `8.5.12` に厳密固定し、`postcss` トップレベルオーバーライドを `$postcss` エイリアスへ変更。既存の構成と矛盾なし。 |
| apps/web/package.json | スタンドアロンインストール向けに同等の `overrides` ブロックを新規追加。`postcss: "^8.5.12"` が devDependencies に存在するため `$postcss` エイリアスは有効。 |
| package-lock.json | `node_modules/next/node_modules/postcss` が 8.4.31 → 8.5.12 に更新され、依存するサブパッケージのレンジも適切に追従。 |
| apps/web/package-lock.json | ルートロックファイルと同一の変更が反映されており、両ロックファイルのインテグリティハッシュも一致。 |

</details>

</details>

<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[npm install] --> B{Install Location}
    B -->|Workspace Root| C[root overrides]
    B -->|apps/web Standalone| D[apps/web overrides]
    C --> E[next postcss pinned 8.5.12]
    C --> F[postcss via devDep ref]
    D --> G[next postcss pinned 8.5.12]
    D --> H[postcss via devDep ref]
    E --> I[next uses postcss 8.5.12]
    G --> I
    F --> J[top-level postcss 8.5.12+]
    H --> J
    I --> K[GHSA-qx2v-qp2m-jg93 resolved]
    J --> K
```

<sub>Reviews (1): Last reviewed commit: ["fix: override next postcss vulnerability"](https://github.com/hiroki-org/openshelf/commit/9d965a40fbdaf57d2fc6e8198153dc11f2bf90d5) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=31712123)</sub>

<!-- /greptile_comment -->