### PR TITLE
🎨 Palette: キーボードアクセシビリティ向上のため focus-visible スタイルを追加

### DIFF
--- a/apps/web/src/app/invites/page.tsx
+++ b/apps/web/src/app/invites/page.tsx
@@ -198,7 +198,7 @@ export default function InvitesPage() {
                         onClick={() => respond(inv.id, "accept")}
                         disabled={isProcessing}
                         aria-busy={processingAction === "accept"}
-                        className="inline-flex min-w-[72px] items-center justify-center gap-2 rounded-xl bg-gray-900 px-4 py-2 text-sm font-medium text-white transition-colors hover:bg-gray-700 disabled:opacity-50 dark:bg-white dark:text-gray-900 dark:hover:bg-gray-200"
+                        className="inline-flex min-w-[72px] items-center justify-center gap-2 rounded-xl bg-gray-900 px-4 py-2 text-sm font-medium text-white transition-colors hover:bg-gray-700 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:ring-gray-900 disabled:opacity-50 dark:bg-white dark:text-gray-900 dark:hover:bg-gray-200 dark:focus-visible:ring-gray-100 dark:focus-visible:ring-offset-gray-950"
                       >
                         {processingAction === "accept" && (
                           <Spinner className="h-4 w-4" />
@@ -218,7 +218,7 @@ export default function InvitesPage() {
                         onClick={() => respond(inv.id, "decline")}
                         disabled={isProcessing}
                         aria-busy={processingAction === "decline"}
-                        className="inline-flex min-w-[72px] items-center justify-center gap-2 rounded-xl border border-gray-300 px-4 py-2 text-sm font-medium text-gray-700 transition-colors hover:bg-gray-50 disabled:opacity-50 dark:border-gray-700 dark:text-gray-200 dark:hover:bg-gray-900"
+                        className="inline-flex min-w-[72px] items-center justify-center gap-2 rounded-xl border border-gray-300 px-4 py-2 text-sm font-medium text-gray-700 transition-colors hover:bg-gray-50 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:ring-gray-900 disabled:opacity-50 dark:border-gray-700 dark:text-gray-200 dark:hover:bg-gray-900 dark:focus-visible:ring-gray-100 dark:focus-visible:ring-offset-gray-950"
                       >
                         {processingAction === "decline" && (
                           <Spinner className="h-4 w-4" />

--- a/apps/web/src/app/upload/page.tsx
+++ b/apps/web/src/app/upload/page.tsx
@@ -476,7 +476,7 @@ export default function UploadPage() {
             onDragLeave={handleDragLeave}
             onDrop={handleDrop}
             aria-describedby="upload-files-label"
-            className={`group flex w-full flex-col items-center justify-center rounded-2xl border-2 border-dashed px-5 py-10 transition-all ${
+            className={`group flex w-full flex-col items-center justify-center rounded-2xl border-2 border-dashed px-5 py-10 transition-all focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:ring-gray-900 dark:focus-visible:ring-gray-100 dark:focus-visible:ring-offset-gray-950 ${
               isDragging
                 ? "border-blue-500 bg-blue-50 dark:border-blue-400 dark:bg-blue-950/30"
                 : "border-gray-300 bg-white hover:border-gray-400 hover:bg-gray-50 dark:border-gray-700 dark:bg-gray-950 dark:hover:border-gray-600 dark:hover:bg-gray-900"
@@ -546,7 +546,7 @@ export default function UploadPage() {
                       type="button"
                       onClick={() => removeFile(i)}
                       aria-label={`${entry.file.name} を削除`}
-                      className="flex h-8 w-8 items-center justify-center rounded-lg text-gray-400 hover:bg-red-50 hover:text-red-500 dark:hover:bg-red-950/40 dark:hover:text-red-400"
+                      className="flex h-8 w-8 items-center justify-center rounded-lg text-gray-400 hover:bg-red-50 hover:text-red-500 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:ring-red-500 dark:hover:bg-red-950/40 dark:hover:text-red-400 dark:focus-visible:ring-red-400 dark:focus-visible:ring-offset-gray-950"
                     >
                       <span>✕</span>
                     </button>
@@ -567,7 +567,7 @@ export default function UploadPage() {
           <button
             type="submit"
             disabled={uploading}
-            className="inline-flex min-w-48 items-center justify-center rounded-xl bg-gray-950 px-6 py-3 text-sm font-semibold text-white transition-all hover:bg-gray-800 focus:outline-none focus:ring-2 focus:ring-gray-950 focus:ring-offset-2 disabled:opacity-50 dark:bg-white dark:text-gray-950 dark:hover:bg-gray-200 dark:focus:ring-white dark:focus:ring-offset-gray-950"
+            className="inline-flex min-w-48 items-center justify-center rounded-xl bg-gray-950 px-6 py-3 text-sm font-semibold text-white transition-all hover:bg-gray-800 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-gray-950 focus-visible:ring-offset-2 disabled:opacity-50 dark:bg-white dark:text-gray-950 dark:hover:bg-gray-200 dark:focus-visible:ring-gray-100 dark:focus-visible:ring-offset-gray-950"
           >
             {uploading ? (
               <span className="flex items-center gap-2">


### PR DESCRIPTION
💡 **何をしたか:**
招待ページの承認/拒否ボタン、およびアップロードページのファイルドロップエリア/削除ボタン/送信ボタンにおいて、キーボードフォーカス時の視覚的フィードバック (`focus-visible:ring-2` など) を追加・修正しました。

🎯 **なぜしたか:**
キーボード操作を行うユーザーが現在どの要素にフォーカスしているかを明確に視認できるようにするためです。また、マウスユーザーがクリックした際に出る不要なフォーカスリングを `focus-visible:` ユーティリティを用いて防止し、全体の体験を向上させます。

📸 **ビフォー/アフター:**
ビフォー: キーボード操作で該当のボタンにフォーカスしても、枠線などの視覚的な変化がなかったり、マウス操作でもフォーカスリングが表示されてしまっていました。
アフター: キーボードでのフォーカス時のみ、明確な枠線が表示されるようになりました。

♿ **アクセシビリティ:**
キーボード操作の可視性が向上し、WCAGのフォーカスインジケータ要件に沿った改善が行われました。

---
*PR created automatically by Jules for task [17091260959340712409](https://jules.google.com/task/17091260959340712409) started by @is0692vs*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Improved keyboard focus indicators for invite actions and upload controls.
  * Added clearer focus-visible rings, offsets, transitions, and dark-mode styling.
  * Preserved existing loading, disabled, and interaction behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

フォーカス表示をキーボード操作時に限定し、アクセシビリティを改善する変更です。
- 招待ページの承認・拒否ボタンに `focus-visible` のフォーカスリングを追加
- アップロードページのファイル選択領域と削除ボタンにフォーカスリングを追加
- 送信ボタンの既存の `focus` スタイルを `focus-visible` に変更
</details>

<details open><summary><h3>Confidence Score: 5/5</h3></summary>

このPRは安全にマージできると考えられます。

変更は既存のTailwind CSS設定でサポートされているフォーカスユーティリティに限定され、各操作要素の動作やデータ処理には影響せず、既存のプロジェクト内パターンとも整合しています。
</details>

<details open><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| apps/web/src/app/invites/page.tsx | 承認・拒否ボタンに、既存のデザイン規約と整合するキーボードフォーカス表示が追加されています。 |
| apps/web/src/app/upload/page.tsx | ファイル選択領域、削除ボタン、送信ボタンのフォーカス表示が、マウス操作とキーボード操作を区別する形に改善されています。 |

</details>

<sub>Reviews (1): Last reviewed commit: ["🎨 Palette: Add focus-visible styles to ..."](https://github.com/hiroki-org/openshelf/commit/f30af0c8bdc2736bfe6c16568f2c40c41541edd9) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=47979531)</sub>

<!-- /greptile_comment -->