### PR TITLE
test: tidy papers route test spacing

### DIFF
--- a/apps/api/src/routes/__tests__/papers.test.ts
+++ b/apps/api/src/routes/__tests__/papers.test.ts
@@ -3268,7 +3268,6 @@ describe("papers routes", () => {
       expect(res.status).toBe(500);
     });
 
-
   });
 });
 


### PR DESCRIPTION
## Summary
- remove the extra blank line flagged in the staging release PR review

## Validation
- git diff --check

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

テストファイル `apps/api/src/routes/__tests__/papers.test.ts` のフォーマット整理です。`staging` リリースPRのレビューで指摘された余分な空行を1行削除しています。

- `describe` ブロック内の末尾にあった二重空行（`});` の前）を単一空行に修正。
</details>

<details open><summary><h3>Confidence Score: 5/5</h3></summary>

テストコードの余分な空行1行を削除するだけの変更であり、動作への影響は一切ありません。

変更はテストファイルの空行1行の削除のみ。ロジック・型・テストの意図に対する影響はゼロです。

特に注意が必要なファイルはありません。
</details>

<details open><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| apps/api/src/routes/__tests__/papers.test.ts | 余分な空行を1行削除するだけのフォーマット変更。ロジックへの影響なし。 |

</details>

</details>

<sub>Reviews (1): Last reviewed commit: ["test: tidy papers route test spacing"](https://github.com/hiroki-org/openshelf/commit/29cc40d293dbc200cc13cc7b54319c182cc87f55) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=31712715)</sub>

<!-- /greptile_comment -->