### PR TITLE
🧪 Add BADGE_CACHE_CONTROL unit test

### DIFF
--- a/apps/api/src/utils/__tests__/badge.test.ts
+++ b/apps/api/src/utils/__tests__/badge.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it } from "vitest";
 import {
+    BADGE_CACHE_CONTROL,
     escapeXml,
     normalizeBadgeStyle,
     normalizeBadgeLabel,
@@ -15,6 +16,14 @@ import {
 } from "../badge";
 
 describe("badge utils", () => {
+    describe("BADGE_CACHE_CONTROL", () => {
+        it("has the correct cache control string", () => {
+            expect(BADGE_CACHE_CONTROL).toBe(
+                "public, max-age=86400, stale-while-revalidate=3600",
+            );
+        });
+    });
+
     describe("escapeXml", () => {
         it("escapes special characters", () => {
             expect(escapeXml('a & b < c > d " e \' f')).toBe(

--- a/apps/api/src/utils/__tests__/badge.test.ts
+++ b/apps/api/src/utils/__tests__/badge.test.ts
@@ -17,7 +17,7 @@ import {
 
 describe("badge utils", () => {
     describe("BADGE_CACHE_CONTROL", () => {
-        it("has the correct cache control string", () => {
+        it("sets 24h public cache with 1h stale-while-revalidate window", () => {
             expect(BADGE_CACHE_CONTROL).toBe(
                 "public, max-age=86400, stale-while-revalidate=3600",
             );


### PR DESCRIPTION
## Summary
- Add focused coverage for BADGE_CACHE_CONTROL without the bot-managed branch noise from #821
- Based on current staging after #811

## Verification
- npm run test -- apps/api/src/utils/__tests__/badge.test.ts
- npm run lint -- apps/api/src/utils/__tests__/badge.test.ts

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

HTTPキャッシュヘッダー定数 `BADGE_CACHE_CONTROL` のユニットテストを追加するシンプルな変更です。

- `badge.ts` が export する `BADGE_CACHE_CONTROL` 定数（`"public, max-age=86400, stale-while-revalidate=3600"`）の値を、既存テストファイルの先頭 `describe` ブロック内に追加。定数値の意図せぬ変更を検知するリグレッションガードとして機能します。
- テスト名は過去のレビュー指摘を受けて「24時間公開キャッシュ＋1時間 stale-while-revalidate」という意味的な説明に更新済みです。実装値との一致も確認済みで、問題なし。
</details>

<details open><summary><h3>Confidence Score: 5/5</h3></summary>

このPRはテストファイルのみを変更しており、プロダクションコードへの影響はありません。

追加されたテストは badge.ts の BADGE_CACHE_CONTROL 定数（値は実装と完全に一致）を正しくアサートしており、ロジックのミスや副作用はありません。

特に注意が必要なファイルはありません。
</details>

<details open><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| apps/api/src/utils/__tests__/badge.test.ts | BADGE_CACHE_CONTROLのユニットテストを追加。定数の意図（24h公開キャッシュ＋1h stale-while-revalidate）をテスト名に明示しており、定数値の意図せぬ変更を検知できる。実装と期待値は一致している。 |

</details>

</details>

<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A["badge.test.ts"] --> B["describe: BADGE_CACHE_CONTROL"]
    B --> C["it: sets 24h public cache with 1h stale-while-revalidate window"]
    C --> D["expect(BADGE_CACHE_CONTROL).toBe(...)"]
    D --> E{"値が一致?"}
    E -- "Yes" --> F["PASS"]
    E -- "No" --> G["FAIL"]
```

<sub>Reviews (3): Last reviewed commit: ["test: clarify badge cache policy asserti..."](https://github.com/hiroki-org/openshelf/commit/29616f9daea351de293f2d3233de20934a90769d) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=32550649)</sub>

<!-- /greptile_comment -->