### PR TITLE
fix(api): keep JWT secrets out of authorization cache keys

### DIFF
--- a/apps/api/src/routes/__tests__/papers.test.ts
+++ b/apps/api/src/routes/__tests__/papers.test.ts
@@ -40,6 +40,28 @@ describe("papers routes", () => {
     };
   });
 
+  it("derives opaque and input-specific authorization cache keys", async () => {
+    const { buildAuthorizationCacheKey } = await import("../papers");
+
+    const first = await buildAuthorizationCacheKey("secret-a", "token-a");
+    const repeated = await buildAuthorizationCacheKey("secret-a", "token-a");
+    const differentSecret = await buildAuthorizationCacheKey(
+      "secret-b",
+      "token-a",
+    );
+    const differentToken = await buildAuthorizationCacheKey(
+      "secret-a",
+      "token-b",
+    );
+
+    expect(first).toMatch(/^[a-f0-9]{64}$/);
+    expect(first).toBe(repeated);
+    expect(first).not.toBe(differentSecret);
+    expect(first).not.toBe(differentToken);
+    expect(first).not.toContain("secret-a");
+    expect(first).not.toContain("token-a");
+  });
+
   it("hits the token cache on subsequent calls and removes expired ones", async () => {
     const app = await createTestApp();
     const { createTestJWT } = await import("../../test/helpers");

--- a/apps/api/src/routes/papers.ts
+++ b/apps/api/src/routes/papers.ts
@@ -317,6 +317,13 @@ async function generateHmacSha256(
     .join("");
 }
 
+export async function buildAuthorizationCacheKey(
+  jwtSecret: string,
+  rawToken: string,
+): Promise<string> {
+  return generateHmacSha256(jwtSecret, rawToken);
+}
+
 async function getPaperPublicStats(
   db: ReturnType<typeof drizzle>,
   paperId: string,
@@ -394,7 +401,7 @@ async function authorizePaperAccess(
     return { ok: false, status: 401, error: "Unauthorized" };
   }
 
-  const token = `${c.env.JWT_SECRET}:${rawToken}`;
+  const token = await buildAuthorizationCacheKey(c.env.JWT_SECRET, rawToken);
   let user: { sub: string };
   const now = Date.now();
   const cached = tokenCache.get(token);


### PR DESCRIPTION
## Summary
- replace plaintext `JWT_SECRET:token` cache keys with HMAC-SHA-256 digests
- keep token-cache and in-flight verification behavior unchanged
- add tests for deterministic, input-specific, opaque cache keys

## Verification
- `npm ci --ignore-scripts` (0 vulnerabilities)
- `npm test --workspace=api -- --run src/routes/__tests__/papers.test.ts` (101 tests)
- `npm run typecheck`
- `npm run lint` (0 errors; one existing image warning)

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

認可キャッシュキーから機密情報を排除する変更です。
- `JWT_SECRET:token` 形式の平文キーを、JWTシークレットを鍵とするHMAC-SHA-256ダイジェストへ置き換えています。
- キャッシュキーの決定性、入力ごとの差異、固定長の16進表現、元データの非露出を検証するテストを追加しています。
</details>

<details open><summary><h3>Confidence Score: 5/5</h3></summary>

マージして問題ないと判断します。

HMACによるキー生成は既存のキャッシュ分離と進行中検証の共有を維持しながら、キー内のJWTシークレットとトークンの平文露出を除去しており、具体的な回帰は確認されませんでした。
</details>

<details open><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| apps/api/src/routes/papers.ts | 認可キャッシュおよび進行中の検証処理で使うキーを、平文のシークレット・トークンから決定的なHMACダイジェストへ安全に置き換えています。 |
| apps/api/src/routes/__tests__/papers.test.ts | 新しいキャッシュキーが決定的かつ入力固有であり、元のシークレットやトークンを露出しないことを検証しています。 |

</details>

<sub>Reviews (1): Last reviewed commit: ["fix(api): derive opaque JWT authorizatio..."](https://github.com/hiroki-org/openshelf/commit/a1a7580633da5d0d07d9cbdba40f5e7eebc1952c) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=47349556)</sub>

<!-- /greptile_comment -->