### PR TITLE
🛡️ Sentinel: [CRITICAL] IPスプーフィング脆弱性の修正 (X-Forwarded-For フォールバックの削除)

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -16,3 +16,7 @@
 **Issue:** String exceptions were not handled, causing the app to return an Internal Server Error.
 **Learning:** `e instanceof Error` correctly identifies built-in errors, but doesn't handle `throw "error"`. It caused Hono to not correctly propagate a 500 status.
 **Prevention:** Handled by validating `e instanceof Error ? e.message : typeof e === 'string' ? e : "";` and throwing an error properly at the end `throw e instanceof Error ? e : new Error(String(e));`.
+## 2026-05-15 - [IPスプーフィングの脆弱性]
+**Vulnerability:** X-Forwarded-For ヘッダーを使用した IP アドレスのフォールバック
+**Learning:** Cloudflare Workers 環境などでは CF-Connecting-IP が信頼できる IP アドレスのソースとなります。X-Forwarded-For にフォールバックすると、クライアントがヘッダーを偽装（スプーフィング）し、IP ベースのアクセス制御やレート制限を回避できる可能性があります。
+**Prevention:** 信頼できるロードバランサーや CDN が設定するヘッダー（例：CF-Connecting-IP）のみを使用し、クライアントから送信される可能性のあるヘッダー（例：X-Forwarded-For）へのフォールバックは避ける。

--- a/apps/api/src/routes/papers.ts
+++ b/apps/api/src/routes/papers.ts
@@ -159,9 +159,6 @@ function isBotUserAgent(userAgent: string | undefined): boolean {
 
 function getClientIp(c: Context<{ Bindings: Env; Variables: Variables }>): string {
     return c.req.header("CF-Connecting-IP")
-        ?? c.req.header("cf-connecting-ip")
-        ?? c.req.header("X-Forwarded-For")?.split(",")[0]?.trim()
-        ?? c.req.header("x-forwarded-for")?.split(",")[0]?.trim()
         ?? "unknown-ip";
 }
 


### PR DESCRIPTION
🚨 Severity: CRITICAL
💡 Vulnerability: `X-Forwarded-For` ヘッダーに対するフォールバックによるIPスプーフィングの脆弱性
🎯 Impact: 悪意のあるユーザーがリクエストの `X-Forwarded-For` ヘッダーを操作することで、IPアドレスを偽装し、IPベースのアクセス制限やレート制限を回避できる可能性がありました。
🔧 Fix: `apps/api/src/routes/papers.ts` の `getClientIp` 関数から、`X-Forwarded-For` および重複する `cf-connecting-ip` の取得処理を削除し、信頼できる `CF-Connecting-IP` のみを利用するように修正しました。
✅ Verification: 全てのAPIおよびWeb側のテスト（`bun x vitest`）を実行し、問題なくパスすることを確認しました。

---
*PR created automatically by Jules for task [10754333442610924551](https://jules.google.com/task/10754333442610924551) started by @is0692vs*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Enhanced client IP detection security by restricting trusted header sources to verified proxies. Removed fallback logic that relied on alternative sources for improved safety.

* **Documentation**
  * Added security guidance documenting client IP header handling best practices and IP spoofing vulnerability considerations.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Hiroki-org/OpenShelf/pull/810)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

このPRは `getClientIp` 関数から `X-Forwarded-For` ヘッダーおよび重複していた小文字の `cf-connecting-ip` フォールバックを削除し、Cloudflare が設定する信頼できる `CF-Connecting-IP` ヘッダーのみを使用するよう修正します。

- **`apps/api/src/routes/papers.ts`**: `getClientIp` から `X-Forwarded-For` / `x-forwarded-for` フォールバックを削除。クライアントが任意のヘッダー値を送信できるため、これらを使用するとIPベースの統計重複排除を回避できる問題があった。
- **`.jules/sentinel.md`**: 本件の脆弱性の内容と対策をナレッジベースに記録。Cloudflare Workers 環境では `CF-Connecting-IP` のみが信頼できる IP ソースであるという学習が残されている。
</details>

<details open><summary><h3>Confidence Score: 5/5</h3></summary>

変更は最小限でリスクが低く、マージに問題はありません。

削除されたフォールバック（X-Forwarded-For、重複の cf-connecting-ip）はいずれも不要であり、Hono の c.req.header() は大文字・小文字を区別しないため、CF-Connecting-IP 単独での取得に問題はありません。getClientIp の使用箇所は統計イベントの重複排除ハッシュ生成のみであり、実際のアクセス制御やレート制限には使われていません。

特に注意が必要なファイルはありません。
</details>

<details open><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| apps/api/src/routes/papers.ts | getClientIp 関数から X-Forwarded-For および重複する小文字の cf-connecting-ip フォールバックを削除し、CF-Connecting-IP のみを使用するように変更。変更は最小限かつ正確。 |
| .jules/sentinel.md | IP スプーフィング脆弱性に関する学習記録を追記。内容は変更内容と一致している。 |

</details>

</details>

<sub>Reviews (1): Last reviewed commit: ["🛡️ Sentinel: \[CRITICAL\] 修正: IPスプーフィングの脆..."](https://github.com/hiroki-org/openshelf/commit/5ede4725e93d81aa5786fa836ff5b5a8884cf261) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=32337941)</sub>

<!-- /greptile_comment -->