### PR TITLE
🧪 Add test for R2 put error handling

### DIFF
--- a/apps/api/src/routes/__tests__/papers.test.ts
+++ b/apps/api/src/routes/__tests__/papers.test.ts
@@ -3442,7 +3442,6 @@ describe("Error handling and untested branches", () => {
     formData.append("file_types_0", "paper");
 
     const customEnv = createTestEnv({
-      DB: mockDb as any,
       BUCKET: {
         put: vi.fn().mockRejectedValue(new Error("R2 put failure")),
         delete: vi.fn().mockResolvedValue(undefined),

--- a/apps/api/src/routes/__tests__/papers.test.ts
+++ b/apps/api/src/routes/__tests__/papers.test.ts
@@ -3416,6 +3416,66 @@ describe("Error handling and untested branches", () => {
     });
   });
 
+  it("POST /api/papers propagates general R2 put errors", async () => {
+    const formData = new FormData();
+    formData.append(
+      "metadata",
+      JSON.stringify({
+        title: "Test Paper",
+        abstract: "Abstract",
+        visibility: "public",
+        showViewCount: true,
+        language: "en",
+        externalUrl: "https://example.com",
+        doi: null,
+        venue: null,
+        venueType: null,
+        year: null,
+        category: null,
+        tags: [],
+      }),
+    );
+    const file = new File(["%PDF-1.4\n%dummy-pdf"], "dummy.pdf", {
+      type: "application/pdf",
+    });
+    formData.append("files_0", file);
+    formData.append("file_types_0", "paper");
+
+    const customEnv = createTestEnv({
+      DB: mockDb as any,
+      BUCKET: {
+        put: vi.fn().mockRejectedValue(new Error("R2 put failure")),
+        delete: vi.fn().mockResolvedValue(undefined),
+      } as any,
+    });
+    const consoleErrorSpy = vi
+      .spyOn(console, "error")
+      .mockImplementation(() => undefined);
+
+    try {
+      const res = await app.request(
+        "http://localhost/api/papers",
+        {
+          method: "POST",
+          headers: { Authorization: `Bearer ${token}` },
+          body: formData,
+        },
+        customEnv as any,
+      );
+
+      expect(res.status).toBe(500);
+      await expect(res.text()).resolves.toBe("Internal Server Error");
+      expect(consoleErrorSpy).toHaveBeenCalledWith(
+        "File upload errors:",
+        expect.objectContaining({
+          errors: ["R2 put failure"],
+        }),
+      );
+    } finally {
+      consoleErrorSpy.mockRestore();
+    }
+  });
+
   it("POST /api/papers/:id/invites handles malformed JSON body", async () => {
     // Send invalid JSON that throws an error when c.req.json() parses it.
     const res = await app.request(


### PR DESCRIPTION
🎯 **What:** The untested `try-catch` block around `c.env.BUCKET.put()` in `POST /api/papers` is now tested.

📊 **Coverage:** A new test `POST /api/papers propagates general R2 put errors` is added. It mocks `BUCKET.put()` to throw an error and asserts that the error correctly bubbles up, resulting in a 500 status and an 'Internal Server Error' response (Hono's default behavior for unhandled route exceptions). It also correctly isolates the `env` context by using `createTestEnv` to prevent test flakiness related to `enableForeignKeys()` DB context sharing.

✨ **Result:** Increased branch and line coverage for `apps/api/src/routes/papers.ts`, ensuring robust failure handling when Cloudflare R2 rejects file uploads.

---
*PR created automatically by Jules for task [4171152528372838620](https://jules.google.com/task/4171152528372838620) started by @is0692vs*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Style**
  * Updated terminology from "deliverables" to "papers" throughout the interface
  * Refined loading state UI with improved visual feedback and spinner indicators
  * Updated button labels and page headings for consistency

* **Refactor**
  * Simplified tag input to use comma-separated format
  * Restructured internal helper functions for better code maintainability

* **Tests**
  * Updated and refined test coverage across API routes and UI components

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Hiroki-org/OpenShelf/pull/830?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

R2 の `put()` が失敗した場合のエラーハンドリングをテストする新規テストケース1件を `papers.test.ts` に追加しています。

- `BUCKET.put` を `mockRejectedValue` でモックし、500 ステータスと `"Internal Server Error"` が返ることを検証します。また `console.error("File upload errors:", ...)` が期待通りに呼ばれることも確認しています。
- `createTestEnv` を使って `BUCKET` を独立したモックに差し替え、他テストとの DB コンテキスト共有による干渉を防ぐ設計になっています。また `try/finally` で `consoleErrorSpy.mockRestore()` を確実に実行し、以前のレビュー指摘事項を反映しています。
</details>

<details open><summary><h3>Confidence Score: 5/5</h3></summary>

テストのみの変更であり、既存の本番コードには一切影響しません。安全にマージできます。

変更はテストコード1件の追加のみです。drizzle-orm/d1 のモック、createTestEnv による BUCKET の分離、try/finally での spy 復元、console.error の呼び出し検証、いずれも正しく実装されており、本番コードのエラーパスを適切にカバーしています。

特に注意が必要なファイルはありません。
</details>

<details open><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| apps/api/src/routes/__tests__/papers.test.ts | R2 put エラー時の 500 レスポンスと console.error 呼び出しを検証する新規テストを追加。try/finally による spy 復元と createTestEnv によるモック分離が適切に実装されている。 |

</details>

</details>

<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant Test
    participant app as Hono App
    participant auth as authMiddleware
    participant route as POST /api/papers
    participant db as mockDb (drizzle mock)
    participant bucket as BUCKET (mock)
    participant spy as consoleErrorSpy

    Test->>app: request("POST /api/papers", formData, customEnv)
    app->>auth: verify JWT
    auth-->>route: next()
    route->>db: drizzle(env.DB) → mockDb
    route->>db: enableForeignKeys() → run() OK
    route->>route: prepareUploadEntries() → validates PDF magic bytes OK
    route->>bucket: BUCKET.put(r2Key, stream)
    bucket-->>route: throws Error("R2 put failure")
    route->>spy: "console.error("File upload errors:", {errors: ["R2 put failure"]})"
    route->>route: throw errors[0]
    route->>db: db.delete(papers).where() [rollback]
    route->>route: rethrow error
    app-->>Test: 500 "Internal Server Error"
    Test->>spy: expect(consoleErrorSpy).toHaveBeenCalledWith(...)
```

<sub>Reviews (8): Last reviewed commit: ["test: clarify R2 put error env setup"](https://github.com/hiroki-org/openshelf/commit/d07f82e23ce56798435cc316eb545955b125f747) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=32529642)</sub>

<!-- /greptile_comment -->