### PR TITLE
🧪 共同執筆者の招待におけるDBエラー処理のテストを追加

### DIFF
--- a/apps/api/src/routes/__tests__/papers.test.ts
+++ b/apps/api/src/routes/__tests__/papers.test.ts
@@ -3246,7 +3246,6 @@ describe("papers routes", () => {
         name: "Uploader",
       });
 
-      const { makeQuery } = await import("../../test/helpers");
       mockDb.select = vi
         .fn()
         .mockImplementationOnce(() =>

--- a/apps/api/src/routes/__tests__/papers.test.ts
+++ b/apps/api/src/routes/__tests__/papers.test.ts
@@ -3238,6 +3238,54 @@ describe("papers routes", () => {
 
       expect(res.status).toBe(500);
     });
+
+    it("POST /api/papers/:id/invites propagates error when fetching invitee by email fails", async () => {
+      const token = await createTestJWT({
+        sub: "user-uploader",
+        githubId: "123",
+        name: "Uploader",
+      });
+
+      const { makeQuery } = await import("../../test/helpers");
+      mockDb.select = vi
+        .fn()
+        .mockImplementationOnce(() =>
+          makeQuery({
+            getResult: {
+              paperId: "paper-1",
+              userId: "user-uploader",
+              role: "uploader",
+            },
+          }),
+        )
+        .mockImplementationOnce(() => {
+          return {
+            from: vi.fn().mockReturnThis(),
+            where: vi.fn().mockReturnThis(),
+            get: vi
+              .fn()
+              .mockRejectedValue(new Error("DB error when fetching by email")),
+          };
+        });
+
+      const app = await createTestApp();
+      const env = createTestEnv();
+
+      const res = await app.request(
+        "http://localhost/api/papers/paper-1/invites",
+        {
+          method: "POST",
+          headers: {
+            "Content-Type": "application/json",
+            Authorization: `Bearer ${token}`,
+          },
+          body: JSON.stringify({ inviteeEmail: "test@example.com" }),
+        },
+        env as any,
+      );
+
+      expect(res.status).toBe(500);
+    });
   });
 });
 


### PR DESCRIPTION
🎯 **What:** `apps/api/src/routes/papers.ts` の共同執筆者招待APIで、メールアドレスからユーザーを検索する際にデータベースエラーが発生した場合のテストが不足していたため、`mockDb.select`でエラーを発生させるユニットテストを追加しました。
📊 **Coverage:** `POST /api/papers/:id/invites` に対して、`inviteeEmail` のDB取得時に例外がスローされた場合でも500エラーとして適切にハンドリングされることを検証するテストケースを追加しました。
✨ **Result:** 未テストだったエラーハンドリングのブランチがカバーされ、APIの信頼性とテスト網羅率が向上しました。

---
*PR created automatically by Jules for task [287226328565717244](https://jules.google.com/task/287226328565717244) started by @is0692vs*

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

このPRは `POST /api/papers/:id/invites` エンドポイントにおいて、招待先メールアドレスのDBルックアップで例外が発生した場合に500エラーを返すことを検証するユニットテストを追加します。

- `mockDb.select` を2回チェーンしてモック化し、1回目はアップローダー権限チェックを通過させ、2回目でDB例外を発生させることで未テストのエラーブランチをカバーしています。
- テストのロジック自体は正確で、プロダクションコードの動作を適切に検証していますが、`makeQuery` の不要な動的インポートという軽微なスタイル上の問題があります。
</details>

<details open><summary><h3>Confidence Score: 4/5</h3></summary>

テストのみの変更でプロダクションコードへの影響はなく、マージしても安全です。

追加されたテストはメールルックアップのDBエラーという実際のコードパスを正しくカバーしており、モックのチェーン構造もプロダクションコードと一致しています。スタイル上の軽微な問題が1件あるものの、テストの正確性には影響しません。

特に注意が必要なファイルはありません。変更はすべてテストファイルに限定されています。
</details>

<details open><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| apps/api/src/routes/__tests__/papers.test.ts | メールアドレスからの招待先ユーザー取得時のDBエラーをカバーするユニットテストを追加。ロジックは正確だが、`makeQuery` の不要な動的インポートがある。 |

</details>

</details>

<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant Test as テストケース
    participant App as Hono App
    participant DB as mockDb.select

    Test->>App: "POST /api/papers/paper-1/invites {inviteeEmail}"
    App->>DB: select() (1回目: アップローダー権限確認)
    DB-->>App: "{paperId, userId, role: uploader}"
    App->>DB: select() (2回目: メールでユーザー検索)
    DB-->>App: throw Error(DB error when fetching by email)
    App-->>Test: HTTP 500
    Test->>Test: expect(res.status).toBe(500)
```

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 1 code review issue. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 1
apps/api/src/routes/__tests__/papers.test.ts:3249-3250
`makeQuery` の不要な動的インポート — `makeQuery` はファイル先頭で静的にインポート済みです（6行目）。同じ `describe` ブロック内の `setupInviteChecks` でも直接使用されており、`await import(...)` を使うと他のテストとスタイルが一致しなくなります。

```suggestion
      mockDb.select = vi
```

`````

</details>

<sub>Reviews (1): Last reviewed commit: ["🧪 招待者のメールアドレス取得時のDBエラーのテストを追加"](https://github.com/hiroki-org/openshelf/commit/0d83b6b9bcc22c8d28e3f0e0829211c8d53d231c) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=32529720)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->