### PR TITLE
🧹 Extract setupOrgApiMock logic into smaller helper functions

### DIFF
--- a/apps/web/src/app/orgs/[slug]/settings/__tests__/page.test.tsx
+++ b/apps/web/src/app/orgs/[slug]/settings/__tests__/page.test.tsx
@@ -78,139 +78,175 @@ function jsonResponse(body: unknown, status = 200) {
   return new Response(JSON.stringify(body), { status });
 }
 
+const userSearchResults = [
+  {
+    id: "user-3",
+    name: "alicecat",
+    displayName: "Alice Candidate",
+    avatarUrl: null,
+  },
+  {
+    id: "user-4",
+    name: "fallbackalice",
+    displayName: null,
+    avatarUrl: null,
+  },
+];
+
+const searchablePapers = [
+  {
+    id: "paper-1",
+    title: "Existing Paper",
+    visibility: "public",
+    year: 2025,
+    venue: "Conf",
+  },
+  {
+    id: "paper-2",
+    title: "Transformer Tricks",
+    visibility: "public",
+    year: 2024,
+    venue: "Journal",
+  },
+];
+
+function handleOrgRequests(
+  url: string,
+  method: string,
+  init: RequestInit | undefined,
+  state: OrgState,
+) {
+  if (url === "/api/orgs/demo-org" && method === "GET") {
+    return jsonResponse({ org: state.org });
+  }
+
+  if (url === "/api/orgs/demo-org" && method === "PATCH") {
+    const body = JSON.parse(String(init?.body ?? "{}"));
+    state.org = {
+      ...state.org,
+      name: body.name,
+      slug: body.slug,
+      description: body.description,
+    };
+    return jsonResponse({ org: state.org });
+  }
+
+  if (url === "/api/orgs/demo-org" && method === "DELETE") {
+    return jsonResponse({ ok: true });
+  }
+
+  return null;
+}
+
+function handleMemberRequests(
+  url: string,
+  method: string,
+  init: RequestInit | undefined,
+  state: OrgState,
+) {
+  if (url === "/api/orgs/demo-org/members" && method === "GET") {
+    return jsonResponse({ members: state.members });
+  }
+
+  if (url === "/api/users/search?q=al" && method === "GET") {
+    return jsonResponse({
+      users: userSearchResults.filter(
+        (user) => !state.members.some((member) => member.userId === user.id),
+      ),
+    });
+  }
+
+  if (url === "/api/orgs/demo-org/members" && method === "POST") {
+    const body = JSON.parse(String(init?.body ?? "{}"));
+    const candidate = userSearchResults.find((user) => user.id === body.userId);
+    if (candidate) {
+      state.members = [
+        ...state.members,
+        {
+          userId: candidate.id,
+          role: body.role,
+          name: candidate.name,
+          displayName: candidate.displayName,
+          avatarUrl: candidate.avatarUrl,
+          githubId: candidate.name,
+        },
+      ];
+    }
+    return jsonResponse({ ok: true });
+  }
+
+  if (url === "/api/orgs/demo-org/members/member-2" && method === "PATCH") {
+    const body = JSON.parse(String(init?.body ?? "{}"));
+    state.members = state.members.map((member) =>
+      member.userId === "member-2" ? { ...member, role: body.role } : member,
+    );
+    return jsonResponse({ ok: true });
+  }
+
+  if (url === "/api/orgs/demo-org/members/member-2" && method === "DELETE") {
+    state.members = state.members.filter(
+      (member) => member.userId !== "member-2",
+    );
+    return jsonResponse({ ok: true });
+  }
+
+  return null;
+}
+
+function handlePaperRequests(
+  url: string,
+  method: string,
+  init: RequestInit | undefined,
+  state: OrgState,
+  options: OrgApiMockOptions,
+) {
+  if (url === "/api/orgs/demo-org/papers" && method === "GET") {
+    return jsonResponse({ papers: state.papers });
+  }
+
+  if (url === "/api/papers" && method === "GET") {
+    return jsonResponse({ papers: searchablePapers });
+  }
+
+  if (url === "/api/orgs/demo-org/papers" && method === "POST") {
+    const body = JSON.parse(String(init?.body ?? "{}"));
+    const paper = searchablePapers.find((entry) => entry.id === body.paperId);
+    if (paper) {
+      state.papers = [...state.papers, paper];
+    }
+    return jsonResponse({ ok: true });
+  }
+
+  if (url.startsWith("/api/orgs/demo-org/papers/") && method === "DELETE") {
+    const paperId = decodeURIComponent(url.split("/").pop() ?? "");
+    if (options.removePaper) {
+      return options.removePaper(paperId);
+    }
+    state.papers = state.papers.filter((paper) => paper.id !== paperId);
+    return jsonResponse({ ok: true });
+  }
+
+  return null;
+}
+
 function setupOrgApiMock(state: OrgState, options: OrgApiMockOptions = {}) {
-  const userSearchResults = [
-    {
-      id: "user-3",
-      name: "alicecat",
-      displayName: "Alice Candidate",
-      avatarUrl: null,
-    },
-    {
-      id: "user-4",
-      name: "fallbackalice",
-      displayName: null,
-      avatarUrl: null,
-    },
-  ];
-
-  const searchablePapers = [
-    {
-      id: "paper-1",
-      title: "Existing Paper",
-      visibility: "public",
-      year: 2025,
-      venue: "Conf",
-    },
-    {
-      id: "paper-2",
-      title: "Transformer Tricks",
-      visibility: "public",
-      year: 2024,
-      venue: "Journal",
-    },
-  ];
-
   vi.mocked(apiFetch).mockImplementation(async (input, init) => {
     const url = String(input);
     const method = init?.method ?? "GET";
 
-    if (url === "/api/orgs/demo-org" && method === "GET") {
-      return jsonResponse({ org: state.org });
-    }
+    const orgResponse = handleOrgRequests(url, method, init, state);
+    if (orgResponse) return orgResponse;
 
-    if (url === "/api/orgs/demo-org/members" && method === "GET") {
-      return jsonResponse({ members: state.members });
-    }
+    const memberResponse = handleMemberRequests(url, method, init, state);
+    if (memberResponse) return memberResponse;
 
-    if (url === "/api/orgs/demo-org/papers" && method === "GET") {
-      return jsonResponse({ papers: state.papers });
-    }
-
-    if (url === "/api/orgs/demo-org" && method === "PATCH") {
-      const body = JSON.parse(String(init?.body ?? "{}"));
-      state.org = {
-        ...state.org,
-        name: body.name,
-        slug: body.slug,
-        description: body.description,
-      };
-      return jsonResponse({ org: state.org });
-    }
-
-    if (url === "/api/orgs/demo-org" && method === "DELETE") {
-      return jsonResponse({ ok: true });
-    }
-
-    if (url === "/api/users/search?q=al" && method === "GET") {
-      return jsonResponse({
-        users: userSearchResults.filter(
-          (user) => !state.members.some((member) => member.userId === user.id),
-        ),
-      });
-    }
-
-    if (url === "/api/orgs/demo-org/members" && method === "POST") {
-      const body = JSON.parse(String(init?.body ?? "{}"));
-      const candidate = userSearchResults.find(
-        (user) => user.id === body.userId,
-      );
-      if (candidate) {
-        state.members = [
-          ...state.members,
-          {
-            userId: candidate.id,
-            role: body.role,
-            name: candidate.name,
-            displayName: candidate.displayName,
-            avatarUrl: candidate.avatarUrl,
-            githubId: candidate.name,
-          },
-        ];
-      }
-      return jsonResponse({ ok: true });
-    }
-
-    if (url === "/api/orgs/demo-org/members/member-2" && method === "PATCH") {
-      const body = JSON.parse(String(init?.body ?? "{}"));
-      state.members = state.members.map((member) =>
-        member.userId === "member-2" ? { ...member, role: body.role } : member,
-      );
-      return jsonResponse({ ok: true });
-    }
-
-    if (url === "/api/orgs/demo-org/members/member-2" && method === "DELETE") {
-      state.members = state.members.filter(
-        (member) => member.userId !== "member-2",
-      );
-      return jsonResponse({ ok: true });
-    }
-
-    if (url === "/api/papers" && method === "GET") {
-      return jsonResponse({ papers: searchablePapers });
-    }
-
-    if (url === "/api/orgs/demo-org/papers" && method === "POST") {
-      const body = JSON.parse(String(init?.body ?? "{}"));
-      const paper = searchablePapers.find((entry) => entry.id === body.paperId);
-      if (paper) {
-        state.papers = [...state.papers, paper];
-      }
-      return jsonResponse({ ok: true });
-    }
-
-    if (url.startsWith("/api/orgs/demo-org/papers/") && method === "DELETE") {
-      const paperId = decodeURIComponent(url.split("/").pop() ?? "");
-      if (options.removePaper) {
-        return options.removePaper(paperId);
-      }
-      state.papers = state.papers.filter((paper) => paper.id !== paperId);
-      return jsonResponse({ ok: true });
-    }
+    const paperResponse = handlePaperRequests(url, method, init, state, options);
+    if (paperResponse) return paperResponse;
 
     throw new Error(`Unexpected request: ${method} ${url}`);
   });
 }
