### PR TITLE
🎨 Palette: アップロード画面のボタンとアイコンのアクセシビリティを改善

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -36,6 +36,6 @@
 **Learning:** ブラウザデフォルトのフォーカスリングは背景色によっては視認性が低く、キーボードユーザーが現在どの要素を操作しているのか見失いやすくなります。特にカスタムボタンやリンクコンポーネントでは、Tailwindの `focus-visible:` ユーティリティを使用して明確なフォーカスリングを定義することがアクセシビリティ向上において非常に重要です。
 **Action:** 今後、インタラクティブな要素（ボタン、リンク、タブなど）を実装する際は、マウスユーザーの体験を損なわないよう `focus:` ではなく `focus-visible:` を使用し、十分なコントラストを持つフォーカスリング（例: `focus-visible:ring-2 focus-visible:ring-offset-2`）を必ず追加するようにします。
 
-## 2026-07-27 - Focus and Screen Reader Improvements for Upload Components
+## 2025-07-27 - Focus and Screen Reader Improvements for Upload Components
 **Learning:** Custom drag-and-drop zones (`<button>` tags visually styled as areas) often lack focus indicators because they don't look like traditional buttons, leading to poor keyboard accessibility. Also, decorative text like "+" and "✕" used in place of icons are read aloud by screen readers unless explicitly hidden.
 **Action:** Always add standard `focus-visible` ring styles to interactive elements regardless of their visual shape. Consistently use `aria-hidden="true"` on decorative text characters serving as icons, and `motion-safe:` for spinners.

--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -35,3 +35,7 @@
 ## 2026-07-20 - Keyboard Focus Visibility
 **Learning:** ブラウザデフォルトのフォーカスリングは背景色によっては視認性が低く、キーボードユーザーが現在どの要素を操作しているのか見失いやすくなります。特にカスタムボタンやリンクコンポーネントでは、Tailwindの `focus-visible:` ユーティリティを使用して明確なフォーカスリングを定義することがアクセシビリティ向上において非常に重要です。
 **Action:** 今後、インタラクティブな要素（ボタン、リンク、タブなど）を実装する際は、マウスユーザーの体験を損なわないよう `focus:` ではなく `focus-visible:` を使用し、十分なコントラストを持つフォーカスリング（例: `focus-visible:ring-2 focus-visible:ring-offset-2`）を必ず追加するようにします。
+
+## 2025-07-27 - Focus and Screen Reader Improvements for Upload Components
+**Learning:** Custom drag-and-drop zones (`<button>` tags visually styled as areas) often lack focus indicators because they don't look like traditional buttons, leading to poor keyboard accessibility. Also, decorative text like "+" and "✕" used in place of icons are read aloud by screen readers unless explicitly hidden.
+**Action:** Always add standard `focus-visible` ring styles to interactive elements regardless of their visual shape. Consistently use `aria-hidden="true"` on decorative text characters serving as icons, and `motion-safe:` for spinners.

--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -36,6 +36,6 @@
 **Learning:** ブラウザデフォルトのフォーカスリングは背景色によっては視認性が低く、キーボードユーザーが現在どの要素を操作しているのか見失いやすくなります。特にカスタムボタンやリンクコンポーネントでは、Tailwindの `focus-visible:` ユーティリティを使用して明確なフォーカスリングを定義することがアクセシビリティ向上において非常に重要です。
 **Action:** 今後、インタラクティブな要素（ボタン、リンク、タブなど）を実装する際は、マウスユーザーの体験を損なわないよう `focus:` ではなく `focus-visible:` を使用し、十分なコントラストを持つフォーカスリング（例: `focus-visible:ring-2 focus-visible:ring-offset-2`）を必ず追加するようにします。
 
-## 2025-07-27 - Focus and Screen Reader Improvements for Upload Components
+## 2026-07-27 - Focus and Screen Reader Improvements for Upload Components
 **Learning:** Custom drag-and-drop zones (`<button>` tags visually styled as areas) often lack focus indicators because they don't look like traditional buttons, leading to poor keyboard accessibility. Also, decorative text like "+" and "✕" used in place of icons are read aloud by screen readers unless explicitly hidden.
 **Action:** Always add standard `focus-visible` ring styles to interactive elements regardless of their visual shape. Consistently use `aria-hidden="true"` on decorative text characters serving as icons, and `motion-safe:` for spinners.

--- a/apps/web/src/app/upload/__tests__/page.test.tsx
+++ b/apps/web/src/app/upload/__tests__/page.test.tsx
@@ -243,6 +243,47 @@ describe("UploadPage", () => {
     expect(await screen.findByText("test.pdf")).toBeInTheDocument();
   });
 
