### PR TITLE
🧪 Add test for BADGE_CACHE_CONTROL

### DIFF
--- a/apps/api/src/utils/__tests__/badge.test.ts
+++ b/apps/api/src/utils/__tests__/badge.test.ts
@@ -1,225 +1,240 @@
 import { describe, expect, it } from "vitest";
 import {
-    escapeXml,
-    normalizeBadgeStyle,
-    normalizeBadgeLabel,
-    normalizeBadgeColor,
-    truncateBadgeText,
-    estimateTextWidth,
-    buildBadgeMessage,
-    buildLeftText,
-    buildBadgeSvg,
-    buildShieldsEndpointPayload,
-    buildNotFoundBadge,
-    createEtag,
+  escapeXml,
+  normalizeBadgeStyle,
+  normalizeBadgeLabel,
+  normalizeBadgeColor,
+  truncateBadgeText,
+  estimateTextWidth,
+  buildBadgeMessage,
+  buildLeftText,
+  buildBadgeSvg,
+  buildShieldsEndpointPayload,
+  buildNotFoundBadge,
+  createEtag,
+  BADGE_CACHE_CONTROL,
 } from "../badge";
 
 describe("badge utils", () => {
-    describe("escapeXml", () => {
-        it("escapes special characters", () => {
-            expect(escapeXml('a & b < c > d " e \' f')).toBe(
-                "a &amp; b &lt; c &gt; d &quot; e &#39; f",
-            );
-        });
-        it("handles empty strings", () => {
-            expect(escapeXml("")).toBe("");
-        });
-        it("handles strings without special characters", () => {
-            expect(escapeXml("hello world")).toBe("hello world");
-        });
+  describe("escapeXml", () => {
+    it("escapes special characters", () => {
+      expect(escapeXml("a & b < c > d \" e ' f")).toBe(
+        "a &amp; b &lt; c &gt; d &quot; e &#39; f",
+      );
     });
-
-    describe("normalizeBadgeStyle", () => {
-        it("returns compact for compact input", () => {
-            expect(normalizeBadgeStyle("compact")).toBe("compact");
-        });
-        it("returns default for other string inputs", () => {
-            expect(normalizeBadgeStyle("flat")).toBe("default");
-            expect(normalizeBadgeStyle("")).toBe("default");
-        });
-        it("returns default for null/undefined", () => {
-            expect(normalizeBadgeStyle(null)).toBe("default");
-            expect(normalizeBadgeStyle(undefined)).toBe("default");
-        });
+    it("handles empty strings", () => {
+      expect(escapeXml("")).toBe("");
     });
-
-    describe("normalizeBadgeLabel", () => {
-        it("returns the label trimmed and whitespace-normalized", () => {
-            expect(normalizeBadgeLabel("  hello   world  ")).toBe("hello world");
-        });
-        it("returns default label for empty, null, or undefined", () => {
-            expect(normalizeBadgeLabel("")).toBe("OpenShelf");
-            expect(normalizeBadgeLabel("   ")).toBe("OpenShelf");
-            expect(normalizeBadgeLabel(null)).toBe("OpenShelf");
-            expect(normalizeBadgeLabel(undefined)).toBe("OpenShelf");
-        });
-        it("truncates long labels", () => {
-            const longLabel = "this is a very long label that exceeds the limit";
-            const normalized = normalizeBadgeLabel(longLabel);
-            expect(normalized.length).toBeLessThanOrEqual(24);
-            expect(normalized.endsWith("…")).toBe(true);
-        });
+    it("handles strings without special characters", () => {
+      expect(escapeXml("hello world")).toBe("hello world");
     });
+  });
 
-    describe("normalizeBadgeColor", () => {
-        it("returns lowercase standard hex colors without #", () => {
-            expect(normalizeBadgeColor("FF0000")).toBe("ff0000");
-            expect(normalizeBadgeColor("#00FF00")).toBe("00ff00");
-            expect(normalizeBadgeColor("123")).toBe("123");
-        });
-        it("returns lowercase named colors", () => {
-            expect(normalizeBadgeColor("Red")).toBe("red");
-            expect(normalizeBadgeColor("blue")).toBe("blue");
-        });
-        it("returns default color for invalid, empty, null, or undefined", () => {
-            expect(normalizeBadgeColor("invalid color!")).toBe("4c1");
-            expect(normalizeBadgeColor("")).toBe("4c1");
-            expect(normalizeBadgeColor(null)).toBe("4c1");
-            expect(normalizeBadgeColor(undefined)).toBe("4c1");
-        });
+  describe("normalizeBadgeStyle", () => {
+    it("returns compact for compact input", () => {
+      expect(normalizeBadgeStyle("compact")).toBe("compact");
     });
-
-    describe("truncateBadgeText", () => {
-        it("does not truncate if within max length", () => {
-            expect(truncateBadgeText("hello", 10)).toBe("hello");
-            expect(truncateBadgeText("hello", 5)).toBe("hello");
-        });
-        it("truncates and adds ellipsis if exceeding max length", () => {
-            expect(truncateBadgeText("hello world", 8)).toBe("hello w…");
-        });
-        it("handles max length <= 1", () => {
-            expect(truncateBadgeText("hello", 1)).toBe("…");
-            expect(truncateBadgeText("hello", 0)).toBe("…");
-        });
-        it("normalizes whitespace before truncating", () => {
-            expect(truncateBadgeText("hello   world", 8)).toBe("hello w…");
-        });
+    it("returns default for other string inputs", () => {
+      expect(normalizeBadgeStyle("flat")).toBe("default");
+      expect(normalizeBadgeStyle("")).toBe("default");
     });
-
-    describe("estimateTextWidth", () => {
-        it("estimates width for basic alphanumeric characters", () => {
-            expect(estimateTextWidth("a")).toBe(6);
-            expect(estimateTextWidth("A")).toBe(7);
-            expect(estimateTextWidth("1")).toBe(6);
-        });
-        it("estimates width for wide characters", () => {
-            expect(estimateTextWidth("あ")).toBe(11);
-        });
-        it("estimates width for emojis", () => {
-            expect(estimateTextWidth("😀")).toBe(12);
-        });
-        it("estimates width for other characters (e.g., symbols, spaces)", () => {
-            expect(estimateTextWidth(" ")).toBe(5);
-            expect(estimateTextWidth("-")).toBe(5);
-        });
-        it("estimates total width", () => {
-            expect(estimateTextWidth("aA1 あ😀 ")).toBe(52);
-        });
+    it("returns default for null/undefined", () => {
+      expect(normalizeBadgeStyle(null)).toBe("default");
+      expect(normalizeBadgeStyle(undefined)).toBe("default");
     });
+  });
 
-    describe("buildBadgeMessage", () => {
-        it("returns 'Paper' for compact style", () => {
-            expect(buildBadgeMessage("Some Title", 2024, "compact")).toBe("Paper");
-        });
-        it("includes title and year for default style", () => {
-            expect(buildBadgeMessage("Some Title", 2024, "default")).toBe("Some Title (2024)");
-        });
-        it("omits year if null", () => {
-            expect(buildBadgeMessage("Some Title", null, "default")).toBe("Some Title");
-        });
-        it("omits year if year is 0", () => {
-            expect(buildBadgeMessage("Some Title", 0, "default")).toBe("Some Title");
-        });
-        it("truncates long titles with year", () => {
-            const title = "This is a very long title that should definitely be truncated";
-            const message = buildBadgeMessage(title, 2024, "default");
-            expect(message).toContain("… (2024)");
-            expect(message.length).toBeLessThanOrEqual(35 + 7); // 35 for title + 7 for " (2024)"
-        });
-        it("truncates long titles without year", () => {
-            const title = "This is a very long title that should definitely be truncated because it is long";
-            const message = buildBadgeMessage(title, null, "default");
-            expect(message).toContain("…");
-            expect(message.length).toBeLessThanOrEqual(38);
-        });
-        it("returns 'Paper' if result is empty", () => {
-            expect(buildBadgeMessage("   ", null, "default")).toBe("Paper");
-        });
+  describe("normalizeBadgeLabel", () => {
+    it("returns the label trimmed and whitespace-normalized", () => {
+      expect(normalizeBadgeLabel("  hello   world  ")).toBe("hello world");
     });
-
-    describe("buildLeftText", () => {
-        it("prepends document emoji", () => {
-            expect(buildLeftText("Label")).toBe("📄 Label");
-        });
+    it("returns default label for empty, null, or undefined", () => {
+      expect(normalizeBadgeLabel("")).toBe("OpenShelf");
+      expect(normalizeBadgeLabel("   ")).toBe("OpenShelf");
+      expect(normalizeBadgeLabel(null)).toBe("OpenShelf");
+      expect(normalizeBadgeLabel(undefined)).toBe("OpenShelf");
     });
-
-    describe("buildBadgeSvg", () => {
-        it("generates a valid SVG string", () => {
-            const svg = buildBadgeSvg("left", "right", "ff0000");
-            expect(svg).toContain("<svg");
-            expect(svg).toContain("</svg>");
-            expect(svg).toContain("left");
-            expect(svg).toContain("right");
-            expect(svg).toContain("#ff0000"); // color is transformed to hex
-        });
-        it("handles empty inputs by using defaults", () => {
-            const svg = buildBadgeSvg("", "", "");
-            expect(svg).toContain("📄 OpenShelf");
-            expect(svg).toContain("Paper");
-            expect(svg).toContain("#4c1");
-        });
-        it("handles named colors", () => {
-            const svg = buildBadgeSvg("left", "right", "red");
-            expect(svg).toContain(`fill="red"`);
-        });
+    it("truncates long labels", () => {
+      const longLabel = "this is a very long label that exceeds the limit";
+      const normalized = normalizeBadgeLabel(longLabel);
+      expect(normalized.length).toBeLessThanOrEqual(24);
+      expect(normalized.endsWith("…")).toBe(true);
     });
+  });
 
-    describe("buildShieldsEndpointPayload", () => {
-        it("returns a Shields.io compatible payload", () => {
-            const payload = buildShieldsEndpointPayload("left", "right", "ff0000");
-            expect(payload).toEqual({
-                schemaVersion: 1,
-                label: "left",
-                message: "right",
-                color: "ff0000",
-            });
-        });
+  describe("normalizeBadgeColor", () => {
+    it("returns lowercase standard hex colors without #", () => {
+      expect(normalizeBadgeColor("FF0000")).toBe("ff0000");
+      expect(normalizeBadgeColor("#00FF00")).toBe("00ff00");
+      expect(normalizeBadgeColor("123")).toBe("123");
     });
-
-    describe("buildNotFoundBadge", () => {
-        it("returns SVG and JSON for not found badge", () => {
-        // NOTE: color and style options are intentionally ignored by buildNotFoundBadge.
-        // It always uses the default NOT_FOUND_COLOR (#9f9f9f) and default style layout.
-
-            const result = buildNotFoundBadge({
-                style: "default",
-                label: "MyLabel",
-                color: "123",
-            });
-            expect(result.svg).toContain("📄 MyLabel");
-            expect(result.svg).toContain("not found");
-            expect(result.svg).toContain("#9f9f9f");
-
-            expect(result.json).toEqual({
-                schemaVersion: 1,
-                label: "📄 MyLabel",
-                message: "not found",
-                color: "9f9f9f",
-            });
-        });
+    it("returns lowercase named colors", () => {
+      expect(normalizeBadgeColor("Red")).toBe("red");
+      expect(normalizeBadgeColor("blue")).toBe("blue");
     });
-
-    describe("createEtag", () => {
-        it("generates a stable 16-character hex string enclosed in quotes", () => {
-            const etag1 = createEtag("hello world");
-            const etag2 = createEtag("hello world");
-            expect(etag1).toBe(etag2);
-            expect(etag1).toMatch(/^"[0-9a-f]{16}"$/);
-        });
-        it("generates different hashes for different inputs", () => {
-            const etag1 = createEtag("hello world");
-            const etag2 = createEtag("hello world!");
-            expect(etag1).not.toBe(etag2);
-        });
+    it("returns default color for invalid, empty, null, or undefined", () => {
+      expect(normalizeBadgeColor("invalid color!")).toBe("4c1");
+      expect(normalizeBadgeColor("")).toBe("4c1");
+      expect(normalizeBadgeColor(null)).toBe("4c1");
+      expect(normalizeBadgeColor(undefined)).toBe("4c1");
     });
+  });
+
+  describe("truncateBadgeText", () => {
+    it("does not truncate if within max length", () => {
+      expect(truncateBadgeText("hello", 10)).toBe("hello");
+      expect(truncateBadgeText("hello", 5)).toBe("hello");
+    });
+    it("truncates and adds ellipsis if exceeding max length", () => {
+      expect(truncateBadgeText("hello world", 8)).toBe("hello w…");
+    });
+    it("handles max length <= 1", () => {
+      expect(truncateBadgeText("hello", 1)).toBe("…");
+      expect(truncateBadgeText("hello", 0)).toBe("…");
+    });
+    it("normalizes whitespace before truncating", () => {
+      expect(truncateBadgeText("hello   world", 8)).toBe("hello w…");
+    });
+  });
+
+  describe("estimateTextWidth", () => {
+    it("estimates width for basic alphanumeric characters", () => {
+      expect(estimateTextWidth("a")).toBe(6);
+      expect(estimateTextWidth("A")).toBe(7);
+      expect(estimateTextWidth("1")).toBe(6);
+    });
+    it("estimates width for wide characters", () => {
+      expect(estimateTextWidth("あ")).toBe(11);
+    });
+    it("estimates width for emojis", () => {
+      expect(estimateTextWidth("😀")).toBe(12);
+    });
+    it("estimates width for other characters (e.g., symbols, spaces)", () => {
+      expect(estimateTextWidth(" ")).toBe(5);
+      expect(estimateTextWidth("-")).toBe(5);
+    });
+    it("estimates total width", () => {
+      expect(estimateTextWidth("aA1 あ😀 ")).toBe(52);
+    });
+  });
+
+  describe("buildBadgeMessage", () => {
+    it("returns 'Paper' for compact style", () => {
+      expect(buildBadgeMessage("Some Title", 2024, "compact")).toBe("Paper");
+    });
+    it("includes title and year for default style", () => {
+      expect(buildBadgeMessage("Some Title", 2024, "default")).toBe(
+        "Some Title (2024)",
+      );
+    });
+    it("omits year if null", () => {
+      expect(buildBadgeMessage("Some Title", null, "default")).toBe(
+        "Some Title",
+      );
+    });
+    it("omits year if year is 0", () => {
+      expect(buildBadgeMessage("Some Title", 0, "default")).toBe("Some Title");
+    });
+    it("truncates long titles with year", () => {
+      const title =
+        "This is a very long title that should definitely be truncated";
+      const message = buildBadgeMessage(title, 2024, "default");
+      expect(message).toContain("… (2024)");
+      expect(message.length).toBeLessThanOrEqual(35 + 7); // 35 for title + 7 for " (2024)"
+    });
+    it("truncates long titles without year", () => {
+      const title =
+        "This is a very long title that should definitely be truncated because it is long";
+      const message = buildBadgeMessage(title, null, "default");
+      expect(message).toContain("…");
+      expect(message.length).toBeLessThanOrEqual(38);
+    });
+    it("returns 'Paper' if result is empty", () => {
+      expect(buildBadgeMessage("   ", null, "default")).toBe("Paper");
+    });
+  });
+
+  describe("buildLeftText", () => {
+    it("prepends document emoji", () => {
+      expect(buildLeftText("Label")).toBe("📄 Label");
+    });
+  });
+
+  describe("buildBadgeSvg", () => {
+    it("generates a valid SVG string", () => {
+      const svg = buildBadgeSvg("left", "right", "ff0000");
+      expect(svg).toContain("<svg");
+      expect(svg).toContain("</svg>");
+      expect(svg).toContain("left");
+      expect(svg).toContain("right");
+      expect(svg).toContain("#ff0000"); // color is transformed to hex
+    });
+    it("handles empty inputs by using defaults", () => {
+      const svg = buildBadgeSvg("", "", "");
+      expect(svg).toContain("📄 OpenShelf");
+      expect(svg).toContain("Paper");
+      expect(svg).toContain("#4c1");
+    });
+    it("handles named colors", () => {
+      const svg = buildBadgeSvg("left", "right", "red");
+      expect(svg).toContain(`fill="red"`);
+    });
+  });
+
+  describe("buildShieldsEndpointPayload", () => {
+    it("returns a Shields.io compatible payload", () => {
+      const payload = buildShieldsEndpointPayload("left", "right", "ff0000");
+      expect(payload).toEqual({
+        schemaVersion: 1,
+        label: "left",
+        message: "right",
+        color: "ff0000",
+      });
+    });
+  });
+
+  describe("buildNotFoundBadge", () => {
+    it("returns SVG and JSON for not found badge", () => {
+      // NOTE: color and style options are intentionally ignored by buildNotFoundBadge.
+      // It always uses the default NOT_FOUND_COLOR (#9f9f9f) and default style layout.
+
+      const result = buildNotFoundBadge({
+        style: "default",
+        label: "MyLabel",
+        color: "123",
+      });
+      expect(result.svg).toContain("📄 MyLabel");
+      expect(result.svg).toContain("not found");
+      expect(result.svg).toContain("#9f9f9f");
+
+      expect(result.json).toEqual({
+        schemaVersion: 1,
+        label: "📄 MyLabel",
+        message: "not found",
+        color: "9f9f9f",
+      });
+    });
+  });
+
+  describe("createEtag", () => {
+    it("generates a stable 16-character hex string enclosed in quotes", () => {
+      const etag1 = createEtag("hello world");
+      const etag2 = createEtag("hello world");
+      expect(etag1).toBe(etag2);
+      expect(etag1).toMatch(/^"[0-9a-f]{16}"$/);
+    });
+    it("generates different hashes for different inputs", () => {
+      const etag1 = createEtag("hello world");
+      const etag2 = createEtag("hello world!");
+      expect(etag1).not.toBe(etag2);
+    });
+  });
+
+  describe("BADGE_CACHE_CONTROL", () => {
+    it("should have the correct cache control value", () => {
+      expect(BADGE_CACHE_CONTROL).toBe(
+        "public, max-age=86400, stale-while-revalidate=3600",
+      );
+    });
+  });
 });

--- a/pr-body.md
+++ b/pr-body.md
@@ -1,0 +1,5 @@
+🎯 **What:** Added missing test for `BADGE_CACHE_CONTROL` constant in `apps/api/src/utils/badge.ts`.
+
+📊 **Coverage:** Ensures the cache control value remains consistent and is intentionally updated.
+
+✨ **Result:** Improved test coverage and reliability for badge constants.


### PR DESCRIPTION
🎯 **What:** Added missing test for `BADGE_CACHE_CONTROL` constant in `apps/api/src/utils/badge.ts`.

📊 **Coverage:** Ensures the cache control value remains consistent and is intentionally updated.

✨ **Result:** Improved test coverage and reliability for badge constants.

---
*PR created automatically by Jules for task [14439140666444032155](https://jules.google.com/task/14439140666444032155) started by @is0692vs*

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

`apps/api/src/utils/__tests__/badge.test.ts` に `BADGE_CACHE_CONTROL` 定数のテストを追加しています。追加されたテスト自体は実装と一致しており正確です。

- **テスト追加**: `BADGE_CACHE_CONTROL` の値が `\"public, max-age=86400, stale-while-revalidate=3600\"` であることを検証するテストを追加。実装側の定数と一致しており正しい。
- **大量フォーマット変更**: ファイル全体のインデントが4スペースから2スペースに変更されており、本来の変更箇所が差分に埋もれている。
- **不要ファイルのコミット**: Jules が自動生成した `pr-body.md` がリポジトリに含まれている。
</details>

<details open><summary><h3>Confidence Score: 4/5</h3></summary>

追加されたテストは実装と一致しており正確。マージ自体に技術的リスクはないが、不要ファイルとフォーマット変更を整理したほうが望ましい。

テストの内容は正しく、既存の動作を壊す変更はない。ただし `pr-body.md` のコミットとファイル全体のインデント変更という2点が気になる。どちらも機能には影響しないが、リポジトリの品質に関わる。

`pr-body.md` はリポジトリに含めるべきでないため削除が必要。`badge.test.ts` のインデント変更は本来の目的とは無関係であり、フォーマット方針を確認したい。
</details>

<details open><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| apps/api/src/utils/__tests__/badge.test.ts | BADGE_CACHE_CONTROL のテストを追加。テストの値は実装と一致しており正確だが、ファイル全体のインデントが4スペース→2スペースに変更され、不要な差分ノイズが発生している。 |
| pr-body.md | Jules の自動PR作成ツールが生成したメタデータファイル。リポジトリに含めるべきではない成果物。 |

</details>

</details>

<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A["badge.test.ts"] --> B["BADGE_CACHE_CONTROL テスト追加"]
    B --> C{"値の検証"}
    C -->|"toBe()"| D["'public, max-age=86400, stale-while-revalidate=3600'"]
    D --> E["badge.ts の定数と一致 ✅"]
    A --> F["インデント変更 (4→2スペース)"]
    F --> G["全225行が差分に含まれる ⚠️"]
    H["pr-body.md"] --> I["Jules の自動生成ファイル ⚠️"]
    I --> J["リポジトリに不要"]
```

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 2 code review issues. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 2
pr-body.md:1-5
**Julesの自動生成ファイルがリポジトリに含まれている**

`pr-body.md` は Jules（Google の自動PR作成ツール）が生成したメタデータファイルであり、ソースコードとして意味を持たない成果物です。このファイルをリポジトリにコミットすると、リポジトリのルートが汚染され、他の開発者に混乱を招く可能性があります。`.gitignore` に追加するか、このファイルをコミットから除外することを推奨します。

### Issue 2 of 2
apps/api/src/utils/__tests__/badge.test.ts:1-15
**インデント変更による大量の差分ノイズ**

このPRの目的は `BADGE_CACHE_CONTROL` のテスト追加ですが、ファイル全体のインデントが4スペースから2スペースに変更されているため、実質的な変更箇所（15行程度）が225行の差分に埋もれています。この種のフォーマット変更は別のPRとして分離するか、プロジェクト全体でフォーマッターを統一したうえで一括適用することを推奨します。レビューの可読性が下がり、将来の `git blame` も汚染されます。

`````

</details>

<sub>Reviews (1): Last reviewed commit: ["🧪 Add test for BADGE\_CACHE\_CONTROL"](https://github.com/hiroki-org/openshelf/commit/9cca8a59f3ee198bea1aadc3b6723cf82015daa3) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=32528478)</sub>

> Greptile also left **2 inline comments** on this PR.

<!-- /greptile_comment -->