### PR TITLE
🧪 Add error tests for db failures in users route

### DIFF
--- a/apps/api/src/routes/__tests__/users.test.ts
+++ b/apps/api/src/routes/__tests__/users.test.ts
@@ -1,290 +1,408 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import {
-    createTestApp,
-    createTestEnv,
-    createTestJWT,
-    makeQuery,
+  createTestApp,
+  createTestEnv,
+  createTestJWT,
+  makeQuery,
 } from "../../test/helpers";
-
 
 let mockDb: any;
 
 vi.mock("drizzle-orm/d1", () => ({
-    drizzle: vi.fn(() => mockDb)
+  drizzle: vi.fn(() => mockDb),
 }));
 
 describe("users routes", () => {
-    beforeEach(() => {
-        vi.restoreAllMocks();
-        vi.resetModules();
-        mockDb = {
-            run: vi.fn(async () => undefined),
-            select: vi.fn(() => makeQuery()),
-            update: vi.fn(() => ({
-                set: vi.fn(() => ({ where: vi.fn(async () => undefined) }))
-            }))
-        };
+  beforeEach(() => {
+    vi.restoreAllMocks();
+    vi.resetModules();
+    mockDb = {
+      run: vi.fn(async () => undefined),
+      select: vi.fn(() => makeQuery()),
+      update: vi.fn(() => ({
+        set: vi.fn(() => ({ where: vi.fn(async () => undefined) })),
+      })),
+    };
+  });
+
+  it("GET /api/users/me returns profile for authenticated user", async () => {
+    const token = await createTestJWT({
+      sub: "user-1",
+      githubId: "123",
+      name: "Tester",
+    });
+    mockDb.select = vi.fn(() =>
+      makeQuery({ getResult: { id: "user-1", name: "Tester" } }),
+    );
+
+    const app = await createTestApp();
+    const env = createTestEnv();
+
+    const res = await app.request(
+      "http://localhost/api/users/me",
+      {
+        headers: { Authorization: `Bearer ${token}` },
+      },
+      env as any,
+    );
+
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as any;
+    expect(body.user.id).toBe("user-1");
+  });
+
+  it("PUT /api/users/me updates display_name", async () => {
+    const token = await createTestJWT({
+      sub: "user-1",
+      githubId: "123",
+      name: "Tester",
+    });
+    mockDb.select = vi.fn(() =>
+      makeQuery({
+        getResult: { id: "user-1", name: "Tester", displayName: "Updated" },
+      }),
+    );
+
+    const app = await createTestApp();
+    const env = createTestEnv();
+
+    const res = await app.request(
+      "http://localhost/api/users/me",
+      {
+        method: "PUT",
+        headers: {
+          Authorization: `Bearer ${token}`,
+          "Content-Type": "application/json",
+        },
+        body: JSON.stringify({ displayName: "Updated" }),
+      },
+      env as any,
+    );
+
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as any;
+    expect(body.user.displayName).toBe("Updated");
+  });
+
+  it("PATCH /api/users/me with malformed JSON returns 400", async () => {
+    const token = await createTestJWT({
+      sub: "user-1",
+      githubId: "123",
+      name: "Tester",
     });
 
-    it("GET /api/users/me returns profile for authenticated user", async () => {
-        const token = await createTestJWT({ sub: "user-1", githubId: "123", name: "Tester" });
-        mockDb.select = vi.fn(() => makeQuery({ getResult: { id: "user-1", name: "Tester" } }));
+    const app = await createTestApp();
+    const env = createTestEnv();
 
-        const app = await createTestApp();
-        const env = createTestEnv();
+    const res = await app.request(
+      "http://localhost/api/users/me",
+      {
+        method: "PATCH",
+        headers: {
+          Authorization: `Bearer ${token}`,
+          "Content-Type": "application/json",
+        },
+        body: '{ "displayName": "New Name", ', // Missing closing brace
+      },
+      env as any,
+    );
 
-        const res = await app.request(
-            "http://localhost/api/users/me",
-            {
-                headers: { Authorization: `Bearer ${token}` }
-            },
-            env as any
-        );
+    expect(res.status).toBe(400);
+    const body = (await res.json()) as any;
+    expect(body.error).toBe("Invalid JSON body");
+  });
 
-        expect(res.status).toBe(200);
-        const body = (await res.json()) as any;
-        expect(body.user.id).toBe("user-1");
+  it("GET /api/users/search?q=... returns search results", async () => {
+    const token = await createTestJWT({
+      sub: "user-1",
+      githubId: "123",
+      name: "Tester",
+    });
+    mockDb.select = vi.fn(() =>
+      makeQuery({
+        allResult: [{ id: "user-2", name: "Alice", githubId: "alice" }],
+      }),
+    );
+
+    const app = await createTestApp();
+    const env = createTestEnv();
+
+    const res = await app.request(
+      "http://localhost/api/users/search?q=ali",
+      {
+        headers: { Authorization: `Bearer ${token}` },
+      },
+      env as any,
+    );
+
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as any;
+    expect(body.users).toHaveLength(1);
+    expect(body.users[0].name).toBe("Alice");
+  });
+
+  it("PATCH /api/users/me rejects non-string display names", async () => {
+    const token = await createTestJWT({
+      sub: "user-1",
+      githubId: "123",
+      name: "Tester",
     });
 
-    it("PUT /api/users/me updates display_name", async () => {
-        const token = await createTestJWT({ sub: "user-1", githubId: "123", name: "Tester" });
-        mockDb.select = vi.fn(() => makeQuery({ getResult: { id: "user-1", name: "Tester", displayName: "Updated" } }));
+    const app = await createTestApp();
+    const env = createTestEnv();
 
-        const app = await createTestApp();
-        const env = createTestEnv();
+    const res = await app.request(
+      "http://localhost/api/users/me",
+      {
+        method: "PATCH",
+        headers: {
+          Authorization: `Bearer ${token}`,
+          "Content-Type": "application/json",
+        },
+        body: JSON.stringify({ displayName: 123 }),
+      },
+      env as any,
+    );
 
-        const res = await app.request(
-            "http://localhost/api/users/me",
-            {
-                method: "PUT",
-                headers: {
-                    Authorization: `Bearer ${token}`,
-                    "Content-Type": "application/json"
-                },
-                body: JSON.stringify({ displayName: "Updated" })
-            },
-            env as any
-        );
+    expect(res.status).toBe(400);
+    expect(((await res.json()) as any).error).toBe(
+      "displayName must be a string or null",
+    );
+  });
 
-        expect(res.status).toBe(200);
-        const body = (await res.json()) as any;
-        expect(body.user.displayName).toBe("Updated");
+  it("PATCH /api/users/me trims blank display names to null", async () => {
+    const token = await createTestJWT({
+      sub: "user-1",
+      githubId: "123",
+      name: "Tester",
+    });
+    const setValues = vi.fn(() => ({ where: vi.fn(async () => undefined) }));
+    mockDb.update = vi.fn(() => ({ set: setValues }));
+    mockDb.select = vi.fn(() =>
+      makeQuery({
+        getResult: { id: "user-1", name: "Tester", displayName: null },
+      }),
+    );
+
+    const app = await createTestApp();
+    const env = createTestEnv();
+
+    const res = await app.request(
+      "http://localhost/api/users/me",
+      {
+        method: "PATCH",
+        headers: {
+          Authorization: `Bearer ${token}`,
+          "Content-Type": "application/json",
+        },
+        body: JSON.stringify({ displayName: "   " }),
+      },
+      env as any,
+    );
+
+    expect(res.status).toBe(200);
+    expect(setValues).toHaveBeenCalledWith(
+      expect.objectContaining({
+        displayName: null,
+        updatedAt: expect.anything(),
+      }),
+    );
+  });
+
+  it("GET /api/users/search returns cached results on repeat queries", async () => {
+    const token = await createTestJWT({
+      sub: "user-1",
+      githubId: "123",
+      name: "Tester",
+    });
+    mockDb.select = vi.fn(() =>
+      makeQuery({
+        allResult: [{ id: "user-2", name: "Alice", githubId: "alice" }],
+      }),
+    );
+
+    const app = await createTestApp();
+    const env = createTestEnv();
+
+    const first = await app.request(
+      "http://localhost/api/users/search?q=ali",
+      {
+        headers: { Authorization: `Bearer ${token}` },
+      },
+      env as any,
+    );
+    expect(first.status).toBe(200);
+
+    const second = await app.request(
+      "http://localhost/api/users/search?q=ali",
+      {
+        headers: { Authorization: `Bearer ${token}` },
+      },
+      env as any,
+    );
+
+    expect(second.status).toBe(200);
+    expect(mockDb.select).toHaveBeenCalledTimes(1);
+  });
+
+  it("GET /api/users/search returns an empty list for short queries", async () => {
+    const token = await createTestJWT({
+      sub: "user-1",
+      githubId: "123",
+      name: "Tester",
     });
 
-    it("PATCH /api/users/me with malformed JSON returns 400", async () => {
-        const token = await createTestJWT({ sub: "user-1", githubId: "123", name: "Tester" });
+    const app = await createTestApp();
+    const env = createTestEnv();
 
-        const app = await createTestApp();
-        const env = createTestEnv();
+    const res = await app.request(
+      "http://localhost/api/users/search?q=a",
+      {
+        headers: { Authorization: `Bearer ${token}` },
+      },
+      env as any,
+    );
 
-        const res = await app.request(
-            "http://localhost/api/users/me",
-            {
-                method: "PATCH",
-                headers: {
-                    Authorization: `Bearer ${token}`,
-                    "Content-Type": "application/json"
-                },
-                body: '{ "displayName": "New Name", ' // Missing closing brace
-            },
-            env as any
-        );
+    expect(res.status).toBe(200);
+    expect(((await res.json()) as any).users).toEqual([]);
+    expect(mockDb.select).not.toHaveBeenCalled();
+  });
 
-        expect(res.status).toBe(400);
-        const body = (await res.json()) as any;
-        expect(body.error).toBe("Invalid JSON body");
+  it("GET /api/users/:id returns 404 when the user does not exist", async () => {
+    mockDb.select = vi.fn(() => makeQuery({ getResult: null }));
+
+    const app = await createTestApp();
+    const env = createTestEnv();
+
+    const res = await app.request(
+      "http://localhost/api/users/missing",
+      {},
+      env as any,
+    );
+
+    expect(res.status).toBe(404);
+    expect(((await res.json()) as any).error).toBe("User not found");
+  });
+
+  it("GET /api/users/search evicts the oldest item when MAX_CACHE_SIZE is reached", async () => {
+    const token = await createTestJWT({
+      sub: "user-1",
+      githubId: "123",
+      name: "Tester",
     });
+    mockDb.select = vi.fn(() =>
+      makeQuery({
+        allResult: [{ id: "user-2", name: "Alice", githubId: "alice" }],
+      }),
+    );
 
-    it("GET /api/users/search?q=... returns search results", async () => {
-        const token = await createTestJWT({ sub: "user-1", githubId: "123", name: "Tester" });
-        mockDb.select = vi.fn(() => makeQuery({ allResult: [{ id: "user-2", name: "Alice", githubId: "alice" }] }));
+    const app = await createTestApp();
+    const env = createTestEnv();
 
-        const app = await createTestApp();
-        const env = createTestEnv();
+    // MAX_CACHE_SIZE is 1000
+    for (let i = 0; i < 1002; i++) {
+      await app.request(
+        `http://localhost/api/users/search?q=ali${i}`,
+        {
+          headers: { Authorization: `Bearer ${token}` },
+        },
+        env as any,
+      );
+    }
 
-        const res = await app.request(
-            "http://localhost/api/users/search?q=ali",
-            {
-                headers: { Authorization: `Bearer ${token}` }
-            },
-            env as any
-        );
+    // The first item `ali0` should be evicted. We mock DB to return Bob if it fetches, otherwise cache.
+    mockDb.select = vi.fn(() =>
+      makeQuery({
+        allResult: [{ id: "user-3", name: "Bob", githubId: "bob" }],
+      }),
+    );
 
-        expect(res.status).toBe(200);
-        const body = (await res.json()) as any;
-        expect(body.users).toHaveLength(1);
-        expect(body.users[0].name).toBe("Alice");
+    const res = await app.request(
+      "http://localhost/api/users/search?q=ali0",
+      {
+        headers: { Authorization: `Bearer ${token}` },
+      },
+      env as any,
+    );
+
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as any;
+    expect(body.users).toHaveLength(1);
+    expect(body.users[0].name).toBe("Bob"); // Fetched from DB since cache was evicted
+  });
+
+  it("escapes wildcard characters correctly in search endpoint", async () => {
+    const token = await createTestJWT({
+      sub: "user-1",
+      githubId: "123",
+      name: "Tester",
     });
+    mockDb.select = vi.fn(() =>
+      makeQuery({ allResult: [{ id: "user-1", name: "Tester" }] }),
+    );
 
-    it("PATCH /api/users/me rejects non-string display names", async () => {
-        const token = await createTestJWT({ sub: "user-1", githubId: "123", name: "Tester" });
+    const app = await createTestApp();
+    const env = createTestEnv();
 
-        const app = await createTestApp();
-        const env = createTestEnv();
+    const res = await app.request(
+      "http://localhost/api/users/search?q=%25%5C_", // %\_
+      { headers: { Authorization: `Bearer ${token}` } },
+      env as any,
+    );
 
-        const res = await app.request(
-            "http://localhost/api/users/me",
-            {
-                method: "PATCH",
-                headers: {
-                    Authorization: `Bearer ${token}`,
-                    "Content-Type": "application/json"
-                },
-                body: JSON.stringify({ displayName: 123 })
-            },
-            env as any
-        );
+    expect(res.status).toBe(200);
+  });
 
-        expect(res.status).toBe(400);
-        expect(((await res.json()) as any).error).toBe("displayName must be a string or null");
+  it("GET /api/users/me returns 500 when DB query fails", async () => {
+    const token = await createTestJWT({
+      sub: "user-1",
+      githubId: "123",
+      name: "Tester",
     });
+    mockDb.select = vi.fn(() => ({
+      from: vi.fn(() => ({
+        where: vi.fn(() => ({
+          get: vi.fn().mockRejectedValue(new Error("DB Error")),
+        })),
+      })),
+    }));
 
-    it("PATCH /api/users/me trims blank display names to null", async () => {
-        const token = await createTestJWT({ sub: "user-1", githubId: "123", name: "Tester" });
-        const setValues = vi.fn(() => ({ where: vi.fn(async () => undefined) }));
-        mockDb.update = vi.fn(() => ({ set: setValues }));
-        mockDb.select = vi.fn(() =>
-            makeQuery({ getResult: { id: "user-1", name: "Tester", displayName: null } }),
-        );
+    const app = await createTestApp();
+    const env = createTestEnv();
 
-        const app = await createTestApp();
-        const env = createTestEnv();
+    const res = await app.request(
+      "http://localhost/api/users/me",
+      {
+        headers: { Authorization: `Bearer ${token}` },
+      },
+      env as any,
+    );
 
-        const res = await app.request(
-            "http://localhost/api/users/me",
-            {
-                method: "PATCH",
-                headers: {
-                    Authorization: `Bearer ${token}`,
-                    "Content-Type": "application/json"
-                },
-                body: JSON.stringify({ displayName: "   " })
-            },
-            env as any
-        );
+    expect(res.status).toBe(500);
+    const body = (await res.json()) as any;
+    expect(body.error).toBe("Failed to fetch user");
+  });
 
-        expect(res.status).toBe(200);
-        expect(setValues).toHaveBeenCalledWith(
-            expect.objectContaining({
-                displayName: null,
-                updatedAt: expect.anything(),
-            }),
-        );
-    });
+  it("GET /api/users/:id returns 500 when DB query fails", async () => {
+    mockDb.select = vi.fn(() => ({
+      from: vi.fn(() => ({
+        where: vi.fn(() => ({
+          get: vi.fn().mockRejectedValue(new Error("DB Error")),
+        })),
+      })),
+    }));
 
-    it("GET /api/users/search returns cached results on repeat queries", async () => {
-        const token = await createTestJWT({ sub: "user-1", githubId: "123", name: "Tester" });
-        mockDb.select = vi.fn(() =>
-            makeQuery({ allResult: [{ id: "user-2", name: "Alice", githubId: "alice" }] }),
-        );
+    const app = await createTestApp();
+    const env = createTestEnv();
 
-        const app = await createTestApp();
-        const env = createTestEnv();
+    const res = await app.request(
+      "http://localhost/api/users/missing",
+      {},
+      env as any,
+    );
 
-        const first = await app.request(
-            "http://localhost/api/users/search?q=ali",
-            {
-                headers: { Authorization: `Bearer ${token}` }
-            },
-            env as any
-        );
-        expect(first.status).toBe(200);
-
-        const second = await app.request(
-            "http://localhost/api/users/search?q=ali",
-            {
-                headers: { Authorization: `Bearer ${token}` }
-            },
-            env as any
-        );
-
-        expect(second.status).toBe(200);
-        expect(mockDb.select).toHaveBeenCalledTimes(1);
-    });
-
-    it("GET /api/users/search returns an empty list for short queries", async () => {
-        const token = await createTestJWT({ sub: "user-1", githubId: "123", name: "Tester" });
-
-        const app = await createTestApp();
-        const env = createTestEnv();
-
-        const res = await app.request(
-            "http://localhost/api/users/search?q=a",
-            {
-                headers: { Authorization: `Bearer ${token}` }
-            },
-            env as any
-        );
-
-        expect(res.status).toBe(200);
-        expect(((await res.json()) as any).users).toEqual([]);
-        expect(mockDb.select).not.toHaveBeenCalled();
-    });
-
-    it("GET /api/users/:id returns 404 when the user does not exist", async () => {
-        mockDb.select = vi.fn(() => makeQuery({ getResult: null }));
-
-        const app = await createTestApp();
-        const env = createTestEnv();
-
-        const res = await app.request(
-            "http://localhost/api/users/missing",
-            {},
-            env as any
-        );
-
-        expect(res.status).toBe(404);
-        expect(((await res.json()) as any).error).toBe("User not found");
-    });
-
-    it("GET /api/users/search evicts the oldest item when MAX_CACHE_SIZE is reached", async () => {
-        const token = await createTestJWT({ sub: "user-1", githubId: "123", name: "Tester" });
-        mockDb.select = vi.fn(() => makeQuery({ allResult: [{ id: "user-2", name: "Alice", githubId: "alice" }] }));
-
-        const app = await createTestApp();
-        const env = createTestEnv();
-
-        // MAX_CACHE_SIZE is 1000
-        for (let i = 0; i < 1002; i++) {
-            await app.request(
-                `http://localhost/api/users/search?q=ali${i}`,
-                {
-                    headers: { Authorization: `Bearer ${token}` }
-                },
-                env as any
-            );
-        }
-
-        // The first item `ali0` should be evicted. We mock DB to return Bob if it fetches, otherwise cache.
-        mockDb.select = vi.fn(() => makeQuery({ allResult: [{ id: "user-3", name: "Bob", githubId: "bob" }] }));
-
-        const res = await app.request(
-            "http://localhost/api/users/search?q=ali0",
-            {
-                headers: { Authorization: `Bearer ${token}` }
-            },
-            env as any
-        );
-
-        expect(res.status).toBe(200);
-        const body = (await res.json()) as any;
-        expect(body.users).toHaveLength(1);
-        expect(body.users[0].name).toBe("Bob"); // Fetched from DB since cache was evicted
-    });
-
-    it("escapes wildcard characters correctly in search endpoint", async () => {
-        const token = await createTestJWT({ sub: "user-1", githubId: "123", name: "Tester" });
-        mockDb.select = vi.fn(() => makeQuery({ allResult: [{ id: "user-1", name: "Tester" }] }));
-
-        const app = await createTestApp();
-        const env = createTestEnv();
-
-        const res = await app.request(
-            "http://localhost/api/users/search?q=%25%5C_", // %\_
-            { headers: { Authorization: `Bearer ${token}` } },
-            env as any
-        );
-
-        expect(res.status).toBe(200);
-    });
+    expect(res.status).toBe(500);
+    const body = (await res.json()) as any;
+    expect(body.error).toBe("Failed to fetch user");
+  });
 });

--- a/apps/api/src/routes/__tests__/users.test.ts
+++ b/apps/api/src/routes/__tests__/users.test.ts
@@ -268,6 +268,33 @@ describe("users routes", () => {
     expect(mockDb.select).not.toHaveBeenCalled();
   });
 
+  it("GET /api/users/:id returns profile for existing user", async () => {
+    mockDb.select = vi.fn(() =>
+      makeQuery({
+        getResult: {
+          id: "user-1",
+          name: "Alice",
+          displayName: "Alice D",
+          avatarUrl: "",
+          githubId: "alice",
+        },
+      }),
+    );
+
+    const app = await createTestApp();
+    const env = createTestEnv();
+
+    const res = await app.request(
+      "http://localhost/api/users/user-1",
+      {},
+      env as any,
+    );
+
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as any;
+    expect(body.user.id).toBe("user-1");
+    expect(body.user.name).toBe("Alice");
+  });
   it("GET /api/users/:id returns 404 when the user does not exist", async () => {
     mockDb.select = vi.fn(() => makeQuery({ getResult: null }));
 

--- a/apps/api/src/routes/users.ts
+++ b/apps/api/src/routes/users.ts
@@ -12,9 +12,17 @@ const usersRoute = new Hono<{ Bindings: Env; Variables: Variables }>();
 usersRoute.get("/me", authMiddleware, async (c) => {
   const db = drizzle(c.env.DB);
   const userId = c.get("user").sub;
-  const user = await db.select().from(users).where(eq(users.id, userId)).get();
-  if (!user) return c.json({ error: "User not found" }, 404);
-  return c.json({ user });
+  try {
+    const user = await db
+      .select()
+      .from(users)
+      .where(eq(users.id, userId))
+      .get();
+    if (!user) return c.json({ error: "User not found" }, 404);
+    return c.json({ user });
+  } catch {
+    return c.json({ error: "Failed to fetch user" }, 500);
+  }
 });
 
 const updateMeHandler = async (
@@ -149,20 +157,24 @@ usersRoute.get("/search", authMiddleware, async (c) => {
 // GET /api/users/:id — public profile
 usersRoute.get("/:id", async (c) => {
   const db = drizzle(c.env.DB);
-  const user = await db
-    .select({
-      id: users.id,
-      name: users.name,
-      displayName: users.displayName,
-      avatarUrl: users.avatarUrl,
-      githubId: users.githubId,
-    })
-    .from(users)
-    .where(eq(users.id, c.req.param("id")))
-    .get();
+  try {
+    const user = await db
+      .select({
+        id: users.id,
+        name: users.name,
+        displayName: users.displayName,
+        avatarUrl: users.avatarUrl,
+        githubId: users.githubId,
+      })
+      .from(users)
+      .where(eq(users.id, c.req.param("id")))
+      .get();
 
-  if (!user) return c.json({ error: "User not found" }, 404);
-  return c.json({ user });
+    if (!user) return c.json({ error: "User not found" }, 404);
+    return c.json({ user });
+  } catch {
+    return c.json({ error: "Failed to fetch user" }, 500);
+  }
 });
 
 export default usersRoute;


### PR DESCRIPTION
🎯 What: Added try-catch blocks to GET /users/me and GET /users/:id to catch DB query failures and return a 500 error instead of crashing. 
📊 Coverage: Added tests to assert the endpoints return a 500 error with message 'Failed to fetch user' when db.select() throws an error. 
✨ Result: The application now gracefully handles database errors for these routes and unit tests ensure these failure conditions are protected from regressions.

---
*PR created automatically by Jules for task [14327272837788825013](https://jules.google.com/task/14327272837788825013) started by @is0692vs*

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

GET `/users/me` と GET `/users/:id` に try-catch ブロックを追加し、DB クエリ失敗時に 500 エラーを返すよう改善したPRです。対応するテストケースも2件追加されています。

- `GET /me` と `GET /:id` の DB 操作を try-catch でラップし、`{ "error": "Failed to fetch user" }` を返す 500 ハンドリングを実装。
- `updateMeHandler`（PATCH/PUT `/me`）と `/search` ルートの DB 操作は今回の変更対象外であり、DB エラー時は Hono のデフォルトエラーハンドラに処理が委ねられるため、JSON 形式でのエラーレスポンスが保証されない状態が残ります。
- catch ブロックでエラーオブジェクトが記録されないため、本番での障害調査が困難です。
</details>


<details open><summary><h3>Confidence Score: 3/5</h3></summary>

PATCH/PUT `/me` と `/search` の DB 操作が依然として未保護であり、エラー時に JSON ではなくテキスト形式の 500 が返る可能性があります。

GET 2ルートへのエラーハンドリング追加とテストは適切ですが、同じファイル内の `updateMeHandler` と `/search` ルートが保護されておらず、エラーレスポンスの形式が不揃いのままです。DB 障害発生時にこれらのルートは Hono のデフォルトハンドラに処理が落ち、API クライアントが期待する JSON エラーレスポンスが返りません。

`apps/api/src/routes/users.ts` の `updateMeHandler` および `/search` ルートに注目が必要です。
</details>


<details open><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| apps/api/src/routes/users.ts | GET /me と GET /:id に try-catch を追加してDBエラーを 500 で返すよう変更。ただし updateMeHandler と /search ルートの DB 操作は未保護のまま残っており、エラーハンドリングが不揃いです。 |
| apps/api/src/routes/__tests__/users.test.ts | GET /me と GET /:id のDB障害テストを2件追加。インデント整形も含む。新規テストのモック構造は実装のチェーン呼び出しと一致しており、適切に機能します。 |

</details>


<h3>Sequence Diagram</h3>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
sequenceDiagram
    participant Client
    participant Hono
    participant Handler
    participant DB

    Client->>Hono: GET /api/users/me
    Hono->>Handler: authMiddleware route handler
    Handler->>DB: db.select().from(users).where(...).get()
    alt DBエラー発生
        DB-->>Handler: throw Error
        Handler-->>Client: 500 Failed to fetch user
    else ユーザー未存在
        DB-->>Handler: null
        Handler-->>Client: 404 User not found
    else 正常
        DB-->>Handler: user record
        Handler-->>Client: 200 user
    end

    Client->>Hono: PATCH /api/users/me 未対応
    Hono->>Handler: updateMeHandler
    Handler->>DB: db.update / db.select
    alt DBエラー発生
        DB-->>Handler: throw Error
        Handler-->>Hono: unhandled rejection
        Hono-->>Client: 500 text 非JSON
    end
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
sequenceDiagram
    participant Client
    participant Hono
    participant Handler
    participant DB

    Client->>Hono: GET /api/users/me
    Hono->>Handler: authMiddleware route handler
    Handler->>DB: db.select().from(users).where(...).get()
    alt DBエラー発生
        DB-->>Handler: throw Error
        Handler-->>Client: 500 Failed to fetch user
    else ユーザー未存在
        DB-->>Handler: null
        Handler-->>Client: 404 User not found
    else 正常
        DB-->>Handler: user record
        Handler-->>Client: 200 user
    end

    Client->>Hono: PATCH /api/users/me 未対応
    Hono->>Handler: updateMeHandler
    Handler->>DB: db.update / db.select
    alt DBエラー発生
        DB-->>Handler: throw Error
        Handler-->>Hono: unhandled rejection
        Hono-->>Client: 500 text 非JSON
    end
```

</a>

<!-- greptile_failed_comments -->
<details open><summary><h3>Comments Outside Diff (2)</h3></summary>

1. `apps/api/src/routes/users.ts`, line 62-68 ([link](https://github.com/hiroki-org/openshelf/blob/744ffa0b23adfe48e9243cb57130082e36294580/apps/api/src/routes/users.ts#L62-L68)) 

   <a href="#"><img alt="P1" src="https://greptile-static-assets.s3.amazonaws.com/badges/p1.svg?v=9" align="top"></a> **`updateMeHandler` の DB 操作が try-catch でラップされていません**

   `db.update()` と直後の `db.select()` がどちらも素の `await` で呼ばれており、DB エラーが発生した場合は Hono のデフォルトエラーハンドラに処理が委ねられます。その場合はテキスト形式の `"Internal Server Error"` が返り、このファイル内の他エンドポイントと同様の JSON レスポンス (`{ "error": "..." }`) にはなりません。このPRでは GET ルートへの try-catch 追加を目的としていますが、同じファイル内の PATCH/PUT `/me` ハンドラが保護されていない状態です。

   <details><summary>Prompt To Fix With AI</summary>

   `````markdown
   This is a comment left during a code review.
   Path: apps/api/src/routes/users.ts
   Line: 62-68

   Comment:
   **`updateMeHandler` の DB 操作が try-catch でラップされていません**

   `db.update()` と直後の `db.select()` がどちらも素の `await` で呼ばれており、DB エラーが発生した場合は Hono のデフォルトエラーハンドラに処理が委ねられます。その場合はテキスト形式の `"Internal Server Error"` が返り、このファイル内の他エンドポイントと同様の JSON レスポンス (`{ "error": "..." }`) にはなりません。このPRでは GET ルートへの try-catch 追加を目的としていますが、同じファイル内の PATCH/PUT `/me` ハンドラが保護されていない状態です。

   How can I resolve this? If you propose a fix, please make it concise.
   `````
   </details>


2. `apps/api/src/routes/users.ts`, line 131-154 ([link](https://github.com/hiroki-org/openshelf/blob/744ffa0b23adfe48e9243cb57130082e36294580/apps/api/src/routes/users.ts#L131-L154)) 

   <a href="#"><img alt="P1" src="https://greptile-static-assets.s3.amazonaws.com/badges/p1.svg?v=9" align="top"></a> **`/search` ルートの DB クエリが try-catch で保護されていません**

   `db.select()...all()` が未ラップのまま `await` されているため、DB エラー時は Hono のデフォルトエラーハンドラが応答します。同一ファイルの GET `/me` および GET `/:id` は今回 try-catch が追加されましたが、`/search` は対象外となっており、エラーレスポンスの形式が不揃いになっています。DB 障害発生時は JSON ではなくテキスト形式の 500 が返ることになります。

   <details><summary>Prompt To Fix With AI</summary>

   `````markdown
   This is a comment left during a code review.
   Path: apps/api/src/routes/users.ts
   Line: 131-154

   Comment:
   **`/search` ルートの DB クエリが try-catch で保護されていません**

   `db.select()...all()` が未ラップのまま `await` されているため、DB エラー時は Hono のデフォルトエラーハンドラが応答します。同一ファイルの GET `/me` および GET `/:id` は今回 try-catch が追加されましたが、`/search` は対象外となっており、エラーレスポンスの形式が不揃いになっています。DB 障害発生時は JSON ではなくテキスト形式の 500 が返ることになります。

   How can I resolve this? If you propose a fix, please make it concise.
   `````
   </details>

</details>

<!-- /greptile_failed_comments -->

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 3 code review issues. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 3
apps/api/src/routes/users.ts:62-68
**`updateMeHandler` の DB 操作が try-catch でラップされていません**

`db.update()` と直後の `db.select()` がどちらも素の `await` で呼ばれており、DB エラーが発生した場合は Hono のデフォルトエラーハンドラに処理が委ねられます。その場合はテキスト形式の `"Internal Server Error"` が返り、このファイル内の他エンドポイントと同様の JSON レスポンス (`{ "error": "..." }`) にはなりません。このPRでは GET ルートへの try-catch 追加を目的としていますが、同じファイル内の PATCH/PUT `/me` ハンドラが保護されていない状態です。

### Issue 2 of 3
apps/api/src/routes/users.ts:131-154
**`/search` ルートの DB クエリが try-catch で保護されていません**

`db.select()...all()` が未ラップのまま `await` されているため、DB エラー時は Hono のデフォルトエラーハンドラが応答します。同一ファイルの GET `/me` および GET `/:id` は今回 try-catch が追加されましたが、`/search` は対象外となっており、エラーレスポンスの形式が不揃いになっています。DB 障害発生時は JSON ではなくテキスト形式の 500 が返ることになります。

### Issue 3 of 3
apps/api/src/routes/users.ts:23-25
**catch ブロックがエラーを完全に握り潰しています**

`catch {}` と書くとエラーオブジェクト自体が捨てられ、本番環境でのデバッグが困難になります。少なくともコンソールへのログ出力を追加することで、DB 障害の原因調査が容易になります。同様のパターンが `/:id` ルートの catch ブロックにも存在します。

```suggestion
  } catch (err) {
    console.error("Failed to fetch user (/me):", err);
    return c.json({ error: "Failed to fetch user" }, 500);
  }
});

const updateMeHandler = async (
```


`````

</details>

<sub>Reviews (1): Last reviewed commit: ["🧪 Add error tests for db failures in us..."](https://github.com/hiroki-org/openshelf/commit/744ffa0b23adfe48e9243cb57130082e36294580) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=40374048)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->