### PR TITLE
🧹 Extract UI components and types from PaperDetailClient

### DIFF
--- a/apps/web/src/app/papers/[id]/__tests__/page-metadata.test.tsx
+++ b/apps/web/src/app/papers/[id]/__tests__/page-metadata.test.tsx
@@ -91,11 +91,9 @@ describe("papers/[id]/page metadata", () => {
     expect(metadata.openGraph?.title).toBe("成果物詳細 | OpenShelf");
   });
 
-
   it("generates generic metadata when id is invalid", async () => {
     // Generate metadata without await as the component is sync for generating metadata via props
     const metadata = await generateMetadata({ params: { id: "../bad" } });
     expect(metadata.title).toBe("成果物詳細 | OpenShelf");
   });
-
 });

--- a/apps/web/src/app/papers/[id]/__tests__/paper-detail-client.test.tsx
+++ b/apps/web/src/app/papers/[id]/__tests__/paper-detail-client.test.tsx
@@ -417,7 +417,9 @@ describe("PaperDetailClient", () => {
     const slideRow = screen.getByText("deck.pptx").closest("li");
     expect(slideRow).not.toBeNull();
     fireEvent.click(
-      within(slideRow!).getByRole("button", { name: "deck.pptxをダウンロード" }),
+      within(slideRow!).getByRole("button", {
+        name: "deck.pptxをダウンロード",
+      }),
     );
 
     await waitFor(() => {
@@ -748,18 +750,21 @@ describe("PaperDetailClient", () => {
     [401, "ログインが必要です"],
     [404, "成果物が見つかりません"],
     [500, "成果物の取得に失敗しました"],
-  ])("maps paper fetch status %s to its error message", async (status, message) => {
-    vi.mocked(apiFetch).mockResolvedValue(new Response("error", { status }));
+  ])(
+    "maps paper fetch status %s to its error message",
+    async (status, message) => {
+      vi.mocked(apiFetch).mockResolvedValue(new Response("error", { status }));
 
-    render(
-      <PaperDetailClient
-        paperId="paper-1"
-        siteBase="https://openshelf.example"
-      />,
-    );
+      render(
+        <PaperDetailClient
+          paperId="paper-1"
+          siteBase="https://openshelf.example"
+        />,
+      );
 
-    expect(await screen.findByText(message)).toBeInTheDocument();
-  });
+      expect(await screen.findByText(message)).toBeInTheDocument();
+    },
+  );
 
   it("shows an error when API request fails entirely", async () => {
     vi.mocked(apiFetch).mockRejectedValue(new Error("Network Error"));
@@ -775,5 +780,4 @@ describe("PaperDetailClient", () => {
       await screen.findByText("成果物の取得に失敗しました"),
     ).toBeInTheDocument();
   });
-
 });

--- a/apps/web/src/app/papers/[id]/__tests__/paper-detail-client.test.tsx
+++ b/apps/web/src/app/papers/[id]/__tests__/paper-detail-client.test.tsx
@@ -780,4 +780,74 @@ describe("PaperDetailClient", () => {
       await screen.findByText("成果物の取得に失敗しました"),
     ).toBeInTheDocument();
   });
+
+
+  it("can cancel the invite dialog", async () => {
+    vi.mocked(apiFetch).mockImplementation(async (input, init) => {
+      const url = String(input);
+      const method = init?.method ?? "GET";
+
+      if (url === "/api/papers/paper-1" && method === "GET") {
+        return jsonResponse({
+          paper: {
+            id: "paper-1",
+            title: "Cancel Invite",
+            abstract: null,
+            visibility: "private",
+            showViewCount: false,
+            publicViewCount: null,
+            publicDownloadCount: null,
+            externalUrl: null,
+            venue: null,
+            venueType: null,
+            year: null,
+            category: null,
+            tags: null,
+            createdAt: "2026-01-01T00:00:00.000Z",
+            updatedAt: "2026-01-02T00:00:00.000Z",
+          },
+          files: [],
+          authors: [
+            {
+              userId: "author-1",
+              role: "uploader",
+              name: "alice",
+              displayName: "Alice",
+              avatarUrl: null,
+            },
+          ],
+        });
+      }
+      if (url === "/api/papers/paper-1/stats?days=30" && method === "GET") {
+        return jsonResponse({
+          total: { views: 0, downloads: 0, previews: 0 },
+          daily: [],
+          days: 30,
+        });
+      }
+
+      throw new Error(`Unexpected request: ${method} ${url}`);
+    });
+
+    render(
+      <PaperDetailClient
+        paperId="paper-1"
+        siteBase="https://openshelf.example"
+      />,
+    );
+
+    await screen.findByRole("heading", { name: "Cancel Invite" });
+
+    fireEvent.click(
+      screen.getByRole("button", {
+        name: "Cancel Inviteに共著者を招待",
+      }),
+    );
+
+    expect(screen.getByRole("heading", { name: "共著者招待" })).toBeInTheDocument();
+
+    fireEvent.click(screen.getByRole("button", { name: "キャンセル" }));
+
+    expect(screen.queryByRole("heading", { name: "共著者招待" })).not.toBeInTheDocument();
+  });
 });

