### PR TITLE
🔧 codecov: コードカバレッジのターゲットを80%から85%に引き上げ

### DIFF
--- a/codecov.yml
+++ b/codecov.yml
@@ -8,11 +8,11 @@ coverage:
   status:
     project:
       default:
-        target: 80%
+        target: 85%
         threshold: 5%
     patch:
       default:
-        target: 70%
+        target: 85%
 
 ignore:
   - ".github/**"


### PR DESCRIPTION
<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

PR #798 は `codecov.yml` のカバレッジターゲットを引き上げるシンプルな設定変更です。プロジェクト全体のターゲットを 80%→85%、パッチのターゲットを 70%→85% に更新しています。

- **project ターゲット**: 80% → 85%（`threshold: 5%` により実質 80% 以上でOK）
- **patch ターゲット**: 70% → 85%（`threshold` 未設定のため厳密に 85% 以上が必要。従来の 70% から 15% の大幅引き上げ）
</details>

<details open><summary><h3>Confidence Score: 4/5</h3></summary>

設定変更のみで、コードロジックへの影響はありません。patch ターゲットの大幅引き上げにより、既存・新規 PR が想定外に失敗する可能性があります。

変更は1ファイルの数値変更のみで影響範囲は限定的です。patch カバレッジターゲットを 70% から 85% へ一気に引き上げており、threshold がないため新規コードに対して厳しい要件が課されます。

codecov.yml — patch の threshold 未設定と 15% の大幅引き上げについて確認が望ましい
</details>

<details open><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| codecov.yml | コードカバレッジのターゲットを project: 80%→85%、patch: 70%→85% に引き上げ。patch に threshold が設定されていない点が注意点。 |

</details>

</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 1 code review issue. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 1
codecov.yml:14-15
**patch ターゲットに threshold が未設定**

`project` は `threshold: 5%` があるため実質 80% 以上であれば通過しますが、`patch` には `threshold` が設定されていません。Codecov のデフォルト threshold は 0% のため、PRで変更した行のカバレッジが 84.9% でも失敗扱いになります。今回 70% → 85% と一気に 15% 引き上げているため、既存のPRや新規コードが想定外に失敗するリスクがあります。意図的であれば問題ありませんが、`project` と同様に `threshold: 5%` を設定することを検討してください。

`````

</details>

<sub>Reviews (1): Last reviewed commit: ["🔧 codecov: コードカバレッジのターゲットを80%から85%に引き上げ"](https://github.com/hiroki-org/openshelf/commit/9312be0dde33131e48e1d61caac88530c198995e) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=32101263)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->