### PR TITLE
🔒 Fix CSRF Origin Check ReDoS Vulnerability

### DIFF
--- a/apps/api/src/utils/__tests__/origin.test.ts
+++ b/apps/api/src/utils/__tests__/origin.test.ts
@@ -97,11 +97,11 @@ describe("origin utils", () => {
         });
 
         it("rejects patterns with excessive wildcards to prevent ReDoS", () => {
-            const pattern = "https://*a*a*a*X.example.com";
-            expect(matchesOriginPattern("https://aaaaaaaaY.example.com", pattern)).toBe(false);
+            const pattern = p("https://*a*a*a*X", "example", "com");
+            expect(matchesOriginPattern(p("https://aaaaaaaaY", "example", "com"), pattern)).toBe(false);
 
             // Should allow up to 2 wildcards
-            expect(matchesOriginPattern("https://a.b.example.com", p("https://*", "*", "example", "com"))).toBe(true);
+            expect(matchesOriginPattern(p("https://a", "b", "example", "com"), p("https://*", "*", "example", "com"))).toBe(true);
         });
 
         it("escapes special regex characters in pattern", () => {

--- a/apps/api/src/utils/__tests__/origin.test.ts
+++ b/apps/api/src/utils/__tests__/origin.test.ts
@@ -97,8 +97,8 @@ describe("origin utils", () => {
         });
 
         it("rejects patterns with excessive wildcards to prevent ReDoS", () => {
-            const pattern = p("https://*a*a*a*X", "example", "com");
-            expect(matchesOriginPattern(p("https://aaaaaaaaY", "example", "com"), pattern)).toBe(false);
+            const excessivePattern = p("https://*", "*", "*", "example", "com");
+            expect(matchesOriginPattern(p("https://a", "b", "c", "example", "com"), excessivePattern)).toBe(false);
 
             // Should allow up to 2 wildcards
             expect(matchesOriginPattern(p("https://a", "b", "example", "com"), p("https://*", "*", "example", "com"))).toBe(true);

--- a/apps/api/src/utils/__tests__/origin.test.ts
+++ b/apps/api/src/utils/__tests__/origin.test.ts
@@ -96,6 +96,14 @@ describe("origin utils", () => {
             expect(matchesOriginPattern("https://api.staging.example.com", pattern)).toBe(true);
         });
 
+        it("rejects patterns with excessive wildcards to prevent ReDoS", () => {
+            const pattern = "https://*a*a*a*X.example.com";
+            expect(matchesOriginPattern("https://aaaaaaaaY.example.com", pattern)).toBe(false);
+
+            // Should allow up to 2 wildcards
+            expect(matchesOriginPattern("https://a.b.example.com", p("https://*", "*", "example", "com"))).toBe(true);
+        });
+
         it("escapes special regex characters in pattern", () => {
             // The pattern has dots which should be treated literally, not as any character regex
             expect(matchesOriginPattern("https://exampleXcom", p("https://*", "example", "com"))).toBe(false);

--- a/apps/api/src/utils/origin.ts
+++ b/apps/api/src/utils/origin.ts
@@ -1,3 +1,5 @@
+const MAX_ORIGIN_PATTERN_WILDCARDS = 2;
+
 export function normalizeOrigin(value: string | undefined): string | null {
     if (!value) return null;
     try {
@@ -30,10 +32,10 @@ export function matchesOriginPattern(origin: string, pattern: string): boolean {
     if (!pattern.includes("*")) return origin === pattern;
 
     const parts = pattern.split("*");
+    const wildcardCount = parts.length - 1;
 
-    // Limit the number of wildcards to prevent ReDoS attacks.
-    // 2 wildcards (3 parts) are sufficient for legitimate use cases.
-    if (parts.length > 3) return false;
+    // Keep wildcard complexity bounded while still allowing app.env.example.com.
+    if (wildcardCount > MAX_ORIGIN_PATTERN_WILDCARDS) return false;
 
     const escapedParts = parts.map((part) => part.replace(/[|\\{}()[\]^$+?.]/g, "\\$&"));
     const regexSource = `^${escapedParts.join("[a-zA-Z0-9-]+")}$`;

--- a/apps/api/src/utils/origin.ts
+++ b/apps/api/src/utils/origin.ts
@@ -30,6 +30,11 @@ export function matchesOriginPattern(origin: string, pattern: string): boolean {
     if (!pattern.includes("*")) return origin === pattern;
 
     const parts = pattern.split("*");
+
+    // Limit the number of wildcards to prevent ReDoS attacks.
+    // 2 wildcards (3 parts) are sufficient for legitimate use cases.
+    if (parts.length > 3) return false;
+
     const escapedParts = parts.map((part) => part.replace(/[|\\{}()[\]^$+?.]/g, "\\$&"));
     const regexSource = `^${escapedParts.join("[a-zA-Z0-9-]+")}$`;
 


### PR DESCRIPTION
🎯 **What:** 
Fixed a Regular Expression Denial of Service (ReDoS) vulnerability in the `matchesOriginPattern` function within `apps/api/src/utils/origin.ts`. The function dynamically generates regular expressions from user-provided wildcard (`*`) patterns but failed to constrain the number of wildcards, leading to exponential backtracking if an attacker or misconfigured setting supplied an excessive amount of wildcards.

⚠️ **Risk:** 
An attacker who can control the allowed origins configuration, or a user who inadvertently misconfigures an origin with many wildcards (e.g., `*.*.*.*.example.com`), could trigger exponential regex backtracking by providing a specially crafted, long input origin that partially matches but ultimately fails. This could cause prolonged CPU saturation and block the event loop, resulting in a Denial of Service (DoS).

🛡️ **Solution:** 
Implemented a strict limitation on the number of wildcards allowed within a pattern. The function now rejects patterns containing more than 2 wildcards (i.e., splitting by `*` yields more than 3 parts), returning `false` immediately before compilation. This securely bounds the backtracking complexity to $O(N^2)$ and eliminates the ReDoS vector, while perfectly preserving legitimate patterns like `https://*.example.com` and `https://*-staging.*.example.com`. Corresponding tests were added to ensure patterns exceeding this complexity are rejected.

---
*PR created automatically by Jules for task [1122902150506077498](https://jules.google.com/task/1122902150506077498) started by @is0692vs*

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

`matchesOriginPattern` 関数に存在していた ReDoS 脆弱性（ワイルドカード数が無制限だったため、悪意ある入力で指数的バックトラッキングが発生しうる問題）を修正するPRです。

- `MAX_ORIGIN_PATTERN_WILDCARDS = 2` 定数を導入し、ワイルドカードが 2 個を超えるパターンを即座に `false` で拒否することで、バックトラッキング複雑度を O(N²) に抑制。
- 過去レビューで指摘されていたテストの有効性問題（限界値チェック削除時にテストがパスしてしまう問題）は本PRで修正済み。
</details>

<details open><summary><h3>Confidence Score: 5/5</h3></summary>

変更は小さく局所的で、既存の正規表現生成ロジックには触れていない。早期リターンのガードを追加したのみで、副作用のリスクは低い。

修正は wildcardCount > MAX_ORIGIN_PATTERN_WILDCARDS の1行ガードのみ。テストは上限チェックを削除するとアサーションが壊れる形で書かれており、リグレッション検出として機能している。影響範囲は matchesOriginPattern のみで、既存の正規表現生成パスへの変更はない。

特に注意が必要なファイルはない。
</details>

<details open><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| apps/api/src/utils/origin.ts | MAX_ORIGIN_PATTERN_WILDCARDS=2 の定数追加と wildcardCount > 2 で早期リターンする ReDoS 対策を実装。ロジックは正しく、既存の正規表現生成パスは変更なし。 |
| apps/api/src/utils/__tests__/origin.test.ts | 新テストは「3つのワイルドカードが拒否される」「2つのワイルドカードは許可される」の両境界を正しく検証しており、上限チェックを削除するとアサーションが失敗するため、リグレッション検出として有効。 |

</details>

</details>

<sub>Reviews (2): Last reviewed commit: ["Merge branch &#39;staging&#39; into fix/csrf-ori..."](https://github.com/hiroki-org/openshelf/commit/cabd89e8b80626ed6ab681cf91020cecd17c7730) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=33702120)</sub>

<!-- /greptile_comment -->