### PR TITLE
🧪 Add explicit test for metadata JSON parsing errors

### DIFF
--- a/apps/api/src/routes/__tests__/papers.test.ts
+++ b/apps/api/src/routes/__tests__/papers.test.ts
@@ -3461,6 +3461,23 @@ describe("Error handling and untested branches", () => {
     });
   });
 
+  it("POST /api/papers rejects upload when form data has completely invalid JSON metadata", async () => {
+    const formData = new FormData();
+    formData.append("metadata", "unparseable-json-here");
+
+    const res = await app.request(
+      "http://localhost/api/papers",
+      {
+        method: "POST",
+        headers: { Authorization: `Bearer ${token}` },
+        body: formData,
+      },
+      env as any,
+    );
+    expect(res.status).toBe(400);
+    expect(await res.json()).toEqual({ error: "Invalid metadata JSON" });
+  });
+
   it("POST /api/papers handles missing/invalid metadata JSON correctly", async () => {
     const formData = new FormData();
     formData.append("metadata", "{"); // invalid JSON

--- a/apps/api/src/routes/__tests__/papers.test.ts
+++ b/apps/api/src/routes/__tests__/papers.test.ts
@@ -3492,22 +3492,25 @@ describe("Error handling and untested branches", () => {
     });
   });
 
