### PR TITLE
🧹 fix: migrate img to next/image in badge-snippet

### DIFF
--- a/apps/web/src/app/papers/[id]/__tests__/badge-snippet.test.tsx
+++ b/apps/web/src/app/papers/[id]/__tests__/badge-snippet.test.tsx
@@ -12,6 +12,11 @@ import { BadgeSnippet } from "../badge-snippet";
 const toastSuccess = vi.fn();
 const toastError = vi.fn();
 
+vi.mock("next/image", () => ({
+  // eslint-disable-next-line @next/next/no-img-element
+  default: ({ unoptimized: _unoptimized, ...props }: any) => <img {...props} />,
+}));
+
 vi.mock("@/components/toast", () => ({
   toast: {
     success: (...args: unknown[]) => toastSuccess(...args),

--- a/apps/web/src/app/papers/[id]/badge-snippet.tsx
+++ b/apps/web/src/app/papers/[id]/badge-snippet.tsx
@@ -2,6 +2,7 @@
 
 import { toast } from "@/components/toast";
 import { useMemo } from "react";
+import Image from "next/image";
 
 type BadgeSnippetProps = {
   paperId: string;
@@ -110,10 +111,13 @@ export function BadgeSnippet({ paperId, title, siteBase }: BadgeSnippetProps) {
       </h2>
 
       <div className="mb-4 rounded-md border border-gray-200 bg-gray-50 p-3 dark:border-gray-700 dark:bg-gray-900/30">
-        <img
+        <Image
           src={badgePreviewUrl}
           alt={`OpenShelf badge preview for ${title}`}
           className="h-5 w-auto"
+          width={0}
+          height={0}
+          unoptimized
         />
       </div>
 


### PR DESCRIPTION
🎯 **What:** Migrated the native `<img>` tag to Next.js `<Image />` component for rendering the badge snippet preview in `badge-snippet.tsx`. Also updated the corresponding test suite to mock the `next/image` component to prevent testing regressions.

💡 **Why:** Resolves the `@next/next/no-img-element` ESLint warning. While this image is a dynamic, externally-generated SVG, utilizing the `<Image />` component with the `unoptimized` prop allows us to adhere to Next.js best practices and code health standards without risking Server-Side optimization crashes or layout shifts.

✅ **Verification:** 
- Formatted and linted code locally, ensuring the warning is gone.
- Executed Vitest across the `apps/web` package (233 tests passed).
- Verified the mocking behavior in `badge-snippet.test.tsx` appropriately handles the replacement without causing Next-specific runtime test failures.

✨ **Result:** Improved codebase maintainability by resolving the lint rule, standardized image usage, and modernized the test suite handling of Next.js Image components.

---
*PR created automatically by Jules for task [2326462111238588177](https://jules.google.com/task/2326462111238588177) started by @is0692vs*

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

バッジプレビュー表示に使用していたネイティブ `<img>` タグを `next/image` の `<Image>` コンポーネントへ移行し、`@next/next/no-img-element` ESLint 警告を解消したPRです。

- `badge-snippet.tsx`: `<img>` → `<Image>` に置換。外部生成 SVG のため `unoptimized` を付与し、最適化パイプラインによるクラッシュを回避している。
- `badge-snippet.test.tsx`: `vi.mock("next/image", ...)` を追加して `unoptimized` prop をフィルタリングし、テスト環境での Next.js 固有ランタイムエラーを防いでいる。
</details>

<details open><summary><h3>Confidence Score: 4/5</h3></summary>

`<img>` を `<Image unoptimized>` に差し替えるだけのシンプルな変更で、ロジックへの影響はなくマージしても安全です。

`width={0}` / `height={0}` はバッジ SVG のアスペクト比ヒントを「0/0（未定義）」にしており、画像ロード前に CSS `width: auto` の計算が定まらない微小な CLS リスクがあります。機能破壊ではありませんが、Next.js の推奨する寸法指定パターンからは外れています。

`badge-snippet.tsx` の `width={0}` / `height={0}` のみ確認を推奨。テストファイルは問題なし。
</details>

<details open><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| apps/web/src/app/papers/[id]/badge-snippet.tsx | `<img>` を `<Image>` に移行。`unoptimized` は妥当だが、`width={0}` / `height={0}` は推奨パターンではなく、CSS によるサイズ制御に不明確な依存が生まれる。 |
| apps/web/src/app/papers/[id]/__tests__/badge-snippet.test.tsx | `next/image` のモックを追加。`unoptimized` prop をフィルタリングして標準 `<img>` に変換するアプローチは適切。 |

</details>

<h3>Flowchart</h3>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[BadgeSnippet コンポーネント] --> B{環境}
    B -->|本番 / 開発| C["next/image の Image コンポーネント\n(unoptimized=true)"]
    B -->|Vitest テスト| D["vi.mock('next/image')\n→ ネイティブ img に差し替え\n(unoptimized を除去)"]
    C --> E["img をそのまま出力\n(Next.js 最適化なし)"]
    D --> F["img src=... alt=... "]
    E --> G[バッジ SVG を外部 API から取得]
    F --> G
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
flowchart TD
    A[BadgeSnippet コンポーネント] --> B{環境}
    B -->|本番 / 開発| C["next/image の Image コンポーネント\n(unoptimized=true)"]
    B -->|Vitest テスト| D["vi.mock('next/image')\n→ ネイティブ img に差し替え\n(unoptimized を除去)"]
    C --> E["img をそのまま出力\n(Next.js 最適化なし)"]
    D --> F["img src=... alt=... "]
    E --> G[バッジ SVG を外部 API から取得]
    F --> G
```

</a>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 1 code review issue. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 1
apps/web/src/app/papers/[id]/badge-snippet.tsx:114-121
`width={0}` と `height={0}` の組み合わせは Next.js の推奨パターンではありません。`unoptimized` を使用する場合でも、Next.js ドキュメントは意味のある寸法を指定することを推奨しています。`width={0}` / `height={0}` を使うと、画像ロード前にブラウザのアスペクト比ヒント（`aspect-ratio: auto 0 / 0`）が未定義になり、CSS `width: auto` の計算が画像データのロード完了まで定まらないため、微小な CLS が発生する可能性があります。バッジ SVG の一般的な寸法（例: `width={88}` `height={20}`）を指定するアプローチが望ましいです。

```suggestion
        <Image
          src={badgePreviewUrl}
          alt={`OpenShelf badge preview for ${title}`}
          className="h-5 w-auto"
          width={88}
          height={20}
          unoptimized
        />
```

`````

</details>

<sub>Reviews (1): Last reviewed commit: ["🧹 fix: migrate img to next/image in bad..."](https://github.com/hiroki-org/openshelf/commit/9f6f885759593b3fa521c7588383b5d6790d429b) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=40371529)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->