### PR TITLE
🧪 handle unique constraint errors on paper updates

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -16,3 +16,7 @@
 **Issue:** String exceptions were not handled, causing the app to return an Internal Server Error.
 **Learning:** `e instanceof Error` correctly identifies built-in errors, but doesn't handle `throw "error"`. It caused Hono to not correctly propagate a 500 status.
 **Prevention:** Handled by validating `e instanceof Error ? e.message : typeof e === 'string' ? e : "";` and throwing an error properly at the end `throw e instanceof Error ? e : new Error(String(e));`.
+## 2026-05-18 - UNIQUE Constraint Handling
+**Vulnerability:** Untested UNIQUE constraint error could crash server or hide useful feedback.
+**Learning:** Add try/catch specifically targeting `isUniqueConstraintError` when inserting/updating, return a 409 status code.
+**Prevention:** Follow the established try/catch patterns for DB operations and mock them in Vitest using mockRejectedValue.

--- a/apps/api/src/routes/__tests__/papers.test.ts
+++ b/apps/api/src/routes/__tests__/papers.test.ts
@@ -1369,7 +1369,7 @@ describe("papers routes", () => {
 
   it("PATCH /api/papers/:id returns 409 when paper title and filename combination already exists (UNIQUE constraint error)", async () => {
     const env = createTestEnv({ DB: mockDb as any });
-    const app = await createTestApp(env);
+    const app = await createTestApp();
     const token = await createTestJWT({ sub: "user-123" });
 
     mockDb.select = vi.fn().mockImplementation(() => {

--- a/apps/api/src/routes/__tests__/papers.test.ts
+++ b/apps/api/src/routes/__tests__/papers.test.ts
@@ -1366,6 +1366,54 @@ describe("papers routes", () => {
     expect(res.status).toBe(204);
   });
 
+
+  it("PATCH /api/papers/:id returns 409 when paper title and filename combination already exists (UNIQUE constraint error)", async () => {
+    const env = createTestEnv({ DB: mockDb as any });
+    const app = await createTestApp(env);
+    const token = await createTestJWT({ sub: "user-123" });
+
+    mockDb.select = vi.fn().mockImplementation(() => {
+      let isAuthorCheck = false;
+      return {
+        from: vi.fn().mockReturnValue({
+          where: vi.fn().mockReturnValue({
+            get: vi.fn().mockImplementation(() => {
+              if (!isAuthorCheck) {
+                isAuthorCheck = true;
+                return { id: "p1", visibility: "public" };
+              }
+              return { paperId: "p1", userId: "user-123", role: "uploader" };
+            }),
+          }),
+        }),
+      };
+    });
+
+    mockDb.update = vi.fn().mockReturnValue({
+      set: vi.fn().mockReturnValue({
+        where: vi.fn().mockRejectedValue(new Error("UNIQUE constraint failed")),
+      }),
+    });
+
+    const res = await app.request("/api/papers/p1", {
+      method: "PATCH",
+      headers: {
+        Authorization: `Bearer ${token}`,
+        "Content-Type": "application/json",
+      },
+      body: JSON.stringify({
+        title: "New Title",
+      }),
+    }, env as any);
+
+    expect(res.status).toBe(409);
+    const body = await res.json();
+    expect(body.error).toBe(
+      "Paper title and filename combination already exists",
+    );
+  });
+
+
   it("DELETE /api/papers/:id handles R2 deletion failure", async () => {
     const token = await createTestJWT({
       sub: "user-1",

--- a/apps/api/src/routes/papers.ts
+++ b/apps/api/src/routes/papers.ts
@@ -25,6 +25,15 @@ import { validateMagicNumbers } from "../utils/file";
 import { buildCitation, isCitationFormat } from "../utils/citation";
 import pMap from "p-map";
 
+function isUniqueConstraintError(err: unknown): boolean {
+    const message = err instanceof Error ? err.message : String(err);
+    return (
+        message.includes("UNIQUE") ||
+        message.includes("unique") ||
+        message.includes("constraint")
+    );
+}
+
 const papersRoute = new Hono<{ Bindings: Env; Variables: Variables }>();
 
 const MAX_FILE_SIZE = 50 * 1024 * 1024; // 50 MB
@@ -1635,7 +1644,14 @@ papersRoute.patch("/:id", authMiddleware, async (c) => {
         return c.json({ error: "No valid fields to update" }, 400);
     }
 
-    await db.update(papers).set(updates).where(eq(papers.id, paperId));
+    try {
+        await db.update(papers).set(updates).where(eq(papers.id, paperId));
+    } catch (err) {
+        if (isUniqueConstraintError(err)) {
+            return c.json({ error: "Paper title and filename combination already exists" }, 409);
+        }
+        throw err;
+    }
     return c.json({ ok: true });
 });
 

--- a/branch_info.js
+++ b/branch_info.js
@@ -1,0 +1,2 @@
+const branchName = "fix-untested-unique-constraint";
+console.log("Branch:", branchName);


### PR DESCRIPTION
🎯 **What:** Handled UNIQUE constraint errors when updating papers in `PATCH /api/papers/:id`. 
📊 **Coverage:** Added test case for duplicate paper title and filename combination.
✨ **Result:** Improved test coverage and reliability by returning a 409 status code with an appropriate error message when a uniqueness constraint is violated.

---
*PR created automatically by Jules for task [5290681101705003288](https://jules.google.com/task/5290681101705003288) started by @is0692vs*

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

このPRは `PATCH /api/papers/:id` において UNIQUE 制約違反時に 409 を返す処理を追加し、対応するテストケースも追加しています。

- `isUniqueConstraintError` ヘルパー関数を新設し、DB 更新処理を try/catch で囲むことで UNIQUE 制約エラーをハンドリング。ただし `message.includes(\"constraint\")` の条件が広すぎるため、外部キー制約や CHECK 制約などの別エラーも誤って 409 として返す恐れがあります。
- テストはモックを用いて 409 レスポンスと `error` メッセージを検証しており、追加パターン自体は既存コードスタイルに沿っています。
- `branch_info.js` という Jules タスクランナーの残留ファイルがコミットに含まれており、削除が必要です。
</details>

<details open><summary><h3>Confidence Score: 3/5</h3></summary>

`isUniqueConstraintError` の判定ロジックが広範すぎるため、マージ前に修正が必要です。

`message.includes("constraint")` は UNIQUE 以外の制約エラー（外部キー・CHECK・NOT NULL など）にもマッチするため、本来 500 系で返すべきエラーが 409 として隠蔽される可能性があります。このロジックは更新処理の全エラーパスに影響するため、早期に修正すべき問題です。

`apps/api/src/routes/papers.ts` の `isUniqueConstraintError` 関数（特に `constraint` の包括的チェック）と、不要な `branch_info.js` を要確認。
</details>

<details open><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| apps/api/src/routes/papers.ts | `isUniqueConstraintError` 関数を追加し PATCH エンドポイントに try/catch を導入。ただし `message.includes("constraint")` が広すぎるため、UNIQUE 以外の制約エラーも 409 として返してしまう問題がある。 |
| apps/api/src/routes/__tests__/papers.test.ts | UNIQUE 制約エラー時に 409 を返すテストケースを追加。モックの構造は既存パターンに沿っており問題なし。 |
| branch_info.js | Jules タスクランナーの残留ファイル。リポジトリに含める必要はなく削除すべき。 |
| .jules/sentinel.md | UNIQUE 制約ハンドリングに関する学習ログのエントリを追加。内容に問題なし。 |

</details>

</details>

<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[PATCH /api/papers/:id] --> B[authMiddleware]
    B --> C[論文・権限の検証]
    C --> D{更新フィールドあり?}
    D -- No --> E[400 No valid fields]
    D -- Yes --> F[db.update]
    F --> G{エラー発生?}
    G -- No --> H[200 ok: true]
    G -- Yes --> I{isUniqueConstraintError?}
    I -- UNIQUE / unique / constraint を含む --> J[409 Paper title and filename combination already exists]
    I -- それ以外 --> K[エラーを再throw → 500]
```

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 2 code review issues. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 2
apps/api/src/routes/papers.ts:28-35
**`constraint` の文字列チェックが広すぎる**

`message.includes("constraint")` は外部キー制約違反・CHECK 制約違反・NOT NULL 制約違反など、UNIQUE 以外のあらゆる制約エラーにもマッチします。その場合、本来なら 500 系で返すべきエラーが 409 として隠蔽され、呼び出し元が誤った判断をする恐れがあります。`isUniqueConstraintError` の名前からも UNIQUE 制約のみを対象とすべきです。`message.includes("UNIQUE constraint")` のように具体的なパターンに絞ることを推奨します。

### Issue 2 of 2
branch_info.js:1-2
Jules タスクランナーの残留ファイルです。リポジトリに含める必要はないので削除してください。

```suggestion

```

`````

</details>

<sub>Reviews (1): Last reviewed commit: ["🧪 handle unique constraint errors on pa..."](https://github.com/hiroki-org/openshelf/commit/38f69d43d5f51ea0649557afbf437ed2e3a51d01) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=32547847)</sub>

> Greptile also left **2 inline comments** on this PR.

<!-- /greptile_comment -->