### PR TITLE
🧹 [コード健全性の向上: TagAutocompleteInputの複雑さ解消]

### DIFF
--- a/apps/web/src/components/tag-autocomplete-input.tsx
+++ b/apps/web/src/components/tag-autocomplete-input.tsx
@@ -34,28 +34,13 @@ function splitEditingState(value: string): {
   return { committed, currentRaw, currentTrimmed: currentRaw.trim() };
 }
 
-export function TagAutocompleteInput({
-  id,
-  value,
-  onChange,
-  placeholder,
-  orgSlug,
-  className,
-}: TagAutocompleteInputProps) {
+function useTagSuggestions(currentTrimmed: string, orgSlug?: string) {
   const [suggestions, setSuggestions] = useState<string[]>([]);
   const [highlightedIndex, setHighlightedIndex] = useState(-1);
   const [open, setOpen] = useState(false);
   const [loading, setLoading] = useState(false);
   const cacheRef = useRef(new Map<string, string[]>());
-  const blurTimeoutRef = useRef<number | null>(null);
   const requestIdRef = useRef(0);
-
-  const { committed, currentTrimmed } = useMemo(
-    () => splitEditingState(value),
-    [value],
-  );
-
-  const displayChips = useMemo(() => splitTagInput(value), [value]);
 
   useEffect(() => {
     const requestId = ++requestIdRef.current;
@@ -116,6 +101,42 @@ export function TagAutocompleteInput({
 
     return () => clearTimeout(timer);
   }, [currentTrimmed, orgSlug]);
+
+  return {
+    suggestions,
+    highlightedIndex,
+    setHighlightedIndex,
+    open,
+    setOpen,
+    loading,
+  };
+}
+
+export function TagAutocompleteInput({
+  id,
+  value,
+  onChange,
+  placeholder,
+  orgSlug,
+  className,
+}: TagAutocompleteInputProps) {
+  const { committed, currentTrimmed } = useMemo(
+    () => splitEditingState(value),
+    [value],
+  );
+
+  const displayChips = useMemo(() => splitTagInput(value), [value]);
+
+  const {
+    suggestions,
+    highlightedIndex,
+    setHighlightedIndex,
+    open,
+    setOpen,
+    loading,
+  } = useTagSuggestions(currentTrimmed, orgSlug);
+
+  const blurTimeoutRef = useRef<number | null>(null);
 
   useEffect(() => {
     return () => {


### PR DESCRIPTION
🎯 **What:** `TagAutocompleteInput` コンポーネント内で直接管理されていたタグの候補取得ロジック（API呼び出し、キャッシュ、デバウンス処理）と状態管理を `useTagSuggestions` カスタムフックとして抽出しました。
💡 **Why:** `TagAutocompleteInput` はAPI通信の副作用とUIの描画処理が混在し、コンポーネントが肥大化していました。これらを分離することで、コードの可読性および保守性が大きく向上します。
✅ **Verification:** 既存の `tag-autocomplete-input.test.tsx` テストスイートがすべて通過すること、および Lint と型チェックでエラーが出ないことを確認しました。
✨ **Result:** UI描画と状態管理ロジックが分離され、コンポーネントの見通しが良くなり健全性が向上しました。機能上の変更はありません。

---
*PR created automatically by Jules for task [3659860090936893121](https://jules.google.com/task/3659860090936893121) started by @is0692vs*

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

このPRは `TagAutocompleteInput` コンポーネントからAPIリクエスト・デバウンス・キャッシュロジックを `useTagSuggestions` カスタムフックに抽出するリファクタリングです。機能的な変更はなく、コンポーネントのUIロジックとデータ取得ロジックを明確に分離しています。

- `useTagSuggestions(currentTrimmed, orgSlug)` フックが `suggestions`・`highlightedIndex`・`open`・`loading` の各状態とそのセッターを返す形に切り出されており、`requestIdRef` による競合状態防止とキャッシュ機構もフック内に適切に封じ込められている。
- `blurTimeoutRef` はコンポーネント固有のUI操作（ブラー遅延）のためフック外に残されており、責任分担は妥当。
</details>

<details open><summary><h3>Confidence Score: 5/5</h3></summary>

純粋なリファクタリングであり、機能変更・ロジック変更はない。安全にマージ可能。

デバウンス・キャッシュ・競合状態防止（requestIdRef）のロジックはすべてフック内で正しく維持されており、コンポーネント側の状態参照・更新経路も変更前と等価。blurTimeoutRef の配置もコンポーネント内に正しく残されている。

特に注意が必要なファイルはない。
</details>

<details open><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| apps/web/src/components/tag-autocomplete-input.tsx | APIフェッチ・デバウンス・キャッシュロジックを useTagSuggestions フックへ抽出。機能的な変更なし。requestIdRef・cacheRef の管理もフック内で正しく維持されている。 |

</details>

<sub>Reviews (1): Last reviewed commit: ["Refactor TagAutocompleteInput to extract..."](https://github.com/hiroki-org/openshelf/commit/14df2c44d6dff9f5df614c2f6016cdc3642af88e) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=42337834)</sub>

<!-- /greptile_comment -->