### PR TITLE
🎨 Palette: 組織作成ページのスラッグ入力のアクセシビリティ改善

### DIFF
--- a/apps/web/src/app/__tests__/orgs-new.test.tsx
+++ b/apps/web/src/app/__tests__/orgs-new.test.tsx
@@ -96,7 +96,7 @@ describe("NewOrgPage", () => {
       await Promise.resolve();
     });
 
-    expect(screen.getByText("✓ 使用可能")).toBeInTheDocument();
+    expect(screen.getByText("使用可能")).toBeInTheDocument();
 
     vi.useRealTimers();
     fireEvent.click(screen.getByRole("button", { name: "作成" }));
@@ -134,7 +134,7 @@ describe("NewOrgPage", () => {
       await Promise.resolve();
     });
 
-    expect(screen.getByText("✓ 使用可能")).toBeInTheDocument();
+    expect(screen.getByText("使用可能")).toBeInTheDocument();
 
     vi.useRealTimers();
     fireEvent.click(screen.getByRole("button", { name: "作成" }));
@@ -206,7 +206,7 @@ describe("NewOrgPage", () => {
         await Promise.resolve();
       });
 
-      expect(screen.getByText("✓ 使用可能")).toBeInTheDocument();
+      expect(screen.getByText("使用可能")).toBeInTheDocument();
     } finally {
       vi.useRealTimers();
     }

--- a/apps/web/src/app/__tests__/orgs-new.test.tsx
+++ b/apps/web/src/app/__tests__/orgs-new.test.tsx
@@ -216,4 +216,30 @@ describe("NewOrgPage", () => {
     expect(await screen.findByText("slug taken")).toBeInTheDocument();
     expect(push).not.toHaveBeenCalled();
   });
+
+  it("shows taken status for existing slug", async () => {
+    vi.useFakeTimers();
+    vi.mocked(apiFetch).mockImplementation(async (url) => {
+      if (url === "/api/orgs/research-lab") {
+        return new Response("{}", { status: 200 }); // slug exists
+      }
+      throw new Error(`Unexpected request: ${String(url)}`);
+    });
+
+    try {
+      render(<NewOrgPage />);
+      fireEvent.change(screen.getByLabelText(/組織名/i), {
+        target: { value: "Research Lab" },
+      });
+
+      await act(async () => {
+        vi.advanceTimersByTime(400);
+        await Promise.resolve();
+      });
+
+      expect(screen.getByText("使用済み")).toBeInTheDocument();
+    } finally {
+      vi.useRealTimers();
+    }
+  });
 });

--- a/apps/web/src/app/orgs/new/page.tsx
+++ b/apps/web/src/app/orgs/new/page.tsx
@@ -123,9 +123,17 @@ export default function NewOrgPage() {
       case "checking":
         return <span className="text-gray-400 text-xs">確認中...</span>;
       case "available":
-        return <span className="text-green-600 text-xs">✓ 使用可能</span>;
+        return (
+          <span className="text-green-600 text-xs">
+            <span aria-hidden="true">✓ </span>使用可能
+          </span>
+        );
       case "taken":
-        return <span className="text-red-600 text-xs">✗ 使用済み</span>;
+        return (
+          <span className="text-red-600 text-xs">
+            <span aria-hidden="true">✗ </span>使用済み
+          </span>
+        );
       case "invalid":
         return (
           <span className="text-red-600 text-xs">
@@ -183,11 +191,14 @@ export default function NewOrgPage() {
                   e.target.value.toLowerCase().replace(/[^a-z0-9-]/g, ""),
                 );
               }}
+              aria-describedby="org-slug-status"
               className="flex-1 rounded-md border border-gray-300 px-3 py-2 text-sm dark:border-gray-700 dark:bg-gray-900"
               required
             />
           </div>
-          <div className="mt-1">{slugStatusText()}</div>
+          <div id="org-slug-status" aria-live="polite" className="mt-1">
+            {slugStatusText()}
+          </div>
         </div>
 
         <div>


### PR DESCRIPTION
💡 What:
組織作成ページ (`/orgs/new`) のスラッグ入力フィールドと、その非同期バリデーション結果を表示するステータス文字列に対してアクセシビリティ改善を行いました。
- スラッグの入力 `<input>` に `aria-describedby="org-slug-status"` を付与しました。
- バリデーション結果の表示要素に `id="org-slug-status"` および `aria-live="polite"` を付与しました。
- ステータス表示に含まれる装飾的なアイコン (✓ や ✗) を `<span aria-hidden="true">` でラップし、スクリーンリーダーが不要な記号を読み上げないように修正しました。

🎯 Why:
これまでは、ユーザーがスラッグを入力した際に非同期で「使用可能」や「使用済み」といったステータスが切り替わっても、スクリーンリーダーを利用しているユーザーにはその変化が伝わりませんでした。
また、入力フィールドにフォーカスがある状態で現在のステータスを把握するための紐付けが不足していました。

📸 Before/After:
Before: `<div><span>✓ 使用可能</span></div>`
After: `<div id="org-slug-status" aria-live="polite"><span><span aria-hidden="true">✓ </span>使用可能</span></div>`

♿ Accessibility:
非同期で変更されるフィードバックを `aria-live` を通じてスクリーンリーダーに伝えるとともに、装飾用の記号が読み上げられる不自然さを `aria-hidden` で排除しました。これにより、視覚に依存せずにフォームの状況を正確に把握できるようになります。

