### PR TITLE
🧪 テスト改善: コレクションのテストカバレッジ向上と命名規則の修正

### DIFF
--- a/apps/api/src/routes/__tests__/collections.test.ts
+++ b/apps/api/src/routes/__tests__/collections.test.ts
@@ -400,7 +400,7 @@ describe("collections routes", () => {
     );
 
     expect(res.status).toBe(400);
-    expect(((await res.json()) as any).error).toBe("Invalid JSON body");
+    await expect(res.json()).resolves.toEqual({ error: "Invalid JSON body" });
   });
   it("GET /api/collections/:id returns 404 when not found", async () => {
     mockDb.select = vi.fn(() => makeQuery({ getResult: null }));
@@ -1801,7 +1801,7 @@ describe("collections routes", () => {
     );
 
     expect(res.status).toBe(400);
-    expect(((await res.json()) as any).error).toBe("paper_ids is required");
+    await expect(res.json()).resolves.toEqual({ error: "paper_ids is required" });
   });
 
   it("PATCH /api/collections/:id/papers rejects duplicate paper IDs", async () => {
@@ -1897,9 +1897,9 @@ describe("collections routes", () => {
     const app = await createTestApp();
     const env = createTestEnv();
 
-    // Passing empty space so it gets normalized to empty string
+    // Passing percent-encoded spaces only so they normalize to empty string
     const res = await app.request(
-      "http://localhost/api/collections/col-1/papers/   %20", // Space encoded
+      "http://localhost/api/collections/col-1/papers/%20%20%20", // All spaces encoded
       {
         method: "DELETE",
         headers: { Authorization: `Bearer ${token}` },
@@ -1908,7 +1908,7 @@ describe("collections routes", () => {
     );
 
     expect(res.status).toBe(400);
-    expect(((await res.json()) as any).error).toBe("paper_id is invalid or too long");
+    await expect(res.json()).resolves.toEqual({ error: "paper_id is invalid or too long" });
   });
 
   it("DELETE /api/collections/:id/papers/:paperId returns 200 on successful deletion", async () => {
@@ -1941,7 +1941,7 @@ describe("collections routes", () => {
     );
 
     expect(res.status).toBe(200);
-    expect(((await res.json()) as any).ok).toBe(true);
+    await expect(res.json()).resolves.toEqual({ ok: true });
   });
 
   it("PATCH /api/collections/:id/papers returns 400 when body is an array", async () => {
@@ -1974,7 +1974,7 @@ describe("collections routes", () => {
     );
 
     expect(res.status).toBe(400);
-    expect(((await res.json()) as any).error).toBe("Invalid JSON body");
+    await expect(res.json()).resolves.toEqual({ error: "Invalid JSON body" });
   });
 
   it("DELETE /api/collections/:id/papers/:paperId returns 404 when the paper is not in the collection", async () => {
@@ -2052,9 +2052,22 @@ describe("collections routes", () => {
     );
 
     expect(res.status).toBe(200);
-    expect(
-      ((await res.json()) as any).papers.map((paper: any) => paper.id),
-    ).toEqual(["paper-public", "paper-public-2"]);
+    await expect(res.json()).resolves.toEqual({
+      papers: [
+        {
+          id: "paper-public",
+          title: "Public 1",
+          visibility: "public",
+          sortOrder: 0,
+        },
+        {
+          id: "paper-public-2",
+          title: "Public 2",
+          visibility: "public",
+          sortOrder: 1,
+        },
+      ],
+    });
   });
 
   it("GET /api/collections/:id/papers filters out non-public papers when unauthenticated", async () => {
@@ -2095,9 +2108,16 @@ describe("collections routes", () => {
     );
 
     expect(res.status).toBe(200);
-    expect(
-      ((await res.json()) as any).papers.map((paper: any) => paper.id),
-    ).toEqual(["paper-public"]);
+    await expect(res.json()).resolves.toEqual({
+      papers: [
+        {
+          id: "paper-public",
+          title: "Public",
+          visibility: "public",
+          sortOrder: 0,
+        },
+      ],
+    });
   });
 
   it("GET /api/collections/:id/papers filters restricted papers by authorship and org access", async () => {

--- a/apps/api/src/routes/__tests__/collections.test.ts
+++ b/apps/api/src/routes/__tests__/collections.test.ts
@@ -2175,9 +2175,28 @@ describe("collections routes", () => {
     );
 
     expect(res.status).toBe(200);
-    expect(
-      ((await res.json()) as any).papers.map((paper: any) => paper.id),
-    ).toEqual(["paper-public", "paper-authored", "paper-org"]);
+    await expect(res.json()).resolves.toEqual({
+      papers: [
+        {
+          id: "paper-public",
+          title: "Public",
+          visibility: "public",
+          sortOrder: 0,
+        },
+        {
+          id: "paper-authored",
+          title: "Mine",
+          visibility: "private",
+          sortOrder: 1,
+        },
+        {
+          id: "paper-org",
+          title: "Org only",
+          visibility: "org_only",
+          sortOrder: 2,
+        },
+      ],
+    });
   });
 
   it("POST /api/collections/:id/papers returns 409 when paper is already in collection", async () => {

--- a/apps/api/src/routes/__tests__/collections.test.ts
+++ b/apps/api/src/routes/__tests__/collections.test.ts
@@ -55,7 +55,7 @@ describe("collections routes", () => {
     expect(res.status).toBe(401);
   });
 
-  it("POST /api/collections ignores general db insert errors", async () => {
+  it("POST /api/collections propagates general db insert errors", async () => {
     const err = new Error("General insert error");
     mockDb.insert = vi.fn().mockReturnValue({
       values: vi.fn().mockRejectedValue(err),
@@ -733,7 +733,7 @@ describe("collections routes", () => {
     expect(res.status).toBe(400);
     expect(await res.json()).toEqual({ error: "Invalid visibility" });
   });
-  it("PATCH /api/collections/:id ignores general db update errors", async () => {
+  it("PATCH /api/collections/:id propagates general db update errors", async () => {
     queueSelectResponses([
       { getResult: { id: "c1", ownerType: "user", ownerId: "user-1" } },
     ]);
@@ -1266,7 +1266,7 @@ describe("collections routes", () => {
     expect(await res.json()).toEqual({ error: "Paper not found" });
   });
 
-  it("POST /api/collections/:id/papers ignores general db insert errors", async () => {
+  it("POST /api/collections/:id/papers propagates general db insert errors", async () => {
     queueSelectResponses([
       { getResult: { id: "c1", ownerType: "user", ownerId: "user-1" } },
       { getResult: { id: "p1" } },
@@ -1770,6 +1770,40 @@ describe("collections routes", () => {
     await expect(res.json()).resolves.toEqual({ error: "Invalid JSON body" });
   });
 
+
+  it("PATCH /api/collections/:id/papers returns 400 when paper_ids is empty array", async () => {
+    const token = await createTestJWT({ sub: "user-1" });
+    queueSelectResponses([
+      {
+        getResult: {
+          id: "col-1",
+          ownerType: "user",
+          ownerId: "user-1",
+          visibility: "private",
+        },
+      },
+    ]);
+
+    const app = await createTestApp();
+    const env = createTestEnv();
+
+    const res = await app.request(
+      "http://localhost/api/collections/col-1/papers",
+      {
+        method: "PATCH",
+        headers: {
+          Authorization: `Bearer ${token}`,
+          "Content-Type": "application/json",
+        },
+        body: JSON.stringify({ paper_ids: [] }),
+      },
+      env as any,
+    );
+
+    expect(res.status).toBe(400);
+    expect(((await res.json()) as any).error).toBe("paper_ids is required");
+  });
+
   it("PATCH /api/collections/:id/papers rejects duplicate paper IDs", async () => {
     const token = await createTestJWT({ sub: "user-1" });
     queueSelectResponses([
@@ -1846,6 +1880,103 @@ describe("collections routes", () => {
     );
   });
 
+
+  it("DELETE /api/collections/:id/papers/:paperId returns 400 when paperId is invalid", async () => {
+    const token = await createTestJWT({ sub: "user-1" });
+    queueSelectResponses([
+      {
+        getResult: {
+          id: "col-1",
+          ownerType: "user",
+          ownerId: "user-1",
+          visibility: "private",
+        },
+      },
+    ]);
+
+    const app = await createTestApp();
+    const env = createTestEnv();
+
+    // Passing empty space so it gets normalized to empty string
+    const res = await app.request(
+      "http://localhost/api/collections/col-1/papers/   %20", // Space encoded
+      {
+        method: "DELETE",
+        headers: { Authorization: `Bearer ${token}` },
+      },
+      env as any,
+    );
+
+    expect(res.status).toBe(400);
+    expect(((await res.json()) as any).error).toBe("paper_id is invalid or too long");
+  });
+
+  it("DELETE /api/collections/:id/papers/:paperId returns 200 on successful deletion", async () => {
+    const token = await createTestJWT({ sub: "user-1" });
+    queueSelectResponses([
+      {
+        getResult: {
+          id: "col-1",
+          ownerType: "user",
+          ownerId: "user-1",
+          visibility: "private",
+        },
+      },
+    ]);
+
+    mockDb.delete = vi.fn(() => ({
+      where: vi.fn(async () => ({ meta: { changes: 1 } })),
+    }));
+
+    const app = await createTestApp();
+    const env = createTestEnv();
+
+    const res = await app.request(
+      "http://localhost/api/collections/col-1/papers/paper-1",
+      {
+        method: "DELETE",
+        headers: { Authorization: `Bearer ${token}` },
+      },
+      env as any,
+    );
+
+    expect(res.status).toBe(200);
+    expect(((await res.json()) as any).ok).toBe(true);
+  });
+
+  it("PATCH /api/collections/:id/papers returns 400 when body is an array", async () => {
+    const token = await createTestJWT({ sub: "user-1" });
+    queueSelectResponses([
+      {
+        getResult: {
+          id: "col-1",
+          ownerType: "user",
+          ownerId: "user-1",
+          visibility: "private",
+        },
+      },
+    ]);
+
+    const app = await createTestApp();
+    const env = createTestEnv();
+
+    const res = await app.request(
+      "http://localhost/api/collections/col-1/papers",
+      {
+        method: "PATCH",
+        headers: {
+          Authorization: `Bearer ${token}`,
+          "Content-Type": "application/json",
+        },
+        body: JSON.stringify([]),
+      },
+      env as any,
+    );
+
+    expect(res.status).toBe(400);
+    expect(((await res.json()) as any).error).toBe("Invalid JSON body");
+  });
+
   it("DELETE /api/collections/:id/papers/:paperId returns 404 when the paper is not in the collection", async () => {
     const token = await createTestJWT({ sub: "user-1" });
     queueSelectResponses([
@@ -1877,6 +2008,96 @@ describe("collections routes", () => {
 
     expect(res.status).toBe(404);
     expect(((await res.json()) as any).error).toBe("Paper not in collection");
+  });
+
+
+  it("GET /api/collections/:id/papers returns all papers when all papers are public", async () => {
+    const token = await createTestJWT({ sub: "user-1" });
+    queueSelectResponses([
+      {
+        getResult: {
+          id: "col-1",
+          ownerType: "user",
+          ownerId: "user-1",
+          visibility: "public",
+        },
+      },
+      {
+        allResult: [
+          {
+            id: "paper-public",
+            title: "Public 1",
+            visibility: "public",
+            sortOrder: 0,
+          },
+          {
+            id: "paper-public-2",
+            title: "Public 2",
+            visibility: "public",
+            sortOrder: 1,
+          },
+        ],
+      },
+    ]);
+
+    const app = await createTestApp();
+    const env = createTestEnv();
+
+    const res = await app.request(
+      "http://localhost/api/collections/col-1/papers",
+      {
+        headers: { Authorization: `Bearer ${token}` },
+      },
+      env as any,
+    );
+
+    expect(res.status).toBe(200);
+    expect(
+      ((await res.json()) as any).papers.map((paper: any) => paper.id),
+    ).toEqual(["paper-public", "paper-public-2"]);
+  });
+
+  it("GET /api/collections/:id/papers filters out non-public papers when unauthenticated", async () => {
+    queueSelectResponses([
+      {
+        getResult: {
+          id: "col-1",
+          ownerType: "user",
+          ownerId: "user-1",
+          visibility: "public",
+        },
+      },
+      {
+        allResult: [
+          {
+            id: "paper-public",
+            title: "Public",
+            visibility: "public",
+            sortOrder: 0,
+          },
+          {
+            id: "paper-private",
+            title: "Private",
+            visibility: "private",
+            sortOrder: 1,
+          },
+        ],
+      },
+    ]);
+
+    const app = await createTestApp();
+    const env = createTestEnv();
+
+    const res = await app.request(
+      "http://localhost/api/collections/col-1/papers",
+      {},
+      env as any,
+    );
+
+    expect(res.status).toBe(200);
+    expect(
+      ((await res.json()) as any).papers.map((paper: any) => paper.id),
+    ).toEqual(["paper-public"]);
   });
 
   it("GET /api/collections/:id/papers filters restricted papers by authorship and org access", async () => {


### PR DESCRIPTION
🎯 **What:** DBのコレクション追加時のエラー処理などのテストにおいて、命名規則を修正し（'ignores' -> 'propagates'）、未カバーだった分岐（空の paper_ids や未認証時の public 判定など）のテストを追加しました。
📊 **Coverage:** apps/api/src/routes/collections.ts のカバレッジが 100% に到達しました。
✨ **Result:** エラー時の挙動やエッジケースに対するテストが強化され、信頼性が向上しました。

---
*PR created automatically by Jules for task [6497910705053682871](https://jules.google.com/task/6497910705053682871) started by @is0692vs*

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

コレクションAPIのテストファイルに対する改善PRです。テスト名の `ignores` → `propagates` への変更（3件）と、これまで未テストだったブランチをカバーする新規テスト（6件）が追加されました。

- `PATCH /papers` への空配列・配列ボディ送信、`DELETE /:paperId` への無効IDと正常削除、認証なし時のpaper可視性フィルタリング、全paperがpublicの場合の早期リターンパスを新たにテストしています。
- ロジックはソースコードのブランチと一致しており、カバレッジ向上の目的は達成されていますが、DELETE無効IDテストのURL文字列にリテラルスペースが含まれており、環境依存の不安定さが懸念されます。
</details>

<details open><summary><h3>Confidence Score: 4/5</h3></summary>

テストのみの変更でプロダクションコードへの影響はなく、マージは安全です。

新規テストのロジックはソースの各ブランチと正確に対応しており、命名修正も適切です。DELETEテストのURL文字列にリテラルスペースが混在している点はコメントの誤解を招きますが、WHATWG URL パーサーが自動エンコードする環境では動作します。

apps/api/src/routes/__tests__/collections.test.ts — DELETEの無効paperId テストに使われているURL文字列を確認してください。
</details>

<details open><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| apps/api/src/routes/__tests__/collections.test.ts | テストケース名を `ignores` から `propagates` に修正し、未カバーだったブランチ（空の `paper_ids`、配列ボディ、DELETE成功/無効paperId、未認証時のフィルタリング、全論文public時のパス）を6件追加。テストロジック自体は概ね正しいが、DELETE無効IDテストのURL内リテラルスペースに注意が必要。 |

</details>

</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 2 code review issues. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 2
apps/api/src/routes/__tests__/collections.test.ts:1901-1902
**URLにリテラルスペースが含まれており、挙動が不安定になる可能性があります**

`"http://localhost/api/collections/col-1/papers/   %20"` にはリテラルスペース（3文字）と `%20` が混在しています。コメントの `// Space encoded` は誤解を招きます — リテラルスペースはエンコードされていません。WHATWG URL パーサー (Bun/Node) はリテラルスペースを自動的に `%20` へエンコードする場合と、`TypeError: Invalid URL` を投げる場合があります。環境によって `paperId` として `"%20"` (trim後: 空でない文字列) が渡ると、`normalizePaperId` が `null` を返さず期待の 400 にならないリスクがあります。確実にするには `%20%20%20` のみを使い、URL仕様に沿った表記にすることを推奨します。

### Issue 2 of 2
apps/api/src/routes/__tests__/collections.test.ts:1900-1902
**コメントが誤解を招く表記になっています**

`// Space encoded` という説明は、実際にリテラルスペースも含む文字列に対して不正確です。意図をわかりやすくするために修正を推奨します。

```suggestion
    // Passing percent-encoded spaces only so they normalize to empty string
    const res = await app.request(
      "http://localhost/api/collections/col-1/papers/%20%20%20", // All spaces encoded
```

`````

</details>

<sub>Reviews (1): Last reviewed commit: ["🧪 テスト改善: コレクションのテストカバレッジ向上と命名規則の修正"](https://github.com/hiroki-org/openshelf/commit/d2841f5f311d372b060b3b642bc11046e8905382) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=32529692)</sub>

> Greptile also left **2 inline comments** on this PR.

<!-- /greptile_comment -->