### PR TITLE
🎨 Palette: ヘッダーのインタラクティブ要素にキーボードフォーカス状態を追加

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -31,3 +31,6 @@
 ## 2026-06-21 - Conditional ARIA roles for dynamic messages
 **Learning:** 保存成功やエラーなど、結果に応じてメッセージの内容とスタイルが変わるコンテナ要素では、単に `<p>` タグで表示するのではなく、メッセージの重大度に応じて `role="alert"`（エラー用）や `role="status"`（成功・一般メッセージ用）を条件付きで切り替えることで、スクリーンリーダーユーザーにとってより適切で邪魔にならないフィードバックを提供できます。
 **Action:** 今後、動的なフィードバックメッセージを表示するコンポーネントを実装・改善する際は、`role={messageType === 'error' ? 'alert' : 'status'}` のような条件分岐を用いた ARIA ロールの設定を適用します。
+## 2026-06-25 - Header Interactive Elements Focus States
+**Learning:** ナビゲーションメニューやヘッダーのリンク、ボタンなど、主要なインタラクティブ要素に `focus-visible` スタイルが不足していると、キーボードやスクリーンリーダーのみで操作するユーザーが現在どこにフォーカスがあるか視認できず、アクセシビリティ（WCAG 2.4.7 Focus Visible）に重大な影響を与えます。TailwindCSS の `focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-offset-2` （および `dark:` バリアント）を利用することで、これを防ぐことができます。
+**Action:** 今後、ナビゲーションやインタラクティブなUIコンポーネントを実装・改善する際は、必ず明確なキーボードフォーカスリング（`focus-visible`）を追加し、すべてのユーザーが現在地を視認できるようにします。

