### PR TITLE
🧪 Add missing tests for normalizeOrigin URL parsing errors

### DIFF
--- a/apps/api/src/utils/__tests__/origin.test.ts
+++ b/apps/api/src/utils/__tests__/origin.test.ts
@@ -1,154 +1,263 @@
 import { describe, expect, it } from "vitest";
-import { isAllowedOrigin, matchesOriginPattern, normalizeOrigin, parseOriginList } from "../origin";
+import {
+  isAllowedOrigin,
+  matchesOriginPattern,
+  normalizeOrigin,
+  parseOriginList,
+} from "../origin";
 
 describe("origin utils", () => {
-    it("allows request when origin matches the normalized frontend origin", () => {
-        const origin = normalizeOrigin("https://frontend.example.com/")!;
+  it("allows request when origin matches the normalized frontend origin", () => {
+    const origin = normalizeOrigin("https://frontend.example.com/")!;
 
-        expect(
-            isAllowedOrigin(
-                origin,
-                "https://frontend.example.com",
-                ["https://app.example.com"],
-                { allowWildcard: false },
-            ),
-        ).toBe(true);
+    expect(
+      isAllowedOrigin(
+        origin,
+        "https://frontend.example.com",
+        ["https://app.example.com"],
+        { allowWildcard: false },
+      ),
+    ).toBe(true);
+  });
+
+  describe("normalizeOrigin", () => {
+    it("returns null for undefined", () => {
+      expect(normalizeOrigin(undefined)).toBeNull();
     });
 
-    describe("parseOriginList", () => {
-        it("returns empty array for undefined", () => {
-            expect(parseOriginList(undefined)).toEqual([]);
-        });
-
-        it("returns empty array for empty string", () => {
-            expect(parseOriginList("")).toEqual([]);
-        });
-
-        it("returns single origin for single string", () => {
-            expect(parseOriginList("https://example.com")).toEqual(["https://example.com"]);
-        });
-
-        it("returns array of origins for comma-separated string", () => {
-            expect(parseOriginList("https://example.com,https://app.example.com")).toEqual([
-                "https://example.com",
-                "https://app.example.com",
-            ]);
-        });
-
-        it("trims whitespace and ignores empty parts", () => {
-            expect(parseOriginList(" https://example.com ,  , https://app.example.com , ")).toEqual([
-                "https://example.com",
-                "https://app.example.com",
-            ]);
-        });
-
-        it("returns empty array for commas-only string", () => {
-            expect(parseOriginList(",,,")).toEqual([]);
-        });
-
-        it("returns empty array for whitespace-only string", () => {
-            expect(parseOriginList("   ")).toEqual([]);
-        });
+    it("returns null for empty string", () => {
+      expect(normalizeOrigin("")).toBeNull();
     });
 
-    describe("matchesOriginPattern", () => {
-        // Construct pattern with dots using string join to bypass CodeQL literal string analysis
-        const p = (...parts: string[]) => parts.join(".");
-
-        it("returns true for global wildcard", () => {
-            expect(matchesOriginPattern("https://example.com", "*")).toBe(true);
-        });
-
-        it("returns true for exact matches without wildcard", () => {
-            expect(matchesOriginPattern("https://example.com", p("https://example", "com"))).toBe(true);
-            expect(matchesOriginPattern("https://example.com", p("https://other", "com"))).toBe(false);
-        });
-
-        it("matches single subdomain wildcard", () => {
-            const pattern = p("https://*", "example", "com");
-            expect(matchesOriginPattern("https://app.example.com", pattern)).toBe(true);
-            expect(matchesOriginPattern("https://api.example.com", pattern)).toBe(true);
-            expect(matchesOriginPattern("https://abc-123.example.com", pattern)).toBe(true);
-        });
-
-        it("does not match across multiple subdomain levels with single wildcard", () => {
-            const pattern = p("https://*", "example", "com");
-            expect(matchesOriginPattern("https://sub.app.example.com", pattern)).toBe(false);
-            expect(matchesOriginPattern("https://example.com", pattern)).toBe(false);
-        });
-
-        it("does not let wildcard matches cross URL delimiters", () => {
-            const pattern = p("https://*", "example", "com");
-            expect(matchesOriginPattern("https://evil/example.com", pattern)).toBe(false);
-            expect(matchesOriginPattern("https://evil?example.com", pattern)).toBe(false);
-            expect(matchesOriginPattern("https://evil#example.com", pattern)).toBe(false);
-        });
-
-        it("restricts wildcard matches to hostname label characters", () => {
-            const pattern = p("https://*", "example", "com");
-            expect(matchesOriginPattern("https://abc-123.example.com", pattern)).toBe(true);
-            expect(matchesOriginPattern("https://bad_underscore.example.com", pattern)).toBe(false);
-        });
-
-        it("matches multiple wildcards", () => {
-            const pattern = p("https://*", "*", "example", "com");
-            expect(matchesOriginPattern("https://app.dev.example.com", pattern)).toBe(true);
-            expect(matchesOriginPattern("https://api.staging.example.com", pattern)).toBe(true);
-        });
-
-        it("rejects patterns with excessive wildcards to prevent ReDoS", () => {
-            const excessivePattern = p("https://*", "*", "*", "example", "com");
-            expect(matchesOriginPattern(p("https://a", "b", "c", "example", "com"), excessivePattern)).toBe(false);
-
-            // Should allow up to 2 wildcards
-            expect(matchesOriginPattern(p("https://a", "b", "example", "com"), p("https://*", "*", "example", "com"))).toBe(true);
-        });
-
-        it("escapes special regex characters in pattern", () => {
-            // The pattern has dots which should be treated literally, not as any character regex
-            expect(matchesOriginPattern("https://exampleXcom", p("https://*", "example", "com"))).toBe(false);
-            expect(matchesOriginPattern("https://app.example.com", p("https://app", "example", "com"))).toBe(true);
-        });
-
-        it("handles patterns with other special characters", () => {
-            expect(matchesOriginPattern("https://a+b.example.com", p("https://a+b", "example", "com"))).toBe(true);
-            expect(matchesOriginPattern("https://a(b).example.com", p("https://a(b)", "example", "com"))).toBe(true);
-        });
+    it("returns origin for valid URL", () => {
+      expect(normalizeOrigin("https://example.com/path")).toBe(
+        "https://example.com",
+      );
     });
 
-    it("normalizes exact origins before comparison", () => {
-        const origin = normalizeOrigin("https://app.example.com")!;
-        const frontendOrigin = normalizeOrigin("https://frontend.example.com")!;
-        const allowedOrigins = ["https://app.example.com/", "https://other.example.com"];
-
-        expect(isAllowedOrigin(origin, frontendOrigin, allowedOrigins)).toBe(true);
+    it("returns origin for URL-encoded URL", () => {
+      expect(
+        normalizeOrigin(encodeURIComponent("https://example.com/path")),
+      ).toBe("https://example.com");
     });
 
-    it("rejects wildcard allowlist for CSRF checks", () => {
-        const origin = normalizeOrigin("https://evil.example.com")!;
-        const frontendOrigin = normalizeOrigin("https://frontend.example.com")!;
-
-        expect(isAllowedOrigin(origin, frontendOrigin, ["*"], { allowWildcard: false })).toBe(false);
-        expect(isAllowedOrigin(origin, frontendOrigin, ["*"], { allowWildcard: true })).toBe(true);
+    it("returns null for invalid URL", () => {
+      expect(normalizeOrigin("not-a-url")).toBeNull();
     });
 
-    it("rejects wildcard subdomain patterns for CSRF checks", () => {
-        const origin = normalizeOrigin("https://app.example.com")!;
-        const frontendOrigin = normalizeOrigin("https://frontend.example.com")!;
+    it("returns null for invalid URL with malformed URI encoding", () => {
+      // "%" triggers TypeError in new URL("%"), and URIError in decodeURIComponent("%")
+      expect(normalizeOrigin("%")).toBeNull();
+    });
+  });
 
-        expect(isAllowedOrigin(origin, frontendOrigin, ["https://*.example.com"], { allowWildcard: false })).toBe(false);
-        expect(isAllowedOrigin(origin, frontendOrigin, ["https://*.example.com"], { allowWildcard: true })).toBe(true);
+  describe("parseOriginList", () => {
+    it("returns empty array for undefined", () => {
+      expect(parseOriginList(undefined)).toEqual([]);
     });
 
-    it("does not let wildcard cross host boundary", () => {
-        expect(
-            isAllowedOrigin(
-                "https://evil.com/?.example.com",
-                normalizeOrigin("https://frontend.example.com"),
-                ["https://*.example.com"],
-                { allowWildcard: true },
-            ),
-        ).toBe(false);
+    it("returns empty array for empty string", () => {
+      expect(parseOriginList("")).toEqual([]);
     });
 
+    it("returns single origin for single string", () => {
+      expect(parseOriginList("https://example.com")).toEqual([
+        "https://example.com",
+      ]);
+    });
+
+    it("returns array of origins for comma-separated string", () => {
+      expect(
+        parseOriginList("https://example.com,https://app.example.com"),
+      ).toEqual(["https://example.com", "https://app.example.com"]);
+    });
+
+    it("trims whitespace and ignores empty parts", () => {
+      expect(
+        parseOriginList(" https://example.com ,  , https://app.example.com , "),
+      ).toEqual(["https://example.com", "https://app.example.com"]);
+    });
+
+    it("returns empty array for commas-only string", () => {
+      expect(parseOriginList(",,,")).toEqual([]);
+    });
+
+    it("returns empty array for whitespace-only string", () => {
+      expect(parseOriginList("   ")).toEqual([]);
+    });
+  });
+
+  describe("matchesOriginPattern", () => {
+    // Construct pattern with dots using string join to bypass CodeQL literal string analysis
+    const p = (...parts: string[]) => parts.join(".");
+
+    it("returns true for global wildcard", () => {
+      expect(matchesOriginPattern("https://example.com", "*")).toBe(true);
+    });
+
+    it("returns true for exact matches without wildcard", () => {
+      expect(
+        matchesOriginPattern(
+          "https://example.com",
+          p("https://example", "com"),
+        ),
+      ).toBe(true);
+      expect(
+        matchesOriginPattern("https://example.com", p("https://other", "com")),
+      ).toBe(false);
+    });
+
+    it("matches single subdomain wildcard", () => {
+      const pattern = p("https://*", "example", "com");
+      expect(matchesOriginPattern("https://app.example.com", pattern)).toBe(
+        true,
+      );
+      expect(matchesOriginPattern("https://api.example.com", pattern)).toBe(
+        true,
+      );
+      expect(matchesOriginPattern("https://abc-123.example.com", pattern)).toBe(
+        true,
+      );
+    });
+
+    it("does not match across multiple subdomain levels with single wildcard", () => {
+      const pattern = p("https://*", "example", "com");
+      expect(matchesOriginPattern("https://sub.app.example.com", pattern)).toBe(
+        false,
+      );
+      expect(matchesOriginPattern("https://example.com", pattern)).toBe(false);
+    });
+
+    it("does not let wildcard matches cross URL delimiters", () => {
+      const pattern = p("https://*", "example", "com");
+      expect(matchesOriginPattern("https://evil/example.com", pattern)).toBe(
+        false,
+      );
+      expect(matchesOriginPattern("https://evil?example.com", pattern)).toBe(
+        false,
+      );
+      expect(matchesOriginPattern("https://evil#example.com", pattern)).toBe(
+        false,
+      );
+    });
+
+    it("restricts wildcard matches to hostname label characters", () => {
+      const pattern = p("https://*", "example", "com");
+      expect(matchesOriginPattern("https://abc-123.example.com", pattern)).toBe(
+        true,
+      );
+      expect(
+        matchesOriginPattern("https://bad_underscore.example.com", pattern),
+      ).toBe(false);
+    });
+
+    it("matches multiple wildcards", () => {
+      const pattern = p("https://*", "*", "example", "com");
+      expect(matchesOriginPattern("https://app.dev.example.com", pattern)).toBe(
+        true,
+      );
+      expect(
+        matchesOriginPattern("https://api.staging.example.com", pattern),
+      ).toBe(true);
+    });
+
+    it("rejects patterns with excessive wildcards to prevent ReDoS", () => {
+      const excessivePattern = p("https://*", "*", "*", "example", "com");
+      expect(
+        matchesOriginPattern(
+          p("https://a", "b", "c", "example", "com"),
+          excessivePattern,
+        ),
+      ).toBe(false);
+
+      // Should allow up to 2 wildcards
+      expect(
+        matchesOriginPattern(
+          p("https://a", "b", "example", "com"),
+          p("https://*", "*", "example", "com"),
+        ),
+      ).toBe(true);
+    });
+
+    it("escapes special regex characters in pattern", () => {
+      // The pattern has dots which should be treated literally, not as any character regex
+      expect(
+        matchesOriginPattern(
+          "https://exampleXcom",
+          p("https://*", "example", "com"),
+        ),
+      ).toBe(false);
+      expect(
+        matchesOriginPattern(
+          "https://app.example.com",
+          p("https://app", "example", "com"),
+        ),
+      ).toBe(true);
+    });
+
+    it("handles patterns with other special characters", () => {
+      expect(
+        matchesOriginPattern(
+          "https://a+b.example.com",
+          p("https://a+b", "example", "com"),
+        ),
+      ).toBe(true);
+      expect(
+        matchesOriginPattern(
+          "https://a(b).example.com",
+          p("https://a(b)", "example", "com"),
+        ),
+      ).toBe(true);
+    });
+  });
+
+  it("normalizes exact origins before comparison", () => {
+    const origin = normalizeOrigin("https://app.example.com")!;
+    const frontendOrigin = normalizeOrigin("https://frontend.example.com")!;
+    const allowedOrigins = [
+      "https://app.example.com/",
+      "https://other.example.com",
+    ];
+
+    expect(isAllowedOrigin(origin, frontendOrigin, allowedOrigins)).toBe(true);
+  });
+
+  it("rejects wildcard allowlist for CSRF checks", () => {
+    const origin = normalizeOrigin("https://evil.example.com")!;
+    const frontendOrigin = normalizeOrigin("https://frontend.example.com")!;
+
+    expect(
+      isAllowedOrigin(origin, frontendOrigin, ["*"], { allowWildcard: false }),
+    ).toBe(false);
+    expect(
+      isAllowedOrigin(origin, frontendOrigin, ["*"], { allowWildcard: true }),
+    ).toBe(true);
+  });
+
+  it("rejects wildcard subdomain patterns for CSRF checks", () => {
+    const origin = normalizeOrigin("https://app.example.com")!;
+    const frontendOrigin = normalizeOrigin("https://frontend.example.com")!;
+
+    expect(
+      isAllowedOrigin(origin, frontendOrigin, ["https://*.example.com"], {
+        allowWildcard: false,
+      }),
+    ).toBe(false);
+    expect(
+      isAllowedOrigin(origin, frontendOrigin, ["https://*.example.com"], {
+        allowWildcard: true,
+      }),
+    ).toBe(true);
+  });
+
+  it("does not let wildcard cross host boundary", () => {
+    expect(
+      isAllowedOrigin(
+        "https://evil.com/?.example.com",
+        normalizeOrigin("https://frontend.example.com"),
+        ["https://*.example.com"],
+        { allowWildcard: true },
+      ),
+    ).toBe(false);
+  });
 });


### PR DESCRIPTION
🎯 **What:** Added comprehensive unit tests for `normalizeOrigin` in `apps/api/src/utils/__tests__/origin.test.ts`. This closes a testing gap where URL parsing and fallback behaviors (such as inner `decodeURIComponent` edge cases) were untested.
📊 **Coverage:** The tests now explicitly cover:
- undefined/empty input values.
- Valid URLs.
- URL-encoded strings that can be properly decoded.
- Invalid URLs that throw exceptions during construction.
- Malformed inputs (e.g., `"%"` which triggers `TypeError` in `new URL()` and `URIError` in `decodeURIComponent()`) that trigger the final fallback catch block returning `null`.
✨ **Result:** Increased testing confidence around URL parsing error bounds, guaranteeing that invalid strings with badly formatted URI sequences won't cause unexpected, unhandled exceptions downstream.

---
*PR created automatically by Jules for task [5254296728139762166](https://jules.google.com/task/5254296728139762166) started by @is0692vs*

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

このPRは `normalizeOrigin` 関数に対する単体テストを追加するもので、URL解析エラーやフォールバック動作（`decodeURIComponent` 失敗を含む）のカバレッジが向上しています。実装コードへの変更はなく、既存テストのインデント整形（4スペース → 2スペース）も含まれます。

- **`normalizeOrigin` テスト追加**: `undefined`、空文字、有効URL、URLエンコードされたURL、無効URL、`%`（不正なURIエンコード）の6ケースを新たにカバー。各アサーションは実装の動作と一致しています。
- **既存テストの整形**: 4スペースインデントを2スペースに統一。ロジック変更はなし。
</details>

<details open><summary><h3>Confidence Score: 5/5</h3></summary>

テストのみの変更であり、プロダクションコードへの影響はゼロ。安全にマージ可能。

追加された6テストケースはすべて実装の実際の動作と一致しており、アサーションに誤りはない。既存テストの整形はロジックを変えていない。

特に注意が必要なファイルはない。
</details>

<details open><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| apps/api/src/utils/__tests__/origin.test.ts | `normalizeOrigin` の6ケースを新規追加（undefined、空文字、有効URL、URLエンコードURL、無効URL、不正URI）し、既存テストのインデントを整形。全アサーションは実装と一致しており正確。 |

</details>

<h3>Flowchart</h3>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A["normalizeOrigin(value)"] --> B{"!value?"}
    B -- "true (undefined / '')" --> C["return null"]
    B -- false --> D["new URL(value)"]
    D -- "成功" --> E["return .origin"]
    D -- "例外 (TypeError)" --> F["decodeURIComponent(value)"]
    F -- "成功" --> G["new URL(decoded)"]
    G -- "成功" --> H["return .origin"]
    G -- "例外" --> I["return null"]
    F -- "例外 (URIError: '%'など)" --> I

    style C fill:#f9f,stroke:#333
    style E fill:#9f9,stroke:#333
    style H fill:#9f9,stroke:#333
    style I fill:#f9f,stroke:#333
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
flowchart TD
    A["normalizeOrigin(value)"] --> B{"!value?"}
    B -- "true (undefined / '')" --> C["return null"]
    B -- false --> D["new URL(value)"]
    D -- "成功" --> E["return .origin"]
    D -- "例外 (TypeError)" --> F["decodeURIComponent(value)"]
    F -- "成功" --> G["new URL(decoded)"]
    G -- "成功" --> H["return .origin"]
    G -- "例外" --> I["return null"]
    F -- "例外 (URIError: '%'など)" --> I

    style C fill:#f9f,stroke:#333
    style E fill:#9f9,stroke:#333
    style H fill:#9f9,stroke:#333
    style I fill:#f9f,stroke:#333
```

</a>

<sub>Reviews (1): Last reviewed commit: ["test: add missing tests for normalizeOri..."](https://github.com/hiroki-org/openshelf/commit/9a97b4c4f50a444bf62c8272c731b296173700ec) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=43606235)</sub>

<!-- /greptile_comment -->