### PR TITLE
🎨 Palette: 動的文字数カウンターの不要な aria-live 属性を削除し過剰な読み上げを防止

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -26,3 +26,6 @@
 ## 2026-05-25 - FeedButton Accessible Names and Tooltips
 **Learning:** フィードボタン（FeedButton）などのアイコン・記号のみのUIにおいて、クリップボードへのコピーや新規タブで開くといったアクションを実行するボタン/リンクには、ユーザーが目的を把握できるように明確な aria-label を設定することが重要です。二重読み上げを防止するため、title 属性との併用は避けるべきです。
 **Action:** 今後、アイコンボタンやラベルが不足しているインタラクティブ要素を実装・改善する際は、必ず aria-label に詳細な説明を含めるようにします。アクセシリティ向上のため、title 属性は原則として併用しません。また、アクセシブルな名前を変更した場合は、関連する単体テスト（getByRole などのクエリ）も必ず追従して修正します。
+## 2024-06-04 - Dynamic Character Counter Accessibility Improvement
+**Learning:** 入力フィールド（textarea など）の文字数カウンターにおいて、カウンター要素に `aria-live="polite"` と `aria-atomic="true"` を付与すると、文字入力のたびにスクリーンリーダーが読み上げを実行してしまい、ユーザーにとって非常に煩わしい体験（ノイズ）になる。代わりに `aria-describedby` を入力要素側に付与するだけで十分である。
+**Action:** 今後、動的な文字数カウンターを実装する際は `aria-live` や `aria-atomic` 属性を付与せず、該当の入力フィールドから `aria-describedby` で紐づけるのみとする。

--- a/apps/web/src/app/collections/new/page.tsx
+++ b/apps/web/src/app/collections/new/page.tsx
@@ -319,8 +319,6 @@ export default function NewCollectionPage() {
           <div className="flex justify-end mt-1">
             <span
               id="description-counter"
-              aria-live="polite"
-              aria-atomic="true"
               className={`text-xs ${counterClassName(description.length, COLLECTION_DESCRIPTION_MAX_LENGTH)}`}
             >
               {description.length}/{COLLECTION_DESCRIPTION_MAX_LENGTH}

--- a/apps/web/src/app/orgs/new/page.tsx
+++ b/apps/web/src/app/orgs/new/page.tsx
@@ -208,8 +208,6 @@ export default function NewOrgPage() {
           />
           <div
             id="org-description-counter"
-            aria-live="polite"
-            aria-atomic="true"
             className={`mt-1 flex justify-end text-xs ${
               description.length >= ORG_DESCRIPTION_MAX_LENGTH
                 ? "text-red-600 dark:text-red-400"


### PR DESCRIPTION
🎨 **Palette: 動的文字数カウンターのアクセシビリティ改善**

💡 **What:** 
コレクション作成フォームと組織作成フォームにおけるテキストエリアの文字数カウンター要素から、`aria-live="polite"` および `aria-atomic="true"` 属性を削除しました。

🎯 **Why:** 
文字を入力するたびに値が動的に変わる文字数カウンターに対して `aria-live` を設定すると、キーストロークごとにスクリーンリーダーが新しい文字数を読み上げてしまいます（例：「1文字 / 500文字」、「2文字 / 500文字」...）。これは支援技術に依存しているユーザーにとって非常に煩わしい体験であり、ノイズとなってしまいます。既存の `aria-describedby` による入力フィールドとの関連付けだけで、必要な情報は適切に伝達されます。

📸 **Before/After:** 
視覚的な変更はありません。

♿ **Accessibility:** 
WCAGおよびARIAのベストプラクティスに従い、過剰な読み上げを抑制することで、スクリーンリーダーユーザーのフォーム入力体験を大幅に改善しました。

---
*PR created automatically by Jules for task [12808541238698362671](https://jules.google.com/task/12808541238698362671) started by @is0692vs*

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

コレクション作成フォーム・組織作成フォームの textarea 文字数カウンター要素から、キーストロークごとに不要な読み上げを発生させていた `aria-live="polite"` と `aria-atomic="true"` を削除しました。入力フィールドとカウンターの関連付けは既存の `aria-describedby` で引き続き維持されています。

- `apps/web/src/app/collections/new/page.tsx` / `orgs/new/page.tsx` の `<span id="description-counter">` および `<div id="org-description-counter">` から `aria-live`・`aria-atomic` を除去。
- `.Jules/palette.md` に今回の変更に関する ARIA ベストプラクティスのラーニングエントリを追加（日付に軽微な誤りあり）。
</details>

<details open><summary><h3>Confidence Score: 5/5</h3></summary>

このPRは安全にマージ可能です。

変更は2ファイルで計4行の属性削除のみです。`aria-describedby` による関連付けは維持されているため、スクリーンリーダーは入力フォーカス時にカウンター値を参照でき、情報の欠落はありません。コードロジックへの影響も一切ありません。

`.Jules/palette.md` のラーニングエントリの日付に軽微な誤り（`2024-06-04`）があります。
</details>

<details open><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| apps/web/src/app/collections/new/page.tsx | `aria-live="polite"` と `aria-atomic="true"` を文字数カウンター要素から削除。`aria-describedby` による紐付けは維持されており、アクセシビリティ上問題なし。 |
| apps/web/src/app/orgs/new/page.tsx | `aria-live="polite"` と `aria-atomic="true"` を org の文字数カウンターから削除。変更内容は `collections/new/page.tsx` と同一で正しい対処。 |
| .Jules/palette.md | 今回の変更内容をドキュメント化したラーニングエントリを追加。日付が "2024-06-04" と記載されており、実際の日付と異なる可能性あり。 |

</details>

</details>

<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant User as ユーザー（スクリーンリーダー）
    participant Input as textarea (aria-describedby)
    participant Counter as 文字数カウンター

    Note over User,Counter: 変更前（Before）
    User->>Input: キー入力
    Input->>Counter: 値更新
    Counter-->>User: aria-live により毎回読み上げ（ノイズ）

    Note over User,Counter: 変更後（After）
    User->>Input: キー入力
    Input->>Counter: 値更新
    Note over Counter: aria-live なし → 自動読み上げなし
    User->>Input: フォーカス時
    Input-->>User: aria-describedby でカウンター内容を参照
```

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 1 code review issue. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 1
.Jules/palette.md:29
ラーニングエントリの日付が `2024-06-04` となっていますが、他のエントリと比較すると `2026-06-04` の誤りと思われます。

```suggestion
## 2026-06-04 - Dynamic Character Counter Accessibility Improvement
```

`````

</details>

<sub>Reviews (1): Last reviewed commit: ["fix(a11y): remove aria-live from charact..."](https://github.com/hiroki-org/openshelf/commit/cd0f32237b41b34cebcb60fa699b33ee6b760b6c) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=35641128)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->