### PR TITLE
🎨 Palette: 統一的なローディングスピナーの導入 (UX/a11y改善)

### DIFF
--- a/apps/web/src/app/__tests__/collections-new.test.tsx
+++ b/apps/web/src/app/__tests__/collections-new.test.tsx
@@ -41,7 +41,9 @@ describe("NewCollectionPage", () => {
     );
 
     expect(status).toBeInTheDocument();
-    expect(status.querySelector('[aria-hidden="true"]')).toHaveTextContent(icon);
+    expect(status.querySelector('[aria-hidden="true"]')).toHaveTextContent(
+      icon,
+    );
   };
 
   const expectSlugAvailable = () => expectSlugStatus("✓ 使用可能", "✓");
@@ -172,7 +174,7 @@ describe("NewCollectionPage", () => {
       await screen.findByRole("button", { name: "作成中..." }),
     ).toBeDisabled();
     expect(
-      container.querySelector('[aria-hidden="true"].animate-spin'),
+      container.querySelector(".motion-safe\\:animate-spin"),
     ).toBeInTheDocument();
 
     resolveCreate(

--- a/apps/web/src/app/__tests__/orgs-new.test.tsx
+++ b/apps/web/src/app/__tests__/orgs-new.test.tsx
@@ -143,7 +143,7 @@ describe("NewOrgPage", () => {
       await screen.findByRole("button", { name: "作成中..." }),
     ).toBeDisabled();
     expect(
-      container.querySelector('[aria-hidden="true"].animate-spin'),
+      container.querySelector(".motion-safe\\:animate-spin"),
     ).toBeInTheDocument();
 
     resolveCreate(

--- a/apps/web/src/app/__tests__/paper-edit-page.test.tsx
+++ b/apps/web/src/app/__tests__/paper-edit-page.test.tsx
@@ -226,7 +226,7 @@ describe("PaperEditPage", () => {
       await screen.findByRole("button", { name: "保存中..." }),
     ).toBeDisabled();
     expect(
-      container.querySelector('[aria-hidden="true"].animate-spin'),
+      container.querySelector(".motion-safe\\:animate-spin"),
     ).toBeInTheDocument();
 
     resolvePatch(new Response("{}", { status: 200 }));
@@ -629,6 +629,8 @@ describe("PaperEditPage", () => {
     authState = { user: null, loading: true };
 
     const { container } = render(<PaperEditPage />);
-    expect(container.querySelector(".animate-spin")).not.toBeNull();
+    expect(
+      container.querySelector(".motion-safe\\:animate-spin"),
+    ).not.toBeNull();
   });
 });

--- a/apps/web/src/app/__tests__/settings-page.test.tsx
+++ b/apps/web/src/app/__tests__/settings-page.test.tsx
@@ -89,7 +89,7 @@ describe("SettingsPage", () => {
       await screen.findByRole("button", { name: "保存中..." }),
     ).toBeDisabled();
     expect(
-      container.querySelector('[aria-hidden="true"].animate-spin'),
+      container.querySelector(".motion-safe\\:animate-spin"),
     ).toBeInTheDocument();
 
     resolveSave(new Response("{}", { status: 200 }));

--- a/apps/web/src/app/collections/new/page.tsx
+++ b/apps/web/src/app/collections/new/page.tsx
@@ -5,6 +5,7 @@ import { apiFetch } from "@/lib/api";
 import { useRouter } from "next/navigation";
 import { useEffect, useMemo, useRef, useState } from "react";
 import Link from "next/link";
+import { Spinner } from "@/components/spinner";
 
 function slugify(text: string): string {
   return text
@@ -374,12 +375,7 @@ export default function NewCollectionPage() {
           }
           className="inline-flex items-center justify-center gap-2 rounded-md bg-gray-900 px-4 py-2 text-sm text-white hover:bg-gray-700 disabled:opacity-50 dark:bg-white dark:text-gray-900 dark:hover:bg-gray-200"
         >
-          {submitting && (
-            <span
-              aria-hidden="true"
-              className="h-4 w-4 animate-spin rounded-full border-2 border-current border-t-transparent"
-            />
-          )}
+          {submitting && <Spinner />}
           {submitting ? "作成中..." : "作成"}
         </button>
       </form>

--- a/apps/web/src/app/orgs/[slug]/settings/page.tsx
+++ b/apps/web/src/app/orgs/[slug]/settings/page.tsx
@@ -6,6 +6,7 @@ import { useParams, useRouter, useSearchParams } from "next/navigation";
 import { useEffect, useState, useCallback, useRef } from "react";
 import Image from "next/image";
 import Link from "next/link";
+import { Spinner } from "@/components/spinner";
 
 type Org = {
   id: string;
@@ -474,10 +475,7 @@ export default function OrgSettingsPage() {
           >
             {saving ? (
               <span className="flex items-center justify-center gap-2">
-                <span
-                  className="h-4 w-4 motion-safe:animate-spin rounded-full border-2 border-current border-t-transparent"
-                  aria-hidden="true"
-                />
+                <Spinner />
                 保存中...
               </span>
             ) : (
@@ -522,10 +520,7 @@ export default function OrgSettingsPage() {
                   >
                     {deleting ? (
                       <span className="flex items-center justify-center gap-2">
-                        <span
-                          className="h-4 w-4 motion-safe:animate-spin rounded-full border-2 border-current border-t-transparent"
-                          aria-hidden="true"
-                        />
+                        <Spinner />
                         削除中...
                       </span>
                     ) : (
@@ -592,10 +587,7 @@ export default function OrgSettingsPage() {
                     >
                       {inviting === u.id ? (
                         <span className="flex items-center justify-center gap-1">
-                          <span
-                            className="h-3 w-3 motion-safe:animate-spin rounded-full border-2 border-current border-t-transparent"
-                            aria-hidden="true"
-                          />
+                          <Spinner className="h-3 w-3" />
                           追加中...
                         </span>
                       ) : (
@@ -689,10 +681,7 @@ export default function OrgSettingsPage() {
                     >
                       {addingPaper === p.id ? (
                         <span className="flex items-center justify-center gap-1">
-                          <span
-                            className="h-3 w-3 motion-safe:animate-spin rounded-full border-2 border-current border-t-transparent"
-                            aria-hidden="true"
-                          />
+                          <Spinner className="h-3 w-3" />
                           追加中...
                         </span>
                       ) : (

--- a/apps/web/src/app/orgs/new/page.tsx
+++ b/apps/web/src/app/orgs/new/page.tsx
@@ -5,6 +5,7 @@ import { apiFetch } from "@/lib/api";
 import { useRouter } from "next/navigation";
 import { useEffect, useState, useCallback, useRef } from "react";
 import Link from "next/link";
+import { Spinner } from "@/components/spinner";
 
 const SLUG_RE = /^[a-z0-9][a-z0-9-]*[a-z0-9]$|^[a-z0-9]$/;
 const ORG_DESCRIPTION_MAX_LENGTH = 500;
@@ -230,12 +231,7 @@ export default function NewOrgPage() {
           }
           className="inline-flex w-full items-center justify-center gap-2 rounded-md bg-gray-900 px-4 py-2.5 text-sm text-white hover:bg-gray-700 disabled:opacity-50 dark:bg-white dark:text-gray-900 dark:hover:bg-gray-200"
         >
-          {submitting && (
-            <span
-              aria-hidden="true"
-              className="h-4 w-4 animate-spin rounded-full border-2 border-current border-t-transparent"
-            />
-          )}
+          {submitting && <Spinner />}
           {submitting ? "作成中..." : "作成"}
         </button>
       </form>

--- a/apps/web/src/app/papers/[id]/edit/page.tsx
+++ b/apps/web/src/app/papers/[id]/edit/page.tsx
@@ -8,6 +8,7 @@ import { splitTagInput } from "@/lib/tags";
 import { useRouter, useParams } from "next/navigation";
 import { useEffect, useState } from "react";
 import Link from "next/link";
+import { Spinner } from "@/components/spinner";
 
 const VISIBILITY_OPTIONS = [
   { value: "private", label: "非公開" },
@@ -229,7 +230,7 @@ export default function PaperEditPage() {
   if (authLoading || loading) {
     return (
       <div className="flex justify-center py-20">
-        <div className="h-8 w-8 animate-spin rounded-full border-4 border-blue-600 border-t-transparent" />
+        <Spinner className="h-8 w-8 border-4 border-blue-600" />
       </div>
     );
   }
@@ -532,12 +533,7 @@ export default function PaperEditPage() {
             disabled={submitting}
             className="inline-flex items-center justify-center gap-2 rounded-md bg-blue-600 px-6 py-2 text-white transition-colors hover:bg-blue-500 disabled:opacity-50 font-medium"
           >
-            {submitting && (
-              <span
-                aria-hidden="true"
-                className="h-4 w-4 animate-spin rounded-full border-2 border-current border-t-transparent"
-              />
-            )}
+            {submitting && <Spinner />}
             {submitting ? "保存中..." : "保存する"}
           </button>
         </div>

--- a/apps/web/src/app/settings/page.tsx
+++ b/apps/web/src/app/settings/page.tsx
@@ -5,6 +5,7 @@ import { apiFetch } from "@/lib/api";
 import { useEffect, useMemo, useState } from "react";
 import { useRouter } from "next/navigation";
 import Link from "next/link";
+import { Spinner } from "@/components/spinner";
 
 export default function SettingsPage() {
   const { user, loading, refresh } = useAuth();
@@ -162,12 +163,7 @@ export default function SettingsPage() {
             disabled={saving}
             className="inline-flex min-w-32 items-center justify-center gap-2 rounded-xl bg-gray-900 px-4 py-2.5 text-sm font-medium text-white transition-colors hover:bg-gray-700 disabled:opacity-50 dark:bg-white dark:text-gray-900 dark:hover:bg-gray-200"
           >
-            {saving && (
-              <span
-                aria-hidden="true"
-                className="h-4 w-4 animate-spin rounded-full border-2 border-current border-t-transparent"
-              />
-            )}
+            {saving && <Spinner />}
             {saving ? "保存中..." : "保存"}
           </button>
 

--- a/apps/web/src/app/upload/page.tsx
+++ b/apps/web/src/app/upload/page.tsx
@@ -7,6 +7,7 @@ import { splitTagInput } from "@/lib/tags";
 import { useRouter } from "next/navigation";
 import { useEffect, useRef, useState } from "react";
 import Link from "next/link";
+import { Spinner } from "@/components/spinner";
 
 const VALID_FILE_TYPES = [
   "paper",
@@ -571,7 +572,7 @@ export default function UploadPage() {
           >
             {uploading ? (
               <span className="flex items-center gap-2">
-                <span className="h-4 w-4 animate-spin rounded-full border-2 border-current border-t-transparent" />
+                <Spinner />
                 アップロード中...
               </span>
             ) : (


### PR DESCRIPTION
💡 What:
各ページの非同期処理ボタン内に直接書かれていたローディングスピナーのHTMLを、既存の `<Spinner />` コンポーネントに置き換えました。また、それに伴いテストファイル内のセレクタを更新しました。

🎯 Why:
コードの重複を減らすとともに、視覚的な一貫性を保ちます。また、一部で欠落していた `aria-hidden` や `prefers-reduced-motion` 対応を `<Spinner />` コンポーネントを通じて全体に適用することで、アクセシビリティを向上させます。

📸 Before/After:
視覚的な変更はありませんが、HTMLの構造が統一されました。

♿ Accessibility:
インラインでハードコーディングされていた箇所にも `aria-hidden="true"` や `motion-safe:` クラスが行き渡るようになり、スクリーンリーダー利用者やアニメーション削減を求めるユーザーへの配慮が向上しました。

---
*PR created automatically by Jules for task [55400039955186331](https://jules.google.com/task/55400039955186331) started by @is0692vs*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Standardized loading indicators across collection, organization, paper, settings, and upload workflows.
  - Spinners now appear consistently during form submission, saving, deletion, adding items, authentication, and uploads.
  - Preserved existing button labels, disabled states, and progress behavior.

- **Tests**
  - Updated loading-state checks to match the standardized spinner presentation and accessibility markup.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

各ページのインラインローディングスピナーを既存の `<Spinner />` コンポーネントに統一し、コードの重複排除・`aria-hidden`・`motion-safe:animate-spin` の一貫した適用によるアクセシビリティ改善を行うリファクタリングです。テストファイルのセレクタも新しいクラス名に合わせて更新されています。

- `<Spinner />` をデフォルト（`h-4 w-4`）で使う箇所は問題ありませんが、`className` プロパティでサイズ・ボーダーを上書きする 3 箇所（`orgs/[slug]/settings` の `h-3 w-3` × 2、`papers/[id]/edit` の `h-8 w-8 border-4 border-blue-600`）でTailwindクラスの競合が発生し、視覚的なリグレッションが起きます。
- プロジェクトに `tailwind-merge` が存在しないため、デフォルトクラスと上書きクラスが両方付与された状態になり、CSSの生成順次第でどちらが適用されるか変わります。特に `h-3 w-3` の上書きは `h-4 w-4` に負けてしまう可能性が高く、元のインラインコードより大きいスピナーが表示されます。
</details>

<details open><summary><h3>Confidence Score: 3/5</h3></summary>

デフォルトサイズを使う箇所は安全ですが、`className` で上書きしている箇所に視覚的なリグレッションがあります。

`Spinner` コンポーネントの `className` を単純結合する実装が、`h-3 w-3` や `border-blue-600` などの上書きを意図通りに反映できません。`orgs/[slug]/settings` ではスピナーが `h-4 w-4` として描画され、元コードより大きく表示される可能性が高いです。`papers/[id]/edit` のページ全体ローディングスピナーは青色が失われる可能性があります。複数ページに影響があり、修正なしでのマージはリスクがあります。

`apps/web/src/components/spinner.tsx`（クラスマージ処理の追加が必要）、`apps/web/src/app/orgs/[slug]/settings/page.tsx`（`h-3 w-3` 上書きが機能しない）、`apps/web/src/app/papers/[id]/edit/page.tsx`（`border-blue-600` 上書きが機能しない可能性）
</details>

<details open><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| apps/web/src/components/spinner.tsx | `className` を単純結合しているため、`h-3 w-3` や `h-8 w-8 border-4 border-blue-600` を渡した際にデフォルトクラスと競合し、視覚リグレッションが発生する |
| apps/web/src/app/orgs/[slug]/settings/page.tsx | `<Spinner className="h-3 w-3" />` を 2 箇所使用しているが、Tailwind のクラス競合により実際は `h-4 w-4` が適用される可能性がある |
| apps/web/src/app/papers/[id]/edit/page.tsx | ページ全体ローディング時に `<Spinner className="h-8 w-8 border-4 border-blue-600" />` を使用。サイズ上書きは動くが `border-blue-600` が `border-current` に負ける可能性あり |
| apps/web/src/app/collections/new/page.tsx | デフォルトの `<Spinner />` に置き換え。クラス競合なし、問題なし |
| apps/web/src/app/orgs/new/page.tsx | デフォルトの `<Spinner />` に置き換え。クラス競合なし、問題なし |
| apps/web/src/app/settings/page.tsx | デフォルトの `<Spinner />` に置き換え。クラス競合なし、問題なし |
| apps/web/src/app/upload/page.tsx | デフォルトの `<Spinner />` に置き換え。元コードは `aria-hidden` なしだったため、アクセシビリティ改善になっている |
| apps/web/src/app/__tests__/collections-new.test.tsx | セレクタを `.motion-safe\\:animate-spin` に更新。Spinner コンポーネントの実際のクラス名と一致している |
| apps/web/src/app/__tests__/orgs-new.test.tsx | セレクタを `.motion-safe\\:animate-spin` に更新。問題なし |
| apps/web/src/app/__tests__/paper-edit-page.test.tsx | セレクタを `.motion-safe\\:animate-spin` に更新。問題なし |
| apps/web/src/app/__tests__/settings-page.test.tsx | セレクタを `.motion-safe\\:animate-spin` に更新。問題なし |

</details>

<h3>Flowchart</h3>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A["各ページコンポーネント"] --> B{"className指定あり?"}
    B -- "なし (デフォルト h-4 w-4)" --> C["Spinner デフォルト ✅"]
    B -- "あり (例: h-3 w-3)" --> D["クラス文字列: h-4 w-4 ... h-3 w-3"]
    D --> E{"Tailwind CSS 生成順"}
    E -- "数値昇順のため h-4 が h-3 より後" --> F["h-4 w-4 が適用される ⚠️"]
    B -- "あり (h-8 w-8 border-4 border-blue-600)" --> G["クラス文字列: h-4 w-4 border-current ... h-8 w-8 border-4 border-blue-600"]
    G --> H{"border-color の生成順"}
    H -- "border-blue-* が border-current より前の場合" --> I["border-current が適用される ⚠️"]
    H -- "border-current が先の場合" --> J["border-blue-600 が適用される ✅"]
    C --> K["意図通りのスピナー表示"]
    F --> L["元コードより大きいスピナー"]
    I --> M["青色ではなくテキスト色のスピナー"]
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
flowchart TD
    A["各ページコンポーネント"] --> B{"className指定あり?"}
    B -- "なし (デフォルト h-4 w-4)" --> C["Spinner デフォルト ✅"]
    B -- "あり (例: h-3 w-3)" --> D["クラス文字列: h-4 w-4 ... h-3 w-3"]
    D --> E{"Tailwind CSS 生成順"}
    E -- "数値昇順のため h-4 が h-3 より後" --> F["h-4 w-4 が適用される ⚠️"]
    B -- "あり (h-8 w-8 border-4 border-blue-600)" --> G["クラス文字列: h-4 w-4 border-current ... h-8 w-8 border-4 border-blue-600"]
    G --> H{"border-color の生成順"}
    H -- "border-blue-* が border-current より前の場合" --> I["border-current が適用される ⚠️"]
    H -- "border-current が先の場合" --> J["border-blue-600 が適用される ✅"]
    C --> K["意図通りのスピナー表示"]
    F --> L["元コードより大きいスピナー"]
    I --> M["青色ではなくテキスト色のスピナー"]
```

</a>

<sub>Reviews (1): Last reviewed commit: ["ローディングスピナーをSpinnerコンポーネントに統一"](https://github.com/hiroki-org/openshelf/commit/d7d9a8f805a4f68e940d98b7d26c0bd57996c61f) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=43640037)</sub>

<!-- /greptile_comment -->