### PR TITLE
🎨 Palette: Markdownエディタのキーボードアクセシビリティ改善

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -31,3 +31,6 @@
 ## 2026-06-21 - Conditional ARIA roles for dynamic messages
 **Learning:** 保存成功やエラーなど、結果に応じてメッセージの内容とスタイルが変わるコンテナ要素では、単に `<p>` タグで表示するのではなく、メッセージの重大度に応じて `role="alert"`（エラー用）や `role="status"`（成功・一般メッセージ用）を条件付きで切り替えることで、スクリーンリーダーユーザーにとってより適切で邪魔にならないフィードバックを提供できます。
 **Action:** 今後、動的なフィードバックメッセージを表示するコンポーネントを実装・改善する際は、`role={messageType === 'error' ? 'alert' : 'status'}` のような条件分岐を用いた ARIA ロールの設定を適用します。
+## 2024-07-21 - [Markdown Editor Keyboard Navigation Fix]
+**Learning:** `focus:outline-none` は、デフォルトのブラウザのフォーカスリングを削除するためにテキストエリアでよく使用されますが、代替となる `focus-visible` がないと、キーボードユーザーはフォーカスの位置を完全に失ってしまいます。カスタムタブコンポーネントにおいて標準のフォーカスリングを使用すると、レイアウト崩れ（クリッピング）が発生することがあります。
+**Action:** アクセシビリティを確保しつつ視覚的なデザインを維持するために、Tailwind で `focus:outline-none` を使用する場合は、常に `focus-visible:ring-2 focus-visible:ring-inset focus-visible:ring-[color]` と組み合わせる必要があります（特にクリッピングが発生しやすいタブ要素などにおいて）。

--- a/apps/web/src/components/markdown-editor.tsx
+++ b/apps/web/src/components/markdown-editor.tsx
@@ -68,7 +68,7 @@ export function MarkdownEditor({
           aria-controls={`${id}-panel-write`}
           tabIndex={mode === "write" ? 0 : -1}
           onClick={() => onModeChange("write")}
-          className={`px-3 py-2 text-sm ${mode === "write" ? "bg-gray-100 font-medium dark:bg-gray-800" : ""}`}
+          className={`px-3 py-2 text-sm focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-inset focus-visible:ring-gray-900 dark:focus-visible:ring-gray-100 ${mode === "write" ? "bg-gray-100 font-medium dark:bg-gray-800" : ""}`}
         >
           Write
         </button>
@@ -81,7 +81,7 @@ export function MarkdownEditor({
           aria-controls={`${id}-panel-preview`}
           tabIndex={mode === "preview" ? 0 : -1}
           onClick={() => onModeChange("preview")}
-          className={`px-3 py-2 text-sm ${mode === "preview" ? "bg-gray-100 font-medium dark:bg-gray-800" : ""}`}
+          className={`px-3 py-2 text-sm focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-inset focus-visible:ring-gray-900 dark:focus-visible:ring-gray-100 ${mode === "preview" ? "bg-gray-100 font-medium dark:bg-gray-800" : ""}`}
         >
           Preview
         </button>
@@ -97,7 +97,7 @@ export function MarkdownEditor({
             value={value}
             onChange={(e) => onChange(e.target.value)}
             rows={12}
-            className="w-full resize-y border-0 bg-transparent p-3 font-mono text-sm focus:outline-none"
+            className="w-full resize-y border-0 bg-transparent p-3 font-mono text-sm focus:outline-none focus-visible:ring-2 focus-visible:ring-inset focus-visible:ring-gray-900 dark:focus-visible:ring-gray-100"
             placeholder={placeholder}
           />
         </div>


### PR DESCRIPTION
💡 What:
Markdownエディタのタブ（Write/Preview）およびテキストエリアに、キーボードフォーカス用のインジケーター（`focus-visible` スタイル）を追加しました。

🎯 Why:
テキストエリアに `focus:outline-none` が指定されており、デフォルトのフォーカスリングが非表示になっていました。そのため、キーボードユーザーがフォーカス位置を視覚的に認識できず、アクセシビリティが著しく損なわれていました。

📸 Before/After:
Before: タブやテキストエリアをキーボード（Tabキーなど）でフォーカスしても、視覚的な変化がありませんでした。
After: フォーカス時に適切なリング（`focus-visible:ring-2` など）が表示されるようになりました。タブ等のレイアウト崩れを防ぐため `ring-inset` も併せて適用しています。

♿ Accessibility:
キーボードナビゲーションにおいて、フォーカス状態が視覚的に明確に認識できるようになりました（WCAG 2.1 Success Criterion 2.4.7 Focus Visible 対応）。

---
*PR created automatically by Jules for task [4625974250784531189](https://jules.google.com/task/4625974250784531189) started by @is0692vs*

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR improves keyboard focus styling for the Markdown editor.

- Adds focus-visible ring styles to the Write and Preview tabs.
- Adds focus-visible ring styles to the editor textarea.
- Records the accessibility learning in the Jules palette notes.
</details>

<details open><summary><h3>Confidence Score: 4/5</h3></summary>

The Markdown editor focus styling needs a forced-colors fallback before merging.

- Normal light and dark themes should get a visible ring.
- High Contrast and forced-colors users can still lose the focus indicator.
- The issue is limited to the changed editor focus classes.

apps/web/src/components/markdown-editor.tsx
</details>

<details open><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| apps/web/src/components/markdown-editor.tsx | Adds focus-visible styles to the Markdown editor tabs and textarea, with forced-colors focus visibility issues still present. |
| .Jules/palette.md | Adds a Markdown editor keyboard accessibility learning note. |

</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 2 code review issues. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 2
apps/web/src/components/markdown-editor.tsx:71
**Forced-Colors Focus Disappears**

When Windows High Contrast or `forced-colors` is active, the new tab focus indicator relies on `ring-*`, which is rendered as box-shadow and can be suppressed by the browser. Since this line also removes the native outline on `:focus-visible`, keyboard users can move focus between Write and Preview without any visible focus state.

### Issue 2 of 2
apps/web/src/components/markdown-editor.tsx:100
**Textarea Focus Ring Vanishes**

The textarea keeps `focus:outline-none` and adds only a `focus-visible:ring-*` replacement. In forced-colors mode, that ring can be dropped because it is box-shadow based, leaving the write-mode editor with no visible keyboard focus even though this control is the main editable field.

`````

</details>

<sub>Reviews (1): Last reviewed commit: ["fix: add focus-visible styles to markdow..."](https://github.com/hiroki-org/openshelf/commit/edb1ed01f73cbe4adcacb5f8a6d66daeca683494) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=45979017)</sub>

> Greptile also left **2 inline comments** on this PR.

<!-- /greptile_comment -->