### PR TITLE
🎨 Palette: PDF Viewerのボタンにaria-labelを追加

### DIFF
--- a/apps/web/src/components/__tests__/pdf-viewer.test.tsx
+++ b/apps/web/src/components/__tests__/pdf-viewer.test.tsx
@@ -284,7 +284,7 @@ describe("PdfViewer", () => {
       expect(screen.getByText("1 / 2")).toBeInTheDocument();
     });
 
-    fireEvent.click(screen.getByRole("button", { name: "次の一致" }));
+    fireEvent.click(screen.getByRole("button", { name: /次の一致/ }));
 
     await waitFor(() => {
       expect(screen.getByText("2 / 2")).toBeInTheDocument();
@@ -294,13 +294,13 @@ describe("PdfViewer", () => {
       expect(renderedPages).toContain(3);
     });
 
-    fireEvent.click(screen.getByRole("button", { name: "前の一致" }));
+    fireEvent.click(screen.getByRole("button", { name: /前の一致/ }));
 
     await waitFor(() => {
       expect(screen.getByText("1 / 2")).toBeInTheDocument();
     });
 
-    fireEvent.click(screen.getByRole("button", { name: "次の一致" }));
+    fireEvent.click(screen.getByRole("button", { name: /次の一致/ }));
     await waitFor(() => {
       expect(screen.getByText("2 / 2")).toBeInTheDocument();
     });
@@ -362,14 +362,14 @@ describe("PdfViewer", () => {
     fireEvent.click(screen.getByRole("button", { name: "ズームアウト" }));
     expect(zoomSelect.value).toBe("1.75");
 
-    fireEvent.click(screen.getByRole("button", { name: "次へ" }));
-    fireEvent.click(screen.getByRole("button", { name: "前へ" }));
+    fireEvent.click(screen.getByRole("button", { name: /次へ/ }));
+    fireEvent.click(screen.getByRole("button", { name: /前へ/ }));
     fireEvent.click(screen.getByRole("button", { name: "連続スクロール" }));
 
     // Mock requestFullscreen
     const container = screen.getByTestId("pdf-viewer-surface");
     container.requestFullscreen = vi.fn().mockResolvedValue(undefined);
-    fireEvent.click(screen.getByRole("button", { name: "全画面" }));
+    fireEvent.click(screen.getByRole("button", { name: /全画面/ }));
     expect(container.requestFullscreen).toHaveBeenCalled();
   });
 

--- a/apps/web/src/components/pdf-viewer.tsx
+++ b/apps/web/src/components/pdf-viewer.tsx
@@ -465,6 +465,7 @@ export function PdfViewer({ fileUrl, onDownloadFallback }: PdfViewerProps) {
             disabled={!canPrev}
             title={!canPrev ? "最初のページです" : undefined}
             className="rounded border border-gray-300 px-2 py-1 text-xs disabled:cursor-not-allowed disabled:opacity-50 dark:border-gray-600"
+            aria-label="前へ: 前のページへ"
           >
             前へ
           </button>
@@ -477,6 +478,7 @@ export function PdfViewer({ fileUrl, onDownloadFallback }: PdfViewerProps) {
             disabled={!canNext}
             title={!canNext ? "最後のページです" : undefined}
             className="rounded border border-gray-300 px-2 py-1 text-xs disabled:cursor-not-allowed disabled:opacity-50 dark:border-gray-600"
+            aria-label="次へ: 次のページへ"
           >
             次へ
           </button>
@@ -530,6 +532,7 @@ export function PdfViewer({ fileUrl, onDownloadFallback }: PdfViewerProps) {
             type="button"
             onClick={toggleFullScreen}
             className="rounded bg-gray-800 px-2 py-1 text-xs text-white hover:bg-gray-700 dark:bg-gray-200 dark:text-gray-900"
+            aria-label="全画面: 全画面表示の切り替え"
           >
             全画面
           </button>
@@ -563,6 +566,7 @@ export function PdfViewer({ fileUrl, onDownloadFallback }: PdfViewerProps) {
             searchMatches.length === 0 ? "検索結果がありません" : undefined
           }
           className="rounded border border-gray-300 px-2 py-1 text-xs disabled:cursor-not-allowed disabled:opacity-50 dark:border-gray-600"
+          aria-label="前の一致: 前の検索結果へ"
         >
           前の一致
         </button>
@@ -574,6 +578,7 @@ export function PdfViewer({ fileUrl, onDownloadFallback }: PdfViewerProps) {
             searchMatches.length === 0 ? "検索結果がありません" : undefined
           }
           className="rounded border border-gray-300 px-2 py-1 text-xs disabled:cursor-not-allowed disabled:opacity-50 dark:border-gray-600"
+          aria-label="次の一致: 次の検索結果へ"
         >
           次の一致
         </button>


### PR DESCRIPTION
💡 What: PDF Viewerの操作ボタン（前へ、次へ、全画面、前/次の一致）に `aria-label` を追加しました。
🎯 Why: ボタンのテキストだけでは文脈が不足する場合があり、スクリーンリーダーユーザーにとって操作の目的をより明確にするためです。また、WCAG 2.5.3 (Label in Name) に準拠するため、表示されているテキストを `aria-label` に含めました。
📸 Before/After: （視覚的な変更はありません）
♿ Accessibility: 複数のインタラクティブ要素に、具体的なアクションを説明するアクセシブルな名前を提供し、元の表示テキストを保持して Label in Name の要件を満たすようにしました。

---
*PR created automatically by Jules for task [9528104584926909990](https://jules.google.com/task/9528104584926909990) started by @is0692vs*

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

このPRはPDF Viewerの操作ボタン5つ（前へ・次へ・全画面・前の一致・次の一致）に `aria-label` を追加し、WCAG 2.5.3（Label in Name）に準拠させるアクセシビリティ改善です。対応するテストも `aria-label` の変更に合わせてボタン取得をregexパターンに更新しています。

- `pdf-viewer.tsx`: 5つのボタンに `aria-label` を追加。いずれも表示テキストを先頭に含む形式（例: `\"前へ: 前のページへ\"`）で、WCAG 2.5.3の要件を満たしている。
- `pdf-viewer.test.tsx`: 変更後のアクセシブルネームに合わせ、`{ name: \"...\" }` の完全一致から `{ name: /.../ }` のregex部分一致に変更。
</details>


<details open><summary><h3>Confidence Score: 4/5</h3></summary>

視覚的変更のないアクセシビリティ改善のみで、既存機能への影響はありません。

全画面ボタンはトグル操作にもかかわらず aria-pressed が設定されておらず、スクリーンリーダーが現在の状態を読み上げられません。他の4つのボタンは正しく実装されており、テストの更新も適切です。

apps/web/src/components/pdf-viewer.tsx の全画面ボタン周辺（aria-pressed の追加が望ましい）
</details>


<details open><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| apps/web/src/components/pdf-viewer.tsx | 5つのボタンにaria-labelを追加。WCAG 2.5.3準拠の実装で概ね問題なし。全画面ボタンはトグルだがaria-pressedがなく、現在の状態（全画面中かどうか）をスクリーンリーダーに伝えられていない点が改善余地あり。 |
| apps/web/src/components/__tests__/pdf-viewer.test.tsx | aria-label追加に伴いボタン取得をregex部分一致に変更。意図通りの対応で問題なし。 |

</details>


<!-- greptile_failed_comments -->
<details open><summary><h3>Comments Outside Diff (1)</h3></summary>

1. `apps/web/src/components/pdf-viewer.tsx`, line 531-538 ([link](https://github.com/hiroki-org/openshelf/blob/43380b94cab9fa794bd3db58e8ee747d40fad30c/apps/web/src/components/pdf-viewer.tsx#L531-L538)) 

   <a href="#"><img alt="P2" src="https://greptile-static-assets.s3.amazonaws.com/badges/p2.svg?v=9" align="top"></a> 「全画面」ボタンはトグル動作ですが、`aria-pressed` が設定されていないため、スクリーンリーダーが現在の状態（全画面中かどうか）を伝えることができません。WCAG 4.1.2 に準拠するには、`aria-pressed` を使って状態を明示し、ラベルも状態に応じて切り替えることが推奨されます。

   

   <details><summary>Prompt To Fix With AI</summary>

   `````markdown
   This is a comment left during a code review.
   Path: apps/web/src/components/pdf-viewer.tsx
   Line: 531-538

   Comment:
   「全画面」ボタンはトグル動作ですが、`aria-pressed` が設定されていないため、スクリーンリーダーが現在の状態（全画面中かどうか）を伝えることができません。WCAG 4.1.2 に準拠するには、`aria-pressed` を使って状態を明示し、ラベルも状態に応じて切り替えることが推奨されます。

   

   How can I resolve this? If you propose a fix, please make it concise.
   `````
   </details>

   Note: If this suggestion doesn't match your team's coding style, reply to this and let me know. I'll remember it for next time!

</details>

<!-- /greptile_failed_comments -->

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 1 code review issue. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 1
apps/web/src/components/pdf-viewer.tsx:531-538
「全画面」ボタンはトグル動作ですが、`aria-pressed` が設定されていないため、スクリーンリーダーが現在の状態（全画面中かどうか）を伝えることができません。WCAG 4.1.2 に準拠するには、`aria-pressed` を使って状態を明示し、ラベルも状態に応じて切り替えることが推奨されます。

```suggestion
          <button
            type="button"
            onClick={toggleFullScreen}
            aria-pressed={!!document.fullscreenElement}
            className="rounded bg-gray-800 px-2 py-1 text-xs text-white hover:bg-gray-700 dark:bg-gray-200 dark:text-gray-900"
            aria-label={document.fullscreenElement ? "全画面: 全画面表示を終了" : "全画面: 全画面表示を開始"}
          >
            全画面
          </button>
```


`````

</details>

<sub>Reviews (1): Last reviewed commit: ["feat: PDF Viewerのボタンにaria-labelを追加してアクセシ..."](https://github.com/hiroki-org/openshelf/commit/43380b94cab9fa794bd3db58e8ee747d40fad30c) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=41916243)</sub>

<!-- /greptile_comment -->