### PR TITLE
🛡️ Sentinel: [LOW] Fix トーストIDの弱い疑似乱数生成器

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -25,3 +25,8 @@
 **Vulnerability:** Unhandled exceptions in the Hono API routes can leak internal application details, such as stack traces, to the client via default 500 error responses.
 **Learning:** Returning raw Error objects or relying on Hono's default error handling without a custom `onError` hook exposes potentially sensitive debugging information.
 **Prevention:** Always define a global `app.onError((err, c) => { ... })` handler in the main application file (e.g., `apps/api/src/index.ts`) to intercept all unhandled exceptions, log a sanitized version of the error internally, and return a safe, generic JSON response to the user.
+
+## 2024-05-28 - [Weak RNG for Component IDs]
+**Vulnerability:** Weak pseudo-random number generator (`Math.random()`) used for generating unique IDs in the toast component (`apps/web/src/components/toast.tsx`).
+**Learning:** `Math.random()` does not provide cryptographically secure random numbers, making generated IDs predictable. While not a critical vulnerability in a toast ID context, it introduces security risks if this pattern is copied and used for more sensitive identifiers (e.g., tokens, session IDs) elsewhere in the application.
+**Prevention:** Always use the standard Web Crypto API (`crypto.randomUUID()`) for generating unique IDs and secure random numbers on the client side to eliminate weak RNG anti-patterns and prevent predictable identifier generation.

--- a/apps/web/src/components/toast.tsx
+++ b/apps/web/src/components/toast.tsx
@@ -20,7 +20,7 @@ export const toast = {
 };
 
 function addToast(message: string, type: ToastType) {
-  const id = Math.random().toString(36).substring(2, 9);
+  const id = crypto.randomUUID();
   const newToast = { id, message, type };
   toasts = [...toasts, newToast];
   notify();


### PR DESCRIPTION
🚨 Severity: LOW
💡 Vulnerability: `Math.random()` による弱い疑似乱数生成器（Weak RNG）の使用
🎯 Impact: 生成されるIDが推測可能になり、将来的に他のコンポーネントで同様の実装が再利用された場合などにセキュリティ上の懸念（予測可能性、衝突）が生じる。
🔧 Fix: `Math.random().toString(36).substring(2, 9)` を標準の Web Crypto API である `crypto.randomUUID()` に置き換え、暗号学的に安全なIDを生成するようにした。
✅ Verification: `pnpm --filter web run test src/components/__tests__/toast.test.tsx` により、自動テストが正常に通過し、機能的な退行がないことを確認した。

---
*PR created automatically by Jules for task [15769885189955233702](https://jules.google.com/task/15769885189955233702) started by @is0692vs*

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

トーストコンポーネントのID生成を `Math.random()` から `crypto.randomUUID()` に置き換え、暗号学的に安全なIDを生成するようにした修正です。変更は1行のみで、IDはReactの `key` 属性と `setTimeout` による自動削除管理にのみ使用されるため、機能への影響はありません。

- `toast.tsx` の `addToast` 関数内の ID 生成を `crypto.randomUUID()` に変更（7文字のランダム文字列 → UUID v4形式の36文字）。コンポーネントは `"use client"` でブラウザ専用のため、`crypto` API の利用に問題はない。
- `.jules/sentinel.md` に弱い RNG パターンの学習記録を追記。同様のパターンが他箇所で使われた際の再発防止に役立つ。
</details>

<details open><summary><h3>Confidence Score: 5/5</h3></summary>

変更は1行のみ、影響範囲はトーストIDの生成に限定されており、既存テストも通過している。

`Math.random()` を `crypto.randomUUID()` に置き換えるだけの最小限の変更。ID はReactの `key` 管理と自動削除タイマーにのみ使われており、UUID形式への変更がUIや機能に影響する経路はない。コンポーネントは `"use client"` でブラウザ専用のため、Web Crypto API の利用環境についても問題がない。

特に注意が必要なファイルはない。
</details>

<details open><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| apps/web/src/components/toast.tsx | `Math.random().toString(36).substring(2, 9)` を `crypto.randomUUID()` に置き換え。変更は1行のみで、UUID の形式（36文字）に変わるが、ID は内部管理にのみ使われるため影響なし。 |
| .jules/sentinel.md | 弱い RNG パターンに関する学習記録を追記。内容・形式ともに問題なし。 |

</details>

<h3>Sequence Diagram</h3>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
sequenceDiagram
    participant Caller as 呼び出し元
    participant Toast as toast.tsx (addToast)
    participant Crypto as crypto.randomUUID()
    participant State as toasts state
    participant UI as ToastContainer

    Caller->>Toast: toast.success("saved")
    Toast->>Crypto: crypto.randomUUID()
    Crypto-->>Toast: "xxxxxxxx-xxxx-4xxx-yxxx-xxxxxxxxxxxx"
    Toast->>State: "toasts = [...toasts, { id, message, type }]"
    Toast->>UI: notify() → setCurrentToasts
    UI-->>Caller: トーストを表示
    Note over Toast: setTimeout 5000ms
    Toast->>State: removeToast(id)
    Toast->>UI: notify() → setCurrentToasts
    UI-->>Caller: トーストを非表示
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
sequenceDiagram
    participant Caller as 呼び出し元
    participant Toast as toast.tsx (addToast)
    participant Crypto as crypto.randomUUID()
    participant State as toasts state
    participant UI as ToastContainer

    Caller->>Toast: toast.success("saved")
    Toast->>Crypto: crypto.randomUUID()
    Crypto-->>Toast: "xxxxxxxx-xxxx-4xxx-yxxx-xxxxxxxxxxxx"
    Toast->>State: "toasts = [...toasts, { id, message, type }]"
    Toast->>UI: notify() → setCurrentToasts
    UI-->>Caller: トーストを表示
    Note over Toast: setTimeout 5000ms
    Toast->>State: removeToast(id)
    Toast->>UI: notify() → setCurrentToasts
    UI-->>Caller: トーストを非表示
```

</a>

<sub>Reviews (1): Last reviewed commit: ["fix(web): トーストIDの生成に暗号学的に安全な乱数を使用"](https://github.com/hiroki-org/openshelf/commit/18ad5cfcaa1b18e9ebdb942204588c8046c915c7) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=43642121)</sub>

<!-- /greptile_comment -->