+  it("exposes accessible upload controls and a reduced-motion-safe spinner", async () => {
+    vi.mocked(apiFetch).mockImplementation(() => new Promise(() => {}));
+    render(<UploadPage />);
+
+    const dropzone = screen.getByRole("button", {
+      description: /添付ファイル/i,
+    });
+    expect(dropzone).toHaveClass("focus-visible:ring-2");
+    expect(screen.getByText("+")).toHaveAttribute("aria-hidden", "true");
+
+    fireEvent.change(screen.getByLabelText(/タイトル/i), {
+      target: { value: "Accessible upload" },
+    });
+    fireEvent.change(screen.getByLabelText("アップロードファイル"), {
+      target: {
+        files: [
+          new File(["%PDF-1.7"], "paper.pdf", {
+            type: "application/pdf",
+          }),
+        ],
+      },
+    });
+
+    const removeButton = await screen.findByRole("button", {
+      name: "paper.pdf を削除",
+    });
+    expect(removeButton).toHaveClass("focus-visible:ring-2");
+    expect(removeButton.firstElementChild).toHaveAttribute("aria-hidden", "true");
+
+    fireEvent.click(
+      screen.getByRole("button", { name: "成果物をアップロードする" }),
+    );
+
+    const spinner = await waitFor(() => {
+      const element = document.querySelector(".motion-safe\\:animate-spin");
+      expect(element).not.toBeNull();
+      return element;
+    });
+    expect(spinner).toHaveAttribute("aria-hidden", "true");
+  });
+
   it("does not show drop feedback for non-file drags", () => {
     render(<UploadPage />);
 

--- a/apps/web/src/app/upload/__tests__/page.test.tsx
+++ b/apps/web/src/app/upload/__tests__/page.test.tsx
@@ -243,47 +243,6 @@ describe("UploadPage", () => {
     expect(await screen.findByText("test.pdf")).toBeInTheDocument();
   });
 
-  it("exposes accessible upload controls and a reduced-motion-safe spinner", async () => {
-    vi.mocked(apiFetch).mockImplementation(() => new Promise(() => {}));
-    render(<UploadPage />);
-
-    const dropzone = screen.getByRole("button", {
-      description: /添付ファイル/i,
-    });
-    expect(dropzone).toHaveClass("focus-visible:ring-2");
-    expect(screen.getByText("+")).toHaveAttribute("aria-hidden", "true");
-
-    fireEvent.change(screen.getByLabelText(/タイトル/i), {
-      target: { value: "Accessible upload" },
-    });
-    fireEvent.change(screen.getByLabelText("アップロードファイル"), {
-      target: {
-        files: [
-          new File(["%PDF-1.7"], "paper.pdf", {
-            type: "application/pdf",
-          }),
-        ],
-      },
-    });
-
-    const removeButton = await screen.findByRole("button", {
-      name: "paper.pdf を削除",
-    });
-    expect(removeButton).toHaveClass("focus-visible:ring-2");
-    expect(removeButton.firstElementChild).toHaveAttribute("aria-hidden", "true");
-
-    fireEvent.click(
-      screen.getByRole("button", { name: "成果物をアップロードする" }),
-    );
-
-    const spinner = await waitFor(() => {
-      const element = document.querySelector(".motion-safe\\:animate-spin");
-      expect(element).not.toBeNull();
-      return element;
-    });
-    expect(spinner).toHaveAttribute("aria-hidden", "true");
-  });
-
   it("does not show drop feedback for non-file drags", () => {
     render(<UploadPage />);
 

--- a/apps/web/src/app/upload/page.tsx
+++ b/apps/web/src/app/upload/page.tsx
@@ -476,7 +476,7 @@ export default function UploadPage() {
             onDragLeave={handleDragLeave}
             onDrop={handleDrop}
             aria-describedby="upload-files-label"
-            className={`group flex w-full flex-col items-center justify-center rounded-2xl border-2 border-dashed px-5 py-10 transition-all ${
+            className={`group flex w-full flex-col items-center justify-center rounded-2xl border-2 border-dashed px-5 py-10 transition-all focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-gray-900 focus-visible:ring-offset-2 dark:focus-visible:ring-gray-100 dark:focus-visible:ring-offset-gray-950 ${
               isDragging
                 ? "border-blue-500 bg-blue-50 dark:border-blue-400 dark:bg-blue-950/30"
                 : "border-gray-300 bg-white hover:border-gray-400 hover:bg-gray-50 dark:border-gray-700 dark:bg-gray-950 dark:hover:border-gray-600 dark:hover:bg-gray-900"
@@ -489,7 +489,7 @@ export default function UploadPage() {
                   : "bg-gray-100 text-gray-600 group-hover:bg-gray-200 dark:bg-gray-800 dark:text-gray-400 dark:group-hover:bg-gray-700"
               }`}
             >
-              <span className="text-2xl">+</span>
+              <span className="text-2xl" aria-hidden="true">+</span>
             </div>
             <span
               className={`mt-4 block text-sm font-medium ${
@@ -546,9 +546,9 @@ export default function UploadPage() {
                       type="button"
                       onClick={() => removeFile(i)}
                       aria-label={`${entry.file.name} を削除`}
-                      className="flex h-8 w-8 items-center justify-center rounded-lg text-gray-400 hover:bg-red-50 hover:text-red-500 dark:hover:bg-red-950/40 dark:hover:text-red-400"
+                      className="flex h-8 w-8 items-center justify-center rounded-lg text-gray-400 hover:bg-red-50 hover:text-red-500 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-red-500 focus-visible:ring-offset-2 dark:hover:bg-red-950/40 dark:hover:text-red-400 dark:focus-visible:ring-red-400 dark:focus-visible:ring-offset-gray-950"
                     >
-                      <span>✕</span>
+                      <span aria-hidden="true">✕</span>
                     </button>
                   </div>
                 </li>
@@ -571,7 +571,7 @@ export default function UploadPage() {
           >
             {uploading ? (
               <span className="flex items-center gap-2">
-                <span className="h-4 w-4 animate-spin rounded-full border-2 border-current border-t-transparent" />
+                <span aria-hidden="true" className="h-4 w-4 motion-safe:animate-spin rounded-full border-2 border-current border-t-transparent" />
                 アップロード中...
               </span>
             ) : (

--- a/apps/web/src/components/markdown-editor.tsx
+++ b/apps/web/src/components/markdown-editor.tsx
@@ -97,7 +97,7 @@ export function MarkdownEditor({
             value={value}
             onChange={(e) => onChange(e.target.value)}
             rows={12}
-            className="w-full resize-y border-0 bg-transparent p-3 font-mono text-sm focus:outline-none focus-visible:ring-2 focus-visible:ring-inset focus-visible:ring-gray-900 dark:focus-visible:ring-gray-100"
+            className="w-full resize-y border-0 bg-transparent p-3 font-mono text-sm focus:outline-none"
             placeholder={placeholder}
           />
         </div>

--- a/apps/web/src/components/markdown-editor.tsx
+++ b/apps/web/src/components/markdown-editor.tsx
@@ -97,7 +97,7 @@ export function MarkdownEditor({
             value={value}
             onChange={(e) => onChange(e.target.value)}
             rows={12}
-            className="w-full resize-y border-0 bg-transparent p-3 font-mono text-sm focus:outline-none"
+            className="w-full resize-y border-0 bg-transparent p-3 font-mono text-sm focus:outline-none focus-visible:ring-2 focus-visible:ring-inset focus-visible:ring-gray-900 dark:focus-visible:ring-gray-100"
             placeholder={placeholder}
           />
         </div>


### PR DESCRIPTION
💡 **What:**
- アップロード画面のドロップゾーンとファイル削除ボタンに `focus-visible` スタイルを追加しました。
- 装飾用の「+」アイコンや「✕」アイコン、アップロード中スピナーに `aria-hidden="true"` を付与しました。
- アップロード中スピナーの回転アニメーションを `motion-safe:animate-spin` に変更しました。

🎯 **Why:**
- カスタムで作成されたドロップゾーンや削除ボタンにおいて、キーボードナビゲーション時にフォーカスが視覚的にわかりにくかったため、既存のフォーカススタイルに準拠した視認性を確保しました。
- スクリーンリーダーが不要なアイコン文字を読み上げるのを防ぎ、UIをよりシンプルに把握できるようにするためです。
- アニメーションを減らす設定を行っているユーザーに配慮するためです。

📸 **Before/After:** (N/A)

♿ **Accessibility:**
- キーボード操作でのフォーカス状態を明確化し、WCAGの視認性ガイドラインに適合させました。
- 装飾アイコンをスクリーンリーダーの読み上げから除外し、情報のノイズを減らしました。
- システムの設定に基づくアニメーション制御(`motion-safe`)を適用しました。

---
*PR created automatically by Jules for task [337282689724871010](https://jules.google.com/task/337282689724871010) started by @is0692vs*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Accessibility**
  * Improved keyboard focus visibility for file upload and remove controls.
  * Hid decorative icons from screen readers.
  * Reduced motion for loading animations when preferred by the user.
* **Documentation**
  * Added guidance for accessible focus indicators, decorative icons, and motion-safe upload animations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

アップロード画面のアクセシビリティを改善する変更です。
- ドロップゾーンとファイル削除ボタンに、キーボード操作時のフォーカスリングを追加
- 装飾用アイコンとスピナーを支援技術から除外
- アップロード中のアニメーションを、ユーザーの視差効果軽減設定に追従するよう変更
- 今回の方針を Palette の学習記録へ追記
</details>

<details open><summary><h3>Confidence Score: 5/5</h3></summary>

問題となる変更は確認されず、このままマージして安全と考えられます。

装飾要素を非表示にした後も各ボタンのアクセシブルネームとアップロード中のテキストは維持され、追加された Tailwind のフォーカスおよび motion-safe スタイルも既存構成と整合しています。
</details>

<details open><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| apps/web/src/app/upload/page.tsx | フォーカス表示、装飾要素の aria-hidden、スピナーの motion-safe 対応はいずれも既存のアクセシブルネームや状態表示を維持しており、問題は確認されませんでした。 |
| .Jules/palette.md | アップロード画面で採用したアクセシビリティ方針を学習記録として追記しています。 |

</details>

<sub>Reviews (1): Last reviewed commit: ["🎨 Palette: アップロード画面のボタンとアイコンのアクセシビリティを改..."](https://github.com/hiroki-org/openshelf/commit/cbdf8aedf560dc8a20a64debece7cca8947ba72f) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=47609801)</sub>

<!-- /greptile_comment -->