### PR TITLE
🛡️ Sentinel: [Medium] 修正 [Toast IDでのセキュアでない乱数生成]

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -25,3 +25,7 @@
 **Vulnerability:** Unhandled exceptions in the Hono API routes can leak internal application details, such as stack traces, to the client via default 500 error responses.
 **Learning:** Returning raw Error objects or relying on Hono's default error handling without a custom `onError` hook exposes potentially sensitive debugging information.
 **Prevention:** Always define a global `app.onError((err, c) => { ... })` handler in the main application file (e.g., `apps/api/src/index.ts`) to intercept all unhandled exceptions, log a sanitized version of the error internally, and return a safe, generic JSON response to the user.
+## 2024-07-28 - Secure Randomness for Unique IDs
+**Vulnerability:** Insecure randomness (`Math.random()`) used for generating unique IDs in the toast component.
+**Learning:** `Math.random()` can cause ID collisions and is not cryptographically secure. `crypto.randomUUID()` is preferred, but requires fallbacks in non-secure HTTP contexts.
+**Prevention:** Use `crypto.randomUUID()` with fallbacks (`crypto.getRandomValues()` or Date/Math fallback) for client-side unique IDs.

--- a/apps/web/src/components/__tests__/toast.test.tsx
+++ b/apps/web/src/components/__tests__/toast.test.tsx
@@ -10,10 +10,11 @@ describe("toast", () => {
   afterEach(() => {
     vi.runOnlyPendingTimers();
     vi.useRealTimers();
+    vi.unstubAllGlobals();
   });
 
   it("renders and auto-removes toast messages", () => {
-    render(<ToastContainer />);
+    const { unmount } = render(<ToastContainer />);
 
     act(() => {
       toast.success("saved");
@@ -32,15 +33,17 @@ describe("toast", () => {
     expect(screen.queryByText("saved")).not.toBeInTheDocument();
     expect(screen.queryByText("failed")).not.toBeInTheDocument();
     expect(screen.queryByText("fyi")).not.toBeInTheDocument();
+    unmount();
   });
 
   it("ToastContainer has correct accessibility attributes", () => {
-    const { container } = render(<ToastContainer />);
+    const { container, unmount } = render(<ToastContainer />);
     const toastWrapper = container.firstChild;
 
     expect(toastWrapper).toHaveAttribute("aria-live", "polite");
     expect(toastWrapper).not.toHaveAttribute("role", "status");
     expect(toastWrapper).not.toHaveAttribute("aria-atomic");
+    unmount();
   });
 
   it("removes listener on unmount", () => {
@@ -56,5 +59,31 @@ describe("toast", () => {
     expect(container.innerHTML).toBe("");
 
     consoleSpy.mockRestore();
+  });
+  it("generates ID using crypto.getRandomValues if randomUUID is missing", () => {
+    const mockGetRandomValues = vi.fn((arr) => {
+      arr[0] = 123456789;
+      return arr;
+    });
+    vi.stubGlobal('crypto', { getRandomValues: mockGetRandomValues });
+
+    const { unmount } = render(<ToastContainer />);
+    act(() => {
+      toast.success("secure-fallback");
+    });
+    expect(screen.getByText("secure-fallback")).toBeInTheDocument();
+    expect(mockGetRandomValues).toHaveBeenCalled();
+    unmount();
+  });
+
+  it("generates ID using Math.random fallback if crypto is completely missing", () => {
+    vi.stubGlobal('crypto', undefined);
+
+    const { unmount } = render(<ToastContainer />);
+    act(() => {
+      toast.success("math-fallback");
+    });
+    expect(screen.getByText("math-fallback")).toBeInTheDocument();
+    unmount();
   });
 });

--- a/apps/web/src/components/toast.tsx
+++ b/apps/web/src/components/toast.tsx
@@ -19,8 +19,22 @@ export const toast = {
   info: (message: string) => addToast(message, "info"),
 };
 
+function generateId() {
+  if (typeof crypto !== "undefined") {
+    if (crypto.randomUUID) {
+      return crypto.randomUUID();
+    }
+    if (crypto.getRandomValues) {
+      const array = new Uint32Array(1);
+      crypto.getRandomValues(array);
+      return array[0].toString(36);
+    }
+  }
+  return Date.now().toString(36) + Math.random().toString(36).substring(2, 9);
+}
+
 function addToast(message: string, type: ToastType) {
-  const id = Math.random().toString(36).substring(2, 9);
+  const id = generateId();
   const newToast = { id, message, type };
   toasts = [...toasts, newToast];
   notify();


### PR DESCRIPTION
🚨 **Severity:** MEDIUM
     
🎯 **What:**
`apps/web/src/components/toast.tsx` 内で、ToastのID生成に使用されている `Math.random()` を、セキュアな `crypto.randomUUID()`（及び互換性のためのフォールバック）に置き換えました。

💡 **Why:**
`Math.random()` は暗号学的に安全な疑似乱数生成器ではなく、予測可能でIDの衝突を引き起こすリスクがあります。これを防ぐためにセキュアな乱数生成器に置き換える必要があります。

✅ **Verification:**
- 関連する単体テストにフォールバック処理を含む複数のID生成パスのテストを追加し、テストが成功することを確認。
- lintチェックが通ることを確認。

✨ **Result:**
ToastのIDがセキュアに生成され、衝突リスクが軽減されます。

---
*PR created automatically by Jules for task [508045120276963601](https://jules.google.com/task/508045120276963601) started by @is0692vs*

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

Toast ID の生成を crypto.randomUUID 優先へ変更しています。
- randomUUID がない環境向けに getRandomValues と Date.now/Math.random のフォールバックを追加
- 各フォールバック経路を確認するコンポーネントテストを追加
- Sentinel のセキュアな ID 生成に関する記録を更新
</details>

<details open><summary><h3>Confidence Score: 4/5</h3></summary>

マージ可能ですが、getRandomValues フォールバックの衝突耐性を広い ID 空間へ改善することを推奨します。

通常の randomUUID 経路は十分な一意性を持つ一方、互換フォールバックでは ID が単一の 32-bit 値へ縮小され、衝突時に複数の Toast が同時削除されます。

**Files Needing Attention:** apps/web/src/components/toast.tsx
</details>

<details open><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| apps/web/src/components/toast.tsx | Toast ID 生成を強化しているが、getRandomValues フォールバックは単一の 32-bit 値に限られている |
| apps/web/src/components/__tests__/toast.test.tsx | randomUUID 不在時と crypto 自体が不在のときのフォールバック経路を追加で検証している |
| .jules/sentinel.md | Toast ID に安全な乱数生成を使用する方針を追記している |

</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
### Issue 1
apps/web/src/components/toast.tsx:29-31
**32-bit フォールバックの衝突耐性**

`randomUUID` がなく `getRandomValues` のみ利用できる環境では、ID が単一の 32-bit 値に縮小されます。値が衝突すると React の key が重複し、一方のタイマーによる `removeToast` が同じ ID の Toast をすべて削除するため、フォールバックにも UUID 相当の広い ID 空間を使用してください。

---

For each issue above, determine whether it is valid and should be fixed. If so, fix it directly.
`````

</details>

<sub>Reviews (1): Last reviewed commit: ["Toast IDのセキュアでない乱数生成を修正"](https://github.com/hiroki-org/openshelf/commit/2d35e714308ee072ab98472bebfd621a404af7e2) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=47980788)</sub>

> Greptile also left **1 inline comment** on this PR.

**Context used:**

- Context used - 日本語で！！！ ([source](https://app.greptile.com/review/custom-context?memory=instruction-0))
- Knowledge Base — [Web Frontend Shell](https://app.greptile.com/hiroki-org/-/custom-context/knowledge-base/hiroki-org/openshelf/-/docs/web-frontend.md)

<!-- /greptile_comment -->