### PR TITLE
🎨 Palette: キーボードフォーカス時の視認性向上

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -28,3 +28,7 @@
 ## 2026-06-20 - Collection Slug Validation Accessibility
 **Learning:** コレクションの slug のような動的にバリデーションされる入力フィールドにおいて、バリデーションステータスの `<p>` タグに `aria-live="polite"` を付与し、かつ `<input>` 要素に `aria-describedby` で関連付けることで、ユーザーが入力した際に非同期で変化する「確認中...」や「✓ 使用可能」などの状態がスクリーンリーダーに正しく読み上げられるようになり、アクセシビリティが向上します。
 **Action:** 今後、動的な入力バリデーション（可用性チェックなど）を実装・改善する際は、必ず入力フィールドに `aria-describedby` を付与し、ステータス表示の要素に `aria-live="polite"` を付与するパターンを適用します。
+
+## 2024-07-12 - [Focus-visible Accessibility on Interactive Elements]
+**Learning:** キーボードナビゲーションのフォーカスリングに `focus-visible:ring-2` と `focus-visible:ring-offset-2` を組み合わせることで、多様な背景色でも視認性が確保できる。
+**Action:** アプリ全体のボタンやリンク（特にHeaderや再利用可能なコンポーネント）において、一貫して `focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-offset-2` とそのダークモード対応を実装する。

