### PR TITLE
🧪 [Testing Improvement] Add tests for isCitationFormat

### DIFF
--- a/apps/api/src/utils/__tests__/citation.test.ts
+++ b/apps/api/src/utils/__tests__/citation.test.ts
@@ -1,172 +1,224 @@
 import { describe, expect, it } from "vitest";
-import { buildCitation } from "../citation";
+import { buildCitation, isCitationFormat } from "../citation";
+
+describe("isCitationFormat", () => {
+  it("returns true for valid citation formats", () => {
+    expect(isCitationFormat("bibtex")).toBe(true);
+    expect(isCitationFormat("biblatex")).toBe(true);
+    expect(isCitationFormat("apa")).toBe(true);
+    expect(isCitationFormat("ieee")).toBe(true);
+    expect(isCitationFormat("mla")).toBe(true);
+    expect(isCitationFormat("plain")).toBe(true);
+  });
+
+  it("returns false for invalid citation formats", () => {
+    expect(isCitationFormat("unknown")).toBe(false);
+    expect(isCitationFormat("chicago")).toBe(false);
+    expect(isCitationFormat("")).toBe(false);
+  });
+});
 
 describe("buildCitation", () => {
-    const paperBase = {
-        id: "paper-1",
-        title: "Balance Boundary Explorer",
-        venue: "ASE",
-        venueType: "conference" as const,
-        year: 2026,
-        category: "other" as const,
-        doi: null,
-        externalUrl: null,
-    };
+  const paperBase = {
+    id: "paper-1",
+    title: "Balance Boundary Explorer",
+    venue: "ASE",
+    venueType: "conference" as const,
+    year: 2026,
+    category: "other" as const,
+    doi: null,
+    externalUrl: null,
+  };
 
-    it("generates bibtex with key and fallback url when doi is missing", () => {
-        const result = buildCitation(
-            paperBase,
-            [
-                { name: "hiroki", displayName: "Hiroki Mukai" },
-                { name: "kato", displayName: "Yusaku Kato" },
-            ],
-            "bibtex",
-            "https://openshelf.example",
-        );
+  it("generates bibtex with key and fallback url when doi is missing", () => {
+    const result = buildCitation(
+      paperBase,
+      [
+        { name: "hiroki", displayName: "Hiroki Mukai" },
+        { name: "kato", displayName: "Yusaku Kato" },
+      ],
+      "bibtex",
+      "https://openshelf.example",
+    );
 
-        expect(result.format).toBe("bibtex");
-        expect(result.key).toBe("mukai2026balance");
-        expect(result.citation).toContain("@inproceedings{mukai2026balance");
-        expect(result.citation).toContain("author = {Hiroki Mukai and Yusaku Kato}");
-        expect(result.citation).toContain("url = {https://openshelf.example/papers/paper-1}");
+    expect(result.format).toBe("bibtex");
+    expect(result.key).toBe("mukai2026balance");
+    expect(result.citation).toContain("@inproceedings{mukai2026balance");
+    expect(result.citation).toContain(
+      "author = {Hiroki Mukai and Yusaku Kato}",
+    );
+    expect(result.citation).toContain(
+      "url = {https://openshelf.example/papers/paper-1}",
+    );
+  });
+
+  describe("when doi exists", () => {
+    const paperWithDoi = { ...paperBase, doi: "10.1145/xxxxxxx.xxxxxxx" };
+    const authors = [{ name: "hiroki", displayName: "Hiroki Mukai" }];
+
+    it("uses doi for bibtex and omits url", () => {
+      const bibtex = buildCitation(
+        paperWithDoi,
+        authors,
+        "bibtex",
+        "https://openshelf.example",
+      );
+      expect(bibtex.citation).toContain("doi = {10.1145/xxxxxxx.xxxxxxx}");
+      expect(bibtex.citation).not.toContain("url = {");
     });
 
-    describe("when doi exists", () => {
-        const paperWithDoi = { ...paperBase, doi: "10.1145/xxxxxxx.xxxxxxx" };
-        const authors = [{ name: "hiroki", displayName: "Hiroki Mukai" }];
-
-        it("uses doi for bibtex and omits url", () => {
-            const bibtex = buildCitation(paperWithDoi, authors, "bibtex", "https://openshelf.example");
-            expect(bibtex.citation).toContain("doi = {10.1145/xxxxxxx.xxxxxxx}");
-            expect(bibtex.citation).not.toContain("url = {");
-        });
-
-        it("uses doi url for plain format", () => {
-            const plain = buildCitation(paperWithDoi, authors, "plain", "https://openshelf.example");
-            expect(plain.citation).toContain("https://doi.org/10.1145/xxxxxxx.xxxxxxx");
-        });
-
-        it("uses doi url for apa format", () => {
-            const apa = buildCitation(paperWithDoi, authors, "apa", "https://openshelf.example");
-            expect(apa.citation).toContain("https://doi.org/10.1145/xxxxxxx.xxxxxxx");
-        });
-
-        it("uses doi prefix for ieee format", () => {
-            const ieee = buildCitation(paperWithDoi, authors, "ieee", "https://openshelf.example");
-            expect(ieee.citation).toContain("doi: 10.1145/xxxxxxx.xxxxxxx");
-        });
-
-        it("uses doi prefix for mla format", () => {
-            const mla = buildCitation(paperWithDoi, authors, "mla", "https://openshelf.example");
-            expect(mla.citation).toContain("doi:10.1145/xxxxxxx.xxxxxxx");
-        });
+    it("uses doi url for plain format", () => {
+      const plain = buildCitation(
+        paperWithDoi,
+        authors,
+        "plain",
+        "https://openshelf.example",
+      );
+      expect(plain.citation).toContain(
+        "https://doi.org/10.1145/xxxxxxx.xxxxxxx",
+      );
     });
 
-    it("supports plain format output", () => {
-        const result = buildCitation(
-            paperBase,
-            [{ name: "hiroki", displayName: "向井 宏樹" }],
-            "plain",
-            "https://openshelf.example",
-        );
-
-        expect(result.format).toBe("plain");
-        expect(result.key).toBeNull();
-        expect(result.citation).toContain("向井 宏樹");
-        expect(result.citation).toContain("Balance Boundary Explorer");
+    it("uses doi url for apa format", () => {
+      const apa = buildCitation(
+        paperWithDoi,
+        authors,
+        "apa",
+        "https://openshelf.example",
+      );
+      expect(apa.citation).toContain("https://doi.org/10.1145/xxxxxxx.xxxxxxx");
     });
 
-    it("maps category and venue type to expected bibtex entry type", () => {
-        const bachelor = buildCitation(
-            { ...paperBase, category: "thesis_bachelor", venueType: null },
-            [{ name: "a", displayName: "Alice" }],
-            "bibtex",
-            "https://openshelf.example",
-        );
-        const master = buildCitation(
-            { ...paperBase, category: "thesis_master", venueType: null },
-            [{ name: "a", displayName: "Alice" }],
-            "bibtex",
-            "https://openshelf.example",
-        );
-        const journal = buildCitation(
-            { ...paperBase, category: "other", venueType: "journal", venue: "JSS" },
-            [{ name: "a", displayName: "Alice" }],
-            "bibtex",
-            "https://openshelf.example",
-        );
-        const report = buildCitation(
-            { ...paperBase, category: "report", venueType: null, venue: null },
-            [{ name: "a", displayName: "Alice" }],
-            "bibtex",
-            "https://openshelf.example",
-        );
-
-        expect(bachelor.citation).toContain("@misc{");
-        expect(master.citation).toContain("@mastersthesis{");
-        expect(journal.citation).toContain("@article{");
-        expect(report.citation).toContain("@techreport{");
+    it("uses doi prefix for ieee format", () => {
+      const ieee = buildCitation(
+        paperWithDoi,
+        authors,
+        "ieee",
+        "https://openshelf.example",
+      );
+      expect(ieee.citation).toContain("doi: 10.1145/xxxxxxx.xxxxxxx");
     });
 
-    it("emits biblatex-specific thesis entry metadata for thesis_master", () => {
-        const result = buildCitation(
-            { ...paperBase, category: "thesis_master", venueType: null, venue: null },
-            [{ name: "hiroki", displayName: "Hiroki Mukai" }],
-            "biblatex",
-            "https://openshelf.example",
-        );
-
-        expect(result.citation).toContain("@thesis{");
-        expect(result.citation).toContain("type = {Master's thesis}");
+    it("uses doi prefix for mla format", () => {
+      const mla = buildCitation(
+        paperWithDoi,
+        authors,
+        "mla",
+        "https://openshelf.example",
+      );
+      expect(mla.citation).toContain("doi:10.1145/xxxxxxx.xxxxxxx");
     });
+  });
 
-    it("formats APA output with surname-initial style", () => {
-        const result = buildCitation(
-            paperBase,
-            [
-                { name: "hiroki", displayName: "Hiroki Mukai" },
-                { name: "kato", displayName: "Yusaku Kato" },
-            ],
-            "apa",
-            "https://openshelf.example",
-        );
+  it("supports plain format output", () => {
+    const result = buildCitation(
+      paperBase,
+      [{ name: "hiroki", displayName: "向井 宏樹" }],
+      "plain",
+      "https://openshelf.example",
+    );
 
-        expect(result.citation).toContain("Mukai, H.");
-        expect(result.citation).toContain("Kato, Y.");
-        expect(result.citation).toContain("(2026).");
-    });
+    expect(result.format).toBe("plain");
+    expect(result.key).toBeNull();
+    expect(result.citation).toContain("向井 宏樹");
+    expect(result.citation).toContain("Balance Boundary Explorer");
+  });
 
-    it("formats IEEE output correctly", () => {
-        const result = buildCitation(
-            paperBase,
-            [
-                { name: "hiroki", displayName: "Hiroki Mukai" },
-                { name: "kato", displayName: "Yusaku Kato" },
-            ],
-            "ieee",
-            "https://openshelf.example",
-        );
+  it("maps category and venue type to expected bibtex entry type", () => {
+    const bachelor = buildCitation(
+      { ...paperBase, category: "thesis_bachelor", venueType: null },
+      [{ name: "a", displayName: "Alice" }],
+      "bibtex",
+      "https://openshelf.example",
+    );
+    const master = buildCitation(
+      { ...paperBase, category: "thesis_master", venueType: null },
+      [{ name: "a", displayName: "Alice" }],
+      "bibtex",
+      "https://openshelf.example",
+    );
+    const journal = buildCitation(
+      { ...paperBase, category: "other", venueType: "journal", venue: "JSS" },
+      [{ name: "a", displayName: "Alice" }],
+      "bibtex",
+      "https://openshelf.example",
+    );
+    const report = buildCitation(
+      { ...paperBase, category: "report", venueType: null, venue: null },
+      [{ name: "a", displayName: "Alice" }],
+      "bibtex",
+      "https://openshelf.example",
+    );
 
-        expect(result.format).toBe("ieee");
-        expect(result.key).toBeNull();
-        expect(result.citation).toContain("Hiroki Mukai, Yusaku Kato");
-        expect(result.citation).toContain('"Balance Boundary Explorer", ASE, 2026, https://openshelf.example/papers/paper-1.');
-    });
+    expect(bachelor.citation).toContain("@misc{");
+    expect(master.citation).toContain("@mastersthesis{");
+    expect(journal.citation).toContain("@article{");
+    expect(report.citation).toContain("@techreport{");
+  });
 
-    it("formats MLA output correctly", () => {
-        const result = buildCitation(
-            paperBase,
-            [
-                { name: "hiroki", displayName: "Hiroki Mukai" },
-                { name: "kato", displayName: "Yusaku Kato" },
-            ],
-            "mla",
-            "https://openshelf.example",
-        );
+  it("emits biblatex-specific thesis entry metadata for thesis_master", () => {
+    const result = buildCitation(
+      { ...paperBase, category: "thesis_master", venueType: null, venue: null },
+      [{ name: "hiroki", displayName: "Hiroki Mukai" }],
+      "biblatex",
+      "https://openshelf.example",
+    );
 
-        expect(result.format).toBe("mla");
-        expect(result.key).toBeNull();
-        expect(result.citation).toContain("Hiroki Mukai, Yusaku Kato.");
-        expect(result.citation).toContain('"Balance Boundary Explorer", ASE, 2026. https://openshelf.example/papers/paper-1.');
-    });
+    expect(result.citation).toContain("@thesis{");
+    expect(result.citation).toContain("type = {Master's thesis}");
+  });
+
+  it("formats APA output with surname-initial style", () => {
+    const result = buildCitation(
+      paperBase,
+      [
+        { name: "hiroki", displayName: "Hiroki Mukai" },
+        { name: "kato", displayName: "Yusaku Kato" },
+      ],
+      "apa",
+      "https://openshelf.example",
+    );
+
+    expect(result.citation).toContain("Mukai, H.");
+    expect(result.citation).toContain("Kato, Y.");
+    expect(result.citation).toContain("(2026).");
+  });
+
+  it("formats IEEE output correctly", () => {
+    const result = buildCitation(
+      paperBase,
+      [
+        { name: "hiroki", displayName: "Hiroki Mukai" },
+        { name: "kato", displayName: "Yusaku Kato" },
+      ],
+      "ieee",
+      "https://openshelf.example",
+    );
+
+    expect(result.format).toBe("ieee");
+    expect(result.key).toBeNull();
+    expect(result.citation).toContain("Hiroki Mukai, Yusaku Kato");
+    expect(result.citation).toContain(
+      '"Balance Boundary Explorer", ASE, 2026, https://openshelf.example/papers/paper-1.',
+    );
+  });
+
+  it("formats MLA output correctly", () => {
+    const result = buildCitation(
+      paperBase,
+      [
+        { name: "hiroki", displayName: "Hiroki Mukai" },
+        { name: "kato", displayName: "Yusaku Kato" },
+      ],
+      "mla",
+      "https://openshelf.example",
+    );
+
+    expect(result.format).toBe("mla");
+    expect(result.key).toBeNull();
+    expect(result.citation).toContain("Hiroki Mukai, Yusaku Kato.");
+    expect(result.citation).toContain(
+      '"Balance Boundary Explorer", ASE, 2026. https://openshelf.example/papers/paper-1.',
+    );
+  });
 });


### PR DESCRIPTION
🎯 **What:** The testing gap addressed: The `isCitationFormat` function in `citation.ts` was missing test coverage.
📊 **Coverage:** What scenarios are now tested: Valid formats ("bibtex", "biblatex", "apa", "ieee", "mla", "plain") are checked and correctly assert to `true`. Invalid formats ("unknown", "chicago", "") are checked and correctly assert to `false`.
✨ **Result:** The improvement in test coverage: We now have 100% test coverage for the `isCitationFormat` utility function, ensuring reliability for format validations.

---
*PR created automatically by Jules for task [526430052765669279](https://jules.google.com/task/526430052765669279) started by @is0692vs*

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

既存テストには存在しなかった `isCitationFormat` ユーティリティ関数のテストケースを追加し、合わせて既存 `buildCitation` テストのインデントを 4 スペースから 2 スペースへ統一した PR です。

- 有効な 6 フォーマット（`bibtex`, `biblatex`, `apa`, `ieee`, `mla`, `plain`）と無効な入力（`\"unknown\"`, `\"chicago\"`, `\"\"`）を検証するテストを追加。
- 既存テストはロジックを変更せずインデントのみ整形。新規テストの正確性は実装（`Array.includes` による完全一致）と一致している。
</details>

<details open><summary><h3>Confidence Score: 4/5</h3></summary>

テスト専用の変更であり、プロダクションコードへの影響はない。安全にマージできる。

追加されたテストの正確性は実装と一致しており、既存テストのリファクタ（インデント整形）にも機能的な変化はない。大文字入力や `it.each` といった改善余地はあるが、現時点での動作を壊すものではない。

`citation.test.ts` の `isCitationFormat` テストにケース感度の明示的なカバレッジを追加すると、将来の仕様変更時の安全網となる。
</details>

<details open><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| apps/api/src/utils/__tests__/citation.test.ts | `isCitationFormat` のテストを追加し、既存 `buildCitation` テストのインデントを 4 スペースから 2 スペースへ統一。テストロジックに変更なし。 |

</details>

</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 2 code review issues. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 2
apps/api/src/utils/__tests__/citation.test.ts:4-14
**大文字・大小混在の入力がカバーされていない**

`isCitationFormat` は内部で厳密な小文字一致（`.includes()` による配列検索）を使用しており、`"BibTeX"` や `"APA"` のような大文字混じりの文字列は `false` を返します。実際の呼び出し側（HTTP クエリパラメータやフォーム入力など）から大文字が渡される可能性があり、その場合に意図せず無効フォーマット扱いになります。ケース非感受性の挙動を明示したテストケースを追加することで、期待動作をドキュメント化できます。

### Issue 2 of 2
apps/api/src/utils/__tests__/citation.test.ts:4-8
**有効フォーマットが 1 つの `it` にまとめられている**

6 種類の有効フォーマットがすべて同一の `it` ブロックにアサートされているため、1 つが失敗しても残りの結果が分からなくなります。各フォーマットを個別の `it` に分けるか、`it.each` を使うことでフォーマット単位のフィードバックが得られます。

`````

</details>

<sub>Reviews (1): Last reviewed commit: ["🧪 Add tests for isCitationFormat"](https://github.com/hiroki-org/openshelf/commit/e582e744ce3d0ab8421e2e5c5c9875c7d1a2a4ac) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=32528593)</sub>

> Greptile also left **2 inline comments** on this PR.

<!-- /greptile_comment -->