### PR TITLE
🧹 [Simplify UserPageClient component]

### DIFF
--- a/apps/web/src/app/users/[id]/user-page-client.tsx
+++ b/apps/web/src/app/users/[id]/user-page-client.tsx
@@ -27,17 +27,10 @@ type UserPageClientProps = {
   initialUser?: UserProfile | null;
 };
 
-export default function UserPageClient({
-  id,
-  initialUser = null,
-}: UserPageClientProps) {
-  const { user } = useAuth();
+function useUserPageData(id: string, initialUser: UserProfile | null) {
   const [profile, setProfile] = useState<UserProfile | null>(initialUser);
   const [collections, setCollections] = useState<Collection[]>([]);
   const [error, setError] = useState("");
-
-  const isSelf = useMemo(() => user?.id === id, [user, id]);
-  const feedUrl = `${process.env.NEXT_PUBLIC_API_URL ?? "http://localhost:8787"}/feed/users/${id}/atom.xml`;
 
   useEffect(() => {
     let cancelled = false;
@@ -92,6 +85,54 @@ export default function UserPageClient({
     };
   }, [id, initialUser]);
 
+  return { profile, collections, error };
+}
+
+function CollectionsList({
+  collections,
+  userId,
+}: {
+  collections: Collection[];
+  userId: string;
+}) {
+  if (collections.length === 0) {
+    return <p className="text-sm text-gray-500">コレクションがありません</p>;
+  }
+
+  return (
+    <ul className="space-y-3">
+      {collections.map((c) => (
+        <li key={c.id}>
+          <Link
+            href={`/users/${userId}/c/${c.slug}`}
+            className="block rounded-md border p-4 hover:bg-gray-50 dark:border-gray-700 dark:hover:bg-gray-800"
+          >
+            <div className="flex items-start justify-between gap-2">
+              <div>
+                <h3 className="font-medium text-sm">{c.name}</h3>
+                {c.description && (
+                  <p className="text-xs text-gray-500 mt-1">{c.description}</p>
+                )}
+              </div>
+              <span className="text-xs text-gray-400">{c.visibility}</span>
+            </div>
+          </Link>
+        </li>
+      ))}
+    </ul>
+  );
+}
+
+export default function UserPageClient({
+  id,
+  initialUser = null,
+}: UserPageClientProps) {
+  const { user } = useAuth();
+  const { profile, collections, error } = useUserPageData(id, initialUser);
+
+  const isSelf = useMemo(() => user?.id === id, [user, id]);
+  const feedUrl = `${process.env.NEXT_PUBLIC_API_URL ?? "http://localhost:8787"}/feed/users/${id}/atom.xml`;
+
   if (error)
     return <div className="text-center py-16 text-red-600">{error}</div>;
   if (!profile) return <div className="text-center py-16">読み込み中...</div>;
@@ -122,32 +163,7 @@ export default function UserPageClient({
         )}
       </div>
 
-      {collections.length === 0 ? (
-        <p className="text-sm text-gray-500">コレクションがありません</p>
-      ) : (
-        <ul className="space-y-3">
-          {collections.map((c) => (
-            <li key={c.id}>
-              <Link
-                href={`/users/${id}/c/${c.slug}`}
-                className="block rounded-md border p-4 hover:bg-gray-50 dark:border-gray-700 dark:hover:bg-gray-800"
-              >
-                <div className="flex items-start justify-between gap-2">
-                  <div>
-                    <h3 className="font-medium text-sm">{c.name}</h3>
-                    {c.description && (
-                      <p className="text-xs text-gray-500 mt-1">
-                        {c.description}
-                      </p>
-                    )}
-                  </div>
-                  <span className="text-xs text-gray-400">{c.visibility}</span>
-                </div>
-              </Link>
-            </li>
-          ))}
-        </ul>
-      )}
+      <CollectionsList collections={collections} userId={id} />
     </div>
   );
 }


### PR DESCRIPTION
🎯 **What:** Extracted data fetching to `useUserPageData` hook and collection rendering to `CollectionsList` component.\n💡 **Why:** Reduces `UserPageClient` size and complexity, separating concerns.\n✅ **Verification:** Verified via tests, linting, and manual code review.\n✨ **Result:** Improved maintainability and readability.

---
*PR created automatically by Jules for task [3514298735865427913](https://jules.google.com/task/3514298735865427913) started by @is0692vs*

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

`UserPageClient` コンポーネントのリファクタリングです。データ取得ロジックを `useUserPageData` カスタムフックへ、コレクション一覧の描画を `CollectionsList` コンポーネントへそれぞれ抽出し、関心の分離を実現しています。

- **`useUserPageData` フック**: プロフィール・コレクション・エラーの状態管理と非同期フェッチを集約。フック自体は非エクスポートでファイル内限定。
- **`CollectionsList` コンポーネント**: `userId` を props として受け取り、リンク生成を担当。空リストの表示もこのコンポーネントが処理する。
</details>

<details open><summary><h3>Confidence Score: 4/5</h3></summary>

このリファクタリングはロジックの移動のみで、動作の変更はなく、マージして問題ありません。

フックとコンポーネントへの分割は正確で、既存の動作を忠実に再現しています。`initialUser` 渡し時にコレクションがロード完了前に空状態メッセージが出る既存の UX 問題が残りますが、このリファクタリングが原因で新たに壊れたものはありません。

`user-page-client.tsx` の `CollectionsList` コンポーネント — コレクションのローディング状態と空状態の区別が今後の改善候補です。
</details>

<details open><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| apps/web/src/app/users/[id]/user-page-client.tsx | useUserPageData フックと CollectionsList コンポーネントへの分割。ロジックの正確性は維持されているが、initialUser が提供された場合にコレクションが空配列で初期化されるため、フェッチ完了前に「コレクションがありません」が一瞬表示される既存の UX 問題が残る。 |

</details>

<h3>Sequence Diagram</h3>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
sequenceDiagram
    participant Parent as Parent (RSC)
    participant UPC as UserPageClient
    participant Hook as useUserPageData
    participant CL as CollectionsList
    participant API as API Server

    Parent->>UPC: render(id, initialUser?)
    UPC->>Hook: useUserPageData(id, initialUser)
    Hook-->>UPC: "{profile, collections, error}"
    UPC->>CL: CollectionsList collections userId

    Note over Hook: useEffect on mount
    Hook->>API: GET /api/users/:id (if no initialUser)
    Hook->>API: GET /api/users/:id/collections
    API-->>Hook: profileData
    API-->>Hook: collectionsData
    Hook-->>UPC: re-render with updated state
    UPC->>CL: re-render with loaded collections
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
sequenceDiagram
    participant Parent as Parent (RSC)
    participant UPC as UserPageClient
    participant Hook as useUserPageData
    participant CL as CollectionsList
    participant API as API Server

    Parent->>UPC: render(id, initialUser?)
    UPC->>Hook: useUserPageData(id, initialUser)
    Hook-->>UPC: "{profile, collections, error}"
    UPC->>CL: CollectionsList collections userId

    Note over Hook: useEffect on mount
    Hook->>API: GET /api/users/:id (if no initialUser)
    Hook->>API: GET /api/users/:id/collections
    API-->>Hook: profileData
    API-->>Hook: collectionsData
    Hook-->>UPC: re-render with updated state
    UPC->>CL: re-render with loaded collections
```

</a>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 1 code review issue. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 1
apps/web/src/app/users/[id]/user-page-client.tsx:98-100
**initialUser 渡し時のコレクション空状態フラッシュ**

`initialUser` が渡されると `profile` は非 null で初期化されますが、`collections` は `[]` のままです。初回レンダリング時に `profile` のガードを通過してしまい、`useEffect` でコレクションが取得されるまでの間、「コレクションがありません」が一瞬表示されます。本 PR で新たに導入された問題ではありませんが、`CollectionsList` の分離によって空状態のロジックが明示化されたため、ここでコレクションの「ローディング中」状態（例：`isLoadingCollections` フラグ）を区別して表示することが検討できます。

`````

</details>

<sub>Reviews (1): Last reviewed commit: ["🧹 code health: simplify UserPageClient ..."](https://github.com/hiroki-org/openshelf/commit/23b662aa787a3762ac5771f900a4c6238cb3c650) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=42341588)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->