---
*PR created automatically by Jules for task [4478301420228151](https://jules.google.com/task/4478301420228151) started by @is0692vs*

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

組織作成ページ (`/orgs/new`) のスラッグ入力フィールドに対するアクセシビリティ改善 PR です。`aria-describedby`・`aria-live="polite"`・`aria-hidden` を用いて、スクリーンリーダー向けに非同期バリデーション結果を正しく伝える実装が追加されています。

- スラッグ `<input>` に `aria-describedby="org-slug-status"` を付与し、ステータス表示コンテナと紐付けました。
- ステータスコンテナに `id="org-slug-status"` と `aria-live="polite"` を付与し、非同期で変化するバリデーション結果をスクリーンリーダーへ通知できるようにしました。
- ✓ / ✗ の装飾的アイコンを `<span aria-hidden="true">` でラップし、読み上げから除外。対応するテストも `getByText("✓ 使用可能")` → `getByText("使用可能")` に更新されています。
</details>


<details open><summary><h3>Confidence Score: 5/5</h3></summary>

アクセシビリティ専用の小規模な変更で、既存の動作ロジックには一切手を加えていないためマージ可能。

変更範囲は ARIA 属性の付与と装飾アイコンの aria-hidden ラップのみ。ビジネスロジック・API 呼び出し・状態管理はすべて変更なし。テスト更新も DOM 構造の変化に正確に追随しており、回帰リスクは低い。

特に注意が必要なファイルはないが、orgs-new.test.tsx に aria-describedby と aria-live の属性アサーションを追加するとより堅牢になる。
</details>


<details open><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| apps/web/src/app/orgs/new/page.tsx | aria-describedby / aria-live / aria-hidden を正しく追加。実装は ARIA 仕様に沿っており、動作上の問題は見当たらない。 |
| apps/web/src/app/__tests__/orgs-new.test.tsx | アイコン分離に伴い getByText のアサーションを更新。新たに追加された ARIA 属性 (aria-describedby / aria-live) 自体を検証するテストは存在しない。 |

</details>


<h3>Sequence Diagram</h3>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
sequenceDiagram
    participant User as ユーザー
    participant Input as slug input
    participant LiveRegion as div aria-live=polite
    participant API as /api/orgs/:slug

    User->>Input: 文字を入力
    Input->>LiveRegion: slugStatus → checking
    LiveRegion-->>User: アナウンス「確認中...」
    Input->>API: GET /api/orgs/slug (400ms debounce)
    API-->>Input: 404 or 200
    Input->>LiveRegion: slugStatus → available or taken
    LiveRegion-->>User: アナウンス「使用可能」or「使用済み」
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
sequenceDiagram
    participant User as ユーザー
    participant Input as slug input
    participant LiveRegion as div aria-live=polite
    participant API as /api/orgs/:slug

    User->>Input: 文字を入力
    Input->>LiveRegion: slugStatus → checking
    LiveRegion-->>User: アナウンス「確認中...」
    Input->>API: GET /api/orgs/slug (400ms debounce)
    API-->>Input: 404 or 200
    Input->>LiveRegion: slugStatus → available or taken
    LiveRegion-->>User: アナウンス「使用可能」or「使用済み」
```

</a>

<!-- greptile_failed_comments -->
<details open><summary><h3>Comments Outside Diff (1)</h3></summary>

1. `apps/web/src/app/__tests__/orgs-new.test.tsx`, line 54-58 ([link](https://github.com/hiroki-org/openshelf/blob/c13ef58889bfdbed95ef7a3c66b4229fddfba332/apps/web/src/app/__tests__/orgs-new.test.tsx#L54-L58)) 

   <a href="#"><img alt="P2" src="https://greptile-static-assets.s3.amazonaws.com/badges/p2.svg?v=9" align="top"></a> **新規 ARIA 属性のテストが存在しない**

   今回追加した `aria-describedby="org-slug-status"`・`id="org-slug-status"`・`aria-live="polite"` の各属性を検証するテストケースがありません。既存の description-counter テストが `aria-describedby` と `id` を正しくアサートしているのと同様に、スラッグ入力についても属性の存在を確認するテストを追加することで、将来の変更でアクセシビリティ対応が意図せず削除されるリスクを防げます。

   <details><summary>Prompt To Fix With AI</summary>

   `````markdown
   This is a comment left during a code review.
   Path: apps/web/src/app/__tests__/orgs-new.test.tsx
   Line: 54-58

   Comment:
   **新規 ARIA 属性のテストが存在しない**

   今回追加した `aria-describedby="org-slug-status"`・`id="org-slug-status"`・`aria-live="polite"` の各属性を検証するテストケースがありません。既存の description-counter テストが `aria-describedby` と `id` を正しくアサートしているのと同様に、スラッグ入力についても属性の存在を確認するテストを追加することで、将来の変更でアクセシビリティ対応が意図せず削除されるリスクを防げます。

   How can I resolve this? If you propose a fix, please make it concise.
   `````
   </details>

   Note: If this suggestion doesn't match your team's coding style, reply to this and let me know. I'll remember it for next time!

</details>

<!-- /greptile_failed_comments -->

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 1 code review issue. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 1
apps/web/src/app/__tests__/orgs-new.test.tsx:54-58
**新規 ARIA 属性のテストが存在しない**

今回追加した `aria-describedby="org-slug-status"`・`id="org-slug-status"`・`aria-live="polite"` の各属性を検証するテストケースがありません。既存の description-counter テストが `aria-describedby` と `id` を正しくアサートしているのと同様に、スラッグ入力についても属性の存在を確認するテストを追加することで、将来の変更でアクセシビリティ対応が意図せず削除されるリスクを防げます。


`````

</details>

<sub>Reviews (1): Last reviewed commit: ["fix(web): 組織作成ページのスラッグ入力にaria-describedb..."](https://github.com/hiroki-org/openshelf/commit/c13ef58889bfdbed95ef7a3c66b4229fddfba332) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=43035980)</sub>

<!-- /greptile_comment -->