### PR TITLE
🎨 Palette: ヘッダーのキーボードナビゲーション時のフォーカス視認性を向上

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -31,3 +31,7 @@
 ## 2026-06-21 - Conditional ARIA roles for dynamic messages
 **Learning:** 保存成功やエラーなど、結果に応じてメッセージの内容とスタイルが変わるコンテナ要素では、単に `<p>` タグで表示するのではなく、メッセージの重大度に応じて `role="alert"`（エラー用）や `role="status"`（成功・一般メッセージ用）を条件付きで切り替えることで、スクリーンリーダーユーザーにとってより適切で邪魔にならないフィードバックを提供できます。
 **Action:** 今後、動的なフィードバックメッセージを表示するコンポーネントを実装・改善する際は、`role={messageType === 'error' ? 'alert' : 'status'}` のような条件分岐を用いた ARIA ロールの設定を適用します。
+
+## 2026-06-25 - Header navigation focus visibility
+**Learning:** ヘッダー内のナビゲーションリンクやボタンは、マウスユーザーだけでなくキーボードナビゲーション（Tabキー）を利用するユーザーにとっても主要な操作対象となります。Tailwind CSS の `focus-visible` ユーティリティ（例: `focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-offset-2`）を用いて視覚的なフォーカスインジケーターを明示することで、WCAG 2.4.7 Focus Visible への準拠が容易になり、操作性が飛躍的に向上します。
+**Action:** 今後、グローバルナビゲーションや主要なアクションエリア内のインタラクティブ要素を実装・改善する際は、必ず `focus-visible` スタイルを追加し、キーボードフォーカスが明確に視認できるようにします。

--- a/apps/web/src/components/header.tsx
+++ b/apps/web/src/components/header.tsx
@@ -22,7 +22,7 @@ export function Header() {
         <div className="flex min-w-0 items-center gap-6">
           <Link
             href="/"
-            className="text-base font-semibold tracking-tight text-gray-950 transition-colors hover:text-gray-700 dark:text-gray-50 dark:hover:text-gray-300"
+            className="text-base font-semibold tracking-tight text-gray-950 transition-colors hover:text-gray-700 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:ring-gray-900 dark:text-gray-50 dark:hover:text-gray-300 dark:focus-visible:ring-gray-100 dark:focus-visible:ring-offset-gray-950"
           >
             OpenShelf
           </Link>
@@ -38,7 +38,7 @@ export function Header() {
                     key={item.href}
                     href={item.href}
                     aria-current={isActive ? "page" : undefined}
-                    className={`rounded-full px-3 py-1.5 transition-colors ${
+                    className={`rounded-full px-3 py-1.5 transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:ring-gray-900 dark:focus-visible:ring-gray-100 dark:focus-visible:ring-offset-gray-950 ${
                       isActive
                         ? "bg-gray-900 text-white dark:bg-gray-100 dark:text-gray-900"
                         : "text-gray-600 hover:bg-gray-100 hover:text-gray-900 dark:text-gray-400 dark:hover:bg-gray-800 dark:hover:text-gray-100"
@@ -70,7 +70,7 @@ export function Header() {
               <button
                 type="button"
                 onClick={logout}
-                className="rounded-full border border-gray-300 px-3 py-1.5 text-sm text-gray-700 transition-colors hover:bg-gray-100 hover:text-gray-900 dark:border-gray-700 dark:text-gray-200 dark:hover:bg-gray-800 dark:hover:text-gray-50"
+                className="rounded-full border border-gray-300 px-3 py-1.5 text-sm text-gray-700 transition-colors hover:bg-gray-100 hover:text-gray-900 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:ring-gray-900 dark:border-gray-700 dark:text-gray-200 dark:hover:bg-gray-800 dark:hover:text-gray-50 dark:focus-visible:ring-gray-100 dark:focus-visible:ring-offset-gray-950"
               >
                 ログアウト
               </button>
@@ -79,7 +79,7 @@ export function Header() {
             <button
               type="button"
               onClick={login}
-              className="rounded-full bg-gray-900 px-4 py-2 text-sm font-medium text-white transition-colors hover:bg-gray-700 dark:bg-white dark:text-gray-900 dark:hover:bg-gray-200"
+              className="rounded-full bg-gray-900 px-4 py-2 text-sm font-medium text-white transition-colors hover:bg-gray-700 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:ring-gray-900 dark:bg-white dark:text-gray-900 dark:hover:bg-gray-200 dark:focus-visible:ring-gray-100 dark:focus-visible:ring-offset-gray-950"
             >
               GitHubでログイン
             </button>


### PR DESCRIPTION
💡 What: ヘッダー内のナビゲーションリンクおよびボタン（ログアウト、ログイン）に、キーボード操作時の明確なフォーカスインジケーター (`focus-visible`) を追加しました。
🎯 Why: マウスを使用しないキーボードユーザーが、現在フォーカスしている要素を明確に視認できるようにし、サイト全体のナビゲーション体験とアクセシビリティを向上させるためです。
📸 Before/After: （視覚的な変更であるため、フォーカス時のリングが表示されるようになります）
♿ Accessibility: キーボードナビゲーション時のフォーカス視認性（WCAG 2.4.7 Focus Visible）を大幅に向上させました。

---
*PR created automatically by Jules for task [4580184474694730362](https://jules.google.com/task/4580184474694730362) started by @is0692vs*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Accessibility Improvements**
  * Improved keyboard navigation visibility in the header.
  * Added clearer focus indicators for the logo, navigation links, and authentication buttons, including support for dark mode.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

このPRは、ヘッダーのキーボードフォーカス表示を改善します。主な変更は次のとおりです。

- ヘッダーのホームリンクに `focus-visible` のリングスタイルを追加。
- ナビゲーションリンクにキーボードフォーカス時のリングを追加。
- ログイン/ログアウトボタンに同じフォーカス表示を追加。
- `.Jules/palette.md` にヘッダーのフォーカス視認性に関する方針を追記。
</details>

<details open><summary><h3>Confidence Score: 5/5</h3></summary>

This looks safe to merge.

- No blocking issues found in the changed code.

</details>

<details open><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| apps/web/src/components/header.tsx | ヘッダー内のリンクとボタンに `focus-visible` のリングスタイルが追加されました。 |
| .Jules/palette.md | ヘッダーのフォーカス視認性に関する学習メモと今後の実装方針が追記されました。 |

</details>

<sub>Reviews (1): Last reviewed commit: ["🎨 Palette: ヘッダーのキーボードナビゲーション時のフォーカス視認性を..."](https://github.com/hiroki-org/openshelf/commit/47349171d921bcd397c945d343d1bd3f76b108dc) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=45668732)</sub>

**Context used:**

- Knowledge Base — [Web Frontend Shell](https://app.greptile.com/hiroki-org/-/custom-context/knowledge-base/hiroki-org/openshelf/-/docs/web-frontend.md)

<!-- /greptile_comment -->