### PR TITLE
🎨 Palette: タグ入力サジェストのローディング状態のアクセシビリティ改善

### DIFF
--- a/apps/web/src/components/tag-autocomplete-input.tsx
+++ b/apps/web/src/components/tag-autocomplete-input.tsx
@@ -238,11 +238,13 @@ export function TagAutocompleteInput({
         </div>
       )}
 
-      {loading && (
-        <p className="mt-1 text-xs text-gray-500 dark:text-gray-400">
-          候補を取得中...
-        </p>
-      )}
+      <div aria-live="polite" aria-atomic="true">
+        {loading && (
+          <p className="mt-1 text-xs text-gray-500 dark:text-gray-400">
+            候補を取得中...
+          </p>
+        )}
+      </div>
     </div>
   );
 }


### PR DESCRIPTION
タグのオートコンプリート入力時、サジェスト候補を取得中のローディング状態がスクリーンリーダーに伝わるように `aria-live` を用いた永続的なラッパー要素を追加しました。

---
*PR created automatically by Jules for task [6587338391992332759](https://jules.google.com/task/6587338391992332759) started by @is0692vs*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Accessibility Improvements**
  * Enhanced the loading state announcement in tag autocomplete to better support assistive technologies and screen readers.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->