-  it("POST /api/papers rejects upload when form data has completely invalid JSON metadata", async () => {
-    const formData = new FormData();
-    formData.append("metadata", "unparseable-json-here");
+  it.each(["\"just a string\"", "42", "null"])(
+    "POST /api/papers rejects upload when parsed metadata JSON is not an object: %s",
+    async (metadata) => {
+      const formData = new FormData();
+      formData.append("metadata", metadata);
 
-    const res = await app.request(
-      "http://localhost/api/papers",
-      {
-        method: "POST",
-        headers: { Authorization: `Bearer ${token}` },
-        body: formData,
-      },
-      env as any,
-    );
-    expect(res.status).toBe(400);
-    expect(await res.json()).toEqual({ error: "Invalid metadata JSON" });
-  });
+      const res = await app.request(
+        "http://localhost/api/papers",
+        {
+          method: "POST",
+          headers: { Authorization: `Bearer ${token}` },
+          body: formData,
+        },
+        env as any,
+      );
+      expect(res.status).toBe(400);
+      expect(await res.json()).toEqual({ error: "Invalid metadata JSON" });
+    },
+  );
 
   it("POST /api/papers handles missing/invalid metadata JSON correctly", async () => {
     const formData = new FormData();

--- a/apps/api/src/routes/papers.ts
+++ b/apps/api/src/routes/papers.ts
@@ -489,14 +489,19 @@ type ParsedMetadata = {
 };
 
 function parseAndValidateMetadata(c: Context, metadataStr: string): { errorResponse?: Response; data?: ParsedMetadata } {
-    let meta: Record<string, unknown>;
+    let meta: unknown;
     try {
         meta = JSON.parse(metadataStr);
     } catch {
         return { errorResponse: c.json({ error: "Invalid metadata JSON" }, 400) };
     }
+    if (meta === null || typeof meta !== "object" || Array.isArray(meta)) {
+        return { errorResponse: c.json({ error: "Invalid metadata JSON" }, 400) };
+    }
 
-    const title = meta.title as string | undefined;
+    const metadata = meta as Record<string, unknown>;
+
+    const title = metadata.title as string | undefined;
     if (
         !title ||
         typeof title !== "string" ||
@@ -505,31 +510,31 @@ function parseAndValidateMetadata(c: Context, metadataStr: string): { errorRespo
     )
         return { errorResponse: c.json({ error: `title is required (1-${MAX_TITLE_LENGTH} chars)` }, 400) };
 
-    const vis = (meta.visibility as string) || "private";
+    const vis = (metadata.visibility as string) || "private";
     if (!VALID_VISIBILITY.includes(vis))
         return { errorResponse: c.json({ error: "Invalid visibility" }, 400) };
 
-    const venueType = (meta.venueType as string | null | undefined) ?? null;
+    const venueType = (metadata.venueType as string | null | undefined) ?? null;
     if (venueType !== null && !(VALID_VENUE_TYPES as readonly string[]).includes(venueType))
         return { errorResponse: c.json({ error: "Invalid venueType" }, 400) };
 
-    const category = (meta.category as string | null | undefined) ?? null;
+    const category = (metadata.category as string | null | undefined) ?? null;
     if (category !== null && !(VALID_CATEGORIES as readonly string[]).includes(category))
         return { errorResponse: c.json({ error: "Invalid category" }, 400) };
 
-    const externalUrl = (meta.externalUrl as string) || null;
+    const externalUrl = (metadata.externalUrl as string) || null;
     if (externalUrl && !isValidUrlScheme(externalUrl)) {
         return { errorResponse: c.json({ error: "Invalid externalUrl scheme (only http/https allowed)" }, 400) };
     }
 
     if (
-        meta.showViewCount !== undefined
-        && typeof meta.showViewCount !== "boolean"
+        metadata.showViewCount !== undefined
+        && typeof metadata.showViewCount !== "boolean"
     ) {
         return { errorResponse: c.json({ error: "showViewCount must be a boolean" }, 400) };
     }
 
-    const orgId = meta.orgId as string | undefined;
+    const orgId = metadata.orgId as string | undefined;
     if (vis === "org_only" && !orgId) {
         return { errorResponse: c.json({ error: "orgId is required for org_only visibility" }, 400) };
     }
@@ -537,17 +542,17 @@ function parseAndValidateMetadata(c: Context, metadataStr: string): { errorRespo
     return {
         data: {
             title: title.trim(),
-            abstract: (meta.abstract as string) || null,
+            abstract: (metadata.abstract as string) || null,
             visibility: vis as "public" | "org_only" | "private",
-            showViewCount: Boolean(meta.showViewCount),
-            language: (meta.language as string) || null,
+            showViewCount: Boolean(metadata.showViewCount),
+            language: (metadata.language as string) || null,
             externalUrl,
-            doi: (meta.doi as string) || null,
-            venue: (meta.venue as string) || null,
+            doi: (metadata.doi as string) || null,
+            venue: (metadata.venue as string) || null,
             venueType: venueType as VenueType | null,
-            year: meta.year ? Number(meta.year) : null,
+            year: metadata.year ? Number(metadata.year) : null,
             category: category as CategoryType | null,
-            tags: meta.tags ? JSON.stringify(meta.tags) : null,
+            tags: metadata.tags ? JSON.stringify(metadata.tags) : null,
             orgId,
         }
     };


### PR DESCRIPTION
🎯 **What:** The codebase currently handles errors thrown when dealing with malformed metadata inputs to the papers creation endpoint.

📊 **Coverage:**
- The newly added \`POST /api/papers rejects upload when form data has completely invalid JSON metadata\` specifically exercises the initial \`JSON.parse(metadataStr)\` branch on non-object inputs.

✨ **Result:** Improved test branch/line coverage over the metadata upload handling block and error safety catch branches.

---
*PR created automatically by Jules for task [216558662135344113](https://jules.google.com/task/216558662135344113) started by @is0692vs*

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

このPRは、`parseAndValidateMetadata` 関数に型ガードを追加し、`JSON.parse` が成功しても非オブジェクト値（`null`、文字列、数値、配列）を返した場合に 400 を返すよう修正します。以前は `"null"` を渡すと `meta.title` へのアクセスで未処理の `TypeError` が発生し 500 が返っていたバグも同時に修正されています。

- **`papers.ts`**: `meta` の型を `unknown` に変更し、`null`・非オブジェクト・配列の 3 条件をチェックするガードを追加。これにより `TypeError` によるサーバーエラーを防止。
- **`papers.test.ts`**: `it.each` で `"just a string"`・`42`・`null` の 3 ケースをカバーするパラメータ化テストを追加し、新ガードの動作を検証。
</details>

<details open><summary><h3>Confidence Score: 5/5</h3></summary>

変更はシンプルな型ガード追加とテスト追加のみで、既存の動作を破壊するリスクはありません。

プロダクションコードの変更は `parseAndValidateMetadata` に限定されており、実際のバグ（`"null"` メタデータで 500 が返る問題）を修正しています。テストも新しいブランチを正しく検証しており、ロジックに問題はありません。

特に注意が必要なファイルはありません。
</details>

<details open><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| apps/api/src/routes/papers.ts | `parseAndValidateMetadata` に型ガードを追加。`meta` の型を `unknown` に変更し、`null`・非オブジェクト・配列のいずれかの場合に 400 を返すことで、以前は未処理の `TypeError` を引き起こしていた `"null"` メタデータ入力のバグを修正。 |
| apps/api/src/routes/__tests__/papers.test.ts | `it.each` で文字列・数値・null の非オブジェクトメタデータに対する新テストを追加。`Array.isArray` ブランチ（配列入力）のテストケースが不足している点を除けば問題なし。 |

</details>

</details>

<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[metadataStr を受け取る] --> B[JSON.parse を試みる]
    B -->|SyntaxError| C[400: Invalid metadata JSON]
    B -->|成功| D{meta の型チェック}
    D -->|null| C
    D -->|typeof !== object| C
    D -->|Array.isArray| C
    D -->|プレーンオブジェクト| E[metadata として型キャスト]
    E --> F[title バリデーション]
    F -->|NG| G[400: title is required]
    F -->|OK| H[visibility / venueType / ... バリデーション]
    H -->|NG| I[400: 各種エラー]
    H -->|OK| J[ParsedMetadata を返す]
```

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 1 code review issue. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 1
apps/api/src/routes/__tests__/papers.test.ts:3495
`Array.isArray` ブランチが未テスト: `papers.ts` line 498 では `null`・非オブジェクト・**配列**の 3 条件をガードしていますが、`it.each` の入力に配列ケース（例: `'[]'` や `'[1,2,3]'`）が含まれておらず、そのブランチがテストカバレッジから漏れています。配列を追加することで `Array.isArray` パスも確認できます。

```suggestion
  it.each(["\"just a string\"", "42", "null", "[]", "[1,2,3]"])(
```

`````

</details>

<sub>Reviews (2): Last reviewed commit: ["Validate parsed metadata shape"](https://github.com/hiroki-org/openshelf/commit/9640d425598bfa526fa01794c71bf196e94c9aca) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=32551490)</sub>

<!-- /greptile_comment -->