### PR TITLE
🎨 Palette: アクセシビリティとUXの改善 (Toast, Tag Autocomplete, PDF Viewer)

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -28,3 +28,12 @@
 ## 2026-06-20 - Collection Slug Validation Accessibility
 **Learning:** コレクションの slug のような動的にバリデーションされる入力フィールドにおいて、バリデーションステータスの `<p>` タグに `aria-live="polite"` を付与し、かつ `<input>` 要素に `aria-describedby` で関連付けることで、ユーザーが入力した際に非同期で変化する「確認中...」や「✓ 使用可能」などの状態がスクリーンリーダーに正しく読み上げられるようになり、アクセシビリティが向上します。
 **Action:** 今後、動的な入力バリデーション（可用性チェックなど）を実装・改善する際は、必ず入力フィールドに `aria-describedby` を付与し、ステータス表示の要素に `aria-live="polite"` を付与するパターンを適用します。
+
+## 2026-07-04 - ARIA role adjustment for Toasts and input ARIA roles, PDF Viewer ARIA label, Tag Autocomplete ARIA attributes.
+**Learning:**
+- Toastコンポーネントで `error` とそれ以外のメッセージで適切な `role` (`alert` か `status`) を出し分けることで、支援技術での読み上げがより正確かつ適切に行われるようになります。また、ラッパーとなるコンテナ要素には `aria-live="polite"` ではなく、個別のToastに `role` を割り当てるのがよりよい実装方法です。さらに、`Math.random()` によるID生成は予測可能かつ衝突する可能性があるため、`crypto.randomUUID()` のようなセキュアなID生成方法を使用することが望ましいです。
+- `<input>`でサジェストリストを出すコンポーネント（Tag Autocomplete）において、`role="combobox"`を設定することで、支援技術を使用するユーザーにとって、テキスト入力とリスト選択の両方が可能な入力要素であることをより明確に伝えられます。また、ローディング時のスピナーに `role="status"` を付与することで進行中のステータス変更が適切に読み上げられます。装飾的な要素（入力済みのチップリストなど）には `aria-hidden="true"` を追加して不必要な読み上げを避けるべきです。
+- PDF Viewerなどのコンポーネントにおいて、「前へ」「次へ」のようなボタンには `aria-label="前のページ"` や `aria-label="次のページ"` のようなより具体的なアクセシブル名をつけることで、アイコンだけでなく文字テキストのボタンでもコンテキストがより明確になります。
+
+**Action:**
+今後、動的な通知（Toast）、入力補助要素（Combobox）、ナビゲーションボタン（Paginationなど）を実装・改善する際は、これらのアクセシビリティのベストプラクティス（`role="alert|status"` の出し分け、`role="combobox"`、`aria-hidden="true"`、具体的な `aria-label`）を適用します。また、一意なID生成には常に `crypto.randomUUID()` を使用します。

