### PR TITLE
🛡️ Sentinel: Toast ID生成のセキュリティ改善

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -25,3 +25,7 @@
 **Vulnerability:** Unhandled exceptions in the Hono API routes can leak internal application details, such as stack traces, to the client via default 500 error responses.
 **Learning:** Returning raw Error objects or relying on Hono's default error handling without a custom `onError` hook exposes potentially sensitive debugging information.
 **Prevention:** Always define a global `app.onError((err, c) => { ... })` handler in the main application file (e.g., `apps/api/src/index.ts`) to intercept all unhandled exceptions, log a sanitized version of the error internally, and return a safe, generic JSON response to the user.
+## 2025-02-18 - [Fix Weak Random Number Generation in Toast IDs]
+**Vulnerability:** Found `Math.random().toString(36)` being used to generate Toast IDs in `apps/web/src/components/toast.tsx`. While not a critical security vulnerability for toast messages, it violates the principle of using strong random number generation.
+**Learning:** Even for non-critical IDs, `Math.random()` can trigger security linters or lead to predictable IDs, potentially causing collision bugs or minor information leakage.
+**Prevention:** Always use `crypto.randomUUID()` when generating unique identifiers on the client, ensuring a safe fallback is in place for environments where the `crypto` API is undefined to prevent runtime crashes.

--- a/apps/web/src/components/toast.tsx
+++ b/apps/web/src/components/toast.tsx
@@ -20,7 +20,7 @@ export const toast = {
 };
 
 function addToast(message: string, type: ToastType) {
-  const id = Math.random().toString(36).substring(2, 9);
+  const id = typeof crypto !== 'undefined' && crypto.randomUUID ? crypto.randomUUID() : Math.random().toString(36).substring(2, 9);
   const newToast = { id, message, type };
   toasts = [...toasts, newToast];
   notify();


### PR DESCRIPTION
🚨 Severity: LOW
💡 Vulnerability: ToastのID生成にMath.randomを使用
🎯 Impact: 衝突の可能性
🔧 Fix: crypto.randomUUIDを使用
✅ Verification: pnpm test

---
*PR created automatically by Jules for task [17269650291712804876](https://jules.google.com/task/17269650291712804876) started by @is0692vs*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved toast notification identification by using stronger unique IDs when supported.
  * Added a compatibility fallback to prevent errors in environments without the required security API.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

Toast IDの生成を `Math.random()` から `crypto.randomUUID()` に変更するセキュリティ改善PRです。セキュリティ学習ログ（`.jules/sentinel.md`）への記録も含まれています。

- `toast.tsx` の ID生成ロジックを `crypto.randomUUID()` に変更。ただし、`crypto` が未定義の場合のフォールバックとして再び `Math.random()` を使用しており、修正の意図と矛盾している。
- `\"use client\"` ディレクティブが付いたコンポーネントのため、実行環境は常に `crypto.randomUUID()` をサポートするブラウザ。フォールバックコードは実質デッドコードになっている。
</details>

<details open><summary><h3>Confidence Score: 4/5</h3></summary>

Toast IDの生成ロジックの変更のみで影響範囲は限定的。フォールバックの矛盾はあるが、実際の動作には影響しない。

変更の意図（Math.random排除）は明確だが、フォールバックで同じMath.randomを使用しているため、セキュリティ改善の効果が完全ではない。ただし、"use client"コンポーネントでは実際にはcrypto.randomUUID()が常に呼ばれるため、ランタイムの動作に問題はない。

apps/web/src/components/toast.tsx — フォールバックのロジックを見直すと、コードの意図がより明確になる。
</details>

<details open><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| apps/web/src/components/toast.tsx | Math.random()をcrypto.randomUUID()に置き換えたが、フォールバックとして再度Math.random()を使用しており、セキュリティ目標と矛盾。"use client"コンポーネントのためフォールバックはほぼデッドコード。 |
| .jules/sentinel.md | セキュリティ学習ログにToast IDのランダム生成に関する知見を追記。内容は適切で問題なし。 |

</details>

<h3>Flowchart</h3>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[addToast called] --> B{crypto available?}
    B -- yes --> C[crypto.randomUUID]
    B -- no --> D[Math.random fallback]
    C --> E[Toast ID generated]
    D --> E
    E --> F[Add to toast list]
    F --> G[Auto-remove after 5s]

    style D fill:#ffcccc,stroke:#cc0000
    style C fill:#ccffcc,stroke:#00cc00
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
flowchart TD
    A[addToast called] --> B{crypto available?}
    B -- yes --> C[crypto.randomUUID]
    B -- no --> D[Math.random fallback]
    C --> E[Toast ID generated]
    D --> E
    E --> F[Add to toast list]
    F --> G[Auto-remove after 5s]

    style D fill:#ffcccc,stroke:#cc0000
    style C fill:#ccffcc,stroke:#00cc00
```

</a>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 1 code review issue. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 1
apps/web/src/components/toast.tsx:23
**フォールバックがセキュリティ目標を損なっている**

このPRの目的は `Math.random()` を排除することですが、フォールバックで再び `Math.random()` を使用しています。`crypto` が利用できない環境では、同じ弱いランダム生成に戻ってしまい、修正の意味が失われます。

`"use client"` ディレクティブがあるため実行環境は常に `crypto.randomUUID()` をサポートする現代ブラウザであり、フォールバックは実質デッドコードです。直接 `crypto.randomUUID()` を呼び出す方がシンプルで意図が明確になります。

```suggestion
  const id = crypto.randomUUID();
```

`````

</details>

<sub>Reviews (1): Last reviewed commit: ["fix: toast id generation security"](https://github.com/hiroki-org/openshelf/commit/8b894331b4549b6bd44effde40f1f525a4da9af6) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=43840206)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->