### PR TITLE
🧪 test: add db error handling test for invitee lookup by email

### DIFF
--- a/apps/api/src/routes/__tests__/papers.test.ts
+++ b/apps/api/src/routes/__tests__/papers.test.ts
@@ -3238,6 +3238,47 @@ describe("papers routes", () => {
 
       expect(res.status).toBe(500);
     });
+    it("POST /api/papers/:id/invites handles database error during invitee lookup by email", async () => {
+      const token = await createTestJWT({
+        sub: "user-uploader",
+        githubId: "123",
+        name: "Uploader",
+      });
+
+      mockDb.select = vi
+        .fn()
+        .mockImplementationOnce(() =>
+          makeQuery({
+            getResult: {
+              paperId: "paper-1",
+              userId: "user-uploader",
+              role: "uploader",
+            },
+          }),
+        )
+        .mockImplementationOnce(() => {
+          throw new Error("DB Error on email lookup");
+        });
+
+      const app = await createTestApp();
+      const env = createTestEnv();
+      const customRes = await app.request(
+        "http://localhost/api/papers/paper-1/invites",
+        {
+          method: "POST",
+          headers: {
+            "Content-Type": "application/json",
+            Authorization: `Bearer ${token}`,
+          },
+          body: JSON.stringify({ inviteeEmail: "error@example.com" }),
+        },
+        env as any,
+      );
+
+      expect(customRes.status).toBe(500);
+      const data = (await customRes.json()) as any;
+      expect(data.error).toBe("Internal server error");
+    });
   });
 });
 

--- a/apps/api/src/routes/papers.ts
+++ b/apps/api/src/routes/papers.ts
@@ -1200,17 +1200,21 @@ papersRoute.post("/:id/invites", authMiddleware, async (c) => {
     let resolvedInviteeEmail: string | null = inviteeEmail;
 
     if (!resolvedInviteeId && resolvedInviteeEmail) {
-        const matchedUser = await db
-            .select({ id: users.id })
-            .from(users)
-            .where(eq(users.email, resolvedInviteeEmail))
-            .get();
-        if (matchedUser) {
-            if (matchedUser.id === userId) {
-                return c.json({ error: "Cannot invite yourself" }, 400);
+        try {
+            const matchedUser = await db
+                .select({ id: users.id })
+                .from(users)
+                .where(eq(users.email, resolvedInviteeEmail))
+                .get();
+            if (matchedUser) {
+                if (matchedUser.id === userId) {
+                    return c.json({ error: "Cannot invite yourself" }, 400);
+                }
+                resolvedInviteeId = matchedUser.id;
+                resolvedInviteeEmail = null;
             }
-            resolvedInviteeId = matchedUser.id;
-            resolvedInviteeEmail = null;
+        } catch (e: unknown) {
+            return c.json({ error: "Internal server error" }, 500);
         }
     }
 


### PR DESCRIPTION
## What:
Added error handling and a missing test when looking up an invitee by email during the coauthor invite operation.

## Coverage:
The database error scenario during email resolution is now fully tested, returning a robust `500 Internal server error` JSON payload.

## Result:
Increased test coverage and better reliability, gracefully handling unexpected DB failures rather than bubbling up raw string errors via Hono's default fallback.

---
*PR created automatically by Jules for task [8379916248373037994](https://jules.google.com/task/8379916248373037994) started by @is0692vs*

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

メールアドレスによる招待対象ユーザー検索（`db.select`）に DB エラーが発生した際のエラーハンドリングを追加し、対応するテストを 3 件追加する PR です。

- `papers.ts`: メール検索の DB 呼び出しを `try/catch` で包み、エラー時に `console.error` でログを出力してから `{ error: "Internal server error" }` (HTTP 500) を返すよう変更。
- `papers.test.ts`: DB エラー時の 500 応答・メールからユーザー ID への正常解決（201）・自己招待の拒否（400）を検証するテストを追加。
</details>

<details open><summary><h3>Confidence Score: 5/5</h3></summary>

変更範囲は小さく、既存の動作を壊すリスクはありません。

本番コードの変更は既存の DB 呼び出しを try/catch で包んだだけであり、正常系の挙動は変わりません。追加された 3 件のテストはすべてモックの呼び出し順序が本番コードのフローと一致しており、アサーションも適切です。

特に注意が必要なファイルはありません。
</details>

<details open><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| apps/api/src/routes/papers.ts | メール検索の DB 呼び出しを try/catch でラップし、エラー時に console.error でログを残したうえで 500 を返すよう修正。 |
| apps/api/src/routes/__tests__/papers.test.ts | メール検索 DB エラー（500）・正常解決（201）・自己招待拒否（400）の 3 テストを追加。 |

</details>

</details>

<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant Client
    participant Handler as POST /:id/invites
    participant DB

    Client->>Handler: "POST { inviteeEmail }"
    Handler->>DB: SELECT paperAuthors (uploader check)
    DB-->>Handler: "{ role: uploader }"
    Handler->>DB: "SELECT users WHERE email = inviteeEmail"
    alt DB success
        DB-->>Handler: matchedUser
        alt self-invite
            Handler-->>Client: 400 Cannot invite yourself
        else
            Handler->>DB: SELECT paperAuthors (duplicate check)
            Handler->>DB: SELECT users (invitee exists)
            Handler->>DB: INSERT coauthorInvites
            Handler-->>Client: 201 ok
        end
    else DB error NEW
        DB-->>Handler: throws Error
        Handler->>Handler: console.error
        Handler-->>Client: 500 Internal server error
    end
```

<sub>Reviews (4): Last reviewed commit: ["Merge remote-tracking branch &#39;origin/sta..."](https://github.com/hiroki-org/openshelf/commit/7cfab0cea1495f8844cecb352b93612272ee21ff) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=32552101)</sub>

<!-- /greptile_comment -->