### PR TITLE
🧹 Code Health: Simplify CiteButton component

### DIFF
--- a/apps/web/src/app/papers/[id]/cite-button.tsx
+++ b/apps/web/src/app/papers/[id]/cite-button.tsx
@@ -21,11 +21,8 @@ type CiteButtonProps = {
   paperId: string;
 };
 
-export function CiteButton({ paperId }: CiteButtonProps) {
+function useDropdown() {
   const [open, setOpen] = useState(false);
-  const [loadingFormat, setLoadingFormat] = useState<CitationFormat | null>(
-    null,
-  );
   const containerRef = useRef<HTMLDivElement | null>(null);
 
   useEffect(() => {
@@ -55,6 +52,14 @@ export function CiteButton({ paperId }: CiteButtonProps) {
       document.removeEventListener("keydown", handleEscape);
     };
   }, [open]);
+
+  return { open, setOpen, containerRef };
+}
+
+function useCitationCopy(paperId: string, setOpen: (open: boolean) => void) {
+  const [loadingFormat, setLoadingFormat] = useState<CitationFormat | null>(
+    null,
+  );
 
   const handleCopy = async (format: CitationFormat) => {
     setLoadingFormat(format);
@@ -89,6 +94,13 @@ export function CiteButton({ paperId }: CiteButtonProps) {
       setLoadingFormat(null);
     }
   };
+
+  return { loadingFormat, handleCopy };
+}
+
+export function CiteButton({ paperId }: CiteButtonProps) {
+  const { open, setOpen, containerRef } = useDropdown();
+  const { loadingFormat, handleCopy } = useCitationCopy(paperId, setOpen);
 
   return (
     <div className="mb-6 relative inline-block" ref={containerRef}>


### PR DESCRIPTION
🎯 **What:** Extracted the click-outside/escape-key dropdown logic and the API/clipboard citation handling logic into custom hooks (`useDropdown` and `useCitationCopy`) within `apps/web/src/app/papers/[id]/cite-button.tsx`.

💡 **Why:** The original `CiteButton` function was moderately long and contained mixed concerns. Extracting these distinct behaviors into sub-components (hooks) significantly simplifies the main component, improving the maintainability and readability of the code without changing functionality.

✅ **Verification:** Verified that tests pass properly by running `pnpm --filter web run test`. Additionally, `pnpm run typecheck` and lint/format checks complete successfully.

✨ **Result:** The `CiteButton` component is now much shorter, simpler to understand, and well-organized according to React best practices for separating logic and presentation.

---
*PR created automatically by Jules for task [8462173886684370426](https://jules.google.com/task/8462173886684370426) started by @is0692vs*

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

このPRは `CiteButton` コンポーネントから2つのカスタムフック（`useDropdown` と `useCitationCopy`）を抽出するリファクタリングです。クリック外・Escapeキーのドロップダウン制御ロジックと、API呼び出し・クリップボードコピーのロジックを分離することで、コンポーネントの可読性と保守性が向上します。

- `useDropdown`：ドロップダウンの開閉状態、クリック外検知（`pointerdown`）、Escapeキーハンドリングを管理し、`open`・`setOpen`・`containerRef` を返す
- `useCitationCopy`：引用フォーマットのAPI取得とクリップボードへのコピー処理を管理し、`loadingFormat`・`handleCopy` を返す。`paperId` と `setOpen` を引数として受け取る設計
</details>


<details open><summary><h3>Confidence Score: 4/5</h3></summary>

機能変更のない純粋なリファクタリングであり、マージしても安全。

カスタムフックへの抽出は適切で、イベントリスナーのクリーンアップも維持されている。handleCopyがuseCallbackでメモ化されていない点は軽微なスタイル上の改善余地として残る。

apps/web/src/app/papers/[id]/cite-button.tsx — useCallbackの使用とインポートの追加を検討
</details>


<details open><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| apps/web/src/app/papers/[id]/cite-button.tsx | CiteButtonコンポーネントをuseDropdownとuseCitationCopyの2つのカスタムフックに分割するリファクタリング。ロジックの分離は明確で、イベントリスナーのクリーンアップも正しく実装されている。handleCopyがuseCallbackでメモ化されていない点は軽微な改善余地。 |

</details>


<!-- greptile_failed_comments -->
<details open><summary><h3>Comments Outside Diff (1)</h3></summary>

1. `apps/web/src/app/papers/[id]/cite-button.tsx`, line 7 ([link](https://github.com/hiroki-org/openshelf/blob/221f974d5d339ce5372f4ac078ae067c988c05b8/apps/web/src/app/papers/[id]/cite-button.tsx#L7)) 

   <a href="#"><img alt="P2" src="https://greptile-static-assets.s3.amazonaws.com/badges/p2.svg?v=9" align="top"></a> `useCallback` を使用する場合、`import` への追加が必要です。また、`useCitationCopy` フックの型シグネチャにおいて、`setOpen` の型が `(open: boolean) => void` と定義されていますが、React の `Dispatch<SetStateAction<boolean>>` と完全に一致させることで型安全性が向上します。

   

   <details><summary>Prompt To Fix With AI</summary>

   `````markdown
   This is a comment left during a code review.
   Path: apps/web/src/app/papers/[id]/cite-button.tsx
   Line: 7

   Comment:
   `useCallback` を使用する場合、`import` への追加が必要です。また、`useCitationCopy` フックの型シグネチャにおいて、`setOpen` の型が `(open: boolean) => void` と定義されていますが、React の `Dispatch<SetStateAction<boolean>>` と完全に一致させることで型安全性が向上します。

   

   How can I resolve this? If you propose a fix, please make it concise.
   `````
   </details>

   Note: If this suggestion doesn't match your team's coding style, reply to this and let me know. I'll remember it for next time!

</details>

<!-- /greptile_failed_comments -->

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 2 code review issues. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 2
apps/web/src/app/papers/[id]/cite-button.tsx:64-96
`handleCopy` が `useCallback` でメモ化されていません。現在の実装では `CiteButton` が再レンダリングされるたびに `handleCopy` が新しい関数として生成されます。`paperId` や `setOpen` が変わらない限り不要な再生成が発生するため、`useCallback` でラップすることを検討してください。

```suggestion
  const handleCopy = useCallback(async (format: CitationFormat) => {
    setLoadingFormat(format);
    try {
      const res = await apiFetch(
        `/api/papers/${safePath(paperId)}/cite?format=${format}`,
      );
      if (!res.ok) {
        toast.error("引用の生成に失敗しました");
        return;
      }
      const data = (await res.json()) as { citation?: string };
      if (!data.citation) {
        toast.error("引用の生成に失敗しました");
        return;
      }
      if (!navigator.clipboard?.writeText) {
        toast.error("このブラウザではクリップボード機能を利用できません");
        return;
      }
      try {
        await navigator.clipboard.writeText(data.citation);
      } catch {
        toast.error("クリップボードへのコピーに失敗しました");
        return;
      }
      toast.success("コピーしました");
      setOpen(false);
    } catch {
      toast.error("引用の生成に失敗しました");
    } finally {
      setLoadingFormat(null);
    }
  }, [paperId, setOpen]);
```

### Issue 2 of 2
apps/web/src/app/papers/[id]/cite-button.tsx:7
`useCallback` を使用する場合、`import` への追加が必要です。また、`useCitationCopy` フックの型シグネチャにおいて、`setOpen` の型が `(open: boolean) => void` と定義されていますが、React の `Dispatch<SetStateAction<boolean>>` と完全に一致させることで型安全性が向上します。

```suggestion
import { useCallback, useEffect, useRef, useState } from "react";
```


`````

</details>

<sub>Reviews (1): Last reviewed commit: ["Refactor CiteButton to extract useDropdo..."](https://github.com/hiroki-org/openshelf/commit/221f974d5d339ce5372f4ac078ae067c988c05b8) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=42336885)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->