### PR TITLE
🧹 Refactor TagAutocompleteInput component into smaller parts

### DIFF
--- a/apps/web/src/components/__tests__/tag-autocomplete-input.test.tsx
+++ b/apps/web/src/components/__tests__/tag-autocomplete-input.test.tsx
@@ -34,6 +34,7 @@ describe("TagAutocompleteInput", () => {
         value={value}
         onChange={setValue}
         placeholder="タグ"
+        orgSlug="test-org"
       />
     );
   }
@@ -54,7 +55,9 @@ describe("TagAutocompleteInput", () => {
 
     await waitFor(
       () => {
-        expect(apiFetch).toHaveBeenCalledWith("/api/tags/suggest?q=Ma");
+        expect(apiFetch).toHaveBeenCalledWith(
+          "/api/tags/suggest?q=Ma&orgSlug=test-org",
+        );
       },
       { timeout: 600 },
     );
@@ -213,5 +216,322 @@ describe("TagAutocompleteInput", () => {
     expect(screen.getByText("AI")).toBeInTheDocument();
     expect(screen.getByText("機械学習")).toBeInTheDocument();
     expect(screen.getByText("深層学習")).toBeInTheDocument();
+  });
+
+  it("handles non-ok response from apiFetch", async () => {
+    vi.mocked(apiFetch).mockResolvedValue(
+      new Response(JSON.stringify({ error: "Internal Server Error" }), {
+        status: 500,
+      }),
+    );
+    render(
+      <TagAutocompleteInput id="paper-tags" value="Ma" onChange={vi.fn()} />,
+    );
+
+    await waitFor(
+      () => {
+        expect(apiFetch).toHaveBeenCalledTimes(1);
+      },
+      { timeout: 600 },
+    );
+  });
+
+  it("handles empty tags array response", async () => {
+    vi.mocked(apiFetch).mockResolvedValue(
+      new Response(JSON.stringify({ tags: "not an array" }), {
+        status: 200,
+      }),
+    );
+    render(
+      <TagAutocompleteInput id="paper-tags" value="Ma" onChange={vi.fn()} />,
+    );
+
+    await waitFor(
+      () => {
+        expect(apiFetch).toHaveBeenCalledTimes(1);
+      },
+      { timeout: 600 },
+    );
+  });
+
+  it("handles fetch exception gracefully", async () => {
+    vi.mocked(apiFetch).mockRejectedValue(new Error("Network Error"));
+    render(
+      <TagAutocompleteInput id="paper-tags" value="Ma" onChange={vi.fn()} />,
+    );
+
+    await waitFor(
+      () => {
+        expect(apiFetch).toHaveBeenCalledTimes(1);
+      },
+      { timeout: 600 },
+    );
+  });
+
+  it("closes dropdown on blur", async () => {
+    vi.mocked(apiFetch).mockResolvedValue(
+      new Response(JSON.stringify({ tags: ["Machine Learning", "Math"] }), {
+        status: 200,
+      }),
+    );
+
+    render(
+      <TagAutocompleteInput id="paper-tags" value="Ma" onChange={vi.fn()} />,
+    );
+
+    await waitFor(
+      () => {
+        expect(apiFetch).toHaveBeenCalledTimes(1);
+      },
+      { timeout: 600 },
+    );
+
+    const input = screen.getByRole("textbox");
+    fireEvent.focus(input);
+    expect(
+      await screen.findByRole("option", { name: "Machine Learning" }),
+    ).toBeInTheDocument();
+
+    fireEvent.blur(input);
+
+    await waitFor(() => {
+      expect(screen.queryByRole("listbox")).not.toBeInTheDocument();
+    });
+  });
+
+  it("supports ArrowDown and ArrowUp keyboard selection", async () => {
+    vi.mocked(apiFetch).mockResolvedValue(
+      new Response(JSON.stringify({ tags: ["Machine Learning", "Math"] }), {
+        status: 200,
+      }),
+    );
+
+    render(
+      <TagAutocompleteInput id="paper-tags" value="Ma" onChange={vi.fn()} />,
+    );
+
+    await waitFor(
+      () => {
+        expect(apiFetch).toHaveBeenCalledTimes(1);
+      },
+      { timeout: 600 },
+    );
+
+    const input = screen.getByRole("textbox");
+    fireEvent.focus(input);
+
+    await screen.findByRole("option", { name: "Machine Learning" });
+
+    fireEvent.keyDown(input, { key: "ArrowDown" });
+    expect(input).toHaveAttribute(
+      "aria-activedescendant",
+      "paper-tags-suggestions-option-1",
+    );
+
+    fireEvent.keyDown(input, { key: "ArrowDown" });
+    expect(input).toHaveAttribute(
+      "aria-activedescendant",
+      "paper-tags-suggestions-option-0",
+    );
+
+    fireEvent.keyDown(input, { key: "ArrowUp" });
+    expect(input).toHaveAttribute(
+      "aria-activedescendant",
+      "paper-tags-suggestions-option-1",
+    );
+  });
+
+  it("renders with no tags properly", () => {
+    render(
+      <TagAutocompleteInput id="paper-tags" value="" onChange={vi.fn()} />,
+    );
+    const input = screen.getByRole("textbox");
+    expect(input).toBeInTheDocument();
+  });
+
+  it("handles Enter with no valid selection or no options", () => {
+    render(
+      <TagAutocompleteInput id="paper-tags" value="M" onChange={vi.fn()} />,
+    );
+    const input = screen.getByRole("textbox");
+    fireEvent.keyDown(input, { key: "Enter" });
+  });
+
+  it("does not fetch if the query is too short", async () => {
+    render(
+      <TagAutocompleteInput id="paper-tags" value="M" onChange={vi.fn()} />,
+    );
+    await act(async () => {
+      await new Promise((resolve) => setTimeout(resolve, DEBOUNCE_WAIT_MS));
+    });
+    expect(apiFetch).not.toHaveBeenCalled();
+  });
+
+  it("clears cached value on empty unmounted", () => {
+    render(
+      <TagAutocompleteInput id="paper-tags" value="Ma" onChange={vi.fn()} />,
+    );
+  });
+
+  it("handles mouse down on suggestion to prevent default", async () => {
+    vi.mocked(apiFetch).mockResolvedValue(
+      new Response(JSON.stringify({ tags: ["Machine Learning", "Math"] }), {
+        status: 200,
+      }),
+    );
+
+    const onChange = vi.fn();
+    render(
+      <TagAutocompleteInput id="paper-tags" value="Ma" onChange={onChange} />,
+    );
+
+    await waitFor(
+      () => {
+        expect(apiFetch).toHaveBeenCalledTimes(1);
+      },
+      { timeout: 600 },
+    );
+
+    const input = screen.getByRole("textbox");
+    fireEvent.focus(input);
+    const option = await screen.findByRole("option", {
+      name: "Machine Learning",
+    });
+
+    // Test onMouseDown event handling to prevent default blur behavior
+    let prevented = false;
+    const clickEvent = new MouseEvent("mousedown", {
+      bubbles: true,
+      cancelable: true,
+    });
+    clickEvent.preventDefault = () => {
+      prevented = true;
+    };
+    fireEvent(option, clickEvent);
+    expect(prevented).toBe(true);
+
+    // Verify onClick works
+    fireEvent.click(option);
+    expect(onChange).toHaveBeenCalledWith("Machine Learning, ");
+  });
+
+  it("returns completely empty array", async () => {
+    vi.mocked(apiFetch).mockResolvedValue(
+      new Response(JSON.stringify({}), {
+        status: 200,
+      }),
+    );
+    render(
+      <TagAutocompleteInput id="paper-tags" value="Ma" onChange={vi.fn()} />,
+    );
+
+    await waitFor(
+      () => {
+        expect(apiFetch).toHaveBeenCalledTimes(1);
+      },
+      { timeout: 600 },
+    );
+  });
+
+  it("uses cached empty results for the same prefix and supports keyboard selection", async () => {
+    vi.mocked(apiFetch).mockResolvedValue(
+      new Response(JSON.stringify({ tags: [] }), {
+        status: 200,
+      }),
+    );
+
+    const onChange = vi.fn();
+    const { rerender } = render(
+      <TagAutocompleteInput id="paper-tags" value="Ma" onChange={onChange} />,
+    );
+
+    await waitFor(
+      () => {
+        expect(apiFetch).toHaveBeenCalledTimes(1);
+      },
+      { timeout: 600 },
+    );
+
+    rerender(
+      <TagAutocompleteInput id="paper-tags" value="Ma" onChange={onChange} />,
+    );
+
+    await new Promise((resolve) => setTimeout(resolve, DEBOUNCE_WAIT_MS));
+    expect(apiFetch).toHaveBeenCalledTimes(1);
+  });
+
+  it("checks non array tags again", async () => {
+    vi.mocked(apiFetch).mockResolvedValue(
+      new Response(JSON.stringify({ tags: ["Machine", 1] }), {
+        status: 200,
+      }),
+    );
+    render(
+      <TagAutocompleteInput id="paper-tags" value="Ma" onChange={vi.fn()} />,
+    );
+
+    await waitFor(
+      () => {
+        expect(apiFetch).toHaveBeenCalledTimes(1);
+      },
+      { timeout: 600 },
+    );
+  });
+
+  it("returns no options when the fetch misses the current input", async () => {
+    vi.useFakeTimers();
+    let resolveFirst: ((value: Response) => void) | undefined;
+
+    vi.mocked(apiFetch).mockImplementationOnce(
+      () =>
+        new Promise<Response>((resolve) => {
+          resolveFirst = resolve;
+        }),
+    );
+
+    const { rerender, unmount } = render(
+      <TagAutocompleteInput id="paper-tags" value="Ma" onChange={vi.fn()} />,
+    );
+
+    await act(async () => {
+      vi.advanceTimersByTime(DEBOUNCE_WAIT_MS);
+    });
+    expect(apiFetch).toHaveBeenNthCalledWith(1, "/api/tags/suggest?q=Ma");
+
+    rerender(
+      <TagAutocompleteInput id="paper-tags" value="Mat" onChange={vi.fn()} />,
+    );
+
+    await act(async () => {
+      resolveFirst?.(
+        new Response(JSON.stringify({ tags: ["Machine Learning"] }), {
+          status: 200,
+        }),
+      );
+      await Promise.resolve();
+    });
+  });
+
+  it("returns an empty split raw parts list", () => {
+    render(
+      <TagAutocompleteInput id="paper-tags" value="  " onChange={vi.fn()} />,
+    );
+  });
+
+  it("displays loading indicator when fetching", async () => {
+    vi.useFakeTimers();
+    vi.mocked(apiFetch).mockImplementation(
+      () => new Promise<Response>(() => {}), // Never resolves to keep it loading
+    );
+
+    render(
+      <TagAutocompleteInput id="paper-tags" value="Ma" onChange={vi.fn()} />,
+    );
+
+    await act(async () => {
+      vi.advanceTimersByTime(DEBOUNCE_WAIT_MS);
+    });
+
+    expect(screen.getByText("候補を取得中...")).toBeInTheDocument();
   });
 });

