### PR TITLE
🧪 Test isCitationFormat

### DIFF
--- a/apps/api/src/utils/__tests__/citation.test.ts
+++ b/apps/api/src/utils/__tests__/citation.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "vitest";
-import { buildCitation } from "../citation";
+import { buildCitation, isCitationFormat } from "../citation";
 
 describe("buildCitation", () => {
     const paperBase = {
@@ -168,5 +168,26 @@ describe("buildCitation", () => {
         expect(result.key).toBeNull();
         expect(result.citation).toContain("Hiroki Mukai, Yusaku Kato.");
         expect(result.citation).toContain('"Balance Boundary Explorer", ASE, 2026. https://openshelf.example/papers/paper-1.');
+    });
+});
+
+describe("isCitationFormat", () => {
+    const validFormats = ["bibtex", "biblatex", "apa", "ieee", "mla", "plain"] as const;
+
+    it.each(validFormats)("returns true for valid format: %s", (format) => {
+        expect(isCitationFormat(format)).toBe(true);
+    });
+
+    it.each([
+        "chicago",
+        "BIBTEX",
+        "",
+        "unknown",
+        "bibtex ",
+        null,
+        undefined,
+        123,
+    ] satisfies unknown[])("returns false for invalid format: %s", (format) => {
+        expect(isCitationFormat(format as string)).toBe(false);
     });
 });


### PR DESCRIPTION
🎯 **What:** Added tests for the `isCitationFormat` function in `apps/api/src/utils/citation.ts` which lacked test coverage.
📊 **Coverage:** Covered both valid (`bibtex`, `biblatex`, `apa`, `ieee`, `mla`, `plain`) and invalid citation formats (e.g., `chicago`, `BIBTEX`, `""`).
✨ **Result:** Test coverage for `isCitationFormat` increased to 100%.

---
*PR created automatically by Jules for task [4465185451225415834](https://jules.google.com/task/4465185451225415834) started by @is0692vs*

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

この PR は `isCitationFormat` 関数（`apps/api/src/utils/citation.ts`）のテストが存在しなかった部分に対し、Vitest を使ったユニットテストを追加するものです。

- 有効なフォーマット 6 種類（`bibtex`, `biblatex`, `apa`, `ieee`, `mla`, `plain`）を `it.each` で個別テストケースとして検証し、デバッグ時の可視性を確保している。
- 無効なフォーマット（大文字・余白付き・空文字・非文字列型の `null` / `undefined` / `123` など）も網羅しており、`satisfies unknown[]` + `format as string` の TypeScript パターンを使って型安全に非文字列値のランタイム動作を検証している。
</details>

<details open><summary><h3>Confidence Score: 5/5</h3></summary>

テストのみの変更でプロダクションコードへの影響はなく、安全にマージできる。

変更はテストファイル 1 つに限定されており、既存の `isCitationFormat` 実装と正確に対応した有効・無効ケースを網羅している。ロジック上の欠陥や型の不整合は確認されなかった。

特に注意が必要なファイルはない。
</details>

<details open><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| apps/api/src/utils/__tests__/citation.test.ts | `isCitationFormat` のテストを追加。有効 6 種・無効 8 種を `it.each` で網羅しており、論理的・型的な問題は見当たらない。 |

</details>

</details>

<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A["describe: isCitationFormat"] --> B["it.each(validFormats)\n有効フォーマット 6 種"]
    A --> C["it.each(invalidFormats)\n無効値 8 種"]
    B --> B1["bibtex → true"]
    B --> B2["biblatex → true"]
    B --> B3["apa → true"]
    B --> B4["ieee → true"]
    B --> B5["mla → true"]
    B --> B6["plain → true"]
    C --> C1["chicago → false"]
    C --> C2["BIBTEX → false"]
    C --> C3["空文字 → false"]
    C --> C4["unknown → false"]
    C --> C5["bibtex（末尾スペース）→ false"]
    C --> C6["null → false"]
    C --> C7["undefined → false"]
    C --> C8["123 → false"]
```

<sub>Reviews (4): Last reviewed commit: ["Test citation format validation"](https://github.com/hiroki-org/openshelf/commit/950f8622f66ddc6566f594206dce1f7deadbbf0b) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=32528636)</sub>

<!-- /greptile_comment -->