### PR TITLE
fix(deps): resolve OSV scanner vulnerable packages

### DIFF
--- a/apps/web/package-lock.json
+++ b/apps/web/package-lock.json
@@ -4244,9 +4244,9 @@
       }
     },
     "node_modules/brace-expansion": {
-      "version": "5.0.5",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.5.tgz",
-      "integrity": "sha512-VZznLgtwhn+Mact9tfiwx64fA9erHH/MCXEUfB/0bX/6Fz6ny5EGTXYltMocqg4xFAQZtnO3DHWWXi8RiuN7cQ==",
+      "version": "5.0.6",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.6.tgz",
+      "integrity": "sha512-kLpxurY4Z4r9sgMsyG0Z9uzsBlgiU/EFKhj/h91/8yHu0edo7XuixOIH3VcJ8kkxs6/jPzoI6U9Vj3WqbMQ94g==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -10807,9 +10807,9 @@
       }
     },
     "node_modules/ws": {
-      "version": "8.19.0",
-      "resolved": "https://registry.npmjs.org/ws/-/ws-8.19.0.tgz",
-      "integrity": "sha512-blAT2mjOEIi0ZzruJfIhb3nps74PRWTCz1IjglWEEpQl5XS/UNama6u2/rjFkDDouqr4L67ry+1aGIALViWjDg==",
+      "version": "8.20.1",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.20.1.tgz",
+      "integrity": "sha512-It4dO0K5v//JtTXuPkfEOaI3uUN87iYPnqo/ZzqCoG3g8uhA66QUMs/SrM0YK7/NAu+r4LMh/9dq2A7k+rHs+w==",
       "dev": true,
       "license": "MIT",
       "engines": {

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -43,10 +43,12 @@
     "vitest": "^4.1.5"
   },
   "overrides": {
+    "brace-expansion": "5.0.6",
     "next": {
       "postcss": "8.5.12"
     },
-    "postcss": "$postcss"
+    "postcss": "$postcss",
+    "ws": "8.20.1"
   },
   "license": "MIT"
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -5560,9 +5560,9 @@
       "license": "MIT"
     },
     "node_modules/brace-expansion": {
-      "version": "5.0.5",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.5.tgz",
-      "integrity": "sha512-VZznLgtwhn+Mact9tfiwx64fA9erHH/MCXEUfB/0bX/6Fz6ny5EGTXYltMocqg4xFAQZtnO3DHWWXi8RiuN7cQ==",
+      "version": "5.0.6",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.6.tgz",
+      "integrity": "sha512-kLpxurY4Z4r9sgMsyG0Z9uzsBlgiU/EFKhj/h91/8yHu0edo7XuixOIH3VcJ8kkxs6/jPzoI6U9Vj3WqbMQ94g==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -9901,7 +9901,7 @@
         "sharp": "^0.34.5",
         "undici": "7.24.8",
         "workerd": "1.20260515.1",
-        "ws": "8.18.0",
+        "ws": "8.20.1",
         "youch": "4.1.0-beta.10"
       },
       "bin": {
@@ -9912,9 +9912,9 @@
       }
     },
     "node_modules/miniflare/node_modules/ws": {
-      "version": "8.18.0",
-      "resolved": "https://registry.npmjs.org/ws/-/ws-8.18.0.tgz",
-      "integrity": "sha512-8VbfWfHLbbwu3+N6OKsOMpBdT4kXPDDB9cJk2bJ6mh9ucxdlnNvH1e+roYkKmN9Nxw2yjz7VzeO9oOz2zJ04Pw==",
+      "version": "8.20.1",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.20.1.tgz",
+      "integrity": "sha512-It4dO0K5v//JtTXuPkfEOaI3uUN87iYPnqo/ZzqCoG3g8uhA66QUMs/SrM0YK7/NAu+r4LMh/9dq2A7k+rHs+w==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -12647,9 +12647,9 @@
       }
     },
     "node_modules/ws": {
-      "version": "8.19.0",
-      "resolved": "https://registry.npmjs.org/ws/-/ws-8.19.0.tgz",
-      "integrity": "sha512-blAT2mjOEIi0ZzruJfIhb3nps74PRWTCz1IjglWEEpQl5XS/UNama6u2/rjFkDDouqr4L67ry+1aGIALViWjDg==",
+      "version": "8.20.1",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.20.1.tgz",
+      "integrity": "sha512-It4dO0K5v//JtTXuPkfEOaI3uUN87iYPnqo/ZzqCoG3g8uhA66QUMs/SrM0YK7/NAu+r4LMh/9dq2A7k+rHs+w==",
       "dev": true,
       "license": "MIT",
       "engines": {

--- a/package.json
+++ b/package.json
@@ -37,6 +37,7 @@
     "@esbuild-kit/core-utils": {
       "esbuild": "^0.25.12"
     },
+    "brace-expansion": "5.0.6",
     "devalue": "^5.6.4",
     "flatted": "^3.4.2",
     "micromatch": {
@@ -46,7 +47,8 @@
     "next": {
       "postcss": "8.5.12"
     },
-    "postcss": "$postcss"
+    "postcss": "$postcss",
+    "ws": "8.20.1"
   },
   "license": "MIT"
 }


### PR DESCRIPTION
## Summary
- force brace-expansion to 5.0.6 in both OSV-scanned lockfiles
- force ws to 8.20.1 in both OSV-scanned lockfiles
- keep the diff scoped to dependency metadata for the open OSV/code-scanning alerts

## Verification
- git diff --check
- vulnerable brace-expansion/ws versions no longer appear in package-lock.json or apps/web/package-lock.json
- npm ci --ignore-scripts --dry-run --no-audit from repo root passes

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated package dependency version overrides for improved system compatibility and stability.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Hiroki-org/OpenShelf/pull/864?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

このPRはOSVスキャナーが検出した脆弱なパッケージ（`brace-expansion` 5.0.5 と `ws` 8.18.0/8.19.0）を修正するため、両方のpackage.jsonに `overrides` エントリを追加し、ロックファイルを更新したものです。

- `brace-expansion` を 5.0.5 → 5.0.6 に更新（ルートおよび `apps/web` の両lockfile）
- `ws` を 8.18.0 / 8.19.0 → 8.20.1 に更新（ルートおよび `apps/web` の両lockfile）
- 差分はメタデータ（`package.json` の `overrides` フィールドとlockfileのハッシュ）のみに限定されており、アプリケーションコードへの変更はなし
</details>

<details open><summary><h3>Confidence Score: 5/5</h3></summary>

依存関係のメタデータのみを変更する最小限のセキュリティパッチであり、マージに問題はありません

変更はすべて `package.json` の `overrides` フィールドとlockfileのハッシュ更新に限定されています。アプリケーションコードへの影響はなく、更新されたパッケージはいずれも同一メジャーバージョン内のパッチアップグレードです。両lockfileで脆弱なバージョンが完全に置き換えられていることを確認しました

特に注意が必要なファイルはありません
</details>

<details open><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| package.json | `overrides` に `brace-expansion: 5.0.6` と `ws: 8.20.1` を追加。構造は正しく、既存の `next.postcss` ネストオーバーライドと共存している |
| apps/web/package.json | `overrides` に `brace-expansion: 5.0.6` と `ws: 8.20.1` を追加。ルートと同様の変更で問題なし |
| package-lock.json | `brace-expansion` が 5.0.6、`ws`（`miniflare` ネストを含む2箇所）が 8.20.1 に更新済み。1.1.14 は `eslint-config-next` のv1系ネスト版であり、今回のOSV対象外 |
| apps/web/package-lock.json | `brace-expansion` が 5.0.6、`ws` が 8.20.1 に更新済み。ルートと同様 |

</details>

</details>

<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[package.json / apps/web/package.json\noverrides 追加] --> B{npm install}
    B --> C[brace-expansion\n5.0.5 → 5.0.6]
    B --> D[ws\n8.18.0 / 8.19.0 → 8.20.1]
    B --> E[miniflare/node_modules/ws\n8.18.0 → 8.20.1]
    B --> F[eslint-config-next/node_modules/\nbrace-expansion 1.1.14\n※v1系・OSV対象外のため変更なし]
    C --> G[package-lock.json 更新]
    D --> G
    E --> G
    C --> H[apps/web/package-lock.json 更新]
    D --> H
```

<sub>Reviews (3): Last reviewed commit: ["Merge branch &#39;staging&#39; into codex/osv-de..."](https://github.com/hiroki-org/openshelf/commit/fc66999c68dafb3f57f2b844bae5444d52938c97) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=33179857)</sub>

<!-- /greptile_comment -->