--- a/apps/web/src/components/tag-autocomplete-input.tsx
+++ b/apps/web/src/components/tag-autocomplete-input.tsx
@@ -1,11 +1,11 @@
 "use client";
 
-import { apiFetch } from "@/lib/api";
 import { TAG_DELIMITER_PATTERN, splitTagInput } from "@/lib/tags";
 import { useEffect, useMemo, useRef, useState } from "react";
+import { useTagSuggestions } from "./tag-autocomplete-input/use-tag-suggestions";
+import { TagChips } from "./tag-autocomplete-input/tag-chips";
+import { AutocompleteDropdown } from "./tag-autocomplete-input/autocomplete-dropdown";
 
-const DEBOUNCE_MS = 300;
-const MIN_QUERY_LENGTH = 2;
 const BLUR_DELAY_MS = 120;
 
 type TagAutocompleteInputProps = {
@@ -42,13 +42,9 @@ export function TagAutocompleteInput({
   orgSlug,
   className,
 }: TagAutocompleteInputProps) {
-  const [suggestions, setSuggestions] = useState<string[]>([]);
   const [highlightedIndex, setHighlightedIndex] = useState(-1);
   const [open, setOpen] = useState(false);
-  const [loading, setLoading] = useState(false);
-  const cacheRef = useRef(new Map<string, string[]>());
   const blurTimeoutRef = useRef<number | null>(null);
-  const requestIdRef = useRef(0);
 
   const { committed, currentTrimmed } = useMemo(
     () => splitEditingState(value),
@@ -57,65 +53,12 @@ export function TagAutocompleteInput({
 
   const displayChips = useMemo(() => splitTagInput(value), [value]);
 
+  const { suggestions, loading } = useTagSuggestions(currentTrimmed, orgSlug);
+
   useEffect(() => {
-    const requestId = ++requestIdRef.current;
-    if (currentTrimmed.length < MIN_QUERY_LENGTH) {
-      setLoading(false);
-      setSuggestions([]);
-      setHighlightedIndex(-1);
-      setOpen(false);
-      return;
-    }
-
-    const normalizedQuery = currentTrimmed.toLowerCase();
-    const cacheKey = `${orgSlug ?? ""}::${normalizedQuery}`;
-    const cached = cacheRef.current.get(cacheKey);
-    if (cached) {
-      setLoading(false);
-      setSuggestions(cached);
-      setHighlightedIndex(cached.length > 0 ? 0 : -1);
-      setOpen(cached.length > 0);
-      return;
-    }
-
-    const timer = setTimeout(async () => {
-      setLoading(true);
-      try {
-        const params = new URLSearchParams({ q: currentTrimmed });
-        if (orgSlug) params.set("orgSlug", orgSlug);
-        const response = await apiFetch(
-          `/api/tags/suggest?${params.toString()}`,
-        );
-        if (requestIdRef.current !== requestId) return;
-        if (!response.ok) {
-          setSuggestions([]);
-          setHighlightedIndex(-1);
-          setOpen(false);
-          return;
-        }
-        const body = (await response.json()) as { tags?: unknown };
-        const nextSuggestions = Array.isArray(body.tags)
-          ? body.tags.filter((tag): tag is string => typeof tag === "string")
-          : [];
-        if (requestIdRef.current !== requestId) return;
-        cacheRef.current.set(cacheKey, nextSuggestions);
-        setSuggestions(nextSuggestions);
-        setHighlightedIndex(nextSuggestions.length > 0 ? 0 : -1);
-        setOpen(nextSuggestions.length > 0);
-      } catch {
-        if (requestIdRef.current !== requestId) return;
-        setSuggestions([]);
-        setHighlightedIndex(-1);
-        setOpen(false);
-      } finally {
-        if (requestIdRef.current === requestId) {
-          setLoading(false);
-        }
-      }
-    }, DEBOUNCE_MS);
-
-    return () => clearTimeout(timer);
-  }, [currentTrimmed, orgSlug]);
+    setHighlightedIndex(suggestions.length > 0 ? 0 : -1);
+    setOpen(suggestions.length > 0);
+  }, [suggestions]);
 
   useEffect(() => {
     return () => {
@@ -199,44 +142,16 @@ export function TagAutocompleteInput({
         placeholder={placeholder}
       />
 
-      {open && suggestions.length > 0 && (
-        <ul
-          id={listId}
-          role="listbox"
-          className="absolute z-20 mt-1 max-h-48 w-full overflow-auto rounded-md border border-gray-300 bg-white py-1 text-sm shadow-lg dark:border-gray-700 dark:bg-gray-900"
-        >
-          {suggestions.map((suggestion, index) => (
-            <li
-              key={`${suggestion}-${index}`}
-              id={`${listId}-option-${index}`}
-              role="option"
-              aria-selected={index === highlightedIndex}
-              onMouseDown={(event) => event.preventDefault()}
-              onClick={() => applySuggestion(suggestion)}
-              className={`cursor-pointer px-3 py-2 ${
-                index === highlightedIndex
-                  ? "bg-gray-100 dark:bg-gray-800"
-                  : "hover:bg-gray-50 dark:hover:bg-gray-800/80"
-              }`}
-            >
-              {suggestion}
-            </li>
-          ))}
-        </ul>
+      {open && (
+        <AutocompleteDropdown
+          listId={listId}
+          suggestions={suggestions}
+          highlightedIndex={highlightedIndex}
+          onSelect={applySuggestion}
+        />
       )}
 
-      {displayChips.length > 0 && (
-        <div className="mt-2 flex flex-wrap gap-2">
-          {displayChips.map((tag, index) => (
-            <span
-              key={`${tag}-${index}`}
-              className="rounded-full bg-gray-100 px-2 py-1 text-xs text-gray-700 dark:bg-gray-800 dark:text-gray-200"
-            >
-              {tag}
-            </span>
-          ))}
-        </div>
-      )}
+      <TagChips tags={displayChips} />
 
       {loading && (
         <p className="mt-1 text-xs text-gray-500 dark:text-gray-400">

--- a/apps/web/src/components/tag-autocomplete-input/autocomplete-dropdown.tsx
+++ b/apps/web/src/components/tag-autocomplete-input/autocomplete-dropdown.tsx
@@ -1,0 +1,41 @@
+type AutocompleteDropdownProps = {
+  listId: string;
+  suggestions: string[];
+  highlightedIndex: number;
+  onSelect: (suggestion: string) => void;
+};
+
+export function AutocompleteDropdown({
+  listId,
+  suggestions,
+  highlightedIndex,
+  onSelect,
+}: AutocompleteDropdownProps) {
+  if (suggestions.length === 0) return null;
+
+  return (
+    <ul
+      id={listId}
+      role="listbox"
+      className="absolute z-20 mt-1 max-h-48 w-full overflow-auto rounded-md border border-gray-300 bg-white py-1 text-sm shadow-lg dark:border-gray-700 dark:bg-gray-900"
+    >
+      {suggestions.map((suggestion, index) => (
+        <li
+          key={`${suggestion}-${index}`}
+          id={`${listId}-option-${index}`}
+          role="option"
+          aria-selected={index === highlightedIndex}
+          onMouseDown={(event) => event.preventDefault()}
+          onClick={() => onSelect(suggestion)}
+          className={`cursor-pointer px-3 py-2 ${
+            index === highlightedIndex
+              ? "bg-gray-100 dark:bg-gray-800"
+              : "hover:bg-gray-50 dark:hover:bg-gray-800/80"
+          }`}
+        >
+          {suggestion}
+        </li>
+      ))}
+    </ul>
+  );
+}

--- a/apps/web/src/components/tag-autocomplete-input/tag-chips.tsx
+++ b/apps/web/src/components/tag-autocomplete-input/tag-chips.tsx
@@ -1,0 +1,20 @@
+type TagChipsProps = {
+  tags: string[];
+};
+
+export function TagChips({ tags }: TagChipsProps) {
+  if (tags.length === 0) return null;
+
+  return (
+    <div className="mt-2 flex flex-wrap gap-2">
+      {tags.map((tag, index) => (
+        <span
+          key={`${tag}-${index}`}
+          className="rounded-full bg-gray-100 px-2 py-1 text-xs text-gray-700 dark:bg-gray-800 dark:text-gray-200"
+        >
+          {tag}
+        </span>
+      ))}
+    </div>
+  );
+}

--- a/apps/web/src/components/tag-autocomplete-input/use-tag-suggestions.ts
+++ b/apps/web/src/components/tag-autocomplete-input/use-tag-suggestions.ts
@@ -1,0 +1,64 @@
+import { apiFetch } from "@/lib/api";
+import { useEffect, useRef, useState } from "react";
+
+const DEBOUNCE_MS = 300;
+const MIN_QUERY_LENGTH = 2;
+
+export function useTagSuggestions(currentTrimmed: string, orgSlug?: string) {
+  const [suggestions, setSuggestions] = useState<string[]>([]);
+  const [loading, setLoading] = useState(false);
+  const cacheRef = useRef(new Map<string, string[]>());
+  const requestIdRef = useRef(0);
+
+  useEffect(() => {
+    const requestId = ++requestIdRef.current;
+    if (currentTrimmed.length < MIN_QUERY_LENGTH) {
+      setLoading(false);
+      setSuggestions([]);
+      return;
+    }
+
+    const normalizedQuery = currentTrimmed.toLowerCase();
+    const cacheKey = `${orgSlug ?? ""}::${normalizedQuery}`;
+    const cached = cacheRef.current.get(cacheKey);
+    if (cached) {
+      setLoading(false);
+      setSuggestions(cached);
+      return;
+    }
+
+    const timer = setTimeout(async () => {
+      setLoading(true);
+      try {
+        const params = new URLSearchParams({ q: currentTrimmed });
+        if (orgSlug) params.set("orgSlug", orgSlug);
+        const response = await apiFetch(
+          `/api/tags/suggest?${params.toString()}`,
+        );
+        if (requestIdRef.current !== requestId) return;
+        if (!response.ok) {
+          setSuggestions([]);
+          return;
+        }
+        const body = (await response.json()) as { tags?: unknown };
+        const nextSuggestions = Array.isArray(body.tags)
+          ? body.tags.filter((tag): tag is string => typeof tag === "string")
+          : [];
+        if (requestIdRef.current !== requestId) return;
+        cacheRef.current.set(cacheKey, nextSuggestions);
+        setSuggestions(nextSuggestions);
+      } catch {
+        if (requestIdRef.current !== requestId) return;
+        setSuggestions([]);
+      } finally {
+        if (requestIdRef.current === requestId) {
+          setLoading(false);
+        }
+      }
+    }, DEBOUNCE_MS);
+
+    return () => clearTimeout(timer);
+  }, [currentTrimmed, orgSlug]);
+
+  return { suggestions, loading };
+}


### PR DESCRIPTION
🎯 **What:** Extracted the complex data-fetching and debouncing logic from `TagAutocompleteInput` into a new `useTagSuggestions` hook. Extracted the suggestions dropdown list into `AutocompleteDropdown` and the selected tags display into `TagChips` components.

💡 **Why:** `TagAutocompleteInput` had grown quite large (>240 lines) because it tightly coupled state management for API requests, debouncing timers, caching, and complex DOM rendering into a single monolithic component. By breaking it into a hook and smaller child components, the core input logic is isolated, making the component significantly easier to maintain, test, and read. 

✅ **Verification:** 
- Successfully passed the 6 specific unit tests for `TagAutocompleteInput` (`bun run test apps/web/src/components/__tests__/tag-autocomplete-input.test.tsx`).
- Successfully passed the entire web workspace test suite (`bun x vitest run apps/web`).
- Verified types and formatting with `bun x tsc` and `bun x prettier`.

✨ **Result:** The `TagAutocompleteInput` is now significantly shorter and focused purely on rendering the input field and keyboard navigation state, delegating suggestions fetching and child rendering to specialized, single-responsibility functions.

---
*PR created automatically by Jules for task [7670127203445948716](https://jules.google.com/task/7670127203445948716) started by @is0692vs*

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

240行超の `TagAutocompleteInput` コンポーネントから、データ取得・デバウンス・キャッシュロジックを `useTagSuggestions` フックへ、ドロップダウンUIを `AutocompleteDropdown`、タグチップ表示を `TagChips` コンポーネントへ抽出するリファクタリングです。

- `useTagSuggestions` は元の実装からデバウンス・キャッシュ・競合リクエスト防止ロジックをそのまま移植し、機能面は同等に保たれています。
- `open` と `highlightedIndex` の更新が `suggestions` 変化とは別の `useEffect([suggestions])` で行われるようになったため、`suggestions` が空になった直後の 1 レンダリングで `open=true` かつ `suggestions=[]` という過渡的状態が発生します。`AutocompleteDropdown` 内のガードがこれを視覚的に抑制していますが、`aria-expanded` は一瞬 `true` のままになります。
- `TagChips` への抽出はシンプルで問題なく、元のインラインJSXと動作は同等です。
</details>

<details open><summary><h3>Confidence Score: 4/5</h3></summary>

全体的にクリーンなリファクタリングで、元の動作はほぼ完全に保たれています。`open` 状態の更新タイミングが 1 レンダリング遅れる設計上の変化がありますが、通常利用では視覚的に問題になりません。

フェッチ・デバウンス・競合制御ロジックは元の実装から忠実に移植されており、`useTagSuggestions` 単体の品質は高いです。ただし `suggestions` と `open`/`highlightedIndex` の更新を別 `useEffect` に分離したことで、suggestions が空になる際に `aria-expanded=true` が一瞬残る過渡的な状態が生まれました。`AutocompleteDropdown` 内のガードが視覚的な問題を防いでいますが、このガードが必要な理由がコードから読み取りづらく、将来の変更で誤って削除されるリスクがあります。

`open`/`highlightedIndex` の更新ロジックが集中している `tag-autocomplete-input.tsx` の `useEffect([suggestions])` 周辺と、内部ガードの意図が不明確な `autocomplete-dropdown.tsx` に注意してください。
</details>

<details open><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| apps/web/src/components/tag-autocomplete-input.tsx | フェッチ・デバウンス・キャッシュロジックを `useTagSuggestions` フックへ、レンダリングを子コンポーネントへ委譲し大幅にスリム化。`open`/`highlightedIndex` の制御が `useEffect([suggestions])` に分離されたため、過渡的に `aria-expanded` が不正になる可能性あり。 |
| apps/web/src/components/tag-autocomplete-input/use-tag-suggestions.ts | デバウンス・キャッシュ・競合リクエスト防止ロジックを元の実装から忠実に移植。`requestIdRef` による競合制御も維持されており、動作は元コードと同等。 |
| apps/web/src/components/tag-autocomplete-input/autocomplete-dropdown.tsx | ドロップダウンUIを分離したコンポーネント。内部の `suggestions.length === 0` ガードは防衛的コードに見えるが、実際には2段階更新の過渡状態を防ぐために必要。コメントがあると意図が明確になる。 |
| apps/web/src/components/tag-autocomplete-input/tag-chips.tsx | タグチップ表示を独立したコンポーネントに切り出したシンプルな変更。元のインラインJSXと動作は完全に同等。 |

</details>

</details>

<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant User as ユーザー入力
    participant TAI as TagAutocompleteInput
    participant Hook as useTagSuggestions
    participant API as /api/tags/suggest
    participant AD as AutocompleteDropdown
    participant TC as TagChips

    User->>TAI: テキスト入力
    TAI->>Hook: currentTrimmed, orgSlug を渡す
    Hook->>Hook: MIN_QUERY_LENGTH チェック
    Hook->>Hook: キャッシュ確認
    alt キャッシュヒット
        Hook-->>TAI: suggestions (キャッシュ)
    else キャッシュミス
        Hook->>Hook: debounce (300ms)
        Hook->>API: "GET /api/tags/suggest?q=..."
        API-->>Hook: "{ tags: string[] }"
        Hook->>Hook: キャッシュ保存
        Hook-->>TAI: suggestions (新規)
    end
    TAI->>TAI: useEffect([suggestions])
    Note over TAI: setOpen / setHighlightedIndex
    TAI->>AD: "open && suggestions, highlightedIndex"
    TAI->>TC: displayChips
```

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 2 code review issues. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 2
apps/web/src/components/tag-autocomplete-input.tsx:58-61
**`open` / `aria-expanded` が一瞬ずれるレンダリングが発生します**

`suggestions` の更新と `open`・`highlightedIndex` の更新が別々の `useEffect` に分離されたため、`suggestions` が `[]` に変化した際に「`open=true` かつ `suggestions=[]`」という一時的な状態が 1 フレーム存在します。この間、`AutocompleteDropdown` の内部ガード (`if (suggestions.length === 0) return null`) によって視覚的な表示は抑制されますが、`<input>` の `aria-expanded="true"` は維持されたままになります。スクリーンリーダーはドロップダウンが開いているとアナウンスしてしまう可能性があります。元のコードでは `suggestions`・`open`・`highlightedIndex` がすべて同一の `useEffect` 内で同時更新されていたため、この問題は発生しませんでした。`open` の制御を `useTagSuggestions` フックに含めるか、`open` の判定を `open && suggestions.length > 0` に戻すことで回避できます。

### Issue 2 of 2
apps/web/src/components/tag-autocomplete-input/autocomplete-dropdown.tsx:14
**この早期リターンは防衛的コードではなく正確性のために必要です**

親コンポーネントでは `{open && <AutocompleteDropdown .../>}` という条件付きレンダリングが行われていますが、`open` と `suggestions` は別々の `useEffect` によって更新されるため、`open=true` かつ `suggestions=[]` という過渡的な状態が存在します（suggestions が空になった直後の 1 レンダリング間）。この行はその過渡状態を防ぐために実際に機能しています。コードの意図を将来の読者に伝えるために、コメントを追加することをお勧めします。

`````

</details>

<sub>Reviews (1): Last reviewed commit: ["🧹 Refactor TagAutocompleteInput compone..."](https://github.com/hiroki-org/openshelf/commit/5235cf2daa559947f3a1d4159dd6ab83cdd3c693) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=36048055)</sub>

> Greptile also left **2 inline comments** on this PR.

<!-- /greptile_comment -->