### PR TITLE
🧹 [Code Health] Migrate from img to next/image in paper details

### DIFF
--- a/apps/web/src/app/papers/[id]/__tests__/paper-detail-client.test.tsx
+++ b/apps/web/src/app/papers/[id]/__tests__/paper-detail-client.test.tsx
@@ -40,7 +40,8 @@ vi.mock("next/link", () => ({
 }));
 
 vi.mock("next/image", () => ({
-  default: ({ src, alt, ...props }: any) => (
+  default: ({ src, alt, unoptimized: _unoptimized, ...props }: any) => (
+    // eslint-disable-next-line @next/next/no-img-element
     <img src={typeof src === "string" ? src : ""} alt={alt} {...props} />
   ),
 }));
@@ -417,7 +418,9 @@ describe("PaperDetailClient", () => {
     const slideRow = screen.getByText("deck.pptx").closest("li");
     expect(slideRow).not.toBeNull();
     fireEvent.click(
-      within(slideRow!).getByRole("button", { name: "deck.pptxをダウンロード" }),
+      within(slideRow!).getByRole("button", {
+        name: "deck.pptxをダウンロード",
+      }),
     );
 
     await waitFor(() => {
@@ -748,18 +751,21 @@ describe("PaperDetailClient", () => {
     [401, "ログインが必要です"],
     [404, "成果物が見つかりません"],
     [500, "成果物の取得に失敗しました"],
-  ])("maps paper fetch status %s to its error message", async (status, message) => {
-    vi.mocked(apiFetch).mockResolvedValue(new Response("error", { status }));
+  ])(
+    "maps paper fetch status %s to its error message",
+    async (status, message) => {
+      vi.mocked(apiFetch).mockResolvedValue(new Response("error", { status }));
 
-    render(
-      <PaperDetailClient
-        paperId="paper-1"
-        siteBase="https://openshelf.example"
-      />,
-    );
+      render(
+        <PaperDetailClient
+          paperId="paper-1"
+          siteBase="https://openshelf.example"
+        />,
+      );
 
-    expect(await screen.findByText(message)).toBeInTheDocument();
-  });
+      expect(await screen.findByText(message)).toBeInTheDocument();
+    },
+  );
 
   it("shows an error when API request fails entirely", async () => {
     vi.mocked(apiFetch).mockRejectedValue(new Error("Network Error"));
@@ -775,5 +781,4 @@ describe("PaperDetailClient", () => {
       await screen.findByText("成果物の取得に失敗しました"),
     ).toBeInTheDocument();
   });
-
 });

--- a/apps/web/src/app/papers/[id]/__tests__/paper-detail-client.test.tsx
+++ b/apps/web/src/app/papers/[id]/__tests__/paper-detail-client.test.tsx
@@ -162,9 +162,16 @@ describe("PaperDetailClient", () => {
     );
 
     await waitFor(() => {
-      expect(screen.getByAltText("poster.png")).toHaveAttribute(
+      const preview = screen.getByAltText("poster.png");
+      expect(preview).toHaveAttribute(
         "src",
         expect.stringMatching(/^blob:mock-/),
+      );
+      expect(preview).toHaveAttribute("width", "800");
+      expect(preview).toHaveAttribute("height", "600");
+      expect(preview).toHaveAttribute(
+        "sizes",
+        "(max-width: 640px) 100vw, 50vw",
       );
     });
 

--- a/apps/web/src/app/papers/[id]/paper-detail-client.tsx
+++ b/apps/web/src/app/papers/[id]/paper-detail-client.tsx
@@ -836,11 +836,15 @@ export default function PaperDetailClient({
                 className="rounded-md border border-gray-200 p-2 dark:border-gray-700"
               >
                 {imagePreviewUrls[img.id] ? (
-                  <img
+                  <Image
                     src={imagePreviewUrls[img.id]}
                     alt={img.filename}
                     className="h-auto w-full rounded"
                     loading="lazy"
+                    unoptimized
+                    width={0}
+                    height={0}
+                    sizes="100vw"
                   />
                 ) : failedImageIds.includes(img.id) ? (
                   <div className="flex h-[180px] items-center justify-center rounded bg-red-50 text-xs text-red-600 dark:bg-red-950/20 dark:text-red-400">

--- a/apps/web/src/app/papers/[id]/paper-detail-client.tsx
+++ b/apps/web/src/app/papers/[id]/paper-detail-client.tsx
@@ -842,9 +842,9 @@ export default function PaperDetailClient({
                     className="h-auto w-full rounded"
                     loading="lazy"
                     unoptimized
-                    width={0}
-                    height={0}
-                    sizes="100vw"
+                    width={800}
+                    height={600}
+                    sizes="(max-width: 640px) 100vw, 50vw"
                   />
                 ) : failedImageIds.includes(img.id) ? (
                   <div className="flex h-[180px] items-center justify-center rounded bg-red-50 text-xs text-red-600 dark:bg-red-950/20 dark:text-red-400">


### PR DESCRIPTION
🎯 **What:** Migrated a native `<img>` tag to the Next.js `<Image />` component in `apps/web/src/app/papers/[id]/paper-detail-client.tsx` at line 839.
💡 **Why:** This resolves the ESLint `@next/next/no-img-element` warning, which improves codebase consistency and leverages Next.js image optimization features. For the `blob:` URLs used here, `unoptimized={true}` and responsive dimensions are configured to prevent server crashes and maintain native styling.
✅ **Verification:** Ran `pnpm exec eslint` on the file to confirm the warning is resolved. Ran `pnpm run test apps/web` to ensure no functionality is broken. Added appropriate Next.js image mocking adjustments in the corresponding test file.
✨ **Result:** The code health issue is resolved, improving maintainability without behavioral changes.

---
*PR created automatically by Jules for task [4953011930270162463](https://jules.google.com/task/4953011930270162463) started by @is0692vs*

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

`blob:` URL を表示する箇所の `<img>` タグを `next/image` の `<Image>` コンポーネントへ移行し、ESLint の `@next/next/no-img-element` 警告を解消した小規模なコードヘルス改善 PR です。

- `unoptimized={true}` を付与することで、Next.js サーバーが `blob:` URL を最適化しようとしてクラッシュするリスクを回避しています。
- テストの `next/image` モックを更新し、`unoptimized` プロップが `<img>` に漏れないよう `_unoptimized` として分離しています。
- `sizes="100vw"` を指定していますが、親コンテナが `sm:grid-cols-2` の2カラムグリッドのため、デスクトップでは `50vw` 相当が正確です（`unoptimized` のため現時点で実害はありません）。
</details>

<details open><summary><h3>Confidence Score: 4/5</h3></summary>

`blob:` URL 向けに `unoptimized={true}` を付けた `next/image` への移行で、動作上の変更はほぼなくマージしても安全です。

`unoptimized` によってサーバークラッシュは防がれており、テストも更新されています。`sizes="100vw"` が2カラムグリッドの実際の表示幅と一致しない点は軽微な不正確さですが、現行では `unoptimized` のため影響なし。

`paper-detail-client.tsx` の `sizes` 指定のみ確認を推奨。テストファイルは問題ありません。
</details>

<details open><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| apps/web/src/app/papers/[id]/paper-detail-client.tsx | `blob:` URL を表示する `<img>` を `<Image unoptimized>` に移行。`width={0}` / `height={0}` + `sizes="100vw"` の組み合わせは `sm:grid-cols-2` レイアウトに対してサイズヒントが不正確だが、`unoptimized` のため実害なし。 |
| apps/web/src/app/papers/[id]/__tests__/paper-detail-client.test.tsx | `next/image` のモックで `unoptimized` プロップを `_unoptimized` として分離し `<img>` へ漏れないよう対処。ESLint コメントも適切に追加。整形の調整のみで問題なし。 |

</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 1 code review issue. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 1
apps/web/src/app/papers/[id]/paper-detail-client.tsx:844-847
`sizes="100vw"` は、親コンテナが `sm:grid-cols-2` の2カラムグリッドのため、デスクトップ幅では実際の表示幅は約50vwです。`unoptimized={true}` が指定されているため最適化パイプラインは使われないので実害はありませんが、値が不正確です。将来 `unoptimized` を外した際に余分な帯域を消費するリスクがあるため、正確な値に修正しておくことを推奨します。

```suggestion
                    unoptimized
                    width={0}
                    height={0}
                    sizes="(max-width: 640px) 100vw, 50vw"
```

`````

</details>

<sub>Reviews (1): Last reviewed commit: ["🧹 Migrate native img to Next.js Image i..."](https://github.com/hiroki-org/openshelf/commit/a7f8b6cc335a8a17a83eabb67a1ae8e29653fd7d) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=40372693)</sub>

> Greptile also left **1 inline comment** on this PR.

**Context used:**

- Context used - 日本語で！！！ ([source](https://app.greptile.com/review/custom-context?memory=instruction-0))

<!-- /greptile_comment -->