### PR TITLE
🛡️ Sentinel: [High] Fix missing authentication on state-changing route

### DIFF
--- a/apps/api/src/routes/__tests__/papers.test.ts
+++ b/apps/api/src/routes/__tests__/papers.test.ts
@@ -730,7 +730,9 @@ describe("papers routes", () => {
         values: vi.fn().mockRejectedValue(dbError),
       }));
 
-    const mockDeleteWhere = vi.fn().mockRejectedValue(new Error("DB cleanup failed"));
+    const mockDeleteWhere = vi
+      .fn()
+      .mockRejectedValue(new Error("DB cleanup failed"));
     mockDb.delete = vi.fn(() => ({ where: mockDeleteWhere }));
 
     const app = await createTestApp();
@@ -1347,6 +1349,7 @@ describe("papers routes", () => {
   });
 
   it("POST /api/papers/:id/track accepts view event", async () => {
+    const token = await createTestJWT({ sub: "user-1" });
     const dedupRun = vi.fn(async () => ({ meta: { changes: 1 } }));
     const dailyRun = vi.fn(async () => ({ meta: { changes: 1 } }));
     const totalRun = vi.fn(async () => ({ meta: { changes: 1 } }));
@@ -1382,6 +1385,7 @@ describe("papers routes", () => {
       {
         method: "POST",
         headers: {
+          Authorization: `Bearer ${token}`,
           "Content-Type": "application/json",
           Origin: "http://localhost:3000",
           "User-Agent": "Vitest",
@@ -1402,6 +1406,7 @@ describe("papers routes", () => {
   });
 
   it("POST /api/papers/:id/track requires a tracking hash secret", async () => {
+    const token = await createTestJWT({ sub: "user-1" });
     mockDb.select = vi
       .fn()
       .mockImplementationOnce(() =>
@@ -1418,6 +1423,7 @@ describe("papers routes", () => {
       {
         method: "POST",
         headers: {
+          Authorization: `Bearer ${token}`,
           "Content-Type": "application/json",
           Origin: "http://localhost:3000",
           "User-Agent": "Vitest",
@@ -1432,6 +1438,7 @@ describe("papers routes", () => {
   });
 
   it("POST /api/papers/:id/track ignores bots", async () => {
+    const token = await createTestJWT({ sub: "user-1" });
     mockDb.select = vi
       .fn()
       .mockImplementationOnce(() =>
@@ -1445,6 +1452,7 @@ describe("papers routes", () => {
       {
         method: "POST",
         headers: {
+          Authorization: `Bearer ${token}`,
           "Content-Type": "application/json",
           Origin: "http://localhost:3000",
           "User-Agent": "googlebot",
@@ -1459,6 +1467,7 @@ describe("papers routes", () => {
   });
 
   it("POST /api/papers/:id/track logs sanitized error on failure (Error instance)", async () => {
+    const token = await createTestJWT({ sub: "user-1" });
     mockDb.select = vi
       .fn()
       .mockImplementationOnce(() =>
@@ -1481,6 +1490,7 @@ describe("papers routes", () => {
       {
         method: "POST",
         headers: {
+          Authorization: `Bearer ${token}`,
           "Content-Type": "application/json",
           Origin: "http://localhost:3000",
           "User-Agent": "Vitest",
@@ -1504,6 +1514,7 @@ describe("papers routes", () => {
   });
 
   it("POST /api/papers/:id/track logs sanitized error on failure (string error)", async () => {
+    const token = await createTestJWT({ sub: "user-1" });
     mockDb.select = vi
       .fn()
       .mockImplementationOnce(() =>
@@ -1524,6 +1535,7 @@ describe("papers routes", () => {
       {
         method: "POST",
         headers: {
+          Authorization: `Bearer ${token}`,
           "Content-Type": "application/json",
           Origin: "http://localhost:3000",
           "User-Agent": "Vitest",
@@ -1547,6 +1559,7 @@ describe("papers routes", () => {
   });
 
   it("POST /api/papers/:id/track handles duplicate dedup rows", async () => {
+    const token = await createTestJWT({ sub: "user-1" });
     const dedupRun = vi.fn(async () => ({ meta: { changes: 0 } }));
     const dailyRun = vi.fn(async () => ({ meta: { changes: 0 } }));
     const totalRun = vi.fn(async () => ({ meta: { changes: 0 } }));
@@ -1581,6 +1594,7 @@ describe("papers routes", () => {
       {
         method: "POST",
         headers: {
+          Authorization: `Bearer ${token}`,
           "Content-Type": "application/json",
           Origin: "http://localhost:3000",
           "User-Agent": "Vitest",
@@ -1632,6 +1646,7 @@ describe("papers routes", () => {
   });
 
   it("POST /api/papers/:id/track returns 404 when paper does not exist", async () => {
+    const token = await createTestJWT({ sub: "user-1" });
     mockDb.select = vi
       .fn()
       .mockImplementationOnce(() => makeQuery({ getResult: null }));
@@ -1643,6 +1658,7 @@ describe("papers routes", () => {
       {
         method: "POST",
         headers: {
+          Authorization: `Bearer ${token}`,
           "Content-Type": "application/json",
           Origin: "http://localhost:3000",
           "User-Agent": "Vitest",
@@ -2390,13 +2406,11 @@ describe("papers routes", () => {
     });
     const set = vi.fn().mockReturnThis();
     const where = vi.fn().mockReturnThis();
-    mockDb.select = vi
-      .fn()
-      .mockImplementation(() =>
-        makeQuery({
-          getResult: { paperId: "paper-1", userId: "user-1", role: "uploader" },
-        }),
-      );
+    mockDb.select = vi.fn().mockImplementation(() =>
+      makeQuery({
+        getResult: { paperId: "paper-1", userId: "user-1", role: "uploader" },
+      }),
+    );
     mockDb.update = vi.fn().mockImplementation(() => ({ set, where }) as any);
 
     const app = await createTestApp();
@@ -2440,13 +2454,11 @@ describe("papers routes", () => {
       githubId: "123",
       name: "Uploader",
     });
-    mockDb.select = vi
-      .fn()
-      .mockImplementation(() =>
-        makeQuery({
-          getResult: { paperId: "paper-1", userId: "user-1", role: "uploader" },
-        }),
-      );
+    mockDb.select = vi.fn().mockImplementation(() =>
+      makeQuery({
+        getResult: { paperId: "paper-1", userId: "user-1", role: "uploader" },
+      }),
+    );
 
     const app = await createTestApp();
     const env = createTestEnv();
@@ -2600,13 +2612,11 @@ describe("papers routes", () => {
     });
     const set = vi.fn().mockReturnThis();
     const where = vi.fn().mockReturnThis();
-    mockDb.select = vi
-      .fn()
-      .mockImplementation(() =>
-        makeQuery({
-          getResult: { paperId: "paper-1", userId: "user-1", role: "uploader" },
-        }),
-      );
+    mockDb.select = vi.fn().mockImplementation(() =>
+      makeQuery({
+        getResult: { paperId: "paper-1", userId: "user-1", role: "uploader" },
+      }),
+    );
     mockDb.update = vi.fn().mockImplementation(() => ({ set, where }) as any);
 
     const app = await createTestApp();
@@ -2652,13 +2662,11 @@ describe("papers routes", () => {
     });
     const set = vi.fn().mockReturnThis();
     const where = vi.fn().mockReturnThis();
-    mockDb.select = vi
-      .fn()
-      .mockImplementation(() =>
-        makeQuery({
-          getResult: { paperId: "paper-1", userId: "user-1", role: "uploader" },
-        }),
-      );
+    mockDb.select = vi.fn().mockImplementation(() =>
+      makeQuery({
+        getResult: { paperId: "paper-1", userId: "user-1", role: "uploader" },
+      }),
+    );
     mockDb.update = vi.fn().mockImplementation(() => ({ set, where }) as any);
 
     const app = await createTestApp();
@@ -2694,13 +2702,11 @@ describe("papers routes", () => {
     });
     const set = vi.fn().mockReturnThis();
     const where = vi.fn().mockReturnThis();
-    mockDb.select = vi
-      .fn()
-      .mockImplementation(() =>
-        makeQuery({
-          getResult: { paperId: "paper-1", userId: "user-1", role: "uploader" },
-        }),
-      );
+    mockDb.select = vi.fn().mockImplementation(() =>
+      makeQuery({
+        getResult: { paperId: "paper-1", userId: "user-1", role: "uploader" },
+      }),
+    );
     mockDb.update = vi.fn().mockImplementation(() => ({ set, where }) as any);
 
     const app = await createTestApp();
@@ -2734,13 +2740,11 @@ describe("papers routes", () => {
       githubId: "123",
       name: "Uploader",
     });
-    mockDb.select = vi
-      .fn()
-      .mockImplementation(() =>
-        makeQuery({
-          getResult: { paperId: "paper-1", userId: "user-1", role: "uploader" },
-        }),
-      );
+    mockDb.select = vi.fn().mockImplementation(() =>
+      makeQuery({
+        getResult: { paperId: "paper-1", userId: "user-1", role: "uploader" },
+      }),
+    );
 
     const app = await createTestApp();
     const env = createTestEnv();
@@ -2770,13 +2774,11 @@ describe("papers routes", () => {
     });
     const set = vi.fn().mockReturnThis();
     const where = vi.fn().mockReturnThis();
-    mockDb.select = vi
-      .fn()
-      .mockImplementation(() =>
-        makeQuery({
-          getResult: { paperId: "paper-1", userId: "user-1", role: "uploader" },
-        }),
-      );
+    mockDb.select = vi.fn().mockImplementation(() =>
+      makeQuery({
+        getResult: { paperId: "paper-1", userId: "user-1", role: "uploader" },
+      }),
+    );
     mockDb.update = vi.fn().mockImplementation(() => ({ set, where }) as any);
 
     const app = await createTestApp();
@@ -2812,13 +2814,11 @@ describe("papers routes", () => {
     });
     const set = vi.fn().mockReturnThis();
     const where = vi.fn().mockReturnThis();
-    mockDb.select = vi
-      .fn()
-      .mockImplementation(() =>
-        makeQuery({
-          getResult: { paperId: "paper-1", userId: "user-1", role: "uploader" },
-        }),
-      );
+    mockDb.select = vi.fn().mockImplementation(() =>
+      makeQuery({
+        getResult: { paperId: "paper-1", userId: "user-1", role: "uploader" },
+      }),
+    );
     mockDb.update = vi.fn().mockImplementation(() => ({ set, where }) as any);
 
     const app = await createTestApp();
@@ -2856,13 +2856,11 @@ describe("papers routes", () => {
     });
     const set = vi.fn().mockReturnThis();
     const where = vi.fn().mockReturnThis();
-    mockDb.select = vi
-      .fn()
-      .mockImplementation(() =>
-        makeQuery({
-          getResult: { paperId: "paper-1", userId: "user-1", role: "uploader" },
-        }),
-      );
+    mockDb.select = vi.fn().mockImplementation(() =>
+      makeQuery({
+        getResult: { paperId: "paper-1", userId: "user-1", role: "uploader" },
+      }),
+    );
     mockDb.update = vi.fn().mockImplementation(() => ({ set, where }) as any);
 
     const app = await createTestApp();
@@ -2898,13 +2896,11 @@ describe("papers routes", () => {
     });
     const set = vi.fn().mockReturnThis();
     const where = vi.fn().mockReturnThis();
-    mockDb.select = vi
-      .fn()
-      .mockImplementation(() =>
-        makeQuery({
-          getResult: { paperId: "paper-1", userId: "user-1", role: "uploader" },
-        }),
-      );
+    mockDb.select = vi.fn().mockImplementation(() =>
+      makeQuery({
+        getResult: { paperId: "paper-1", userId: "user-1", role: "uploader" },
+      }),
+    );
     mockDb.update = vi.fn().mockImplementation(() => ({ set, where }) as any);
 
     const app = await createTestApp();
@@ -2940,13 +2936,11 @@ describe("papers routes", () => {
     });
     const set = vi.fn().mockReturnThis();
     const where = vi.fn().mockReturnThis();
-    mockDb.select = vi
-      .fn()
-      .mockImplementation(() =>
-        makeQuery({
-          getResult: { paperId: "paper-1", userId: "user-1", role: "uploader" },
-        }),
-      );
+    mockDb.select = vi.fn().mockImplementation(() =>
+      makeQuery({
+        getResult: { paperId: "paper-1", userId: "user-1", role: "uploader" },
+      }),
+    );
     mockDb.update = vi.fn().mockImplementation(() => ({ set, where }) as any);
 
     const app = await createTestApp();
@@ -2990,13 +2984,11 @@ describe("papers routes", () => {
       githubId: "123",
       name: "Uploader",
     });
-    mockDb.select = vi
-      .fn()
-      .mockImplementation(() =>
-        makeQuery({
-          getResult: { paperId: "paper-1", userId: "user-1", role: "uploader" },
-        }),
-      );
+    mockDb.select = vi.fn().mockImplementation(() =>
+      makeQuery({
+        getResult: { paperId: "paper-1", userId: "user-1", role: "uploader" },
+      }),
+    );
 
     const app = await createTestApp();
     const env = createTestEnv();
@@ -3150,13 +3142,11 @@ describe("papers routes", () => {
     });
     const set = vi.fn().mockReturnThis();
     const where = vi.fn().mockReturnThis();
-    mockDb.select = vi
-      .fn()
-      .mockImplementation(() =>
-        makeQuery({
-          getResult: { paperId: "paper-1", userId: "user-1", role: "uploader" },
-        }),
-      );
+    mockDb.select = vi.fn().mockImplementation(() =>
+      makeQuery({
+        getResult: { paperId: "paper-1", userId: "user-1", role: "uploader" },
+      }),
+    );
     mockDb.update = vi.fn().mockImplementation(() => ({ set, where }) as any);
 
     const app = await createTestApp();
@@ -3195,13 +3185,11 @@ describe("papers routes", () => {
   });
 
   it("GET /api/papers/:id returns 401 for private paper without Bearer token", async () => {
-    mockDb.select = vi
-      .fn()
-      .mockImplementationOnce(() =>
-        makeQuery({
-          getResult: { id: "paper-1", title: "P1", visibility: "private" },
-        }),
-      );
+    mockDb.select = vi.fn().mockImplementationOnce(() =>
+      makeQuery({
+        getResult: { id: "paper-1", title: "P1", visibility: "private" },
+      }),
+    );
 
     const app = await createTestApp();
     const env = createTestEnv();
@@ -3624,7 +3612,9 @@ describe("papers routes", () => {
       );
 
       expect(customRes.status).toBe(400);
-      expect(await customRes.json()).toEqual({ error: "Cannot invite yourself" });
+      expect(await customRes.json()).toEqual({
+        error: "Cannot invite yourself",
+      });
     });
   });
 });
@@ -3718,7 +3708,9 @@ describe("Error handling and untested branches", () => {
       );
 
       expect(res.status).toBe(500);
-      await expect(res.json()).resolves.toEqual({ error: "Internal Server Error" });
+      await expect(res.json()).resolves.toEqual({
+        error: "Internal Server Error",
+      });
       expect(consoleErrorSpy).toHaveBeenCalledWith(
         "File upload errors:",
         expect.objectContaining({
@@ -3937,7 +3929,7 @@ describe("Error handling and untested branches", () => {
     });
   });
 
-  it.each(["\"just a string\"", "42", "null"])(
+  it.each(['"just a string"', "42", "null"])(
     "POST /api/papers rejects upload when parsed metadata JSON is not an object: %s",
     async (metadata) => {
       const formData = new FormData();
@@ -4173,7 +4165,11 @@ describe("Error handling and untested branches", () => {
 
     mockDb.update = vi.fn().mockReturnValue({
       set: vi.fn().mockReturnValue({
-        where: vi.fn().mockRejectedValue(new Error("NOT NULL constraint failed: papers.title")),
+        where: vi
+          .fn()
+          .mockRejectedValue(
+            new Error("NOT NULL constraint failed: papers.title"),
+          ),
       }),
     });
 
@@ -4191,19 +4187,20 @@ describe("Error handling and untested branches", () => {
     );
 
     expect(res.status).toBe(500);
-    await expect(res.json()).resolves.toEqual({ error: "Internal Server Error" });
+    await expect(res.json()).resolves.toEqual({
+      error: "Internal Server Error",
+    });
   });
 
   it("POST /api/papers/:id/track handles missing json payload", async () => {
+    const token = await createTestJWT({ sub: "user-1" });
     const { makeQuery } = await import("../../test/helpers");
     mockDb = {
       run: vi.fn().mockResolvedValue({}),
-      prepare: vi
-        .fn()
-        .mockImplementation(() => ({
-          bind: vi.fn().mockReturnThis(),
-          all: vi.fn().mockResolvedValue([]),
-        })),
+      prepare: vi.fn().mockImplementation(() => ({
+        bind: vi.fn().mockReturnThis(),
+        all: vi.fn().mockResolvedValue([]),
+      })),
       select: vi
         .fn()
         .mockImplementationOnce(() =>
@@ -4217,6 +4214,7 @@ describe("Error handling and untested branches", () => {
       {
         method: "POST",
         headers: {
+          Authorization: `Bearer ${token}`,
           "Content-Type": "application/json",
           Origin: "http://localhost:3000",
         },
@@ -4229,15 +4227,14 @@ describe("Error handling and untested branches", () => {
   });
 
   it("POST /api/papers/:id/track handles non-object JSON body", async () => {
+    const token = await createTestJWT({ sub: "user-1" });
     const { makeQuery } = await import("../../test/helpers");
     mockDb = {
       run: vi.fn().mockResolvedValue({}),
-      prepare: vi
-        .fn()
-        .mockImplementation(() => ({
-          bind: vi.fn().mockReturnThis(),
-          all: vi.fn().mockResolvedValue([]),
-        })),
+      prepare: vi.fn().mockImplementation(() => ({
+        bind: vi.fn().mockReturnThis(),
+        all: vi.fn().mockResolvedValue([]),
+      })),
       select: vi
         .fn()
         .mockImplementationOnce(() =>
@@ -4251,6 +4248,7 @@ describe("Error handling and untested branches", () => {
       {
         method: "POST",
         headers: {
+          Authorization: `Bearer ${token}`,
           "Content-Type": "application/json",
           Origin: "http://localhost:3000",
         },
@@ -4263,6 +4261,7 @@ describe("Error handling and untested branches", () => {
   });
 
   it("POST /api/papers/:id/track captures parsing errors in promise", async () => {
+    const token = await createTestJWT({ sub: "user-1" });
     const { makeQuery } = await import("../../test/helpers");
     mockDb = {
       select: vi
@@ -4270,11 +4269,9 @@ describe("Error handling and untested branches", () => {
         .mockImplementationOnce(() =>
           makeQuery({ getResult: { id: "paper-1", visibility: "public" } }),
         ),
-      prepare: vi
-        .fn()
-        .mockImplementation(() => ({
-          bind: vi.fn().mockReturnThis(),
-          all: vi.fn().mockRejectedValue(new Error("Track DB failure")),
+      prepare: vi.fn().mockImplementation(() => ({
+        bind: vi.fn().mockReturnThis(),
+        all: vi.fn().mockRejectedValue(new Error("Track DB failure")),
       })),
       run: vi.fn().mockResolvedValue({}),
     };
@@ -4290,6 +4287,7 @@ describe("Error handling and untested branches", () => {
       {
         method: "POST",
         headers: {
+          Authorization: `Bearer ${token}`,
           "Content-Type": "application/json",
           Origin: "http://localhost:3000",
         },

--- a/apps/api/src/routes/papers.ts
+++ b/apps/api/src/routes/papers.ts
@@ -204,7 +204,9 @@ async function buildTrackSessionHash(
 
 function getTrackingHashSecret(env: Env): string {
   if (!env.TRACKING_HASH_SECRET) {
-    throw new Error("TRACKING_HASH_SECRET is required for paper stats tracking");
+    throw new Error(
+      "TRACKING_HASH_SECRET is required for paper stats tracking",
+    );
   }
   return env.TRACKING_HASH_SECRET;
 }
@@ -1024,7 +1026,7 @@ papersRoute.get("/:id/cite", async (c) => {
 });
 
 // POST /api/papers/:id/track — record daily stats events
-papersRoute.post("/:id/track", async (c) => {
+papersRoute.post("/:id/track", authMiddleware, async (c) => {
   const paperId = c.req.param("id");
   const db = drizzle(c.env.DB);
   await enableForeignKeys(db);

--- a/patch_tests.js
+++ b/patch_tests.js
@@ -1,0 +1,55 @@
+const fs = require('fs');
+const path = 'apps/api/src/routes/__tests__/papers.test.ts';
+let content = fs.readFileSync(path, 'utf8');
+
+const testNames = [
+  'POST /api/papers/:id/track accepts view event',
+  'POST /api/papers/:id/track requires a tracking hash secret',
+  'POST /api/papers/:id/track ignores bots',
+  'POST /api/papers/:id/track logs sanitized error on failure (Error instance)',
+  'POST /api/papers/:id/track logs sanitized error on failure (string error)',
+  'POST /api/papers/:id/track handles duplicate dedup rows',
+  'POST /api/papers/:id/track returns 404 when paper does not exist',
+  'POST /api/papers/:id/track handles missing json payload',
+  'POST /api/papers/:id/track handles non-object JSON body',
+  'POST /api/papers/:id/track captures parsing errors in promise'
+];
+
+for (const testName of testNames) {
+  const index = content.indexOf(`it("${testName}", async () => {`);
+  if (index === -1) {
+    console.error(`Could not find test: ${testName}`);
+    continue;
+  }
+
+  // Find the body of the test
+  const bodyStart = index + `it("${testName}", async () => {\n`.length;
+
+  // Inject token creation
+  const injectTokenStr = `    const token = await createTestJWT({ sub: "user-1" });\n`;
+  content = content.slice(0, bodyStart) + injectTokenStr + content.slice(bodyStart);
+
+  // Find the app.request call within this test
+  // It looks like:
+  // const res = await app.request(
+  //   "http://localhost/api/papers/paper-1/track",
+  //   {
+  //     method: "POST",
+  //     headers: {
+  //       "Content-Type": "application/json",
+  //       Origin: "http://localhost:3000",
+  //       "User-Agent": "Vitest",
+  //     },
+
+  const nextAppRequest = content.indexOf('"http://localhost/api/papers/', index);
+  if (nextAppRequest !== -1) {
+    const headersIndex = content.indexOf('headers: {', nextAppRequest);
+    if (headersIndex !== -1) {
+      const insertPoint = headersIndex + 'headers: {\n'.length;
+      content = content.slice(0, insertPoint) + `          Authorization: \`Bearer \${token}\`,\n` + content.slice(insertPoint);
+    }
+  }
+}
+
+fs.writeFileSync(path, content, 'utf8');
+console.log("Tests patched successfully");

--- a/patch_track_auth.js
+++ b/patch_track_auth.js
@@ -1,0 +1,11 @@
+const fs = require('fs');
+const path = 'apps/api/src/routes/papers.ts';
+let content = fs.readFileSync(path, 'utf8');
+
+content = content.replace(
+  /papersRoute\.post\("\/:id\/track", async \(c\) => \{/g,
+  'papersRoute.post("/:id/track", authMiddleware, async (c) => {'
+);
+
+fs.writeFileSync(path, content, 'utf8');
+console.log("File patched successfully");


### PR DESCRIPTION
🚨 Severity: High

💡 Vulnerability: Missing authentication on a state-changing route (`POST /api/papers/:id/track`), allowing unauthenticated tracking data modification.

🎯 Impact: An unauthenticated attacker could pollute tracking analytics data by sending arbitrary `view`, `download`, and `preview` events.

🔧 Fix: Added `authMiddleware` to the route definition to require a valid JWT token.

✅ Verification: Formatted, linted, and passed the full test suite after updating tests to supply proper authentication tokens.

---
*PR created automatically by Jules for task [3131848666840030685](https://jules.google.com/task/3131848666840030685) started by @is0692vs*

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

`POST /api/papers/:id/track` に `authMiddleware` を追加することで未認証ユーザーによるトラッキングデータ汚染を防ぐ修正です。あわせてテストに JWT を付与し、一部コードのフォーマットも整理しています。

- **ルート保護**: `papers.ts` L1029 の `papersRoute.post(\"/:id/track\")` に `authMiddleware` を挿入。プライベート論文については `authorizePaperAccess` でも二重に保護されるが、公開論文を閲覧する非ログインユーザーのトラッキングリクエストも 401 で遮断される点が懸念。
- **テスト更新**: トラッキング系テスト 10 件に `createTestJWT` を追加。ただし「トークンなしで 401 になること」を確認するネガティブテストが不在。
- **スクリプト混入**: `patch_track_auth.js` / `patch_tests.js` という一時変換スクリプトがコミットに含まれており、削除を推奨。
</details>

<details open><summary><h3>Confidence Score: 3/5</h3></summary>

公開論文を非ログインで閲覧するユーザーのトラッキングリクエストがすべて 401 になる可能性があり、マージ前に設計意図を確認する必要があります。

ルートに `authMiddleware` を加えた結果、ハンドラー内の `authorizePaperAccess` が公開論文を認証不要と判定する以前に全リクエストが遮断されます。これはログイン不要で公開論文を閲覧できる匿名ユーザーのトラッキングを破壊するため、意図的な仕様変更でなければ analytics データの欠損につながります。さらに認証保護の有無を確認するネガティブテストがなく、将来的なリグレッション検知が難しい状態です。

最も注意が必要なのは `apps/api/src/routes/papers.ts` の L1029 です。`authorizePaperAccess` との役割分担と、公開論文の匿名トラッキングを許可する設計かどうかを確認してください。
</details>

<details open><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| apps/api/src/routes/papers.ts | POST /:id/track に authMiddleware を追加。公開論文の非認証トラッキングを誤って遮断する可能性あり（意図した設計かどうか要確認） |
| apps/api/src/routes/__tests__/papers.test.ts | 既存のトラッキングテストに JWT トークンを付与。しかし「認証なしで 401 が返ること」を検証する新テストが追加されていない |
| patch_track_auth.js | papers.ts に authMiddleware を適用するための一時的なスクリプト。リポジトリにコミットすべきでないスクリプト |
| patch_tests.js | テストに JWT を注入するための一時的な変換スクリプト。本番リポジトリに残すべきではない |

</details>

<h3>Sequence Diagram</h3>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
sequenceDiagram
    participant Client
    participant authMiddleware
    participant TrackHandler
    participant authorizePaperAccess
    participant DB

    Note over Client,DB: Before this PR (公開論文の非認証アクセス可能)
    Client->>TrackHandler: POST /api/papers/:id/track
    TrackHandler->>authorizePaperAccess: "paper.visibility=public?"
    authorizePaperAccess-->>TrackHandler: ok: true (no auth needed)
    TrackHandler-->>Client: 204 No Content

    Note over Client,DB: After this PR (authMiddleware 追加後)
    Client->>authMiddleware: POST /api/papers/:id/track (no token)
    authMiddleware-->>Client: 401 Unauthorized (公開論文でも遮断)

    Client->>authMiddleware: POST /api/papers/:id/track (with JWT)
    authMiddleware->>TrackHandler: pass
    TrackHandler->>DB: fetch paper
    DB-->>TrackHandler: paper (public/private)
    TrackHandler->>authorizePaperAccess: check access
    authorizePaperAccess-->>TrackHandler: ok: true
    TrackHandler-->>Client: 204 No Content
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
sequenceDiagram
    participant Client
    participant authMiddleware
    participant TrackHandler
    participant authorizePaperAccess
    participant DB

    Note over Client,DB: Before this PR (公開論文の非認証アクセス可能)
    Client->>TrackHandler: POST /api/papers/:id/track
    TrackHandler->>authorizePaperAccess: "paper.visibility=public?"
    authorizePaperAccess-->>TrackHandler: ok: true (no auth needed)
    TrackHandler-->>Client: 204 No Content

    Note over Client,DB: After this PR (authMiddleware 追加後)
    Client->>authMiddleware: POST /api/papers/:id/track (no token)
    authMiddleware-->>Client: 401 Unauthorized (公開論文でも遮断)

    Client->>authMiddleware: POST /api/papers/:id/track (with JWT)
    authMiddleware->>TrackHandler: pass
    TrackHandler->>DB: fetch paper
    DB-->>TrackHandler: paper (public/private)
    TrackHandler->>authorizePaperAccess: check access
    authorizePaperAccess-->>TrackHandler: ok: true
    TrackHandler-->>Client: 204 No Content
```

</a>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 3 code review issues. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 3
apps/api/src/routes/papers.ts:1029
**公開論文の非認証トラッキングが意図せず遮断される**

`authMiddleware` はルートレベルで有効な JWT を必須とするため、ログインしていないユーザーが公開論文を閲覧した際にフロントエンドが送信するトラッキングリクエストが 401 で弾かれてしまいます。ハンドラー内の `authorizePaperAccess` はすでに `visibility === "public"` の場合は無条件に `ok: true` を返しており、プライベート論文のみ認証を要求しています。`authMiddleware` を追加すると、その既存のロジックよりも先に全リクエストを遮断するため、公開論文の analytics が欠損します。

プライベート論文への不正書き込みを防ぐ意図であれば、ルートレベルの `authMiddleware` は過剰な制約です。`authorizePaperAccess` が既に担保していたプライベート論文の保護は変わらないため、`authMiddleware` を除去するか、または公開論文でも認証を必須にするという仕様変更であれば PR 説明にその旨を明記する必要があります。

### Issue 2 of 3
apps/api/src/routes/__tests__/papers.test.ts:1349
**認証なしリクエストが 401 を返すことを検証するテストが存在しない**

既存のテストにはすべてトークンが付与されましたが、「`Authorization` ヘッダーを省略した場合に 401 が返ること」を確認するネガティブテストが追加されていません。このテストが欠けると、将来 `authMiddleware` が誤って外れてもリグレッションを検知できません。

### Issue 3 of 3
patch_track_auth.js:1-11
**一時的なパッチスクリプトをリポジトリにコミットすべきでない**

`patch_track_auth.js` と `patch_tests.js` はコード変換のために一度だけ使用された自動生成スクリプトです。これらをリポジトリに残すと、将来のメンテナーが誤って再実行するリスクがあり、コードベースのノイズになります。`.gitignore` に追加するか、このコミットから除外することを推奨します。

`````

</details>

<sub>Reviews (1): Last reviewed commit: ["fix(api): enforce authentication on trac..."](https://github.com/hiroki-org/openshelf/commit/8d7942298d143520f3e08a66cedcde465db78c12) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=42339255)</sub>

> Greptile also left **3 inline comments** on this PR.

<!-- /greptile_comment -->