### PR TITLE
🧹 [code health improvement] Simplify InvitesPage by extracting InviteItem component

### DIFF
--- a/apps/web/src/app/invites/invite-item.tsx
+++ b/apps/web/src/app/invites/invite-item.tsx
@@ -1,0 +1,90 @@
+import Link from "next/link";
+import { getInviteStatusBadge } from "@/lib/presentation";
+import { Spinner } from "@/components/spinner";
+import { ReceivedInvite, InviteAction } from "./types";
+
+export function InviteItem({
+  inv,
+  processingAction,
+  respond,
+}: {
+  inv: ReceivedInvite;
+  processingAction: InviteAction | undefined;
+  respond: (inviteId: string, action: InviteAction) => Promise<void>;
+}) {
+  const isProcessing = processingAction !== undefined;
+  return (
+    <li
+      key={inv.id}
+      className="rounded-2xl border border-gray-200 bg-white p-5 shadow-sm dark:border-gray-800 dark:bg-gray-950"
+    >
+      <div className="flex flex-col gap-4 sm:flex-row sm:items-center sm:justify-between">
+        <div className="min-w-0 flex-1">
+          <div className="flex flex-wrap items-center gap-2">
+            {(() => {
+              const badge = getInviteStatusBadge(inv.status);
+              return (
+                <span
+                  className={`inline-flex items-center rounded-full px-2.5 py-1 text-xs font-medium ${badge.className}`}
+                >
+                  {badge.label}
+                </span>
+              );
+            })()}
+          </div>
+
+          <Link
+            href={`/papers/${inv.paperId}`}
+            className="mt-3 block text-base font-semibold text-gray-950 transition-colors hover:text-gray-700 hover:underline dark:text-gray-50 dark:hover:text-gray-200"
+          >
+            {inv.paperTitle}
+          </Link>
+          <p className="mt-2 text-sm text-gray-600 dark:text-gray-400">
+            {inv.inviterName} からの招待
+          </p>
+        </div>
+
+        {inv.status === "pending" ? (
+          <div className="flex shrink-0 gap-2">
+            <button
+              type="button"
+              onClick={() => respond(inv.id, "accept")}
+              disabled={isProcessing}
+              aria-busy={processingAction === "accept"}
+              className="inline-flex min-w-[72px] items-center justify-center gap-2 rounded-xl bg-gray-900 px-4 py-2 text-sm font-medium text-white transition-colors hover:bg-gray-700 disabled:opacity-50 dark:bg-white dark:text-gray-900 dark:hover:bg-gray-200"
+            >
+              {processingAction === "accept" && <Spinner className="h-4 w-4" />}
+              <span
+                className={
+                  processingAction === "accept" ? "sr-only" : undefined
+                }
+              >
+                承認
+              </span>
+            </button>
+            <button
+              type="button"
+              onClick={() => respond(inv.id, "decline")}
+              disabled={isProcessing}
+              aria-busy={processingAction === "decline"}
+              className="inline-flex min-w-[72px] items-center justify-center gap-2 rounded-xl border border-gray-300 px-4 py-2 text-sm font-medium text-gray-700 transition-colors hover:bg-gray-50 disabled:opacity-50 dark:border-gray-700 dark:text-gray-200 dark:hover:bg-gray-900"
+            >
+              {processingAction === "decline" && (
+                <Spinner className="h-4 w-4" />
+              )}
+              <span
+                className={
+                  processingAction === "decline" ? "sr-only" : undefined
+                }
+              >
+                拒否
+              </span>
+            </button>
+          </div>
+        ) : (
+          <div className="shrink-0 text-xs text-gray-400">対応済み</div>
+        )}
+      </div>
+    </li>
+  );
+}

--- a/apps/web/src/app/invites/page.tsx
+++ b/apps/web/src/app/invites/page.tsx
@@ -5,21 +5,10 @@ import { apiFetch } from "@/lib/api";
 import { useEffect, useState } from "react";
 import { useRouter } from "next/navigation";
 import Link from "next/link";
-import { getInviteStatusBadge } from "@/lib/presentation";
-import { Spinner } from "@/components/spinner";
 import { toast } from "@/components/toast";
 
