### PR TITLE
🎨 Palette: 説明フィールドへの文字数カウンターの追加 (アクセシビリティ向上)

### DIFF
--- a/apps/web/src/app/__tests__/collections-new.test.tsx
+++ b/apps/web/src/app/__tests__/collections-new.test.tsx
@@ -45,6 +45,25 @@ describe("NewCollectionPage", () => {
     authState = { user: { id: "user-1" }, loading: false };
   });
 
+  it("updates the description character counter and keeps it associated with the textarea", () => {
+    render(<NewCollectionPage />);
+
+    const description = screen.getByLabelText("description");
+    const counter = screen.getByText("0/500");
+
+    expect(description).toHaveAttribute("aria-describedby", "description-counter");
+    expect(counter).toHaveAttribute("id", "description-counter");
+    expect(counter).toHaveClass("text-gray-500");
+
+    fireEvent.change(description, { target: { value: "abc" } });
+
+    expect(screen.getByText("3/500")).toBeInTheDocument();
+
+    fireEvent.change(description, { target: { value: "x".repeat(500) } });
+
+    expect(screen.getByText("500/500")).toHaveClass("text-red-600");
+  });
+
   it("slugifies the name, checks availability, and creates a user collection", async () => {
     vi.useFakeTimers();
     vi.mocked(apiFetch).mockImplementation(async (url, init) => {

--- a/apps/web/src/app/__tests__/orgs-new.test.tsx
+++ b/apps/web/src/app/__tests__/orgs-new.test.tsx
@@ -45,6 +45,28 @@ describe("NewOrgPage", () => {
     authState = { user: { id: "user-1" }, loading: false };
   });
 
+  it("updates the description character counter and keeps it associated with the textarea", () => {
+    render(<NewOrgPage />);
+
+    const description = screen.getByLabelText(/説明/i);
+    const counter = screen.getByText("0/500");
+
+    expect(description).toHaveAttribute(
+      "aria-describedby",
+      "org-description-counter",
+    );
+    expect(counter).toHaveAttribute("id", "org-description-counter");
+    expect(counter).toHaveClass("text-gray-500");
+
+    fireEvent.change(description, { target: { value: "abc" } });
+
+    expect(screen.getByText("3/500")).toBeInTheDocument();
+
+    fireEvent.change(description, { target: { value: "x".repeat(500) } });
+
+    expect(screen.getByText("500/500")).toHaveClass("text-red-600");
+  });
+
   it("checks slug availability and creates an org", async () => {
     vi.useFakeTimers();
     vi.mocked(apiFetch).mockImplementation(async (url, init) => {

--- a/apps/web/src/app/collections/new/page.tsx
+++ b/apps/web/src/app/collections/new/page.tsx
@@ -15,7 +15,6 @@ function slugify(text: string): string {
 }
 
 const SLUG_RE = /^[a-z0-9][a-z0-9-]*[a-z0-9]$|^[a-z0-9]$/;
-const DESCRIPTION_MAX_LENGTH = 500;
 
 export default function NewCollectionPage() {
   const { user, loading } = useAuth();
@@ -295,15 +294,19 @@ export default function NewCollectionPage() {
             value={description}
             onChange={(e) => setDescription(e.target.value)}
             rows={3}
-            maxLength={DESCRIPTION_MAX_LENGTH}
+            maxLength={500}
             aria-describedby="description-counter"
             className="w-full rounded-md border border-gray-300 px-3 py-2 text-sm dark:border-gray-700 dark:bg-gray-900"
           />
           <div
             id="description-counter"
-            className={"mt-1 flex justify-end text-xs " + (description.length >= DESCRIPTION_MAX_LENGTH ? "text-red-600 dark:text-red-400" : "text-gray-500 dark:text-gray-400")}
+            className={`mt-1 flex justify-end text-xs ${
+              description.length >= 500
+                ? "text-red-600 dark:text-red-400"
+                : "text-gray-500 dark:text-gray-400"
+            }`}
           >
-            {description.length}/{DESCRIPTION_MAX_LENGTH} 文字
+            {description.length}/500
           </div>
         </div>
 

--- a/apps/web/src/app/collections/new/page.tsx
+++ b/apps/web/src/app/collections/new/page.tsx
@@ -15,6 +15,7 @@ function slugify(text: string): string {
 }
 
 const SLUG_RE = /^[a-z0-9][a-z0-9-]*[a-z0-9]$|^[a-z0-9]$/;
+const DESCRIPTION_MAX_LENGTH = 500;
 
 export default function NewCollectionPage() {
   const { user, loading } = useAuth();
@@ -294,15 +295,15 @@ export default function NewCollectionPage() {
             value={description}
             onChange={(e) => setDescription(e.target.value)}
             rows={3}
-            maxLength={500}
+            maxLength={DESCRIPTION_MAX_LENGTH}
             aria-describedby="description-counter"
             className="w-full rounded-md border border-gray-300 px-3 py-2 text-sm dark:border-gray-700 dark:bg-gray-900"
           />
           <div
             id="description-counter"
-            className="mt-1 flex justify-end text-xs text-gray-500 dark:text-gray-400"
+            className={"mt-1 flex justify-end text-xs " + (description.length >= DESCRIPTION_MAX_LENGTH ? "text-red-600 dark:text-red-400" : "text-gray-500 dark:text-gray-400")}
           >
-            {description.length}/500
+            {description.length}/{DESCRIPTION_MAX_LENGTH} 文字
           </div>
         </div>
 

--- a/apps/web/src/app/collections/new/page.tsx
+++ b/apps/web/src/app/collections/new/page.tsx
@@ -295,8 +295,15 @@ export default function NewCollectionPage() {
             onChange={(e) => setDescription(e.target.value)}
             rows={3}
             maxLength={500}
+            aria-describedby="description-counter"
             className="w-full rounded-md border border-gray-300 px-3 py-2 text-sm dark:border-gray-700 dark:bg-gray-900"
           />
+          <div
+            id="description-counter"
+            className="mt-1 flex justify-end text-xs text-gray-500 dark:text-gray-400"
+          >
+            {description.length}/500
+          </div>
         </div>
 
         <div>

--- a/apps/web/src/app/orgs/new/page.tsx
+++ b/apps/web/src/app/orgs/new/page.tsx
@@ -16,8 +16,6 @@ function slugify(text: string): string {
     .slice(0, 40);
 }
 
-const DESCRIPTION_MAX_LENGTH = 500;
-
 export default function NewOrgPage() {
   const { user, loading } = useAuth();
   const router = useRouter();
@@ -203,15 +201,19 @@ export default function NewOrgPage() {
             value={description}
             onChange={(e) => setDescription(e.target.value)}
             rows={3}
-            maxLength={DESCRIPTION_MAX_LENGTH}
+            maxLength={500}
             aria-describedby="org-description-counter"
             className="w-full rounded-md border border-gray-300 px-3 py-2 text-sm dark:border-gray-700 dark:bg-gray-900"
           />
           <div
             id="org-description-counter"
-            className={"mt-1 flex justify-end text-xs " + (description.length >= DESCRIPTION_MAX_LENGTH ? "text-red-600 dark:text-red-400" : "text-gray-500 dark:text-gray-400")}
+            className={`mt-1 flex justify-end text-xs ${
+              description.length >= 500
+                ? "text-red-600 dark:text-red-400"
+                : "text-gray-500 dark:text-gray-400"
+            }`}
           >
-            {description.length}/{DESCRIPTION_MAX_LENGTH} 文字
+            {description.length}/500
           </div>
         </div>
 

--- a/apps/web/src/app/orgs/new/page.tsx
+++ b/apps/web/src/app/orgs/new/page.tsx
@@ -202,8 +202,15 @@ export default function NewOrgPage() {
             onChange={(e) => setDescription(e.target.value)}
             rows={3}
             maxLength={500}
+            aria-describedby="org-description-counter"
             className="w-full rounded-md border border-gray-300 px-3 py-2 text-sm dark:border-gray-700 dark:bg-gray-900"
           />
+          <div
+            id="org-description-counter"
+            className="mt-1 flex justify-end text-xs text-gray-500 dark:text-gray-400"
+          >
+            {description.length}/500
+          </div>
         </div>
 
         {error && <p className="text-sm text-red-600">{error}</p>}

--- a/apps/web/src/app/orgs/new/page.tsx
+++ b/apps/web/src/app/orgs/new/page.tsx
@@ -16,6 +16,8 @@ function slugify(text: string): string {
     .slice(0, 40);
 }
 
+const DESCRIPTION_MAX_LENGTH = 500;
+
 export default function NewOrgPage() {
   const { user, loading } = useAuth();
   const router = useRouter();
@@ -201,15 +203,15 @@ export default function NewOrgPage() {
             value={description}
             onChange={(e) => setDescription(e.target.value)}
             rows={3}
-            maxLength={500}
+            maxLength={DESCRIPTION_MAX_LENGTH}
             aria-describedby="org-description-counter"
             className="w-full rounded-md border border-gray-300 px-3 py-2 text-sm dark:border-gray-700 dark:bg-gray-900"
           />
           <div
             id="org-description-counter"
-            className="mt-1 flex justify-end text-xs text-gray-500 dark:text-gray-400"
+            className={"mt-1 flex justify-end text-xs " + (description.length >= DESCRIPTION_MAX_LENGTH ? "text-red-600 dark:text-red-400" : "text-gray-500 dark:text-gray-400")}
           >
-            {description.length}/500
+            {description.length}/{DESCRIPTION_MAX_LENGTH} 文字
           </div>
         </div>
 


### PR DESCRIPTION
💡 **What:** 
組織作成ページおよびコレクション作成ページの説明（description）フィールドに、視覚的な文字数カウンターを追加しました。

🎯 **Why:** 
ユーザーが入力制限（`maxLength={500}`）に対して現在どの程度入力しているかを直感的に把握できるようにし、UXを向上させるためです。これまでは制限に達するまで視覚的なフィードバックがありませんでした。

♿ **Accessibility:**
スクリーンリーダーのユーザーが入力ごとに毎回文字数を読み上げられてしまう煩わしさを回避するため、`aria-live` を使用せず、`aria-describedby` 属性を用いて入力フィールドとカウンターをプログラム的に紐付けました。これは Palette のジャーナルに基づくベストプラクティスです。

---
*PR created automatically by Jules for task [7442345914039484388](https://jules.google.com/task/7442345914039484388) started by @is0692vs*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added real-time character counters to description fields during collection and organization creation, displaying current count out of 500 character limit.
  * Enhanced accessibility with improved input field descriptors.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Hiroki-org/OpenShelf/pull/860?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

コレクション作成ページおよび組織作成ページの説明フィールドにリアルタイム文字数カウンター（`{length}/500`）を追加し、UX とアクセシビリティを向上させます。`aria-describedby` でカウンター要素をテキストエリアに紐付けており、500文字到達時は `text-red-600` に切り替わります。

- `collections/new/page.tsx` と `orgs/new/page.tsx` の `<textarea>` に `aria-describedby` を追加し、直後に ID 付きの `<div>` カウンターを配置。
- 両ページに対応するテストを追加し、初期状態・入力更新・上限到達時の色変化・ARIA 属性の紐付けを検証している。
</details>

<details open><summary><h3>Confidence Score: 5/5</h3></summary>

変更はUIの文字数カウンター追加のみで、既存ロジックへの影響はなく安全にマージできます。

変更はUIレイヤーのみに限定されており、既存の送信ロジックや状態管理には影響しません。テストが ARIA 属性・カウンター値・色変化をすべてカバーしており、実装と一致しています。

特に注意が必要なファイルはありません。
</details>

<details open><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| apps/web/src/app/collections/new/page.tsx | 説明テキストエリアに文字数カウンターを追加。`aria-describedby` で紐付け、500文字到達時は `text-red-600` に切り替え。実装は正確。 |
| apps/web/src/app/orgs/new/page.tsx | 組織作成ページの説明フィールドにも同様のカウンターを追加。IDは `org-description-counter` と適切にスコープされており、`collections` 側との衝突なし。 |
| apps/web/src/app/__tests__/collections-new.test.tsx | カウンターの初期表示・入力更新・上限到達時の色変化・aria 属性の紐付けを網羅するテストを追加。アサーション内容は実装と一致している。 |
| apps/web/src/app/__tests__/orgs-new.test.tsx | 組織作成ページ用の同等テストを追加。ラベルテキストの取得に `/説明/i` 正規表現を使用しており、collections 側との一貫性も保たれている。 |

</details>

</details>

<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[ユーザー入力] --> B[setDescription]
    B --> C{description.length >= 500?}
    C -- Yes --> D["カウンター: text-red-600\n例: 500/500"]
    C -- No --> E["カウンター: text-gray-500\n例: 123/500"]
    D --> F["div id=counter に反映"]
    E --> F
    F --> G["textarea の aria-describedby\nでスクリーンリーダーに提供"]
```

<sub>Reviews (3): Last reviewed commit: ["test(web): cover description counters"](https://github.com/hiroki-org/openshelf/commit/2007e7ee601c4f55d9d23dba88062e748a075ca1) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=32922024)</sub>

<!-- /greptile_comment -->