--- a/apps/web/src/components/header.tsx
+++ b/apps/web/src/components/header.tsx
@@ -22,7 +22,7 @@ export function Header() {
         <div className="flex min-w-0 items-center gap-6">
           <Link
             href="/"
-            className="text-base font-semibold tracking-tight text-gray-950 transition-colors hover:text-gray-700 dark:text-gray-50 dark:hover:text-gray-300"
+            className="text-base font-semibold tracking-tight text-gray-950 transition-colors hover:text-gray-700 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-gray-900 focus-visible:ring-offset-2 dark:text-gray-50 dark:hover:text-gray-300 dark:focus-visible:ring-gray-100 dark:focus-visible:ring-offset-gray-950"
           >
             OpenShelf
           </Link>
@@ -38,7 +38,7 @@ export function Header() {
                     key={item.href}
                     href={item.href}
                     aria-current={isActive ? "page" : undefined}
-                    className={`rounded-full px-3 py-1.5 transition-colors ${
+                    className={`rounded-full px-3 py-1.5 transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-gray-900 focus-visible:ring-offset-2 dark:focus-visible:ring-gray-100 dark:focus-visible:ring-offset-gray-950 ${
                       isActive
                         ? "bg-gray-900 text-white dark:bg-gray-100 dark:text-gray-900"
                         : "text-gray-600 hover:bg-gray-100 hover:text-gray-900 dark:text-gray-400 dark:hover:bg-gray-800 dark:hover:text-gray-100"
@@ -70,7 +70,7 @@ export function Header() {
               <button
                 type="button"
                 onClick={logout}
-                className="rounded-full border border-gray-300 px-3 py-1.5 text-sm text-gray-700 transition-colors hover:bg-gray-100 hover:text-gray-900 dark:border-gray-700 dark:text-gray-200 dark:hover:bg-gray-800 dark:hover:text-gray-50"
+                className="rounded-full border border-gray-300 px-3 py-1.5 text-sm text-gray-700 transition-colors hover:bg-gray-100 hover:text-gray-900 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-gray-900 focus-visible:ring-offset-2 dark:border-gray-700 dark:text-gray-200 dark:hover:bg-gray-800 dark:hover:text-gray-50 dark:focus-visible:ring-gray-100 dark:focus-visible:ring-offset-gray-950"
               >
                 ログアウト
               </button>
@@ -79,7 +79,7 @@ export function Header() {
             <button
               type="button"
               onClick={login}
-              className="rounded-full bg-gray-900 px-4 py-2 text-sm font-medium text-white transition-colors hover:bg-gray-700 dark:bg-white dark:text-gray-900 dark:hover:bg-gray-200"
+              className="rounded-full bg-gray-900 px-4 py-2 text-sm font-medium text-white transition-colors hover:bg-gray-700 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-gray-900 focus-visible:ring-offset-2 dark:bg-white dark:text-gray-900 dark:hover:bg-gray-200 dark:focus-visible:ring-gray-100 dark:focus-visible:ring-offset-gray-950"
             >
               GitHubでログイン
             </button>


### PR DESCRIPTION
### 💡 What
ヘッダー内のリンク（ナビゲーションアイテム、OpenShelfロゴ）およびボタン（ログイン、ログアウト）に `:focus-visible` スタイルを追加しました。

### 🎯 Why
これまでヘッダー内の要素をキーボードでフォーカスした際、標準のアウトラインが表示されるか、あるいは全く視覚的フィードバックがない状態でした。キーボードのみでナビゲーションするユーザーが、現在どの要素にフォーカスが当たっているかを明確に視認できるようにするためです。

### 📸 Before/After
UIに変更はありません（キーボードでタブ移動した際のみリングが表示されます）。

### ♿ Accessibility
- **キーボードナビゲーション**: 独自のフォーカスリング (`focus-visible:ring-2`) を追加し、コントラストの高い視覚的フィードバックを提供することで、WCAG 2.4.7 (Focus Visible) に準拠しやすくなりました。

---
*PR created automatically by Jules for task [4292875814385893863](https://jules.google.com/task/4292875814385893863) started by @is0692vs*

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

このPRはヘッダーのキーボードフォーカス表示を追加しています。主な変更は次のとおりです。

- OpenShelf ロゴリンクに `focus-visible` スタイルを追加。
- ナビゲーションリンクに `focus-visible` スタイルを追加。
- ログイン、ログアウトボタンに `focus-visible` スタイルを追加。
- `.Jules/palette.md` にヘッダーのフォーカス表示に関する学習を追記。
</details>

<details open><summary><h3>Confidence Score: 4/5</h3></summary>

ヘッダーのフォーカス表示は一部の状態で見えなくなります。

- アクティブなナビゲーションリンクでは、リング色が背景色と同じになります。
- ログインボタンでも、ライト時とダーク時の両方でリングが背景に同化します。
- `outline-none` により、標準のフォーカス表示が代替として残りません。

apps/web/src/components/header.tsx
</details>

<details open><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| .Jules/palette.md | ヘッダーのインタラクティブ要素に明確なフォーカスリングを追加する方針を追記しています。 |
| apps/web/src/components/header.tsx | ヘッダー内のリンクとボタンに `focus-visible` のリングスタイルを追加していますが、一部の状態でリングが背景と同化します。 |

</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 3 code review issues. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 3
apps/web/src/components/header.tsx:41
**Active Nav Ring Disappears**

現在のページのナビゲーションリンクは、ライト時に `bg-gray-900` と `focus-visible:ring-gray-900`、ダーク時に `dark:bg-gray-100` と `dark:focus-visible:ring-gray-100` が同じ色になります。キーボードでアクティブなリンクへ移動すると標準アウトラインは `outline-none` で消え、追加したリングも背景と同化するため、フォーカス位置が見えなくなります。

### Issue 2 of 3
apps/web/src/components/header.tsx:82
**Login Button Ring Disappears**

ログインボタンはライト時に `bg-gray-900` と `focus-visible:ring-gray-900` が同じ色で、ダーク時も白いボタン上に `dark:focus-visible:ring-gray-100` がほぼ同化します。キーボードで `GitHubでログイン` にフォーカスすると標準アウトラインが消えた状態で、追加したフォーカス表示が見えにくくなります。

### Issue 3 of 3
apps/web/src/components/header.tsx:25
**Forced Colors Lose Focus**

ヘッダーのフォーカス表示を `outline-none` と box-shadow ベースの Tailwind ring だけに置き換えると、Windows High Contrast などの `forced-colors` 環境で ring が描画されず、標準アウトラインも消えます。ロゴ、ナビゲーション、ログイン、ログアウトの全ヘッダー操作でキーボードフォーカスが見えなくなる可能性があります。

`````

</details>

<sub>Reviews (1): Last reviewed commit: ["feat: add focus visible states to header..."](https://github.com/hiroki-org/openshelf/commit/c3177abd65a529836b7116dcde6a36cacc9b58a5) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=45333006)</sub>

> Greptile also left **3 inline comments** on this PR.

**Context used:**

- Knowledge Base — [Web Frontend Shell](https://app.greptile.com/hiroki-org/-/custom-context/knowledge-base/hiroki-org/openshelf/-/docs/web-frontend.md)

<!-- /greptile_comment -->