### PR TITLE
🧹 Simplify BadgeSnippet component

### DIFF
--- a/apps/web/src/app/papers/[id]/__tests__/badge-snippet.test.tsx
+++ b/apps/web/src/app/papers/[id]/__tests__/badge-snippet.test.tsx
@@ -99,6 +99,54 @@ describe("BadgeSnippet", () => {
     });
   });
 
+  it("shows error toast if clipboard is not supported", async () => {
+    vi.stubGlobal("navigator", {});
+    render(
+      <BadgeSnippet
+        paperId="paper-1"
+        title="Paper Title"
+        siteBase="https://openshelf.example"
+      />,
+    );
+
+    const markdownPanel = screen.getByText("Markdown").closest("div");
+    fireEvent.click(
+      markdownPanel!.querySelector("button") as HTMLButtonElement,
+    );
+
+    await waitFor(() => {
+      expect(toastError).toHaveBeenCalledWith(
+        "このブラウザではクリップボード機能を利用できません",
+      );
+    });
+  });
+
+  it("shows error toast if clipboard copy fails", async () => {
+    vi.stubGlobal("navigator", {
+      clipboard: {
+        writeText: vi.fn().mockRejectedValue(new Error("Failed")),
+      },
+    });
+    render(
+      <BadgeSnippet
+        paperId="paper-1"
+        title="Paper Title"
+        siteBase="https://openshelf.example"
+      />,
+    );
+
+    const markdownPanel = screen.getByText("Markdown").closest("div");
+    fireEvent.click(
+      markdownPanel!.querySelector("button") as HTMLButtonElement,
+    );
+
+    await waitFor(() => {
+      expect(toastError).toHaveBeenCalledWith(
+        "クリップボードへのコピーに失敗しました",
+      );
+    });
+  });
+
   it("escapes title content in HTML snippet", () => {
     render(
       <BadgeSnippet

--- a/apps/web/src/app/papers/[id]/badge-snippet.tsx
+++ b/apps/web/src/app/papers/[id]/badge-snippet.tsx
@@ -46,6 +46,41 @@ function sanitizeUrl(url: string): string {
   }
 }
 
+function SnippetBlock({ snippet }: { snippet: SnippetItem }) {
+  const copySnippet = async (value: string) => {
+    if (!navigator.clipboard?.writeText) {
+      toast.error("このブラウザではクリップボード機能を利用できません");
+      return;
+    }
+
+    try {
+      await navigator.clipboard.writeText(value);
+      toast.success("コピーしました");
+    } catch {
+      toast.error("クリップボードへのコピーに失敗しました");
+    }
+  };
+
+  return (
+    <div className="rounded-md border border-gray-200 dark:border-gray-700">
+      <div className="flex items-center justify-between border-b border-gray-200 px-3 py-2 text-xs text-gray-500 dark:border-gray-700 dark:text-gray-300">
+        <span>{snippet.label}</span>
+        <button
+          type="button"
+          aria-label={`Copy ${snippet.label}`}
+          className="rounded bg-blue-600 px-2 py-1 text-white hover:bg-blue-500"
+          onClick={() => copySnippet(snippet.value)}
+        >
+          Copy
+        </button>
+      </div>
+      <pre className="overflow-x-auto p-3 text-xs text-gray-700 dark:text-gray-200">
+        <code>{snippet.value}</code>
+      </pre>
+    </div>
+  );
+}
+
 export function BadgeSnippet({ paperId, title, siteBase }: BadgeSnippetProps) {
   const { snippets, badgePreviewUrl } = useMemo(() => {
     const normalizedSiteBase =
@@ -90,20 +125,6 @@ export function BadgeSnippet({ paperId, title, siteBase }: BadgeSnippetProps) {
     return { snippets: items, badgePreviewUrl: badgeSvgUrl };
   }, [paperId, title, siteBase]);
 
-  const copySnippet = async (value: string) => {
-    if (!navigator.clipboard?.writeText) {
-      toast.error("このブラウザではクリップボード機能を利用できません");
-      return;
-    }
-
-    try {
-      await navigator.clipboard.writeText(value);
-      toast.success("コピーしました");
-    } catch {
-      toast.error("クリップボードへのコピーに失敗しました");
-    }
-  };
-
   return (
     <section className="mb-6 rounded-xl border border-gray-200 p-4 dark:border-gray-700">
       <h2 className="mb-3 text-sm font-medium text-gray-500 dark:text-gray-300">
@@ -123,25 +144,7 @@ export function BadgeSnippet({ paperId, title, siteBase }: BadgeSnippetProps) {
 
       <div className="space-y-3">
         {snippets.map((snippet) => (
-          <div
-            key={snippet.key}
-            className="rounded-md border border-gray-200 dark:border-gray-700"
-          >
-            <div className="flex items-center justify-between border-b border-gray-200 px-3 py-2 text-xs text-gray-500 dark:border-gray-700 dark:text-gray-300">
-              <span>{snippet.label}</span>
-              <button
-                type="button"
-                aria-label={`Copy ${snippet.label}`}
-                className="rounded bg-blue-600 px-2 py-1 text-white hover:bg-blue-500"
-                onClick={() => copySnippet(snippet.value)}
-              >
-                Copy
-              </button>
-            </div>
-            <pre className="overflow-x-auto p-3 text-xs text-gray-700 dark:text-gray-200">
-              <code>{snippet.value}</code>
-            </pre>
-          </div>
+          <SnippetBlock key={snippet.key} snippet={snippet} />
         ))}
       </div>
     </section>


### PR DESCRIPTION
🎯 **What:** Extracted the repetitive snippet rendering and copying logic from `BadgeSnippet` into a new `SnippetBlock` sub-component.
💡 **Why:** Reduces the overall length and complexity of `BadgeSnippet`, making it easier to read and maintain. The copy logic is now localized to the snippet block itself.
✅ **Verification:** Verified that all existing unit tests in `badge-snippet.test.tsx` pass successfully, and full tests/linting pass.
✨ **Result:** The `BadgeSnippet` function is now much cleaner and easier to understand, achieving better code health without altering functionality.

---
*PR created automatically by Jules for task [8199441400934808229](https://jules.google.com/task/8199441400934808229) started by @is0692vs*

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

`BadgeSnippet` コンポーネント内で繰り返し記述されていたスニペット表示・コピーロジックを `SnippetBlock` サブコンポーネントへ抽出するリファクタリングです。機能的な変更はなく、既存のユニットテストもすべて通過しています。

- **`SnippetBlock` の抽出**: スニペットのレンダリング・コピー処理を専用サブコンポーネントに移動し、`BadgeSnippet` の本体を大幅にスリム化。
- **`key` プロップの移動**: `<div key={snippet.key}>` から `<SnippetBlock key={snippet.key}>` へ移行し、React のリスト管理の観点でも正しい位置に配置。
- **コピーロジックの局所化**: `copySnippet` が各スニペットブロックに閉じた形になり、関心の分離が向上。
</details>

<details open><summary><h3>Confidence Score: 5/5</h3></summary>

コピーロジックとUIを `SnippetBlock` へ抽出した純粋なリファクタリングで、既存の動作は完全に維持されています。

`copySnippet` 関数のロジック・エラーハンドリングは元の実装と同一で、表示構造も変わっていません。`key` プロップの位置も正しく、既存テストが通過していることからリグレッションのリスクは非常に低いです。

特に注意が必要なファイルはありません。変更は `badge-snippet.tsx` 1ファイルのみで、影響範囲は限定的です。
</details>

<details open><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| apps/web/src/app/papers/[id]/badge-snippet.tsx | `BadgeSnippet` から `SnippetBlock` サブコンポーネントへの抽出。コピーロジックと表示ロジックが局所化され、機能的な変更なし。微細なスタイル上の改善余地あり（`copySnippet` の不要なパラメータ）。 |

</details>

<h3>Flowchart</h3>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[BadgeSnippet] --> B[useMemo: スニペット生成]
    B --> C[snippets配列\nmarkdown / html / shields]
    A --> D[badges プレビュー表示]
    C --> E{snippets.map}
    E --> F[SnippetBlock\nkey=snippet.key]
    F --> G[スニペットラベル表示]
    F --> H[Copyボタン]
    H --> I{copySnippet}
    I -->|成功| J[toast.success]
    I -->|clipboard未対応| K[toast.error]
    I -->|例外| L[toast.error]
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
flowchart TD
    A[BadgeSnippet] --> B[useMemo: スニペット生成]
    B --> C[snippets配列\nmarkdown / html / shields]
    A --> D[badges プレビュー表示]
    C --> E{snippets.map}
    E --> F[SnippetBlock\nkey=snippet.key]
    F --> G[スニペットラベル表示]
    F --> H[Copyボタン]
    H --> I{copySnippet}
    I -->|成功| J[toast.success]
    I -->|clipboard未対応| K[toast.error]
    I -->|例外| L[toast.error]
```

</a>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 1 code review issue. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 1
apps/web/src/app/papers/[id]/badge-snippet.tsx:50-73
`copySnippet` は `value` パラメータを受け取っていますが、`snippet` はすでにクロージャでアクセス可能です。パラメータをなくすことで `onClick` のラッパーアロー関数も省略でき、よりシンプルになります。

```suggestion
  const copySnippet = async () => {
    if (!navigator.clipboard?.writeText) {
      toast.error("このブラウザではクリップボード機能を利用できません");
      return;
    }

    try {
      await navigator.clipboard.writeText(snippet.value);
      toast.success("コピーしました");
    } catch {
      toast.error("クリップボードへのコピーに失敗しました");
    }
  };

  return (
    <div className="rounded-md border border-gray-200 dark:border-gray-700">
      <div className="flex items-center justify-between border-b border-gray-200 px-3 py-2 text-xs text-gray-500 dark:border-gray-700 dark:text-gray-300">
        <span>{snippet.label}</span>
        <button
          type="button"
          aria-label={`Copy ${snippet.label}`}
          className="rounded bg-blue-600 px-2 py-1 text-white hover:bg-blue-500"
          onClick={copySnippet}
        >
```

`````

</details>

<sub>Reviews (1): Last reviewed commit: ["refactor: simplify BadgeSnippet componen..."](https://github.com/hiroki-org/openshelf/commit/09776c3ec313dc5543a6da5d536479cc52590137) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=42337852)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->