### PR TITLE
🛡️ Sentinel: [Medium] Fix weak random number generation

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -25,3 +25,7 @@
 **Vulnerability:** Unhandled exceptions in the Hono API routes can leak internal application details, such as stack traces, to the client via default 500 error responses.
 **Learning:** Returning raw Error objects or relying on Hono's default error handling without a custom `onError` hook exposes potentially sensitive debugging information.
 **Prevention:** Always define a global `app.onError((err, c) => { ... })` handler in the main application file (e.g., `apps/api/src/index.ts`) to intercept all unhandled exceptions, log a sanitized version of the error internally, and return a safe, generic JSON response to the user.
+## 2024-07-08 - [Weak Random Number Generation]
+**Vulnerability:** トースト通知のID生成に脆弱な Math.random() が使用されていた。
+**Learning:** クライアントサイドでIDを生成する際に Math.random() などの推測可能な疑似乱数生成器を使用すると、衝突のリスクやセキュリティ上の問題（コンポーネントの状態汚染など）が発生する可能性がある。
+**Prevention:** ID生成には標準の Web Crypto API である crypto.randomUUID() を使用する。

--- a/apps/web/src/components/toast.tsx
+++ b/apps/web/src/components/toast.tsx
@@ -20,7 +20,7 @@ export const toast = {
 };
 
 function addToast(message: string, type: ToastType) {
-  const id = Math.random().toString(36).substring(2, 9);
+  const id = crypto.randomUUID();
   const newToast = { id, message, type };
   toasts = [...toasts, newToast];
   notify();


### PR DESCRIPTION
🚨 Severity: MEDIUM
💡 Vulnerability: トースト通知のID生成に脆弱な Math.random() が使用されていました。
🎯 Impact: IDが推測可能になり、衝突のリスクやコンポーネントの状態管理に予期せぬ不具合を引き起こす可能性があります。
🔧 Fix: Math.random() を安全な Web Crypto API の crypto.randomUUID() に置き換えました。
✅ Verification: テスト (`pnpm test`) が正常に通過し、IDが一意に生成されることを確認しました。

---
*PR created automatically by Jules for task [13305480474406878986](https://jules.google.com/task/13305480474406878986) started by @is0692vs*

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

トースト通知コンポーネントにおける ID 生成を `Math.random()` から `crypto.randomUUID()` へ置き換えるセキュリティ修正 PR です。変更は1行のみで、コードの動作・UI への影響はありません。

- **`toast.tsx`**: `addToast` 関数内の ID 生成を `Math.random().toString(36).substring(2, 9)` から `crypto.randomUUID()` に変更。React の `key` prop およびタイムアウトによるトースト削除処理に引き続き問題なく使用できます。
- **`.jules/sentinel.md`**: 脆弱性の学習記録を追加。なお、記録の日付が `2024-07-08` となっており実際の日付（`2026-07-08`）と一致しないため修正が必要です。
</details>

<details open><summary><h3>Confidence Score: 4/5</h3></summary>

変更は1行のみで影響範囲が非常に限定的。`crypto.randomUUID()` はモダンブラウザで広くサポートされており、既存の動作を破壊するリスクはほぼない。

`toast.tsx` の修正自体は正確で問題なく動作する。唯一の指摘事項は `sentinel.md` の日付が実際より2年前になっている点で、コード動作には影響しないが記録として不正確。

`.jules/sentinel.md` の記録日付（`2024-07-08`）が実際の変更日と一致しておらず、要修正。`toast.tsx` は特に問題なし。
</details>

<details open><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| apps/web/src/components/toast.tsx | `Math.random()` による ID 生成を `crypto.randomUUID()` に置き換え。変更は1行のみで、動作上の問題はない。 |
| .jules/sentinel.md | 脆弱性の学習記録を追加。ただし記載日付が 2024-07-08 となっており、実際の日付 2026-07-08 と2年ずれている。 |

</details>

<h3>Flowchart</h3>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A["toast.success / error / info(message)"] --> B["addToast(message, type)"]
    B --> C{"ID 生成"}
    C -- "変更前" --> D["Math.random().toString(36).substring(2,9)\n⚠️ 擬似乱数、予測可能"]
    C -- "変更後" --> E["crypto.randomUUID()\n✅ 暗号論的乱数、衝突困難"]
    D --> F["Toast オブジェクト作成\n{ id, message, type }"]
    E --> F
    F --> G["toasts 配列に追加 & notify()"]
    G --> H["ToastContainer が再レンダリング\n(key=id で React が識別)"]
    H --> I["setTimeout 5秒後 → removeToast(id)\nid で該当トーストをフィルタ除去"]
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
flowchart TD
    A["toast.success / error / info(message)"] --> B["addToast(message, type)"]
    B --> C{"ID 生成"}
    C -- "変更前" --> D["Math.random().toString(36).substring(2,9)\n⚠️ 擬似乱数、予測可能"]
    C -- "変更後" --> E["crypto.randomUUID()\n✅ 暗号論的乱数、衝突困難"]
    D --> F["Toast オブジェクト作成\n{ id, message, type }"]
    E --> F
    F --> G["toasts 配列に追加 & notify()"]
    G --> H["ToastContainer が再レンダリング\n(key=id で React が識別)"]
    H --> I["setTimeout 5秒後 → removeToast(id)\nid で該当トーストをフィルタ除去"]
```

</a>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 1 code review issue. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 1
.jules/sentinel.md:28
`sentinel.md` に記録された日付が `2024-07-08` となっていますが、実際の変更日は `2026-07-08` です。2年ずれているため、将来の参照時に混乱を招く可能性があります。

```suggestion
## 2026-07-08 - [Weak Random Number Generation]
```

`````

</details>

<sub>Reviews (1): Last reviewed commit: ["fix: use crypto.randomUUID for toast id ..."](https://github.com/hiroki-org/openshelf/commit/93c42e8563ad9769aed3a4e955a4174f3b8274fa) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=42747692)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->