+
 
 describe("OrgSettingsPage", () => {
   beforeEach(() => {


### PR DESCRIPTION
🎯 **What:** Extracted the massive setupOrgApiMock function into smaller helper functions (handleOrgRequests, handleMemberRequests, handlePaperRequests).

💡 **Why:** The setupOrgApiMock function was over 130 lines long and handled multiple entity types (org, members, papers) in a single large block of if statements. By extracting parts of the mock setup into smaller helpers, the code is much more readable and maintainable.

✅ **Verification:** Ran the full test suite (pnpm run test) and confirmed all tests still pass, including the tests in apps/web/src/app/orgs/[slug]/settings/__tests__/page.test.tsx.

✨ **Result:** Improved maintainability and readability by breaking down a large function into smaller, well-scoped helpers without changing behavior.

---
*PR created automatically by Jules for task [14096522148886484374](https://jules.google.com/task/14096522148886484374) started by @is0692vs*

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

このPRは、org設定ページのテスト用APIモックを小さな関数に分割しています。

- org関連リクエストを `handleOrgRequests` に分離。
- member関連リクエストを `handleMemberRequests` に分離。
- paper関連リクエストを `handlePaperRequests` に分離。
- 検索用ユーザーとpaperの固定データをモジュール定数へ移動。
</details>

<details open><summary><h3>Confidence Score: 5/5</h3></summary>

This looks safe to merge.

- No blocking issues found in the changed code.

</details>

<details open><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| apps/web/src/app/orgs/[slug]/settings/__tests__/page.test.tsx | 既存の `setupOrgApiMock` を helper 関数に分割し、同じモックレスポンスと状態更新を維持しています。 |

</details>

<sub>Reviews (1): Last reviewed commit: ["🧹 Extract setupOrgApiMock logic into sm..."](https://github.com/hiroki-org/openshelf/commit/76ddc8111bb19dd3d04a2234592630fc59adf0be) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=46180664)</sub>

**Context used:**

- Knowledge Base — [Collections, Orgs, and Invites](https://app.greptile.com/hiroki-org/-/custom-context/knowledge-base/hiroki-org/openshelf/-/docs/collections-orgs-invites.md)

<!-- /greptile_comment -->