### PR TITLE
🧪 Add test for malformed OLE2 header

### DIFF
--- a/apps/api/src/utils/__tests__/file.test.ts
+++ b/apps/api/src/utils/__tests__/file.test.ts
@@ -194,6 +194,27 @@ describe("validateMagicNumbers", () => {
     );
   });
 
+  it("rejects legacy PowerPoint files with malformed OLE2 header (invalid sector shift)", async () => {
+    const validOle2 = createMockOle2(["PowerPoint Document"]);
+
+    // Create a modified buffer with an invalid sector shift (e.g., 10 instead of 9 or 12)
+    const modifiedBuffer = new Uint8Array(validOle2.length);
+    modifiedBuffer.set(validOle2);
+
+    const view = new DataView(modifiedBuffer.buffer);
+    view.setUint16(30, 10, true);
+
+    const ppt = createFile(
+      "slides.ppt",
+      "application/vnd.ms-powerpoint",
+      modifiedBuffer,
+    );
+
+    await expect(
+      validateMagicNumbers(ppt, "application/vnd.ms-powerpoint"),
+    ).resolves.toBe(false);
+  });
+
   it("rejects legacy PowerPoint files when the target entry is not a stream (objectType !== 2)", async () => {
     const ppt = createFile(
       "slides.ppt",
@@ -224,7 +245,7 @@ describe("validateMagicNumbers", () => {
     ).resolves.toBe(false);
   });
 
-it("returns false when File.slice throws RangeError", async () => {
+  it("returns false when File.slice throws RangeError", async () => {
     const errorFile = {
       slice: () => ({
         arrayBuffer: async () => {
@@ -235,10 +256,12 @@ it("returns false when File.slice throws RangeError", async () => {
       type: "application/pdf",
     } as unknown as File;
 
-    await expect(validateMagicNumbers(errorFile, "application/pdf")).resolves.toBe(false);
+    await expect(
+      validateMagicNumbers(errorFile, "application/pdf"),
+    ).resolves.toBe(false);
   });
 
-it("returns false when File.slice throws TypeError", async () => {
+  it("returns false when File.slice throws TypeError", async () => {
     const errorFile = {
       slice: () => ({
         arrayBuffer: async () => {
@@ -249,10 +272,12 @@ it("returns false when File.slice throws TypeError", async () => {
       type: "application/pdf",
     } as unknown as File;
 
-    await expect(validateMagicNumbers(errorFile, "application/pdf")).resolves.toBe(false);
+    await expect(
+      validateMagicNumbers(errorFile, "application/pdf"),
+    ).resolves.toBe(false);
   });
 
-it("returns false when File.slice throws DOMException with InvalidStateError", async () => {
+  it("returns false when File.slice throws DOMException with InvalidStateError", async () => {
     const errorFile = {
       slice: () => ({
         arrayBuffer: async () => {
@@ -263,10 +288,12 @@ it("returns false when File.slice throws DOMException with InvalidStateError", a
       type: "application/pdf",
     } as unknown as File;
 
-    await expect(validateMagicNumbers(errorFile, "application/pdf")).resolves.toBe(false);
+    await expect(
+      validateMagicNumbers(errorFile, "application/pdf"),
+    ).resolves.toBe(false);
   });
 
-it("throws the error when File.slice throws an unexpected error", async () => {
+  it("throws the error when File.slice throws an unexpected error", async () => {
     const customError = new Error("Unexpected error");
     const errorFile = {
       slice: () => ({
@@ -278,7 +305,9 @@ it("throws the error when File.slice throws an unexpected error", async () => {
       type: "application/pdf",
     } as unknown as File;
 
-    await expect(validateMagicNumbers(errorFile, "application/pdf")).rejects.toThrow("Unexpected error");
+    await expect(
+      validateMagicNumbers(errorFile, "application/pdf"),
+    ).rejects.toThrow("Unexpected error");
   });
 
   it("throws the error when File.slice throws DOMException with AbortError", async () => {
@@ -293,6 +322,8 @@ it("throws the error when File.slice throws an unexpected error", async () => {
       type: "application/pdf",
     } as unknown as File;
 
-    await expect(validateMagicNumbers(errorFile, "application/pdf")).rejects.toThrow(customError);
+    await expect(
+      validateMagicNumbers(errorFile, "application/pdf"),
+    ).rejects.toThrow(customError);
   });
 });


### PR DESCRIPTION
🎯 **What:** The testing gap addressed is a missing edge case for a malformed OLE2 header in `parseOleHeader` inside `apps/api/src/utils/file.ts`. Specifically, when `sectorShift` is an invalid value (not 9 or 12).
📊 **Coverage:** A new test case has been added to `apps/api/src/utils/__tests__/file.test.ts` which uses a valid mocked OLE2 file and modifies its `sectorShift` at offset 30 to 10. The test verifies that `validateMagicNumbers` resolves to `false` for this file.
✨ **Result:** Test coverage is improved, ensuring the robustness of the OLE2 parsing logic against malformed files.

---
*PR created automatically by Jules for task [4519042012167199868](https://jules.google.com/task/4519042012167199868) started by @is0692vs*

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

本PRは `validateMagicNumbers` のテストスイートに 1 件のテストケースを追加し、`sectorShift` が不正値（9 でも 12 でもない）の OLE2 ヘッダを持つファイルが正しく拒否されることを検証します。あわせて、`describe` ブロック外に誤ってぶら下がっていた 4 件の `it` ケースのインデントも修正されています。

- **新テスト追加**: `createMockOle2` で生成したバッファのオフセット 30 番地 (`sectorShift`) を `10` に書き換えて `File` を作成し、`validateMagicNumbers` が `false` を返すことを確認。`parseOleHeader` 内の `sectorShift !== 9 && sectorShift !== 12` ガードが正しく機能することをカバー。
- **インデント修正**: `RangeError` / `TypeError` / `DOMException` / `AbortError` に関する 4 件のテストが `describe` スコープに正しく収まるよう整形。
</details>

<details open><summary><h3>Confidence Score: 5/5</h3></summary>

テストのみの変更で、プロダクションコードへの影響は一切ない。安全にマージ可能。

新しいテストは sectorShift の不正値に対するガードを正確に踏んでおり、アサーションも期待値に合致している。インデント修正も誤りなし。

特に注意が必要なファイルはない。
</details>

<details open><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| apps/api/src/utils/__tests__/file.test.ts | malformed OLE2 sectorShift テストを追加し、`describe` ブロック外にあった 4 つの `it` ケースのインデントを修正。テストロジックに問題なし。 |

</details>

</details>

<sub>Reviews (1): Last reviewed commit: ["test: add edge case test for malformed O..."](https://github.com/hiroki-org/openshelf/commit/a91bf16ffb612e20572697f9d92304d82e854dee) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=35544703)</sub>

<!-- /greptile_comment -->