### PR TITLE
🎨 Palette: CiteButtonへのローディングスピナー追加

### DIFF
--- a/apps/web/src/app/papers/[id]/cite-button.tsx
+++ b/apps/web/src/app/papers/[id]/cite-button.tsx
@@ -111,12 +111,20 @@ export function CiteButton({ paperId }: CiteButtonProps) {
             <button
               key={option.value}
               type="button"
-              className="block w-full rounded px-3 py-2 text-left text-sm text-gray-700 hover:bg-gray-100 disabled:cursor-not-allowed disabled:opacity-60 dark:text-gray-200 dark:hover:bg-gray-800"
+              className="flex w-full items-center justify-between rounded px-3 py-2 text-left text-sm text-gray-700 hover:bg-gray-100 disabled:cursor-not-allowed disabled:opacity-60 dark:text-gray-200 dark:hover:bg-gray-800"
               onClick={() => handleCopy(option.value)}
               disabled={loadingFormat !== null}
               role="menuitem"
             >
-              {loadingFormat === option.value ? "生成中..." : option.label}
+              <span>
+                {loadingFormat === option.value ? "生成中..." : option.label}
+              </span>
+              {loadingFormat === option.value && (
+                <span
+                  className="h-4 w-4 animate-spin rounded-full border-2 border-current border-t-transparent"
+                  aria-hidden="true"
+                />
+              )}
             </button>
           ))}
         </div>


### PR DESCRIPTION
💡 **What:** 
`CiteButton` において、引用フォーマットを生成している間の非同期状態を示す視覚的なローディングスピナーを追加しました。

🎯 **Why:** 
ユーザーが引用フォーマット（例: BibTeX）をクリックした際、これまでは「生成中...」というテキストのみで進行状況を伝えていましたが、より直感的に「処理中である」ことが伝わるように視覚的フィードバックを改善しました。

📸 **Before/After:** 
ボタン内部のレイアウトを `flex items-center justify-between` に変更し、右側に既存のTailwind CSSスピナーが表示されるようになりました。

♿ **Accessibility:** 
スピナー要素には `aria-hidden="true"` を付与し、スクリーンリーダーで「生成中...」というテキストのみが読み上げられるように配慮しています。

---
*PR created automatically by Jules for task [16256833988510954468](https://jules.google.com/task/16256833988510954468) started by @is0692vs*

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

レビュー完了。`CiteButton` へのローディングスピナー追加はアクセシビリティ配慮も含め概ね良好な実装。ローディング中ボタンに `disabled:opacity-60` が適用される視覚的矛盾のみP2として指摘。
</details>

<details open><summary><h3>Confidence Score: 4/5</h3></summary>

変更範囲は CiteButton の表示ロジックのみで、既存の非同期処理・エラーハンドリングには影響なし。マージは概ね安全。

スピナー追加自体はシンプルで機能的に正しいが、ローディング中のボタン自身にも disabled が付与されることで opacity-60 が適用され、回転するスピナーがフェード表示になる視覚的な矛盾が残る。

apps/web/src/app/papers/[id]/cite-button.tsx — disabled 状態とローディング中ボタンの opacity 挙動を確認。
</details>

<details open><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| apps/web/src/app/papers/[id]/cite-button.tsx | ローディングスピナーの追加。ボタンレイアウトを flex に変更し、loadingFormat === option.value のときのみスピナーを表示。aria-hidden="true" でアクセシビリティにも配慮されているが、ローディング中のボタン自身にも disabled が付いて opacity-60 になる視覚的矛盾がある。 |

</details>

</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 1 code review issue. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 1
apps/web/src/app/papers/[id]/cite-button.tsx:116
**ローディング中のボタンが薄く表示される問題**

`disabled={loadingFormat !== null}` により、実際にローディング中のボタン自身にも `disabled` 属性が付与されます。`disabled:opacity-60` クラスが適用されてスピナーが 60% の不透明度で表示されるため、「処理中（スピナーが回転）」と「利用不可（フェード表示）」という相反するビジュアルシグナルが同時に出てしまいます。ローディング中のボタンのみ `disabled` を除外するか（`disabled={loadingFormat !== null && loadingFormat !== option.value}`）、`disabled:opacity-60` を `disabled` 属性ではなく `loadingFormat` の状態で制御するアプローチが考えられます。

`````

</details>

<sub>Reviews (1): Last reviewed commit: ["feat(ux): add loading spinner to cite bu..."](https://github.com/hiroki-org/openshelf/commit/595e088861a5ade41152b0748ffa096cef8750af) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=32510193)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->