### PR TITLE
🧪 [テスト改善] コレクション名更新時のUNIQUE制約エラーキャッチ処理のテストを追加

### DIFF
--- a/apps/api/src/routes/__tests__/collections.test.ts
+++ b/apps/api/src/routes/__tests__/collections.test.ts
@@ -764,69 +764,45 @@ describe("collections routes", () => {
     expect(res.status).toBe(500);
   });
 
-  it("PATCH /api/collections/:id returns 409 if sqlite throws a unique constraint error D1_ERROR", async () => {
-    queueSelectResponses([
-      { getResult: { id: "c1", ownerType: "user", ownerId: "user-1" } },
-    ]);
-    const err = new Error("D1_ERROR: UNIQUE constraint failed: collections.slug");
-    mockDb.update = vi.fn().mockReturnValue({
-      set: vi.fn().mockReturnValue({
-        where: vi.fn().mockRejectedValue(err),
-      }),
-    });
-    const app = await createTestApp();
-    const env = createTestEnv();
-    const res = await app.request(
-      "http://localhost/api/collections/c1",
-      {
-        method: "PATCH",
-        headers: {
-          Authorization: `Bearer ${await createTestJWT({ sub: "user-1" })}`,
-        },
-        body: JSON.stringify({
-          name: "C2",
-          slug: "col-2",
-          description: "desc",
-          visibility: "public",
+  it.each([
+    "D1_ERROR: UNIQUE constraint failed: collections.slug",
+    "UNIQUE constraint failed: collections.slug",
+  ])(
+    "PATCH /api/collections/:id returns 409 if slug already in use (%s)",
+    async (errorMessage) => {
+      queueSelectResponses([
+        { getResult: { id: "c1", ownerType: "user", ownerId: "user-1" } },
+      ]);
+      const err = new Error(errorMessage);
+      mockDb.update = vi.fn().mockReturnValue({
+        set: vi.fn().mockReturnValue({
+          where: vi.fn().mockRejectedValue(err),
         }),
-      },
-      env,
-    );
-    expect(res.status).toBe(409);
-    expect(await res.json()).toEqual({ error: "slug already in use" });
-  });
-
-  it("PATCH /api/collections/:id returns 409 if slug already in use", async () => {
-    queueSelectResponses([
-      { getResult: { id: "c1", ownerType: "user", ownerId: "user-1" } },
-    ]);
-    const err = new Error("UNIQUE constraint failed: collections.slug");
-    mockDb.update = vi.fn().mockReturnValue({
-      set: vi.fn().mockReturnValue({
-        where: vi.fn().mockRejectedValue(err),
-      }),
-    });
-    const app = await createTestApp();
-    const env = createTestEnv();
-    const res = await app.request(
-      "http://localhost/api/collections/c1",
-      {
-        method: "PATCH",
-        headers: {
-          Authorization: `Bearer ${await createTestJWT({ sub: "user-1" })}`,
+      });
+      const app = await createTestApp();
+      const env = createTestEnv();
+      const res = await app.request(
+        "http://localhost/api/collections/c1",
+        {
+          method: "PATCH",
+          headers: {
+            Authorization: `Bearer ${await createTestJWT({ sub: "user-1" })}`,
+          },
+          body: JSON.stringify({
+            name: "C2",
+            slug: "col-2",
+            description: "desc",
+            visibility: "public",
+          }),
         },
-        body: JSON.stringify({
-          name: "C2",
-          slug: "col-2",
-          description: "desc",
-          visibility: "public",
-        }),
-      },
-      env,
-    );
-    expect(res.status).toBe(409);
-    expect(await res.json()).toEqual({ error: "slug already in use" });
-  });
+        env,
+      );
+      expect(res.status).toBe(409);
+      await expect(res.json()).resolves.toEqual({
+        error: "slug already in use",
+      });
+    },
+  );
 
   it("PATCH /api/collections/:id returns 400 when name is invalid", async () => {
     queueSelectResponses([

--- a/apps/api/src/routes/__tests__/collections.test.ts
+++ b/apps/api/src/routes/__tests__/collections.test.ts
@@ -764,6 +764,38 @@ describe("collections routes", () => {
     expect(res.status).toBe(500);
   });
 
+  it("PATCH /api/collections/:id returns 409 if sqlite throws a unique constraint error D1_ERROR", async () => {
+    queueSelectResponses([
+      { getResult: { id: "c1", ownerType: "user", ownerId: "user-1" } },
+    ]);
+    const err = new Error("D1_ERROR: UNIQUE constraint failed: collections.slug");
+    mockDb.update = vi.fn().mockReturnValue({
+      set: vi.fn().mockReturnValue({
+        where: vi.fn().mockRejectedValue(err),
+      }),
+    });
+    const app = await createTestApp();
+    const env = createTestEnv();
+    const res = await app.request(
+      "http://localhost/api/collections/c1",
+      {
+        method: "PATCH",
+        headers: {
+          Authorization: `Bearer ${await createTestJWT({ sub: "user-1" })}`,
+        },
+        body: JSON.stringify({
+          name: "C2",
+          slug: "col-2",
+          description: "desc",
+          visibility: "public",
+        }),
+      },
+      env,
+    );
+    expect(res.status).toBe(409);
+    expect(await res.json()).toEqual({ error: "slug already in use" });
+  });
+
   it("PATCH /api/collections/:id returns 409 if slug already in use", async () => {
     queueSelectResponses([
       { getResult: { id: "c1", ownerType: "user", ownerId: "user-1" } },


### PR DESCRIPTION
🎯 **目的:** コレクション名変更時に発生するSQLiteのUNIQUE制約エラー (`D1_ERROR: UNIQUE constraint failed`) が正しくキャッチされ、409が返ることを検証するテストが不足していた問題を解決しました。

📊 **カバレッジ改善:**
*   `apps/api/src/routes/collections.ts:396-406` において、`isUniqueConstraintError` が真になり `409` (`slug already in use`) を返す分岐のテストを確実に行えるようになりました。
*   既存の `PATCH /api/collections/:id returns 409 if slug already in use` テストとは別に、実際のSQLiteでのエラーストリング形式に沿ったエラー `D1_ERROR: UNIQUE constraint failed: collections.slug` をモックするテストを追加しました。

✨ **結果:**
*   D1からスローされるエラーに対してUNIQUE制約処理が正しく動作することが保証され、コードカバレッジが向上しました。

---
*PR created automatically by Jules for task [12623132512567060756](https://jules.google.com/task/12623132512567060756) started by @is0692vs*

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

コレクション名更新時のUNIQUE制約エラー（409レスポンス）をカバーするテストを、`it.each` を使ったパラメータ化テストに書き換えた変更です。D1固有のエラー文字列形式（`D1_ERROR: UNIQUE constraint failed: collections.slug`）も明示的にカバーするケースが追加されました。

- 既存の単一テストを `it.each` に変換し、`\"D1_ERROR: UNIQUE constraint failed: collections.slug\"` と `\"UNIQUE constraint failed: collections.slug\"` の2パターンを実行するように変更。
- アサーションを `expect(await res.json()).toEqual(...)` から `await expect(res.json()).resolves.toEqual(...)` に修正し、非同期テストのエラーメッセージの可読性を向上。
</details>

<details open><summary><h3>Confidence Score: 5/5</h3></summary>

テストファイルのみの変更で、プロダクションコードへの影響はありません。安全にマージできます。

変更はテストコードのみで、既存テストをパラメータ化テストに書き換えているだけです。両方のエラー文字列は isUniqueConstraintError の条件に合致しており、テストロジックは正確です。

特に注意が必要なファイルはありません。
</details>

<details open><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| apps/api/src/routes/__tests__/collections.test.ts | 既存の「UNIQUE constraint failed」単体テストを it.each による2パターン（D1形式・標準SQLite形式）のパラメータ化テストに変換。アサーション形式も改善。ロジック上の問題なし。 |

</details>

</details>

<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant Test as テストケース (it.each)
    participant App as Hono App
    participant DB as mockDb.update
    participant Handler as PATCH /collections/:id

    Test->>App: PATCH /api/collections/c1 (Bearer JWT)
    App->>Handler: ルーティング
    Handler->>DB: .update().set().where()
    DB-->>Handler: throw Error(D1_ERROR or standard UNIQUE constraint)
    Handler->>Handler: isUniqueConstraintError(err) → true
    Handler-->>App: "c.json({ error: slug already in use }, 409)"
    App-->>Test: HTTP 409
    Test->>Test: expect(res.status).toBe(409) ✅
    Test->>Test: expect(res.json()).resolves.toEqual(...) ✅
```

<sub>Reviews (2): Last reviewed commit: ["Merge remote-tracking branch &#39;origin/sta..."](https://github.com/hiroki-org/openshelf/commit/17d63b24996b88551477bba59b0c402680689814) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=32530264)</sub>

<!-- /greptile_comment -->