--- a/apps/web/src/components/__tests__/pdf-viewer.test.tsx
+++ b/apps/web/src/components/__tests__/pdf-viewer.test.tsx
@@ -362,8 +362,8 @@ describe("PdfViewer", () => {
     fireEvent.click(screen.getByRole("button", { name: "ズームアウト" }));
     expect(zoomSelect.value).toBe("1.75");
 
-    fireEvent.click(screen.getByRole("button", { name: "次へ（次のページ）" }));
-    fireEvent.click(screen.getByRole("button", { name: "前へ（前のページ）" }));
+    fireEvent.click(screen.getByRole("button", { name: "次のページ" }));
+    fireEvent.click(screen.getByRole("button", { name: "前のページ" }));
     fireEvent.click(screen.getByRole("button", { name: "連続スクロール" }));
 
     // Mock requestFullscreen

--- a/apps/web/src/components/__tests__/pdf-viewer.test.tsx
+++ b/apps/web/src/components/__tests__/pdf-viewer.test.tsx
@@ -362,8 +362,8 @@ describe("PdfViewer", () => {
     fireEvent.click(screen.getByRole("button", { name: "ズームアウト" }));
     expect(zoomSelect.value).toBe("1.75");
 
-    fireEvent.click(screen.getByRole("button", { name: "次へ" }));
-    fireEvent.click(screen.getByRole("button", { name: "前へ" }));
+    fireEvent.click(screen.getByRole("button", { name: "次のページ" }));
+    fireEvent.click(screen.getByRole("button", { name: "前のページ" }));
     fireEvent.click(screen.getByRole("button", { name: "連続スクロール" }));
 
     // Mock requestFullscreen

--- a/apps/web/src/components/__tests__/pdf-viewer.test.tsx
+++ b/apps/web/src/components/__tests__/pdf-viewer.test.tsx
@@ -362,8 +362,8 @@ describe("PdfViewer", () => {
     fireEvent.click(screen.getByRole("button", { name: "ズームアウト" }));
     expect(zoomSelect.value).toBe("1.75");
 
-    fireEvent.click(screen.getByRole("button", { name: "次のページ" }));
-    fireEvent.click(screen.getByRole("button", { name: "前のページ" }));
+    fireEvent.click(screen.getByRole("button", { name: "次へ（次のページ）" }));
+    fireEvent.click(screen.getByRole("button", { name: "前へ（前のページ）" }));
     fireEvent.click(screen.getByRole("button", { name: "連続スクロール" }));
 
     // Mock requestFullscreen

--- a/apps/web/src/components/__tests__/tag-autocomplete-input.test.tsx
+++ b/apps/web/src/components/__tests__/tag-autocomplete-input.test.tsx
@@ -80,6 +80,7 @@ describe("TagAutocompleteInput", () => {
     );
 
     const input = screen.getByRole("combobox");
+    expect(input).toHaveAttribute("aria-haspopup", "listbox");
     fireEvent.focus(input);
     expect(
       await screen.findByRole("option", { name: "Machine Learning" }),

--- a/apps/web/src/components/__tests__/tag-autocomplete-input.test.tsx
+++ b/apps/web/src/components/__tests__/tag-autocomplete-input.test.tsx
@@ -79,8 +79,7 @@ describe("TagAutocompleteInput", () => {
       { timeout: 600 },
     );
 
-    const input = screen.getByRole("combobox");
-    expect(input).toHaveAttribute("aria-haspopup", "listbox");
+    const input = screen.getByRole("textbox");
     fireEvent.focus(input);
     expect(
       await screen.findByRole("option", { name: "Machine Learning" }),
@@ -94,7 +93,7 @@ describe("TagAutocompleteInput", () => {
     );
     await new Promise((resolve) => setTimeout(resolve, DEBOUNCE_WAIT_MS));
     expect(apiFetch).toHaveBeenCalledTimes(1);
-    fireEvent.focus(screen.getByRole("combobox"));
+    fireEvent.focus(screen.getByRole("textbox"));
     expect(
       screen.getByRole("option", { name: "Machine Learning" }),
     ).toBeInTheDocument();
@@ -111,7 +110,7 @@ describe("TagAutocompleteInput", () => {
       <TagAutocompleteInput id="paper-tags" value="Ma" onChange={vi.fn()} />,
     );
 
-    const input = screen.getByRole("combobox");
+    const input = screen.getByRole("textbox");
     expect(
       await screen.findByRole("option", { name: "Machine Learning" }),
     ).toBeInTheDocument();

--- a/apps/web/src/components/__tests__/tag-autocomplete-input.test.tsx
+++ b/apps/web/src/components/__tests__/tag-autocomplete-input.test.tsx
@@ -79,7 +79,8 @@ describe("TagAutocompleteInput", () => {
       { timeout: 600 },
     );
 
-    const input = screen.getByRole("textbox");
+    const input = screen.getByRole("combobox");
+    expect(input).toHaveAttribute("aria-haspopup", "listbox");
     fireEvent.focus(input);
     expect(
       await screen.findByRole("option", { name: "Machine Learning" }),
@@ -93,7 +94,7 @@ describe("TagAutocompleteInput", () => {
     );
     await new Promise((resolve) => setTimeout(resolve, DEBOUNCE_WAIT_MS));
     expect(apiFetch).toHaveBeenCalledTimes(1);
-    fireEvent.focus(screen.getByRole("textbox"));
+    fireEvent.focus(screen.getByRole("combobox"));
     expect(
       screen.getByRole("option", { name: "Machine Learning" }),
     ).toBeInTheDocument();
@@ -110,7 +111,7 @@ describe("TagAutocompleteInput", () => {
       <TagAutocompleteInput id="paper-tags" value="Ma" onChange={vi.fn()} />,
     );
 
-    const input = screen.getByRole("textbox");
+    const input = screen.getByRole("combobox");
     expect(
       await screen.findByRole("option", { name: "Machine Learning" }),
     ).toBeInTheDocument();

--- a/apps/web/src/components/__tests__/tag-autocomplete-input.test.tsx
+++ b/apps/web/src/components/__tests__/tag-autocomplete-input.test.tsx
@@ -79,7 +79,7 @@ describe("TagAutocompleteInput", () => {
       { timeout: 600 },
     );
 
-    const input = screen.getByRole("textbox");
+    const input = screen.getByRole("combobox");
     fireEvent.focus(input);
     expect(
       await screen.findByRole("option", { name: "Machine Learning" }),
@@ -93,7 +93,7 @@ describe("TagAutocompleteInput", () => {
     );
     await new Promise((resolve) => setTimeout(resolve, DEBOUNCE_WAIT_MS));
     expect(apiFetch).toHaveBeenCalledTimes(1);
-    fireEvent.focus(screen.getByRole("textbox"));
+    fireEvent.focus(screen.getByRole("combobox"));
     expect(
       screen.getByRole("option", { name: "Machine Learning" }),
     ).toBeInTheDocument();
@@ -110,7 +110,7 @@ describe("TagAutocompleteInput", () => {
       <TagAutocompleteInput id="paper-tags" value="Ma" onChange={vi.fn()} />,
     );
 
-    const input = screen.getByRole("textbox");
+    const input = screen.getByRole("combobox");
     expect(
       await screen.findByRole("option", { name: "Machine Learning" }),
     ).toBeInTheDocument();

--- a/apps/web/src/components/__tests__/toast.test.tsx
+++ b/apps/web/src/components/__tests__/toast.test.tsx
@@ -46,13 +46,13 @@ describe("toast", () => {
 
     const successToast = screen.getByText("saved");
     expect(successToast).toHaveAttribute("role", "status");
-    expect(successToast).not.toHaveAttribute("aria-live");
-    expect(successToast).not.toHaveAttribute("aria-atomic");
+    expect(successToast).toHaveAttribute("aria-live", "polite");
+    expect(successToast).toHaveAttribute("aria-atomic", "true");
 
     const errorToast = screen.getByText("failed");
     expect(errorToast).toHaveAttribute("role", "alert");
-    expect(errorToast).not.toHaveAttribute("aria-live");
-    expect(errorToast).not.toHaveAttribute("aria-atomic");
+    expect(errorToast).toHaveAttribute("aria-live", "assertive");
+    expect(errorToast).toHaveAttribute("aria-atomic", "true");
   });
 
   it("renders when crypto.randomUUID is unavailable", () => {

--- a/apps/web/src/components/__tests__/toast.test.tsx
+++ b/apps/web/src/components/__tests__/toast.test.tsx
@@ -41,7 +41,7 @@ describe("toast", () => {
     const { container } = render(<ToastContainer />);
     const toastWrapper = container.firstChild;
 
-    expect(toastWrapper).toHaveAttribute("aria-live", "polite");
+    expect(toastWrapper).not.toHaveAttribute("aria-live");
     expect(toastWrapper).not.toHaveAttribute("role", "status");
     expect(toastWrapper).not.toHaveAttribute("aria-atomic");
   });

--- a/apps/web/src/components/__tests__/toast.test.tsx
+++ b/apps/web/src/components/__tests__/toast.test.tsx
@@ -24,6 +24,9 @@ describe("toast", () => {
     expect(screen.getByText("saved")).toBeInTheDocument();
     expect(screen.getByText("failed")).toBeInTheDocument();
     expect(screen.getByText("fyi")).toBeInTheDocument();
+    expect(screen.getByText("saved")).toHaveAttribute("role", "status");
+    expect(screen.getByText("failed")).toHaveAttribute("role", "alert");
+    expect(screen.getByText("fyi")).toHaveAttribute("role", "status");
 
     act(() => {
       vi.advanceTimersByTime(5000);

--- a/apps/web/src/components/__tests__/toast.test.tsx
+++ b/apps/web/src/components/__tests__/toast.test.tsx
@@ -1,4 +1,4 @@
-import { act, render, screen } from "@testing-library/react";
+import { act, cleanup, render, screen } from "@testing-library/react";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { ToastContainer, toast } from "../toast";
 
@@ -9,7 +9,9 @@ describe("toast", () => {
 
   afterEach(() => {
     vi.runOnlyPendingTimers();
+    cleanup();
     vi.useRealTimers();
+    vi.unstubAllGlobals();
   });
 
   it("renders and auto-removes toast messages", () => {
@@ -42,15 +44,26 @@ describe("toast", () => {
       toast.error("failed");
     });
 
-    const successToast = screen.getAllByText("saved")[1];
+    const successToast = screen.getByText("saved");
     expect(successToast).toHaveAttribute("role", "status");
     expect(successToast).not.toHaveAttribute("aria-live");
     expect(successToast).not.toHaveAttribute("aria-atomic");
 
-    const errorToast = screen.getAllByText("failed")[1];
+    const errorToast = screen.getByText("failed");
     expect(errorToast).toHaveAttribute("role", "alert");
     expect(errorToast).not.toHaveAttribute("aria-live");
     expect(errorToast).not.toHaveAttribute("aria-atomic");
+  });
+
+  it("renders when crypto.randomUUID is unavailable", () => {
+    vi.stubGlobal("crypto", {});
+    render(<ToastContainer />);
+
+    act(() => {
+      toast.info("fallback id");
+    });
+
+    expect(screen.getByText("fallback id")).toHaveAttribute("role", "status");
   });
 
   it("removes listener on unmount", () => {

--- a/apps/web/src/components/__tests__/toast.test.tsx
+++ b/apps/web/src/components/__tests__/toast.test.tsx
@@ -24,9 +24,6 @@ describe("toast", () => {
     expect(screen.getByText("saved")).toBeInTheDocument();
     expect(screen.getByText("failed")).toBeInTheDocument();
     expect(screen.getByText("fyi")).toBeInTheDocument();
-    expect(screen.getByText("saved")).toHaveAttribute("role", "status");
-    expect(screen.getByText("failed")).toHaveAttribute("role", "alert");
-    expect(screen.getByText("fyi")).toHaveAttribute("role", "status");
 
     act(() => {
       vi.advanceTimersByTime(5000);
@@ -38,12 +35,22 @@ describe("toast", () => {
   });
 
   it("ToastContainer has correct accessibility attributes", () => {
-    const { container } = render(<ToastContainer />);
-    const toastWrapper = container.firstChild;
+    render(<ToastContainer />);
 
-    expect(toastWrapper).not.toHaveAttribute("aria-live");
-    expect(toastWrapper).not.toHaveAttribute("role", "status");
-    expect(toastWrapper).not.toHaveAttribute("aria-atomic");
+    act(() => {
+      toast.success("saved");
+      toast.error("failed");
+    });
+
+    const successToast = screen.getAllByText("saved")[1];
+    expect(successToast).toHaveAttribute("role", "status");
+    expect(successToast).not.toHaveAttribute("aria-live");
+    expect(successToast).not.toHaveAttribute("aria-atomic");
+
+    const errorToast = screen.getAllByText("failed")[1];
+    expect(errorToast).toHaveAttribute("role", "alert");
+    expect(errorToast).not.toHaveAttribute("aria-live");
+    expect(errorToast).not.toHaveAttribute("aria-atomic");
   });
 
   it("removes listener on unmount", () => {

--- a/apps/web/src/components/pdf-viewer.tsx
+++ b/apps/web/src/components/pdf-viewer.tsx
@@ -461,7 +461,7 @@ export function PdfViewer({ fileUrl, onDownloadFallback }: PdfViewerProps) {
         <div className="flex items-center gap-2">
           <button
             type="button"
-            aria-label="前へ（前のページ）"
+            aria-label="前のページ"
             onClick={() => goToPage(activePage - 1)}
             disabled={!canPrev}
             title={!canPrev ? "最初のページです" : undefined}
@@ -474,7 +474,7 @@ export function PdfViewer({ fileUrl, onDownloadFallback }: PdfViewerProps) {
           </span>
           <button
             type="button"
-            aria-label="次へ（次のページ）"
+            aria-label="次のページ"
             onClick={() => goToPage(activePage + 1)}
             disabled={!canNext}
             title={!canNext ? "最後のページです" : undefined}

--- a/apps/web/src/components/pdf-viewer.tsx
+++ b/apps/web/src/components/pdf-viewer.tsx
@@ -461,7 +461,7 @@ export function PdfViewer({ fileUrl, onDownloadFallback }: PdfViewerProps) {
         <div className="flex items-center gap-2">
           <button
             type="button"
-            aria-label="前のページ"
+            aria-label="前へ（前のページ）"
             onClick={() => goToPage(activePage - 1)}
             disabled={!canPrev}
             title={!canPrev ? "最初のページです" : undefined}
@@ -474,7 +474,7 @@ export function PdfViewer({ fileUrl, onDownloadFallback }: PdfViewerProps) {
           </span>
           <button
             type="button"
-            aria-label="次のページ"
+            aria-label="次へ（次のページ）"
             onClick={() => goToPage(activePage + 1)}
             disabled={!canNext}
             title={!canNext ? "最後のページです" : undefined}

--- a/apps/web/src/components/pdf-viewer.tsx
+++ b/apps/web/src/components/pdf-viewer.tsx
@@ -461,6 +461,7 @@ export function PdfViewer({ fileUrl, onDownloadFallback }: PdfViewerProps) {
         <div className="flex items-center gap-2">
           <button
             type="button"
+            aria-label="前のページ"
             onClick={() => goToPage(activePage - 1)}
             disabled={!canPrev}
             title={!canPrev ? "最初のページです" : undefined}
@@ -473,6 +474,7 @@ export function PdfViewer({ fileUrl, onDownloadFallback }: PdfViewerProps) {
           </span>
           <button
             type="button"
+            aria-label="次のページ"
             onClick={() => goToPage(activePage + 1)}
             disabled={!canNext}
             title={!canNext ? "最後のページです" : undefined}

--- a/apps/web/src/components/tag-autocomplete-input.tsx
+++ b/apps/web/src/components/tag-autocomplete-input.tsx
@@ -2,6 +2,7 @@
 
 import { apiFetch } from "@/lib/api";
 import { TAG_DELIMITER_PATTERN, splitTagInput } from "@/lib/tags";
+import { Spinner } from "@/components/spinner";
 import { useEffect, useMemo, useRef, useState } from "react";
 
 const DEBOUNCE_MS = 300;
@@ -143,6 +144,7 @@ export function TagAutocompleteInput({
       <input
         id={id}
         type="text"
+        role="combobox"
         value={value}
         onChange={(event) => onChange(event.target.value)}
         onFocus={() => {
@@ -226,7 +228,7 @@ export function TagAutocompleteInput({
       )}
 
       {displayChips.length > 0 && (
-        <div className="mt-2 flex flex-wrap gap-2">
+        <div className="mt-2 flex flex-wrap gap-2" aria-hidden="true">
           {displayChips.map((tag, index) => (
             <span
               key={`${tag}-${index}`}
@@ -239,9 +241,13 @@ export function TagAutocompleteInput({
       )}
 
       {loading && (
-        <p className="mt-1 text-xs text-gray-500 dark:text-gray-400">
-          候補を取得中...
-        </p>
+        <div
+          role="status"
+          className="mt-1 flex items-center gap-1 text-xs text-gray-500 dark:text-gray-400"
+        >
+          <Spinner className="h-3 w-3" />
+          <span>候補を取得中...</span>
+        </div>
       )}
     </div>
   );

--- a/apps/web/src/components/tag-autocomplete-input.tsx
+++ b/apps/web/src/components/tag-autocomplete-input.tsx
@@ -192,9 +192,11 @@ export function TagAutocompleteInput({
             applySuggestion(selectedSuggestion);
           }
         }}
+        role="combobox"
+        aria-haspopup="listbox"
         aria-autocomplete="list"
         aria-expanded={open}
-        aria-controls={listId}
+        aria-controls={open && suggestions.length > 0 ? listId : undefined}
         aria-activedescendant={activeDescendantId}
         className={className}
         placeholder={placeholder}

--- a/apps/web/src/components/tag-autocomplete-input.tsx
+++ b/apps/web/src/components/tag-autocomplete-input.tsx
@@ -145,6 +145,7 @@ export function TagAutocompleteInput({
         id={id}
         type="text"
         role="combobox"
+        aria-haspopup="listbox"
         value={value}
         onChange={(event) => onChange(event.target.value)}
         onFocus={() => {

--- a/apps/web/src/components/tag-autocomplete-input.tsx
+++ b/apps/web/src/components/tag-autocomplete-input.tsx
@@ -144,8 +144,6 @@ export function TagAutocompleteInput({
       <input
         id={id}
         type="text"
-        role="combobox"
-        aria-haspopup="listbox"
         value={value}
         onChange={(event) => onChange(event.target.value)}
         onFocus={() => {

--- a/apps/web/src/components/toast.tsx
+++ b/apps/web/src/components/toast.tsx
@@ -20,7 +20,7 @@ export const toast = {
 };
 
 function addToast(message: string, type: ToastType) {
-  const id = Math.random().toString(36).substring(2, 9);
+  const id = crypto.randomUUID();
   const newToast = { id, message, type };
   toasts = [...toasts, newToast];
   notify();

--- a/apps/web/src/components/toast.tsx
+++ b/apps/web/src/components/toast.tsx
@@ -57,7 +57,6 @@ export function ToastContainer() {
 
   return (
     <div
-      aria-live="polite"
       className="fixed bottom-4 right-4 z-50 flex flex-col gap-2 pointer-events-none"
     >
       {currentToasts.map((t) => (

--- a/apps/web/src/components/toast.tsx
+++ b/apps/web/src/components/toast.tsx
@@ -57,6 +57,7 @@ export function ToastContainer() {
 
   return (
     <div
+      aria-live="polite"
       className="fixed bottom-4 right-4 z-50 flex flex-col gap-2 pointer-events-none"
     >
       {currentToasts.map((t) => (
@@ -69,6 +70,8 @@ export function ToastContainer() {
                 ? "bg-red-600"
                 : "bg-blue-600"
           }`}
+          aria-atomic="true"
+          aria-live={t.type === "error" ? "assertive" : "polite"}
           role={t.type === "error" ? "alert" : "status"}
         >
           {t.message}

--- a/apps/web/src/components/toast.tsx
+++ b/apps/web/src/components/toast.tsx
@@ -48,10 +48,7 @@ export function ToastContainer() {
   }, []);
 
   return (
-    <div
-      aria-live="polite"
-      className="fixed bottom-4 right-4 z-50 flex flex-col gap-2 pointer-events-none"
-    >
+    <div className="fixed bottom-4 right-4 z-50 flex flex-col gap-2 pointer-events-none">
       {currentToasts.map((t) => (
         <div
           key={t.id}

--- a/apps/web/src/components/toast.tsx
+++ b/apps/web/src/components/toast.tsx
@@ -55,6 +55,7 @@ export function ToastContainer() {
       {currentToasts.map((t) => (
         <div
           key={t.id}
+          role={t.type === "error" ? "alert" : "status"}
           className={`px-4 py-2 rounded-md shadow-lg text-white text-sm transition-all animate-in fade-in slide-in-from-right-4 pointer-events-auto ${
             t.type === "success"
               ? "bg-green-600"

--- a/apps/web/src/components/toast.tsx
+++ b/apps/web/src/components/toast.tsx
@@ -48,11 +48,12 @@ export function ToastContainer() {
   }, []);
 
   return (
-    <div className="fixed bottom-4 right-4 z-50 flex flex-col gap-2 pointer-events-none">
+    <div
+      className="fixed bottom-4 right-4 z-50 flex flex-col gap-2 pointer-events-none"
+    >
       {currentToasts.map((t) => (
         <div
           key={t.id}
-          role={t.type === "error" ? "alert" : "status"}
           className={`px-4 py-2 rounded-md shadow-lg text-white text-sm transition-all animate-in fade-in slide-in-from-right-4 pointer-events-auto ${
             t.type === "success"
               ? "bg-green-600"
@@ -60,6 +61,7 @@ export function ToastContainer() {
                 ? "bg-red-600"
                 : "bg-blue-600"
           }`}
+          role={t.type === "error" ? "alert" : "status"}
         >
           {t.message}
         </div>

--- a/apps/web/src/components/toast.tsx
+++ b/apps/web/src/components/toast.tsx
@@ -12,6 +12,7 @@ interface Toast {
 
 let toastListeners: ((toasts: Toast[]) => void)[] = [];
 let toasts: Toast[] = [];
+let fallbackToastId = 0;
 
 export const toast = {
   success: (message: string) => addToast(message, "success"),
@@ -20,11 +21,18 @@ export const toast = {
 };
 
 function addToast(message: string, type: ToastType) {
-  const id = crypto.randomUUID();
+  const id = createToastId();
   const newToast = { id, message, type };
   toasts = [...toasts, newToast];
   notify();
   setTimeout(() => removeToast(id), 5000);
+}
+
+function createToastId() {
+  return (
+    globalThis.crypto?.randomUUID?.() ??
+    `toast-${Date.now()}-${fallbackToastId++}`
+  );
 }
 
 function removeToast(id: string) {


### PR DESCRIPTION
💡 What:
- Toastコンポーネントで、メッセージの種類に応じた適切な `role` (`alert` または `status`) を設定。ID生成を `crypto.randomUUID()` に変更。
- Tag Autocompleteコンポーネントで `<input>` に `role="combobox"` を設定し、ローディングスピナーに `role="status"`、装飾的な要素に `aria-hidden="true"` を追加。
- PDF Viewerコンポーネントのページ送りボタンに具体的な `aria-label` を追加。

🎯 Why:
- スクリーンリーダーなどの支援技術を利用するユーザーに、現在の状態やUIの役割をより正確に伝え、アクセシビリティを向上させるため。
- セキュリティのベストプラクティスに基づき、予測可能で衝突する可能性がある `Math.random()` の使用を排除するため。

📸 Before/After:
- **Before:** Toastコンポーネントに `role` がなく、コンテナレベルで `aria-live` に依存していた。Tag Autocomplete がテキスト入力フィールドとしてのみ認識され、PDF Viewer のページ送りボタンの用途が視覚的にしか示されていなかった。
- **After:** 各種ステータスが個別に適切な `role` でマークされ、入力要素の振る舞い（combobox）やボタンの意図（前のページ/次のページ）がスクリーンリーダーに正しく伝わるようになった。

♿ Accessibility:
- Toastへの適切な `role="alert|status"` の適用。
- `role="combobox"`、`role="status"`、`aria-hidden="true"` の追加によるタグ入力フィールドのアクセシビリティ向上。
- アイコン（テキスト）のみのページ送りボタンに対する `aria-label` の追加。

---
*PR created automatically by Jules for task [11966258403905686049](https://jules.google.com/task/11966258403905686049) started by @is0692vs*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Accessibility**
  * Improved screen reader support for toasts, loading states, tag input chips, and PDF navigation buttons.
  * Added clearer labels and roles so important UI elements are announced more consistently.

* **Bug Fixes**
  * Toasts now still generate usable IDs even when browser UUID support is unavailable.
  * Updated PDF navigation behavior in tests to match the full accessible button names.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

このPRはToast、Tag Autocomplete、PDF Viewerの3コンポーネントにアクセシビリティ改善を加え、スクリーンリーダー向けに適切なARIAロール・ラベルを設定します。また、`Math.random()`ベースのID生成を`crypto.randomUUID()`（フォールバック付き）に置き換えるセキュリティ改善も含まれています。

- **Toast**: コンテナの`aria-live`を削除し、各トーストに`role="alert|status"`を付与。`crypto.randomUUID()`が利用できない環境向けのフォールバックも実装。
- **Tag Autocomplete**: `<input>`に`role="combobox"`と`aria-haspopup="listbox"`を追加し、ローディングインジケータを`role="status"`付きのSpinnerに変更。タグチップ表示エリアに`aria-hidden="true"`を追加して重複読み上げを防止。
- **PDF Viewer**: ページ送りボタンに`aria-label="前へ（前のページ）"`および`aria-label="次へ（次のページ）"`を追加し、各テストも対応するボタン名に更新。
</details>


<details open><summary><h3>Confidence Score: 5/5</h3></summary>

アクセシビリティ属性の追加とID生成のセキュリティ改善のみを含む変更であり、マージして問題ありません。

変更はすべてARIA属性の追加・修正とID生成ロジックの改善に限定されており、既存の機能ロジックに手を加えていません。Spinnerは既に`aria-hidden="true"`を持ち、テストも適切に更新されています。`role="alert"`に対する`aria-live`の明示的な付与は冗長ですが機能上の問題はなく、`crypto.randomUUID()`のフォールバック実装も正確です。

特に注意が必要なファイルはありません。`toast.tsx`の冗長なARIA属性は動作に影響しません。
</details>


<details open><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| apps/web/src/components/toast.tsx | コンテナの`aria-live`を削除し、各トーストに`role`と`aria-live`を付与。`role="alert"`は`aria-live="assertive"`と`aria-atomic="true"`を暗黙的に持つため、明示的な付与は冗長。`crypto.randomUUID()`フォールバック実装は正しい。 |
| apps/web/src/components/tag-autocomplete-input.tsx | `role="combobox"`・`aria-haspopup="listbox"`の追加、チップへの`aria-hidden="true"`、ローディング状態の`role="status"`付与はすべてARIA仕様に準拠した正しい実装。Spinnerは既存で`aria-hidden="true"`済み。 |
| apps/web/src/components/pdf-viewer.tsx | ページ送りボタンに`aria-label`を追加。視覚ラベルとの一致はPrevious Threadsで既に議論済み。変更自体は単純で安全。 |
| apps/web/src/components/__tests__/toast.test.tsx | `cleanup()`・`vi.unstubAllGlobals()`をafterEachに追加し、テスト間の状態汚染を防止。`crypto`スタブテストとアクセシビリティ属性テストも適切に実装。 |
| apps/web/src/components/__tests__/tag-autocomplete-input.test.tsx | `getByRole("textbox")`を`getByRole("combobox")`に更新し、`aria-haspopup="listbox"`の確認も追加。変更に対応した妥当なテスト更新。 |
| apps/web/src/components/__tests__/pdf-viewer.test.tsx | ボタン名を新しい`aria-label`に合わせて更新。単純な文字列変更のみ。 |
| .Jules/palette.md | 今回のPRで得られたアクセシビリティ改善のナレッジをログに追記。ドキュメントのみの変更。 |

</details>


<h3>Flowchart</h3>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A["toast.success / error / info"] --> B["createToastId()"]
    B --> C{"crypto.randomUUID\n利用可能?"}
    C -->|"Yes"| D["crypto.randomUUID()"]
    C -->|"No"| E["toast-Date.now()-fallbackId"]
    D --> F["addToast → ToastContainer"]
    E --> F
    F --> H{"type === error?"}
    H -->|"Yes"| I["div role=alert\naria-live=assertive"]
    H -->|"No"| J["div role=status\naria-live=polite"]

    K["TagAutocompleteInput"] --> L["input role=combobox\naria-haspopup=listbox"]
    L --> M{"open && suggestions?"}
    M -->|"Yes"| N["ul role=listbox"]
    M -->|"No"| O["aria-controls=undefined"]
    K --> P{"loading?"}
    P -->|"Yes"| Q["div role=status + Spinner"]
    K --> R{"displayChips?"}
    R -->|"Yes"| S["div aria-hidden=true"]
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
flowchart TD
    A["toast.success / error / info"] --> B["createToastId()"]
    B --> C{"crypto.randomUUID\n利用可能?"}
    C -->|"Yes"| D["crypto.randomUUID()"]
    C -->|"No"| E["toast-Date.now()-fallbackId"]
    D --> F["addToast → ToastContainer"]
    E --> F
    F --> H{"type === error?"}
    H -->|"Yes"| I["div role=alert\naria-live=assertive"]
    H -->|"No"| J["div role=status\naria-live=polite"]

    K["TagAutocompleteInput"] --> L["input role=combobox\naria-haspopup=listbox"]
    L --> M{"open && suggestions?"}
    M -->|"Yes"| N["ul role=listbox"]
    M -->|"No"| O["aria-controls=undefined"]
    K --> P{"loading?"}
    P -->|"Yes"| Q["div role=status + Spinner"]
    K --> R{"displayChips?"}
    R -->|"Yes"| S["div aria-hidden=true"]
```

</a>

<!-- greptile_failed_comments -->
<details open><summary><h3>Comments Outside Diff (2)</h3></summary>

1. `apps/web/src/components/toast.tsx`, line 55-68 ([link](https://github.com/hiroki-org/openshelf/blob/52896d9c1dae841f21cdaba6db352aa381f28e37/apps/web/src/components/toast.tsx#L55-L68)) 

   <a href="#"><img alt="P1" src="https://greptile-static-assets.s3.amazonaws.com/badges/p1.svg?v=9" align="top"></a> **Toast に `role` が実装されていない**

   PRの説明では「`error` の場合は `role="alert"`、それ以外は `role="status"` を設定する」と記載されていますが、実際のコードでは個別のToastアイテム `<div>` に `role` 属性が追加されていません。現状ではコンテナの `aria-live="polite"` のみに依存しているため、エラートーストも「丁寧な（polite）」優先度でアナウンスされます。緊急のエラーは`role="alert"`（= `aria-live="assertive"` と同義）で即座に読み上げられるべきです。

   <details><summary>Prompt To Fix With AI</summary>

   `````markdown
   This is a comment left during a code review.
   Path: apps/web/src/components/toast.tsx
   Line: 55-68

   Comment:
   **Toast に `role` が実装されていない**

   PRの説明では「`error` の場合は `role="alert"`、それ以外は `role="status"` を設定する」と記載されていますが、実際のコードでは個別のToastアイテム `<div>` に `role` 属性が追加されていません。現状ではコンテナの `aria-live="polite"` のみに依存しているため、エラートーストも「丁寧な（polite）」優先度でアナウンスされます。緊急のエラーは`role="alert"`（= `aria-live="assertive"` と同義）で即座に読み上げられるべきです。

   How can I resolve this? If you propose a fix, please make it concise.
   `````
   </details>

2. `apps/web/src/components/toast.tsx`, line 58-80 ([link](https://github.com/hiroki-org/openshelf/blob/20ca6ebfa3fe61560a4d8855c4c44d3f6dd8a241/apps/web/src/components/toast.tsx#L58-L80)) 

   <a href="#"><img alt="P1" src="https://greptile-static-assets.s3.amazonaws.com/badges/p1.svg?v=9" align="top"></a> **aria-live のネスト: エラートーストが "polite" として読み上げられる可能性**

   外側コンテナに残っている `aria-live="polite"` と、個別トーストに追加された `aria-live` 属性がネストしている状態です。NVDA・JAWS・VoiceOver はネストした live region の扱いが異なり、特に JAWS では外側の `aria-live="polite"` が優先されてエラートーストが "assertive" ではなく "polite" の優先度で読み上げられる可能性があります。今回の変更の主目的（エラーを即座に読み上げる）が達成されないケースが生じます。

   外側 `<div>` の `aria-live="polite"` を削除することで解決できます。各トーストが自身の `role`（`alert` / `status`）と `aria-live` を持つようになったため、コンテナレベルの `aria-live` は不要です。

   <details><summary>Prompt To Fix With AI</summary>

   `````markdown
   This is a comment left during a code review.
   Path: apps/web/src/components/toast.tsx
   Line: 58-80

   Comment:
   **aria-live のネスト: エラートーストが "polite" として読み上げられる可能性**

   外側コンテナに残っている `aria-live="polite"` と、個別トーストに追加された `aria-live` 属性がネストしている状態です。NVDA・JAWS・VoiceOver はネストした live region の扱いが異なり、特に JAWS では外側の `aria-live="polite"` が優先されてエラートーストが "assertive" ではなく "polite" の優先度で読み上げられる可能性があります。今回の変更の主目的（エラーを即座に読み上げる）が達成されないケースが生じます。

   外側 `<div>` の `aria-live="polite"` を削除することで解決できます。各トーストが自身の `role`（`alert` / `status`）と `aria-live` を持つようになったため、コンテナレベルの `aria-live` は不要です。

   How can I resolve this? If you propose a fix, please make it concise.
   `````
   </details>
</details>

<!-- /greptile_failed_comments -->

<sub>Reviews (12): Last reviewed commit: ["fix: avoid nested toast live regions"](https://github.com/hiroki-org/openshelf/commit/08d5fc484b53fd6631da7a6d29047f5c7081e847) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=41813371)</sub>

<!-- /greptile_comment -->