-type ReceivedInvite = {
-  id: string;
-  paperId: string;
-  paperTitle: string;
-  inviterId: string;
-  inviterName: string;
-  status: string;
-  createdAt: string;
-};
-
-type InviteAction = "accept" | "decline";
+import { InviteItem } from "./invite-item";
+import { ReceivedInvite, InviteAction } from "./types";
 
 export default function InvitesPage() {
   const { user, loading } = useAuth();
@@ -158,89 +147,14 @@ export default function InvitesPage() {
         <ul className="space-y-4">
           {invites.map((inv) => {
             const processingAction = processingById.get(inv.id);
-            const isProcessing = processingAction !== undefined;
 
             return (
-              <li
+              <InviteItem
                 key={inv.id}
-                className="rounded-2xl border border-gray-200 bg-white p-5 shadow-sm dark:border-gray-800 dark:bg-gray-950"
-              >
-                <div className="flex flex-col gap-4 sm:flex-row sm:items-center sm:justify-between">
-                  <div className="min-w-0 flex-1">
-                    <div className="flex flex-wrap items-center gap-2">
-                      {(() => {
-                        const badge = getInviteStatusBadge(inv.status);
-                        return (
-                          <span
-                            className={`inline-flex items-center rounded-full px-2.5 py-1 text-xs font-medium ${badge.className}`}
-                          >
-                            {badge.label}
-                          </span>
-                        );
-                      })()}
-                    </div>
-
-                    <Link
-                      href={`/papers/${inv.paperId}`}
-                      className="mt-3 block text-base font-semibold text-gray-950 transition-colors hover:text-gray-700 hover:underline dark:text-gray-50 dark:hover:text-gray-200"
-                    >
-                      {inv.paperTitle}
-                    </Link>
-                    <p className="mt-2 text-sm text-gray-600 dark:text-gray-400">
-                      {inv.inviterName} からの招待
-                    </p>
-                  </div>
-
-                  {inv.status === "pending" ? (
-                    <div className="flex shrink-0 gap-2">
-                      <button
-                        type="button"
-                        onClick={() => respond(inv.id, "accept")}
-                        disabled={isProcessing}
-                        aria-busy={processingAction === "accept"}
-                        className="inline-flex min-w-[72px] items-center justify-center gap-2 rounded-xl bg-gray-900 px-4 py-2 text-sm font-medium text-white transition-colors hover:bg-gray-700 disabled:opacity-50 dark:bg-white dark:text-gray-900 dark:hover:bg-gray-200"
-                      >
-                        {processingAction === "accept" && (
-                          <Spinner className="h-4 w-4" />
-                        )}
-                        <span
-                          className={
-                            processingAction === "accept"
-                              ? "sr-only"
-                              : undefined
-                          }
-                        >
-                          承認
-                        </span>
-                      </button>
-                      <button
-                        type="button"
-                        onClick={() => respond(inv.id, "decline")}
-                        disabled={isProcessing}
-                        aria-busy={processingAction === "decline"}
-                        className="inline-flex min-w-[72px] items-center justify-center gap-2 rounded-xl border border-gray-300 px-4 py-2 text-sm font-medium text-gray-700 transition-colors hover:bg-gray-50 disabled:opacity-50 dark:border-gray-700 dark:text-gray-200 dark:hover:bg-gray-900"
-                      >
-                        {processingAction === "decline" && (
-                          <Spinner className="h-4 w-4" />
-                        )}
-                        <span
-                          className={
-                            processingAction === "decline"
-                              ? "sr-only"
-                              : undefined
-                          }
-                        >
-                          拒否
-                        </span>
-                      </button>
-                    </div>
-                  ) : (
-                    <div className="shrink-0 text-xs text-gray-400">
-                      対応済み
-                    </div>
-                  )}
-                </div>
-              </li>
+                inv={inv}
+                processingAction={processingAction}
+                respond={respond}
+              />
             );
           })}
         </ul>

--- a/apps/web/src/app/invites/types.ts
+++ b/apps/web/src/app/invites/types.ts
@@ -1,0 +1,11 @@
+export type ReceivedInvite = {
+  id: string;
+  paperId: string;
+  paperTitle: string;
+  inviterId: string;
+  inviterName: string;
+  status: string;
+  createdAt: string;
+};
+
+export type InviteAction = "accept" | "decline";


### PR DESCRIPTION
🎯 **What:** Extracted the complex invite rendering logic from `InvitesPage` into a separate `InviteItem` component and separated types to `types.ts`.
💡 **Why:** `InvitesPage` was moderately long (~250 lines) due to inline rendering of invite items. Extracting this improves readability and maintainability by separating concerns.
✅ **Verification:** Verified that linting, formatting, type checking, and tests pass, and the component behavior is exactly the same.
✨ **Result:** A simplified `InvitesPage` and a reusable `InviteItem` component.

---
*PR created automatically by Jules for task [14429583402701629162](https://jules.google.com/task/14429583402701629162) started by @is0692vs*

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

招待アイテムの描画ロジックを `InvitesPage` から `InviteItem` コンポーネントとして分離し、型定義を `types.ts` に切り出したリファクタリング PR です。ロジックや UI の変更はなく、コードの可読性・保守性の向上を目的としています。

- **`invite-item.tsx`**: 招待一覧の各行（ステータスバッジ・論文リンク・承認/拒否ボタン）を担う新コンポーネントを追加。
- **`types.ts`**: `ReceivedInvite` と `InviteAction` の型定義を独立ファイルに移動し、両コンポーネントから共有できるよう整理。
- **`page.tsx`**: `InviteItem` を利用することで描画ロジックを削減し、約 90 行スリム化。
</details>

<details open><summary><h3>Confidence Score: 4/5</h3></summary>

機能変更のない純粋なリファクタリングであり、マージして問題ありません。

ロジックはすべて元の実装と等価に保たれており、型定義の共有化も正しく行われています。コンポーネント内部の <li> に残った不要な key プロパティは小さな改善点ですが、動作に影響しません。

invite-item.tsx の <li key={inv.id}> を確認してください。
</details>

<details open><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| apps/web/src/app/invites/invite-item.tsx | InvitesPage から招待アイテムの描画ロジックを抽出した新しいコンポーネント。機能的には完全に同等だが、<li> 要素に不要な key プロパティが残っている。 |
| apps/web/src/app/invites/page.tsx | InviteItem コンポーネントと types.ts の利用によりリファクタリング済み。ロジックはすべて保持されており問題なし。 |
| apps/web/src/app/invites/types.ts | ReceivedInvite と InviteAction の型定義を page.tsx から分離した新ファイル。内容に変更なし。 |

</details>

<h3>Flowchart</h3>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[InvitesPage\npage.tsx] -->|invites.map| B[InviteItem\ninvite-item.tsx]
    A -->|import types| C[types.ts\nReceivedInvite\nInviteAction]
    B -->|import types| C
    B -->|status === pending| D{ボタン表示}
    D -->|accept / decline| E[respond\nPATCH /api/invites/:id]
    D -->|対応済み| F[テキスト表示]
    E -->|成功| G[setInvites\nステータス更新]
    E -->|失敗| H[toast.error]
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
flowchart TD
    A[InvitesPage\npage.tsx] -->|invites.map| B[InviteItem\ninvite-item.tsx]
    A -->|import types| C[types.ts\nReceivedInvite\nInviteAction]
    B -->|import types| C
    B -->|status === pending| D{ボタン表示}
    D -->|accept / decline| E[respond\nPATCH /api/invites/:id]
    D -->|対応済み| F[テキスト表示]
    E -->|成功| G[setInvites\nステータス更新]
    E -->|失敗| H[toast.error]
```

</a>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 1 code review issue. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 1
apps/web/src/app/invites/invite-item.tsx:17-20
`<li>` 要素に設定されている `key={inv.id}` は不要です。React の `key` プロパティはリスト内で要素を識別するためにものであり、親コンポーネントの `map()` 呼び出し側（`page.tsx` の `<InviteItem key={inv.id} .../>`）で指定するものです。コンポーネント内部の JSX 要素に `key` を直接設定しても React に無視されます。

```suggestion
    <li
      className="rounded-2xl border border-gray-200 bg-white p-5 shadow-sm dark:border-gray-800 dark:bg-gray-950"
    >
```

`````

</details>

<sub>Reviews (1): Last reviewed commit: ["Refactor InvitesPage to extract InviteIt..."](https://github.com/hiroki-org/openshelf/commit/ffae8b4dbc66eba820ead9cbd617453dfa67d0df) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=42339129)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->