--- a/apps/web/src/components/feed-button.tsx
+++ b/apps/web/src/components/feed-button.tsx
@@ -13,7 +13,7 @@ type FeedButtonProps = {
 
 export function FeedButton({
   url,
-  className = "rounded-md border border-gray-300 px-3 py-1.5 text-sm hover:bg-gray-50 dark:border-gray-700 dark:hover:bg-gray-800",
+  className = "rounded-md border border-gray-300 px-3 py-1.5 text-sm hover:bg-gray-50 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-gray-900 focus-visible:ring-offset-2 dark:border-gray-700 dark:hover:bg-gray-800 dark:focus-visible:ring-gray-100 dark:focus-visible:ring-offset-gray-950",
   label = "📡 Feed",
   ariaLabel,
 }: FeedButtonProps) {
@@ -74,12 +74,12 @@ export function FeedButton({
             aria-label="フィード URL"
             value={url}
             rows={3}
-            className="mt-2 w-full resize-none rounded-md border border-gray-300 bg-gray-50 px-3 py-2 text-xs text-gray-700 dark:border-gray-700 dark:bg-gray-950 dark:text-gray-200"
+            className="mt-2 w-full resize-none rounded-md border border-gray-300 bg-gray-50 px-3 py-2 text-xs text-gray-700 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-gray-900 focus-visible:ring-offset-2 dark:border-gray-700 dark:bg-gray-950 dark:text-gray-200 dark:focus-visible:ring-gray-100 dark:focus-visible:ring-offset-gray-950"
           />
           <div className="mt-3 flex items-center gap-2">
             <button
               type="button"
-              className="rounded-md border border-gray-300 px-3 py-1.5 text-sm hover:bg-gray-50 dark:border-gray-700 dark:hover:bg-gray-800"
+              className="rounded-md border border-gray-300 px-3 py-1.5 text-sm hover:bg-gray-50 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-gray-900 focus-visible:ring-offset-2 dark:border-gray-700 dark:hover:bg-gray-800 dark:focus-visible:ring-gray-100 dark:focus-visible:ring-offset-gray-950"
               aria-label="フィードURLをクリップボードにコピー"
               onClick={handleCopy}
             >
@@ -89,7 +89,7 @@ export function FeedButton({
               href={url}
               target="_blank"
               rel="noreferrer noopener"
-              className="rounded-md border border-gray-300 px-3 py-1.5 text-sm hover:bg-gray-50 dark:border-gray-700 dark:hover:bg-gray-800"
+              className="rounded-md border border-gray-300 px-3 py-1.5 text-sm hover:bg-gray-50 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-gray-900 focus-visible:ring-offset-2 dark:border-gray-700 dark:hover:bg-gray-800 dark:focus-visible:ring-gray-100 dark:focus-visible:ring-offset-gray-950"
               aria-label="フィードを新しいタブで開く"
             >
               開く

--- a/apps/web/src/components/header.tsx
+++ b/apps/web/src/components/header.tsx
@@ -38,7 +38,7 @@ export function Header() {
                     key={item.href}
                     href={item.href}
                     aria-current={isActive ? "page" : undefined}
-                    className={`rounded-full px-3 py-1.5 transition-colors ${
+                    className={`rounded-full px-3 py-1.5 transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-gray-900 focus-visible:ring-offset-2 dark:focus-visible:ring-gray-100 dark:focus-visible:ring-offset-gray-950 ${
                       isActive
                         ? "bg-gray-900 text-white dark:bg-gray-100 dark:text-gray-900"
                         : "text-gray-600 hover:bg-gray-100 hover:text-gray-900 dark:text-gray-400 dark:hover:bg-gray-800 dark:hover:text-gray-100"
@@ -70,7 +70,7 @@ export function Header() {
               <button
                 type="button"
                 onClick={logout}
-                className="rounded-full border border-gray-300 px-3 py-1.5 text-sm text-gray-700 transition-colors hover:bg-gray-100 hover:text-gray-900 dark:border-gray-700 dark:text-gray-200 dark:hover:bg-gray-800 dark:hover:text-gray-50"
+                className="rounded-full border border-gray-300 px-3 py-1.5 text-sm text-gray-700 transition-colors hover:bg-gray-100 hover:text-gray-900 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-gray-900 focus-visible:ring-offset-2 dark:border-gray-700 dark:text-gray-200 dark:hover:bg-gray-800 dark:hover:text-gray-50 dark:focus-visible:ring-gray-100 dark:focus-visible:ring-offset-gray-950"
               >
                 ログアウト
               </button>
@@ -79,7 +79,7 @@ export function Header() {
             <button
               type="button"
               onClick={login}
-              className="rounded-full bg-gray-900 px-4 py-2 text-sm font-medium text-white transition-colors hover:bg-gray-700 dark:bg-white dark:text-gray-900 dark:hover:bg-gray-200"
+              className="rounded-full bg-gray-900 px-4 py-2 text-sm font-medium text-white transition-colors hover:bg-gray-700 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-gray-900 focus-visible:ring-offset-2 dark:bg-white dark:text-gray-900 dark:hover:bg-gray-200 dark:focus-visible:ring-gray-100 dark:focus-visible:ring-offset-gray-950"
             >
               GitHubでログイン
             </button>


### PR DESCRIPTION
💡 What: ヘッダーやフィードボタンの各種ボタン・リンクに `focus-visible` クラスを追加し、キーボード操作時のフォーカスインジケーターを明確にしました。

🎯 Why: キーボードユーザーが現在どこにフォーカスが当たっているかを視覚的に把握しやすくするため。

📸 Before/After: N/A

♿ Accessibility: キーボードナビゲーション時の視認性が向上しました。

---
*PR created automatically by Jules for task [14607321236183531301](https://jules.google.com/task/14607321236183531301) started by @is0692vs*

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

ヘッダーとフィードボタンのインタラクティブ要素（ナビリンク・ログアウト/ログインボタン・コピーボタン・開くリンク・textarea）に `focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-gray-900 focus-visible:ring-offset-2` とダークモード対応クラスを追加し、キーボードナビゲーション時のフォーカスインジケーターを改善するPRです。

- `header.tsx`: ナビリンク・ログアウトボタン・ログインボタンの3箇所に focus-visible クラスを追加。ただし「OpenShelf」ロゴリンクが未対応のまま残っています。
- `feed-button.tsx`: トリガーボタン（デフォルト className）・dialog内の textarea・コピーボタン・開くリンクの4箇所に一貫して focus-visible クラスを追加。こちらは網羅的に対応されています。
- `.Jules/palette.md`: 今回採用したフォーカスリングパターンをチームの学習ログとして記録。
</details>


<details open><summary><h3>Confidence Score: 4/5</h3></summary>

アクセシビリティ向上のための小規模なスタイル追加のみで、機能ロジックへの変更はなくマージしても安全です。

「OpenShelf」ロゴリンクへの対応漏れとアクティブ状態でのフォーカスリングコントラスト問題があり、PRの目的（すべてのインタラクティブ要素への対応）が完全には達成されていません。ただし既存の動作を壊す変更はなく、アクセシビリティは全体的に向上しています。

apps/web/src/components/header.tsx — ロゴリンクへの対応漏れとアクティブリンクのコントラストについて確認が必要です。
</details>


<details open><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| .Jules/palette.md | focus-visible パターンのベストプラクティスをチームの学習ログとして記録。内容は適切。 |
| apps/web/src/components/feed-button.tsx | デフォルト className・textarea・コピーボタン・開くリンクに一貫して focus-visible クラスを追加。対応は網羅的で問題なし。 |
| apps/web/src/components/header.tsx | ナビリンク・ログアウトボタン・ログインボタンに focus-visible クラスを追加したが、「OpenShelf」ロゴリンクが未対応。アクティブなナビリンクでリングと背景が同色になる可能性あり。 |

</details>


<h3>Flowchart</h3>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[キーボード操作 Tab キー] --> B{フォーカス対象}
    B --> C[Header: OpenShelfロゴリンク]
    B --> D[Header: ナビリンク]
    B --> E[Header: ログアウトボタン]
    B --> F[Header: ログインボタン]
    B --> G[FeedButton: トリガーボタン]
    C -->|❌ focus-visible 未対応| C1[フォーカスリング非表示]
    D -->|✅ focus-visible 追加| D1[ring-2 ring-gray-900 表示]
    E -->|✅ focus-visible 追加| E1[ring-2 ring-gray-900 表示]
    F -->|✅ focus-visible 追加| F1[ring-2 ring-gray-900 表示]
    G -->|✅ focus-visible 追加| G1[ring-2 ring-gray-900 表示]
    G1 --> H[ダイアログ開く]
    H --> I[textarea]
    H --> J[コピーボタン]
    H --> K[開くリンク]
    I -->|✅ focus-visible 追加| I1[ring-2 ring-gray-900 表示]
    J -->|✅ focus-visible 追加| J1[ring-2 ring-gray-900 表示]
    K -->|✅ focus-visible 追加| K1[ring-2 ring-gray-900 表示]
    D1 --> L{アクティブ状態?}
    L -->|Yes: bg-gray-900 + ring-gray-900| M[⚠️ 同色でコントラスト低]
    L -->|No| N[✅ 適切なコントラスト]
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
flowchart TD
    A[キーボード操作 Tab キー] --> B{フォーカス対象}
    B --> C[Header: OpenShelfロゴリンク]
    B --> D[Header: ナビリンク]
    B --> E[Header: ログアウトボタン]
    B --> F[Header: ログインボタン]
    B --> G[FeedButton: トリガーボタン]
    C -->|❌ focus-visible 未対応| C1[フォーカスリング非表示]
    D -->|✅ focus-visible 追加| D1[ring-2 ring-gray-900 表示]
    E -->|✅ focus-visible 追加| E1[ring-2 ring-gray-900 表示]
    F -->|✅ focus-visible 追加| F1[ring-2 ring-gray-900 表示]
    G -->|✅ focus-visible 追加| G1[ring-2 ring-gray-900 表示]
    G1 --> H[ダイアログ開く]
    H --> I[textarea]
    H --> J[コピーボタン]
    H --> K[開くリンク]
    I -->|✅ focus-visible 追加| I1[ring-2 ring-gray-900 表示]
    J -->|✅ focus-visible 追加| J1[ring-2 ring-gray-900 表示]
    K -->|✅ focus-visible 追加| K1[ring-2 ring-gray-900 表示]
    D1 --> L{アクティブ状態?}
    L -->|Yes: bg-gray-900 + ring-gray-900| M[⚠️ 同色でコントラスト低]
    L -->|No| N[✅ 適切なコントラスト]
```

</a>

<!-- greptile_failed_comments -->
<details open><summary><h3>Comments Outside Diff (2)</h3></summary>

1. `apps/web/src/components/header.tsx`, line 23-28 ([link](https://github.com/hiroki-org/openshelf/blob/81c8783952d65632c66ec93dab666cebbd206e15/apps/web/src/components/header.tsx#L23-L28)) 

   <a href="#"><img alt="P2" src="https://greptile-static-assets.s3.amazonaws.com/badges/p2.svg?v=9" align="top"></a> **「OpenShelf」ロゴリンクの `focus-visible` 対応漏れ**

   このPRはヘッダー内のインタラクティブ要素へのフォーカスリング追加を目的としていますが、「OpenShelf」ロゴの `Link` コンポーネント（23行目）が対応漏れになっています。キーボードナビゲーション時に Tab キーでこのリンクにフォーカスが当たっても、フォーカスインジケーターが表示されません。他のリンク・ボタンと同様に `focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-gray-900 focus-visible:ring-offset-2 dark:focus-visible:ring-gray-100 dark:focus-visible:ring-offset-gray-950` を追加してください。

   <details><summary>Prompt To Fix With AI</summary>

   `````markdown
   This is a comment left during a code review.
   Path: apps/web/src/components/header.tsx
   Line: 23-28

   Comment:
   **「OpenShelf」ロゴリンクの `focus-visible` 対応漏れ**

   このPRはヘッダー内のインタラクティブ要素へのフォーカスリング追加を目的としていますが、「OpenShelf」ロゴの `Link` コンポーネント（23行目）が対応漏れになっています。キーボードナビゲーション時に Tab キーでこのリンクにフォーカスが当たっても、フォーカスインジケーターが表示されません。他のリンク・ボタンと同様に `focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-gray-900 focus-visible:ring-offset-2 dark:focus-visible:ring-gray-100 dark:focus-visible:ring-offset-gray-950` を追加してください。

   How can I resolve this? If you propose a fix, please make it concise.
   `````
   </details>

   Note: If this suggestion doesn't match your team's coding style, reply to this and let me know. I'll remember it for next time!


2. `apps/web/src/components/header.tsx`, line 41-45 ([link](https://github.com/hiroki-org/openshelf/blob/81c8783952d65632c66ec93dab666cebbd206e15/apps/web/src/components/header.tsx#L41-L45)) 

   <a href="#"><img alt="P2" src="https://greptile-static-assets.s3.amazonaws.com/badges/p2.svg?v=9" align="top"></a> **アクティブ状態のナビリンクでフォーカスリングのコントラストが低い**

   アクティブな navリンクは `bg-gray-900`（ライト）/ `bg-gray-100`（ダーク）の背景を持ちますが、フォーカスリングも `ring-gray-900`（ライト）/ `ring-gray-100`（ダーク）として設定されているため、リングとボタン本体が同色になります。`ring-offset-2` による2pxの白い間隔があるため完全に不可視ではありませんが、リング自体がボタン外縁と同色で一体化して見えるため、視認性が目的を十分に達成できない可能性があります。ライトモードのアクティブ状態では `ring-white` を、ダークモードのアクティブ状態では `ring-gray-900` を使うよう条件分岐させるか、`ring-offset` の色を明示的に指定することを検討してください。

   <details><summary>Prompt To Fix With AI</summary>

   `````markdown
   This is a comment left during a code review.
   Path: apps/web/src/components/header.tsx
   Line: 41-45

   Comment:
   **アクティブ状態のナビリンクでフォーカスリングのコントラストが低い**

   アクティブな navリンクは `bg-gray-900`（ライト）/ `bg-gray-100`（ダーク）の背景を持ちますが、フォーカスリングも `ring-gray-900`（ライト）/ `ring-gray-100`（ダーク）として設定されているため、リングとボタン本体が同色になります。`ring-offset-2` による2pxの白い間隔があるため完全に不可視ではありませんが、リング自体がボタン外縁と同色で一体化して見えるため、視認性が目的を十分に達成できない可能性があります。ライトモードのアクティブ状態では `ring-white` を、ダークモードのアクティブ状態では `ring-gray-900` を使うよう条件分岐させるか、`ring-offset` の色を明示的に指定することを検討してください。

   How can I resolve this? If you propose a fix, please make it concise.
   `````
   </details>

</details>

<!-- /greptile_failed_comments -->

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 2 code review issues. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 2
apps/web/src/components/header.tsx:23-28
**「OpenShelf」ロゴリンクの `focus-visible` 対応漏れ**

このPRはヘッダー内のインタラクティブ要素へのフォーカスリング追加を目的としていますが、「OpenShelf」ロゴの `Link` コンポーネント（23行目）が対応漏れになっています。キーボードナビゲーション時に Tab キーでこのリンクにフォーカスが当たっても、フォーカスインジケーターが表示されません。他のリンク・ボタンと同様に `focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-gray-900 focus-visible:ring-offset-2 dark:focus-visible:ring-gray-100 dark:focus-visible:ring-offset-gray-950` を追加してください。

### Issue 2 of 2
apps/web/src/components/header.tsx:41-45
**アクティブ状態のナビリンクでフォーカスリングのコントラストが低い**

アクティブな navリンクは `bg-gray-900`（ライト）/ `bg-gray-100`（ダーク）の背景を持ちますが、フォーカスリングも `ring-gray-900`（ライト）/ `ring-gray-100`（ダーク）として設定されているため、リングとボタン本体が同色になります。`ring-offset-2` による2pxの白い間隔があるため完全に不可視ではありませんが、リング自体がボタン外縁と同色で一体化して見えるため、視認性が目的を十分に達成できない可能性があります。ライトモードのアクティブ状態では `ring-white` を、ダークモードのアクティブ状態では `ring-gray-900` を使うよう条件分岐させるか、`ring-offset` の色を明示的に指定することを検討してください。


`````

</details>

<sub>Reviews (1): Last reviewed commit: ["feat(web): improve keyboard focus styles"](https://github.com/hiroki-org/openshelf/commit/81c8783952d65632c66ec93dab666cebbd206e15) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=43641410)</sub>

<!-- /greptile_comment -->