--- a/apps/web/src/app/papers/[id]/cite-button.tsx
+++ b/apps/web/src/app/papers/[id]/cite-button.tsx
@@ -121,9 +121,7 @@ export function CiteButton({ paperId }: CiteButtonProps) {
                 <span className="flex items-center gap-2">
                   <Spinner className="h-3 w-3" />
                   <span aria-hidden="true">生成中...</span>
-                  <span className="sr-only">
-                    {option.label} の引用を生成中
-                  </span>
+                  <span className="sr-only">{option.label} の引用を生成中</span>
                 </span>
               ) : (
                 option.label

--- a/apps/web/src/app/papers/[id]/components/paper-analytics-summary.tsx
+++ b/apps/web/src/app/papers/[id]/components/paper-analytics-summary.tsx
@@ -1,0 +1,49 @@
+import { Paper, PaperStats } from "../types";
+
+type PaperAnalyticsSummaryProps = {
+  paper: Paper;
+  isAuthor: boolean;
+  stats: PaperStats | null;
+  formatCount: (value: number | null | undefined) => string;
+};
+
+export function PaperAnalyticsSummary({
+  paper,
+  isAuthor,
+  stats,
+  formatCount,
+}: PaperAnalyticsSummaryProps) {
+  if (!paper.showViewCount && !isAuthor) return null;
+
+  const summaryViews =
+    paper.showViewCount || !isAuthor
+      ? paper.publicViewCount
+      : (stats?.total.views ?? null);
+  const summaryDownloads =
+    paper.showViewCount || !isAuthor
+      ? paper.publicDownloadCount
+      : (stats?.total.downloads ?? null);
+
+  return (
+    <div className="mb-6 inline-flex items-end gap-4 rounded-2xl border border-blue-100 bg-blue-50/70 px-4 py-3 text-blue-950 dark:border-blue-900/60 dark:bg-blue-950/30 dark:text-blue-100">
+      <div>
+        <p className="text-xs font-medium uppercase tracking-[0.2em] text-blue-700 dark:text-blue-300">
+          Analytics
+        </p>
+        <p className="mt-1 text-sm text-blue-800/80 dark:text-blue-200/80">
+          {paper.showViewCount
+            ? "公開表示中の閲覧・ダウンロード数"
+            : "著者向けの閲覧・ダウンロード数"}
+        </p>
+      </div>
+      <p className="text-lg font-semibold tabular-nums">
+        👁️ {summaryViews === null ? "..." : formatCount(summaryViews)} views
+        {" · "}
+        📥 {summaryDownloads === null
+          ? "..."
+          : formatCount(summaryDownloads)}{" "}
+        downloads
+      </p>
+    </div>
+  );
+}

--- a/apps/web/src/app/papers/[id]/components/paper-authors-list.tsx
+++ b/apps/web/src/app/papers/[id]/components/paper-authors-list.tsx
@@ -1,0 +1,71 @@
+import Image from "next/image";
+import Link from "next/link";
+import { getRoleBadge } from "@/lib/presentation";
+import { Author } from "../types";
+
+type PaperAuthorsListProps = {
+  authors: Author[];
+  isUploader: boolean;
+  paperTitle: string;
+  setShowInvite: (show: boolean) => void;
+};
+
+export function PaperAuthorsList({
+  authors,
+  isUploader,
+  paperTitle,
+  setShowInvite,
+}: PaperAuthorsListProps) {
+  return (
+    <div className="mb-6">
+      <h2 className="text-sm font-medium text-gray-500 mb-2">著者</h2>
+      <ul className="space-y-2">
+        {authors.map((a) => (
+          <li
+            key={a.userId}
+            className="flex items-center justify-between rounded-xl border border-gray-100 bg-gray-50/50 p-2.5 dark:border-gray-800 dark:bg-gray-900/50"
+          >
+            <div className="flex items-center gap-3">
+              {a.avatarUrl && (
+                <Image
+                  src={a.avatarUrl}
+                  alt={a.name}
+                  width={28}
+                  height={28}
+                  className="rounded-full ring-1 ring-gray-200 dark:ring-gray-700"
+                />
+              )}
+              <Link
+                href={`/users/${encodeURIComponent(a.userId)}`}
+                className="text-sm font-medium text-blue-600 hover:underline dark:text-blue-400"
+              >
+                {a.displayName ?? a.name}
+              </Link>
+            </div>
+            {(() => {
+              const badge = getRoleBadge(a.role);
+              return (
+                <span
+                  className={`inline-flex items-center rounded-full px-2 py-0.5 text-[10px] font-bold uppercase tracking-wider ${badge.className}`}
+                >
+                  {badge.label}
+                </span>
+              );
+            })()}
+          </li>
+        ))}
+      </ul>
+
+      {isUploader && (
+        <button
+          type="button"
+          onClick={() => setShowInvite(true)}
+          aria-label={`${paperTitle}に共著者を招待`}
+          className="mt-3 text-sm text-blue-600 hover:underline dark:text-blue-400"
+        >
+          + 共著者を招待
+        </button>
+      )}
+    </div>
+  );
+}

--- a/apps/web/src/app/papers/[id]/components/paper-files-list.tsx
+++ b/apps/web/src/app/papers/[id]/components/paper-files-list.tsx
@@ -1,0 +1,125 @@
+import dynamic from "next/dynamic";
+import { PaperFile, PreviewResponse } from "../types";
+
+const PdfViewer = dynamic(
+  () => import("@/components/pdf-viewer").then((mod) => mod.PdfViewer),
+  { ssr: false },
+);
+
+type PaperFilesListProps = {
+  pdfFile: PaperFile | null;
+  previewLoading: boolean;
+  preview: PreviewResponse | null;
+  previewError: boolean;
+  imageFiles: PaperFile[];
+  imagePreviewUrls: Record<string, string>;
+  failedImageIds: string[];
+  files: PaperFile[];
+  handleDownload: (f: PaperFile) => void;
+  formatSize: (bytes: number) => string;
+  getFileIcon: (fileType: string) => string;
+};
+
+export function PaperFilesList({
+  pdfFile,
+  previewLoading,
+  preview,
+  previewError,
+  imageFiles,
+  imagePreviewUrls,
+  failedImageIds,
+  files,
+  handleDownload,
+  formatSize,
+  getFileIcon,
+}: PaperFilesListProps) {
+  return (
+    <div className="mb-6">
+      <h2 className="text-sm font-medium text-gray-500 mb-2">ファイル</h2>
+
+      {pdfFile && (
+        <div className="mb-4 space-y-2">
+          <h3 className="text-sm font-medium">PDFプレビュー</h3>
+          {previewLoading && (
+            <div className="h-[420px] animate-pulse rounded-md bg-gray-200 dark:bg-gray-800" />
+          )}
+          {!previewLoading && preview?.url && (
+            <PdfViewer
+              fileUrl={preview.url}
+              onDownloadFallback={() => handleDownload(pdfFile)}
+            />
+          )}
+          {!previewLoading && previewError && (
+            <div className="rounded-md border border-red-300 bg-red-50 p-3 text-sm text-red-700 dark:border-red-800 dark:bg-red-950/40 dark:text-red-300">
+              <p>プレビューを読み込めません</p>
+              <button
+                type="button"
+                className="underline"
+                onClick={() => handleDownload(pdfFile)}
+                aria-label={`${pdfFile.filename}をPDFプレビューからダウンロード`}
+              >
+                ダウンロードする
+              </button>
+            </div>
+          )}
+        </div>
+      )}
+
+      {imageFiles.length > 0 && (
+        <div className="mb-4 grid grid-cols-1 gap-3 sm:grid-cols-2">
+          {imageFiles.map((img) => (
+            <div
+              key={img.id}
+              className="rounded-md border border-gray-200 p-2 dark:border-gray-700"
+            >
+              {imagePreviewUrls[img.id] ? (
+                // eslint-disable-next-line @next/next/no-img-element
+                <img
+                  src={imagePreviewUrls[img.id]}
+                  alt={img.filename}
+                  className="h-auto w-full rounded"
+                  loading="lazy"
+                />
+              ) : failedImageIds.includes(img.id) ? (
+                <div className="flex h-[180px] items-center justify-center rounded bg-red-50 text-xs text-red-600 dark:bg-red-950/20 dark:text-red-400">
+                  画像の読み込みに失敗しました
+                </div>
+              ) : (
+                <div className="h-[180px] animate-pulse rounded bg-gray-200 dark:bg-gray-800" />
+              )}
+            </div>
+          ))}
+        </div>
+      )}
+
+      <ul className="space-y-2">
+        {files.map((f) => (
+          <li
+            key={f.id}
+            className="flex items-center justify-between text-sm border rounded-md p-3 dark:border-gray-700 hover:bg-gray-50 dark:hover:bg-gray-800 transition-colors"
+          >
+            <div className="flex items-center gap-3">
+              <span className="text-xl" title={f.fileType}>
+                {getFileIcon(f.fileType)}
+              </span>
+              <div className="flex flex-col">
+                <span className="font-medium">{f.filename}</span>
+                <span className="text-xs text-gray-400">
+                  {formatSize(f.sizeBytes)}
+                </span>
+              </div>
+            </div>
+            <button
+              type="button"
+              onClick={() => handleDownload(f)}
+              aria-label={`${f.filename}をダウンロード`}
+              className="rounded bg-blue-600 px-3 py-1.5 text-xs text-white hover:bg-blue-500 transition-colors"
+            >
+              ダウンロード
+            </button>
+          </li>
+        ))}
+      </ul>
+    </div>
+  );
+}

--- a/apps/web/src/app/papers/[id]/components/paper-header.tsx
+++ b/apps/web/src/app/papers/[id]/components/paper-header.tsx
@@ -1,0 +1,58 @@
+import Link from "next/link";
+import { getVisibilityBadge } from "@/lib/presentation";
+import { Paper } from "../types";
+
+type PaperHeaderProps = {
+  paper: Paper;
+  isAuthor: boolean;
+};
+
+export function PaperHeader({ paper, isAuthor }: PaperHeaderProps) {
+  return (
+    <>
+      <div className="mb-6">
+        <Link
+          href="/"
+          className="text-sm text-blue-600 hover:underline dark:text-blue-400"
+        >
+          ← ダッシュボードに戻る
+        </Link>
+      </div>
+
+      <div className="flex justify-between items-start mb-2">
+        <h1 className="text-2xl font-bold">{paper.title}</h1>
+        {isAuthor && (
+          <Link
+            href={`/papers/${paper.id}/edit`}
+            className="rounded-md bg-white px-3 py-1.5 text-sm font-medium text-gray-900 shadow-sm ring-1 ring-inset ring-gray-300 hover:bg-gray-50 dark:bg-gray-800 dark:text-gray-100 dark:ring-gray-700 dark:hover:bg-gray-700 shrink-0"
+          >
+            編集
+          </Link>
+        )}
+      </div>
+
+      <div className="flex flex-wrap gap-2 text-sm text-gray-500 mb-6">
+        {(() => {
+          const badge = getVisibilityBadge(paper.visibility);
+          return (
+            <span
+              className={`inline-flex items-center rounded-full px-2.5 py-1 text-xs font-medium ${badge.className}`}
+            >
+              {badge.label}
+            </span>
+          );
+        })()}
+        {paper.year && (
+          <span className="flex items-center rounded-full bg-gray-100 px-2.5 py-1 text-xs font-medium text-gray-600 dark:bg-gray-800 dark:text-gray-400">
+            {paper.year}年
+          </span>
+        )}
+        {paper.venue && (
+          <span className="flex items-center rounded-full bg-gray-100 px-2.5 py-1 text-xs font-medium text-gray-600 dark:bg-gray-800 dark:text-gray-400">
+            {paper.venue}
+          </span>
+        )}
+      </div>
+    </>
+  );
+}

--- a/apps/web/src/app/papers/[id]/components/paper-invite-dialog.tsx
+++ b/apps/web/src/app/papers/[id]/components/paper-invite-dialog.tsx
@@ -1,0 +1,95 @@
+import Image from "next/image";
+import { SearchUser } from "../types";
+
+type PaperInviteDialogProps = {
+  showInvite: boolean;
+  setShowInvite: (show: boolean) => void;
+  searchQuery: string;
+  handleSearch: (q: string) => void;
+  searchResults: SearchUser[];
+  handleInvite: (userId: string) => void;
+  inviting: string | null;
+  setSearchQuery: (q: string) => void;
+  setSearchResults: (results: SearchUser[]) => void;
+};
+
+export function PaperInviteDialog({
+  showInvite,
+  setShowInvite,
+  searchQuery,
+  handleSearch,
+  searchResults,
+  handleInvite,
+  inviting,
+  setSearchQuery,
+  setSearchResults,
+}: PaperInviteDialogProps) {
+  if (!showInvite) return null;
+
+  return (
+    <div className="mb-6 rounded-md border border-gray-200 p-4 dark:border-gray-700">
+      <h3 className="font-medium mb-2">共著者招待</h3>
+      <input
+        type="text"
+        value={searchQuery}
+        onChange={(e) => handleSearch(e.target.value)}
+        placeholder="ユーザー名で検索..."
+        className="w-full rounded-md border border-gray-300 px-3 py-2 text-sm mb-2 dark:border-gray-700 dark:bg-gray-900"
+      />
+      {searchResults.length > 0 && (
+        <ul className="space-y-1 max-h-40 overflow-y-auto">
+          {searchResults.map((u) => (
+            <li
+              key={u.id}
+              className="flex items-center justify-between p-2 text-sm hover:bg-gray-50 rounded dark:hover:bg-gray-800"
+            >
+              <div className="flex items-center gap-2">
+                {u.avatarUrl && (
+                  <Image
+                    src={u.avatarUrl}
+                    alt={u.name}
+                    width={20}
+                    height={20}
+                    className="rounded-full"
+                  />
+                )}
+                <span>{u.displayName ?? u.name}</span>
+              </div>
+              <button
+                type="button"
+                onClick={() => handleInvite(u.id)}
+                disabled={inviting !== null}
+                aria-busy={inviting === u.id}
+                aria-label={`${u.displayName ?? u.name}を共著者として招待`}
+                className="inline-flex min-w-[72px] items-center justify-center rounded bg-blue-600 px-2 py-1 text-xs text-white hover:bg-blue-500 disabled:opacity-50"
+              >
+                {inviting === u.id ? (
+                  <span className="flex items-center justify-center gap-1">
+                    <span
+                      className="h-3 w-3 motion-safe:animate-spin rounded-full border-2 border-current border-t-transparent"
+                      aria-hidden="true"
+                    />
+                    招待中...
+                  </span>
+                ) : (
+                  "招待"
+                )}
+              </button>
+            </li>
+          ))}
+        </ul>
+      )}
+      <button
+        type="button"
+        onClick={() => {
+          setShowInvite(false);
+          setSearchQuery("");
+          setSearchResults([]);
+        }}
+        className="mt-2 text-sm text-gray-500 hover:underline"
+      >
+        キャンセル
+      </button>
+    </div>
+  );
+}

--- a/apps/web/src/app/papers/[id]/components/paper-pending-invites.tsx
+++ b/apps/web/src/app/papers/[id]/components/paper-pending-invites.tsx
@@ -1,0 +1,44 @@
+import { getInviteStatusBadge } from "@/lib/presentation";
+import { Invite } from "../types";
+
+type PaperPendingInvitesProps = {
+  isUploader: boolean;
+  invites: Invite[];
+};
+
+export function PaperPendingInvites({
+  isUploader,
+  invites,
+}: PaperPendingInvitesProps) {
+  if (!isUploader || invites.length === 0) return null;
+
+  return (
+    <div className="mb-6">
+      <h2 className="text-sm font-medium text-gray-500 mb-2">招待状況</h2>
+      <ul className="space-y-1">
+        {invites.map((inv) => (
+          <li
+            key={inv.id}
+            className="flex items-center justify-between text-sm border rounded-md p-2 dark:border-gray-700"
+          >
+            <div className="flex items-center gap-2">
+              <span className="text-sm font-medium text-gray-900 dark:text-gray-100">
+                {inv.inviteeName}
+              </span>
+            </div>
+            {(() => {
+              const badge = getInviteStatusBadge(inv.status);
+              return (
+                <span
+                  className={`inline-flex items-center rounded-full px-2.5 py-1 text-xs font-medium ${badge.className}`}
+                >
+                  {badge.label}
+                </span>
+              );
+            })()}
+          </li>
+        ))}
+      </ul>
+    </div>
+  );
+}

--- a/apps/web/src/app/papers/[id]/components/paper-stats-section.tsx
+++ b/apps/web/src/app/papers/[id]/components/paper-stats-section.tsx
@@ -1,0 +1,148 @@
+import { PaperStats } from "../types";
+
+type PaperStatsSectionProps = {
+  stats: PaperStats | null;
+  statsLoading: boolean;
+  statsError: string;
+  selectedStatsDays: 7 | 30 | 90 | 365;
+  setSelectedStatsDays: (days: 7 | 30 | 90 | 365) => void;
+  maxDailyViewCount: number;
+};
+
+function formatStatsDateLabel(date: string) {
+  const [, month, day] = date.split("-");
+  return `${Number(month)}/${Number(day)}`;
+}
+
+function formatCount(value: number | null | undefined): string {
+  return new Intl.NumberFormat().format(value ?? 0);
+}
+
+export function PaperStatsSection({
+  stats,
+  statsLoading,
+  statsError,
+  selectedStatsDays,
+  setSelectedStatsDays,
+  maxDailyViewCount,
+}: PaperStatsSectionProps) {
+  return (
+    <section className="mb-8 rounded-3xl border border-gray-200 bg-gray-50/70 p-5 dark:border-gray-800 dark:bg-gray-900/40">
+      <div className="flex flex-col gap-2 sm:flex-row sm:items-end sm:justify-between">
+        <div>
+          <p className="text-xs font-medium uppercase tracking-[0.18em] text-gray-500">
+            Author Stats
+          </p>
+          <h2 className="mt-2 text-lg font-semibold text-gray-950 dark:text-gray-50">
+            閲覧統計
+          </h2>
+        </div>
+        <p className="text-xs text-gray-500">投稿者と共著者のみ閲覧できます</p>
+      </div>
+
+      {statsLoading && (
+        <div className="mt-4 rounded-2xl bg-white p-4 text-sm text-gray-500 shadow-sm dark:bg-gray-950 dark:text-gray-400">
+          統計情報を読み込み中...
+        </div>
+      )}
+
+      {!statsLoading && statsError && (
+        <div className="mt-4 rounded-2xl border border-red-200 bg-red-50 p-4 text-sm text-red-700 dark:border-red-900/60 dark:bg-red-950/30 dark:text-red-300">
+          {statsError}
+        </div>
+      )}
+
+      {!statsLoading && stats && (
+        <>
+          <div className="mt-4 flex flex-wrap gap-2">
+            {([7, 30, 90, 365] as const).map((days) => (
+              <button
+                key={days}
+                type="button"
+                onClick={() => setSelectedStatsDays(days)}
+                className={`rounded-full px-3 py-1 text-xs font-medium transition-colors ${
+                  selectedStatsDays === days
+                    ? "bg-gray-900 text-white dark:bg-gray-100 dark:text-gray-900"
+                    : "bg-white text-gray-600 hover:bg-gray-100 dark:bg-gray-900 dark:text-gray-300 dark:hover:bg-gray-800"
+                }`}
+              >
+                {days}日
+              </button>
+            ))}
+          </div>
+
+          <div className="mt-4 grid gap-3 sm:grid-cols-3">
+            <div className="rounded-2xl bg-white p-4 shadow-sm dark:bg-gray-950">
+              <p className="text-xs font-medium uppercase tracking-[0.18em] text-gray-500">
+                Total Views
+              </p>
+              <p className="mt-3 text-3xl font-semibold tabular-nums text-gray-950 dark:text-gray-50">
+                {formatCount(stats.total.views)}
+              </p>
+            </div>
+            <div className="rounded-2xl bg-white p-4 shadow-sm dark:bg-gray-950">
+              <p className="text-xs font-medium uppercase tracking-[0.18em] text-gray-500">
+                Total Downloads
+              </p>
+              <p className="mt-3 text-3xl font-semibold tabular-nums text-gray-950 dark:text-gray-50">
+                {formatCount(stats.total.downloads)}
+              </p>
+            </div>
+            <div className="rounded-2xl bg-white p-4 shadow-sm dark:bg-gray-950">
+              <p className="text-xs font-medium uppercase tracking-[0.18em] text-gray-500">
+                Total Previews
+              </p>
+              <p className="mt-3 text-3xl font-semibold tabular-nums text-gray-950 dark:text-gray-50">
+                {formatCount(stats.total.previews)}
+              </p>
+            </div>
+          </div>
+
+          <div className="mt-5 rounded-2xl bg-white p-4 shadow-sm dark:bg-gray-950">
+            <div className="flex items-center justify-between gap-3">
+              <h3 className="text-sm font-medium text-gray-700 dark:text-gray-300">
+                日別推移
+              </h3>
+              <p className="text-xs text-gray-500">直近{stats.days}日</p>
+            </div>
+
+            <div className="mt-4 overflow-x-auto">
+              <div className="flex min-w-[720px] items-end gap-2">
+                {stats.daily.map((entry) => {
+                  const barHeight =
+                    maxDailyViewCount === 0
+                      ? 4
+                      : Math.max(
+                          4,
+                          Math.round((entry.views / maxDailyViewCount) * 120),
+                        );
+
+                  return (
+                    <div
+                      key={entry.date}
+                      className="flex min-w-0 flex-1 flex-col items-center gap-2"
+                    >
+                      <div className="flex h-32 w-full items-end">
+                        <div
+                          className="w-full rounded-t-xl bg-gray-900/85 dark:bg-gray-100/85"
+                          style={{ height: `${barHeight}px` }}
+                          title={`${entry.date}: ${entry.views} views / ${entry.downloads} downloads`}
+                        />
+                      </div>
+                      <span className="text-[10px] font-medium text-gray-500">
+                        {entry.views}
+                      </span>
+                      <span className="text-[10px] text-gray-400">
+                        {formatStatsDateLabel(entry.date)}
+                      </span>
+                    </div>
+                  );
+                })}
+              </div>
+            </div>
+          </div>
+        </>
+      )}
+    </section>
+  );
+}

--- a/apps/web/src/app/papers/[id]/paper-detail-client.tsx
+++ b/apps/web/src/app/papers/[id]/paper-detail-client.tsx
@@ -4,96 +4,26 @@ import { useAuth } from "@/components/auth-provider";
 import { toast } from "@/components/toast";
 import { apiFetch } from "@/lib/api";
 import { useEffect, useState, useCallback, useMemo, useRef } from "react";
-import Link from "next/link";
-import Image from "next/image";
-import dynamic from "next/dynamic";
 import { safePath } from "@/lib/sanitization";
-import {
-  getVisibilityBadge,
-  getInviteStatusBadge,
-  getRoleBadge,
-} from "@/lib/presentation";
 import { CiteButton } from "./cite-button";
 import { MarkdownRenderer } from "@/components/markdown-renderer";
 import { BadgeSnippet } from "./badge-snippet";
-
-const PdfViewer = dynamic(
-  () => import("@/components/pdf-viewer").then((mod) => mod.PdfViewer),
-  { ssr: false },
-);
-
-type Paper = {
-  id: string;
-  title: string;
-  abstract: string | null;
-  description: string | null;
-  descriptionUpdatedAt: string | null;
-  visibility: string;
-  showViewCount: boolean;
-  publicViewCount: number | null;
-  publicDownloadCount: number | null;
-  externalUrl: string | null;
-  venue: string | null;
-  venueType: string | null;
-  year: number | null;
-  category: string | null;
-  tags: string | null;
-  createdAt: string;
-  updatedAt: string;
-};
-
-type PaperFile = {
-  id: string;
-  filename: string;
-  fileType: string;
-  sizeBytes: number;
-  mimeType: string | null;
-  downloadUrl: string;
-};
-
-type Author = {
-  userId: string;
-  role: string;
-  name: string;
-  displayName: string | null;
-  avatarUrl: string | null;
-};
-
-type Invite = {
-  id: string;
-  inviteeId: string | null;
-  inviteeName: string;
-  status: string;
-  createdAt: string;
-};
-
-type SearchUser = {
-  id: string;
-  name: string;
-  displayName: string | null;
-  avatarUrl: string | null;
-};
-
-type PreviewResponse = {
-  url: string;
-  mimeType: string;
-  filename: string;
-};
-
-type PaperStats = {
-  total: {
-    views: number;
-    downloads: number;
-    previews: number;
-  };
-  daily: Array<{
-    date: string;
-    views: number;
-    downloads: number;
-    previews: number;
-  }>;
-  days: 7 | 30 | 90 | 365;
-};
+import { PaperHeader } from "./components/paper-header";
+import { PaperAnalyticsSummary } from "./components/paper-analytics-summary";
+import { PaperStatsSection } from "./components/paper-stats-section";
+import { PaperFilesList } from "./components/paper-files-list";
+import { PaperAuthorsList } from "./components/paper-authors-list";
+import { PaperInviteDialog } from "./components/paper-invite-dialog";
+import { PaperPendingInvites } from "./components/paper-pending-invites";
+import {
+  Paper,
+  PaperFile,
+  Author,
+  Invite,
+  SearchUser,
+  PreviewResponse,
+  PaperStats,
+} from "./types";
 
 const isAbsoluteUrl = (url: string) => /^https?:\/\//i.test(url);
 
@@ -110,11 +40,6 @@ type PaperDetailClientProps = {
   paperId: string;
   siteBase: string;
 };
-
-function formatStatsDateLabel(date: string) {
-  const [, month, day] = date.split("-");
-  return `${Number(month)}/${Number(day)}`;
-}
 
 function formatCount(value: number | null | undefined): string {
   return new Intl.NumberFormat().format(value ?? 0);
@@ -548,84 +473,17 @@ export default function PaperDetailClient({
 
   const showExternalLink =
     paper.externalUrl && isValidExternalUrl(paper.externalUrl);
-  const summaryViews =
-    paper.showViewCount || !isAuthor
-      ? paper.publicViewCount
-      : (stats?.total.views ?? null);
-  const summaryDownloads =
-    paper.showViewCount || !isAuthor
-      ? paper.publicDownloadCount
-      : (stats?.total.downloads ?? null);
 
   return (
     <div className="max-w-3xl">
-      <div className="mb-6">
-        <Link
-          href="/"
-          className="text-sm text-blue-600 hover:underline dark:text-blue-400"
-        >
-          ← ダッシュボードに戻る
-        </Link>
-      </div>
+      <PaperHeader paper={paper} isAuthor={isAuthor} />
 
-      <div className="flex justify-between items-start mb-2">
-        <h1 className="text-2xl font-bold">{paper.title}</h1>
-        {isAuthor && (
-          <Link
-            href={`/papers/${paper.id}/edit`}
-            className="rounded-md bg-white px-3 py-1.5 text-sm font-medium text-gray-900 shadow-sm ring-1 ring-inset ring-gray-300 hover:bg-gray-50 dark:bg-gray-800 dark:text-gray-100 dark:ring-gray-700 dark:hover:bg-gray-700 shrink-0"
-          >
-            編集
-          </Link>
-        )}
-      </div>
-
-      <div className="flex flex-wrap gap-2 text-sm text-gray-500 mb-6">
-        {(() => {
-          const badge = getVisibilityBadge(paper.visibility);
-          return (
-            <span
-              className={`inline-flex items-center rounded-full px-2.5 py-1 text-xs font-medium ${badge.className}`}
-            >
-              {badge.label}
-            </span>
-          );
-        })()}
-        {paper.year && (
-          <span className="flex items-center rounded-full bg-gray-100 px-2.5 py-1 text-xs font-medium text-gray-600 dark:bg-gray-800 dark:text-gray-400">
-            {paper.year}年
-          </span>
-        )}
-        {paper.venue && (
-          <span className="flex items-center rounded-full bg-gray-100 px-2.5 py-1 text-xs font-medium text-gray-600 dark:bg-gray-800 dark:text-gray-400">
-            {paper.venue}
-          </span>
-        )}
-      </div>
-
-      {(paper.showViewCount || isAuthor) && (
-        <div className="mb-6 inline-flex items-end gap-4 rounded-2xl border border-blue-100 bg-blue-50/70 px-4 py-3 text-blue-950 dark:border-blue-900/60 dark:bg-blue-950/30 dark:text-blue-100">
-          <div>
-            <p className="text-xs font-medium uppercase tracking-[0.2em] text-blue-700 dark:text-blue-300">
-              Analytics
-            </p>
-            <p className="mt-1 text-sm text-blue-800/80 dark:text-blue-200/80">
-              {paper.showViewCount
-                ? "公開表示中の閲覧・ダウンロード数"
-                : "著者向けの閲覧・ダウンロード数"}
-            </p>
-          </div>
-          <p className="text-lg font-semibold tabular-nums">
-            👁️ {summaryViews === null ? "..." : formatCount(summaryViews)} views
-            {" · "}
-            📥{" "}
-            {summaryDownloads === null
-              ? "..."
-              : formatCount(summaryDownloads)}{" "}
-            downloads
-          </p>
-        </div>
-      )}
+      <PaperAnalyticsSummary
+        paper={paper}
+        isAuthor={isAuthor}
+        stats={stats}
+        formatCount={formatCount}
+      />
 
       {paper.abstract && (
         <div className="mb-6">
@@ -647,127 +505,14 @@ export default function PaperDetailClient({
       )}
 
       {isAuthor && (
-        <section className="mb-8 rounded-3xl border border-gray-200 bg-gray-50/70 p-5 dark:border-gray-800 dark:bg-gray-900/40">
-          <div className="flex flex-col gap-2 sm:flex-row sm:items-end sm:justify-between">
-            <div>
-              <p className="text-xs font-medium uppercase tracking-[0.18em] text-gray-500">
-                Author Stats
-              </p>
-              <h2 className="mt-2 text-lg font-semibold text-gray-950 dark:text-gray-50">
-                閲覧統計
-              </h2>
-            </div>
-            <p className="text-xs text-gray-500">
-              投稿者と共著者のみ閲覧できます
-            </p>
-          </div>
-
-          {statsLoading && (
-            <div className="mt-4 rounded-2xl bg-white p-4 text-sm text-gray-500 shadow-sm dark:bg-gray-950 dark:text-gray-400">
-              統計情報を読み込み中...
-            </div>
-          )}
-
-          {!statsLoading && statsError && (
-            <div className="mt-4 rounded-2xl border border-red-200 bg-red-50 p-4 text-sm text-red-700 dark:border-red-900/60 dark:bg-red-950/30 dark:text-red-300">
-              {statsError}
-            </div>
-          )}
-
-          {!statsLoading && stats && (
-            <>
-              <div className="mt-4 flex flex-wrap gap-2">
-                {([7, 30, 90, 365] as const).map((days) => (
-                  <button
-                    key={days}
-                    type="button"
-                    onClick={() => setSelectedStatsDays(days)}
-                    className={`rounded-full px-3 py-1 text-xs font-medium transition-colors ${
-                      selectedStatsDays === days
-                        ? "bg-gray-900 text-white dark:bg-gray-100 dark:text-gray-900"
-                        : "bg-white text-gray-600 hover:bg-gray-100 dark:bg-gray-900 dark:text-gray-300 dark:hover:bg-gray-800"
-                    }`}
-                  >
-                    {days}日
-                  </button>
-                ))}
-              </div>
-
-              <div className="mt-4 grid gap-3 sm:grid-cols-3">
-                <div className="rounded-2xl bg-white p-4 shadow-sm dark:bg-gray-950">
-                  <p className="text-xs font-medium uppercase tracking-[0.18em] text-gray-500">
-                    Total Views
-                  </p>
-                  <p className="mt-3 text-3xl font-semibold tabular-nums text-gray-950 dark:text-gray-50">
-                    {formatCount(stats.total.views)}
-                  </p>
-                </div>
-                <div className="rounded-2xl bg-white p-4 shadow-sm dark:bg-gray-950">
-                  <p className="text-xs font-medium uppercase tracking-[0.18em] text-gray-500">
-                    Total Downloads
-                  </p>
-                  <p className="mt-3 text-3xl font-semibold tabular-nums text-gray-950 dark:text-gray-50">
-                    {formatCount(stats.total.downloads)}
-                  </p>
-                </div>
-                <div className="rounded-2xl bg-white p-4 shadow-sm dark:bg-gray-950">
-                  <p className="text-xs font-medium uppercase tracking-[0.18em] text-gray-500">
-                    Total Previews
-                  </p>
-                  <p className="mt-3 text-3xl font-semibold tabular-nums text-gray-950 dark:text-gray-50">
-                    {formatCount(stats.total.previews)}
-                  </p>
-                </div>
-              </div>
-
-              <div className="mt-5 rounded-2xl bg-white p-4 shadow-sm dark:bg-gray-950">
-                <div className="flex items-center justify-between gap-3">
-                  <h3 className="text-sm font-medium text-gray-700 dark:text-gray-300">
-                    日別推移
-                  </h3>
-                  <p className="text-xs text-gray-500">直近{stats.days}日</p>
-                </div>
-
-                <div className="mt-4 overflow-x-auto">
-                  <div className="flex min-w-[720px] items-end gap-2">
-                    {stats.daily.map((entry) => {
-                      const barHeight =
-                        maxDailyViewCount === 0
-                          ? 4
-                          : Math.max(
-                              4,
-                              Math.round(
-                                (entry.views / maxDailyViewCount) * 120,
-                              ),
-                            );
-
-                      return (
-                        <div
-                          key={entry.date}
-                          className="flex min-w-0 flex-1 flex-col items-center gap-2"
-                        >
-                          <div className="flex h-32 w-full items-end">
-                            <div
-                              className="w-full rounded-t-xl bg-gray-900/85 dark:bg-gray-100/85"
-                              style={{ height: `${barHeight}px` }}
-                              title={`${entry.date}: ${entry.views} views / ${entry.downloads} downloads`}
-                            />
-                          </div>
-                          <span className="text-[10px] font-medium text-gray-500">
-                            {entry.views}
-                          </span>
-                          <span className="text-[10px] text-gray-400">
-                            {formatStatsDateLabel(entry.date)}
-                          </span>
-                        </div>
-                      );
-                    })}
-                  </div>
-                </div>
-              </div>
-            </>
-          )}
-        </section>
+        <PaperStatsSection
+          stats={stats}
+          statsLoading={statsLoading}
+          statsError={statsError}
+          selectedStatsDays={selectedStatsDays}
+          setSelectedStatsDays={setSelectedStatsDays}
+          maxDailyViewCount={maxDailyViewCount}
+        />
       )}
 
       {showExternalLink && (
@@ -796,244 +541,40 @@ export default function PaperDetailClient({
         />
       )}
 
-      {/* Files */}
-      <div className="mb-6">
-        <h2 className="text-sm font-medium text-gray-500 mb-2">ファイル</h2>
+      <PaperFilesList
+        pdfFile={pdfFile}
+        previewLoading={previewLoading}
+        preview={preview}
+        previewError={previewError}
+        imageFiles={imageFiles}
+        imagePreviewUrls={imagePreviewUrls}
+        failedImageIds={failedImageIds}
+        files={files}
+        handleDownload={handleDownload}
+        formatSize={formatSize}
+        getFileIcon={getFileIcon}
+      />
 
-        {pdfFile && (
-          <div className="mb-4 space-y-2">
-            <h3 className="text-sm font-medium">PDFプレビュー</h3>
-            {previewLoading && (
-              <div className="h-[420px] animate-pulse rounded-md bg-gray-200 dark:bg-gray-800" />
-            )}
-            {!previewLoading && preview?.url && (
-              <PdfViewer
-                fileUrl={preview.url}
-                onDownloadFallback={() => handleDownload(pdfFile)}
-              />
-            )}
-            {!previewLoading && previewError && (
-              <div className="rounded-md border border-red-300 bg-red-50 p-3 text-sm text-red-700 dark:border-red-800 dark:bg-red-950/40 dark:text-red-300">
-                <p>プレビューを読み込めません</p>
-                <button
-                  type="button"
-                  className="underline"
-                  onClick={() => handleDownload(pdfFile)}
-                  aria-label={`${pdfFile.filename}をPDFプレビューからダウンロード`}
-                >
-                  ダウンロードする
-                </button>
-              </div>
-            )}
-          </div>
-        )}
+      <PaperAuthorsList
+        authors={authors}
+        isUploader={isUploader}
+        paperTitle={paper.title}
+        setShowInvite={setShowInvite}
+      />
 
-        {imageFiles.length > 0 && (
-          <div className="mb-4 grid grid-cols-1 gap-3 sm:grid-cols-2">
-            {imageFiles.map((img) => (
-              <div
-                key={img.id}
-                className="rounded-md border border-gray-200 p-2 dark:border-gray-700"
-              >
-                {imagePreviewUrls[img.id] ? (
-                  <img
-                    src={imagePreviewUrls[img.id]}
-                    alt={img.filename}
-                    className="h-auto w-full rounded"
-                    loading="lazy"
-                  />
-                ) : failedImageIds.includes(img.id) ? (
-                  <div className="flex h-[180px] items-center justify-center rounded bg-red-50 text-xs text-red-600 dark:bg-red-950/20 dark:text-red-400">
-                    画像の読み込みに失敗しました
-                  </div>
-                ) : (
-                  <div className="h-[180px] animate-pulse rounded bg-gray-200 dark:bg-gray-800" />
-                )}
-              </div>
-            ))}
-          </div>
-        )}
+      <PaperInviteDialog
+        showInvite={showInvite}
+        setShowInvite={setShowInvite}
+        searchQuery={searchQuery}
+        handleSearch={handleSearch}
+        searchResults={searchResults}
+        handleInvite={handleInvite}
+        inviting={inviting}
+        setSearchQuery={setSearchQuery}
+        setSearchResults={setSearchResults}
+      />
 
-        <ul className="space-y-2">
-          {files.map((f) => (
-            <li
-              key={f.id}
-              className="flex items-center justify-between text-sm border rounded-md p-3 dark:border-gray-700 hover:bg-gray-50 dark:hover:bg-gray-800 transition-colors"
-            >
-              <div className="flex items-center gap-3">
-                <span className="text-xl" title={f.fileType}>
-                  {getFileIcon(f.fileType)}
-                </span>
-                <div className="flex flex-col">
-                  <span className="font-medium">{f.filename}</span>
-                  <span className="text-xs text-gray-400">
-                    {formatSize(f.sizeBytes)}
-                  </span>
-                </div>
-              </div>
-              <button
-                type="button"
-                onClick={() => handleDownload(f)}
-                aria-label={`${f.filename}をダウンロード`}
-                className="rounded bg-blue-600 px-3 py-1.5 text-xs text-white hover:bg-blue-500 transition-colors"
-              >
-                ダウンロード
-              </button>
-            </li>
-          ))}
-        </ul>
-      </div>
-
-      {/* Authors */}
-      <div className="mb-6">
-        <h2 className="text-sm font-medium text-gray-500 mb-2">著者</h2>
-        <ul className="space-y-2">
-          {authors.map((a) => (
-            <li
-              key={a.userId}
-              className="flex items-center justify-between rounded-xl border border-gray-100 bg-gray-50/50 p-2.5 dark:border-gray-800 dark:bg-gray-900/50"
-            >
-              <div className="flex items-center gap-3">
-                {a.avatarUrl && (
-                  <Image
-                    src={a.avatarUrl}
-                    alt={a.name}
-                    width={28}
-                    height={28}
-                    className="rounded-full ring-1 ring-gray-200 dark:ring-gray-700"
-                  />
-                )}
-                <Link
-                  href={`/users/${encodeURIComponent(a.userId)}`}
-                  className="text-sm font-medium text-blue-600 hover:underline dark:text-blue-400"
-                >
-                  {a.displayName ?? a.name}
-                </Link>
-              </div>
-              {(() => {
-                const badge = getRoleBadge(a.role);
-                return (
-                  <span
-                    className={`inline-flex items-center rounded-full px-2 py-0.5 text-[10px] font-bold uppercase tracking-wider ${badge.className}`}
-                  >
-                    {badge.label}
-                  </span>
-                );
-              })()}
-            </li>
-          ))}
-        </ul>
-
-        {isUploader && (
-          <button
-            type="button"
-            onClick={() => setShowInvite(true)}
-            aria-label={`${paper.title}に共著者を招待`}
-            className="mt-3 text-sm text-blue-600 hover:underline dark:text-blue-400"
-          >
-            + 共著者を招待
-          </button>
-        )}
-      </div>
-
-      {/* Invite dialog */}
-      {showInvite && (
-        <div className="mb-6 rounded-md border border-gray-200 p-4 dark:border-gray-700">
-          <h3 className="font-medium mb-2">共著者招待</h3>
-          <input
-            type="text"
-            value={searchQuery}
-            onChange={(e) => handleSearch(e.target.value)}
-            placeholder="ユーザー名で検索..."
-            className="w-full rounded-md border border-gray-300 px-3 py-2 text-sm mb-2 dark:border-gray-700 dark:bg-gray-900"
-          />
-          {searchResults.length > 0 && (
-            <ul className="space-y-1 max-h-40 overflow-y-auto">
-              {searchResults.map((u) => (
-                <li
-                  key={u.id}
-                  className="flex items-center justify-between p-2 text-sm hover:bg-gray-50 rounded dark:hover:bg-gray-800"
-                >
-                  <div className="flex items-center gap-2">
-                    {u.avatarUrl && (
-                      <Image
-                        src={u.avatarUrl}
-                        alt={u.name}
-                        width={20}
-                        height={20}
-                        className="rounded-full"
-                      />
-                    )}
-                    <span>{u.displayName ?? u.name}</span>
-                  </div>
-                  <button
-                    type="button"
-                    onClick={() => handleInvite(u.id)}
-                    disabled={inviting !== null}
-                    aria-busy={inviting === u.id}
-                    aria-label={`${u.displayName ?? u.name}を共著者として招待`}
-                    className="inline-flex min-w-[72px] items-center justify-center rounded bg-blue-600 px-2 py-1 text-xs text-white hover:bg-blue-500 disabled:opacity-50"
-                  >
-                    {inviting === u.id ? (
-                      <span className="flex items-center justify-center gap-1">
-                        <span
-                          className="h-3 w-3 motion-safe:animate-spin rounded-full border-2 border-current border-t-transparent"
-                          aria-hidden="true"
-                        />
-                        招待中...
-                      </span>
-                    ) : (
-                      "招待"
-                    )}
-                  </button>
-                </li>
-              ))}
-            </ul>
-          )}
-          <button
-            type="button"
-            onClick={() => {
-              setShowInvite(false);
-              setSearchQuery("");
-              setSearchResults([]);
-            }}
-            className="mt-2 text-sm text-gray-500 hover:underline"
-          >
-            キャンセル
-          </button>
-        </div>
-      )}
-
-      {/* Pending invites */}
-      {isUploader && invites.length > 0 && (
-        <div className="mb-6">
-          <h2 className="text-sm font-medium text-gray-500 mb-2">招待状況</h2>
-          <ul className="space-y-1">
-            {invites.map((inv) => (
-              <li
-                key={inv.id}
-                className="flex items-center justify-between text-sm border rounded-md p-2 dark:border-gray-700"
-              >
-                <div className="flex items-center gap-2">
-                  <span className="text-sm font-medium text-gray-900 dark:text-gray-100">
-                    {inv.inviteeName}
-                  </span>
-                </div>
-                {(() => {
-                  const badge = getInviteStatusBadge(inv.status);
-                  return (
-                    <span
-                      className={`inline-flex items-center rounded-full px-2.5 py-1 text-xs font-medium ${badge.className}`}
-                    >
-                      {badge.label}
-                    </span>
-                  );
-                })()}
-              </li>
-            ))}
-          </ul>
-        </div>
-      )}
+      <PaperPendingInvites isUploader={isUploader} invites={invites} />
     </div>
   );
 }

--- a/apps/web/src/app/papers/[id]/types.ts
+++ b/apps/web/src/app/papers/[id]/types.ts
@@ -1,0 +1,72 @@
+export type Paper = {
+  id: string;
+  title: string;
+  abstract: string | null;
+  description: string | null;
+  descriptionUpdatedAt: string | null;
+  visibility: string;
+  showViewCount: boolean;
+  publicViewCount: number | null;
+  publicDownloadCount: number | null;
+  externalUrl: string | null;
+  venue: string | null;
+  venueType: string | null;
+  year: number | null;
+  category: string | null;
+  tags: string | null;
+  createdAt: string;
+  updatedAt: string;
+};
+
+export type PaperFile = {
+  id: string;
+  filename: string;
+  fileType: string;
+  sizeBytes: number;
+  mimeType: string | null;
+  downloadUrl: string;
+};
+
+export type Author = {
+  userId: string;
+  role: string;
+  name: string;
+  displayName: string | null;
+  avatarUrl: string | null;
+};
+
+export type Invite = {
+  id: string;
+  inviteeId: string | null;
+  inviteeName: string;
+  status: string;
+  createdAt: string;
+};
+
+export type SearchUser = {
+  id: string;
+  name: string;
+  displayName: string | null;
+  avatarUrl: string | null;
+};
+
+export type PreviewResponse = {
+  url: string;
+  mimeType: string;
+  filename: string;
+};
+
+export type PaperStats = {
+  total: {
+    views: number;
+    downloads: number;
+    previews: number;
+  };
+  daily: Array<{
+    date: string;
+    views: number;
+    downloads: number;
+    previews: number;
+  }>;
+  days: 7 | 30 | 90 | 365;
+};


### PR DESCRIPTION
🎯 **What:** `PaperDetailClient` をリファクタリングし、多数のUIコンポーネント（ヘッダー、解析サマリー、ファイルリスト、著者リスト、招待ダイアログなど）を個別のファイルに分割しました。また、型定義を `types.ts` に抽出しました。
💡 **Why:** `PaperDetailClient` は1000行以上に肥大化しており、可読性と保守性が低下していました。個別のコンポーネントに分割することで、コードの構造が明確になり、各機能の責任範囲が分離されます。
✅ **Verification:** 
- リファクタリングによるコンポーネントの分割と型の抽出を行いました。
- すべての単体テスト（`bun x vitest run apps/web`）が合格することを確認しました。
- TypeScriptの型チェック（`bun x tsc`）、Eslintのチェック、および Next.js のビルドが正常に完了することを確認しました。
✨ **Result:** `paper-detail-client.tsx` の行数を大幅に削減し、コンポーネントごとの責務を明確化したことで、今後の拡張と保守が容易になりました。

---
*PR created automatically by Jules for task [9811771458010900413](https://jules.google.com/task/9811771458010900413) started by @is0692vs*

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

1000行超に膨張していた `PaperDetailClient` から、ヘッダー・アナリティクスサマリー・ファイルリスト・著者リスト・招待ダイアログ・統計セクションの6コンポーネントを個別ファイルへ抽出し、型定義を `types.ts` に集約したリファクタリングです。ロジックの変更はなく、既存テストも全て通過しています。

- **コンポーネント分割**: 7つの新ファイル（6コンポーネント + `types.ts`）を追加し、`paper-detail-client.tsx` を大幅に短縮。
- **`formatCount` の不一致**: `paper-stats-section.tsx` はローカル定義しているのに対し、`PaperAnalyticsSummary` は親から props 経由で受け取る設計になっており、アプローチが統一されていない（コード重複あり）。
</details>

<details open><summary><h3>Confidence Score: 4/5</h3></summary>

純粋なリファクタリングであり、ロジック変更はなくマージは安全です。

`formatCount` が `paper-detail-client.tsx` と `paper-stats-section.tsx` の両方に独立して定義されており、`PaperAnalyticsSummary` へは props 経由で渡すという一貫性のない設計が残っています。動作上の問題ではありませんが、今後の修正漏れにつながりやすいコード重複です。

`paper-analytics-summary.tsx` と `paper-stats-section.tsx` の `formatCount` の扱いを確認してください。
</details>

<details open><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| apps/web/src/app/papers/[id]/paper-detail-client.tsx | 各UIブロックを子コンポーネントへ委譲。formatCount が依然このファイルで定義され props として渡されているが、paper-stats-section.tsx でも同一関数をローカル定義しており二重定義が残る。 |
| apps/web/src/app/papers/[id]/types.ts | 全型定義を新規 types.ts に移動。内容は元の paper-detail-client.tsx と完全一致。 |
| apps/web/src/app/papers/[id]/components/paper-analytics-summary.tsx | 表示条件・計算ロジックは元コードと等価だが、formatCount を props 経由で受け取る設計が一貫していない（stats-section は内部定義）。 |
| apps/web/src/app/papers/[id]/components/paper-stats-section.tsx | 統計グラフ UI を抽出。formatCount と formatStatsDateLabel をローカル定義しており、ロジックは元コードと同一。 |
| apps/web/src/app/papers/[id]/components/paper-invite-dialog.tsx | 招待ダイアログを抽出。showInvite=false 時に null を返す形に変更されたが、内部 state を持たないため動作は等価。 |
| apps/web/src/app/papers/[id]/components/paper-files-list.tsx | ファイル一覧 UI を抽出。PdfViewer の dynamic import も一緒に移動されており、元コードと等価。 |

</details>

</details>

<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    PDC["PaperDetailClient"]
    PH["PaperHeader"]
    PAS["PaperAnalyticsSummary"]
    PSS["PaperStatsSection"]
    PFL["PaperFilesList"]
    PAL["PaperAuthorsList"]
    PID["PaperInviteDialog"]
    PPI["PaperPendingInvites"]
    T["types.ts"]
    PDC --> PH
    PDC --> PAS
    PDC --> PSS
    PDC --> PFL
    PDC --> PAL
    PDC --> PID
    PDC --> PPI
    T --> PH
    T --> PAS
    T --> PSS
    T --> PFL
    T --> PAL
    T --> PID
    T --> PPI
```

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 1 code review issue. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 1
apps/web/src/app/papers/[id]/components/paper-analytics-summary.tsx:3-8
`formatCount` が `paper-detail-client.tsx` にも定義されており、props 経由で渡されていますが、`paper-stats-section.tsx` では同一関数をローカルに定義しています。アプローチが統一されておらず、`paper-detail-client.tsx` の `formatCount` はこのコンポーネントに渡すためだけに残っています。コンポーネント内でローカル定義するか、共有ユーティリティから import する方が一貫性が出ます。

```suggestion
type PaperAnalyticsSummaryProps = {
  paper: Paper;
  isAuthor: boolean;
  stats: PaperStats | null;
};
```

`````

</details>

<sub>Reviews (1): Last reviewed commit: ["🧹 Extract UI components and types from ..."](https://github.com/hiroki-org/openshelf/commit/3a8ea865acf1eb895b71b5c911f284e4036b6074) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=35546553)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->