### PR TITLE
🛡️ Sentinel: [MEDIUM] Fix [メモリリーク(DoS)の脆弱性]

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -25,3 +25,8 @@
 **Vulnerability:** Unhandled exceptions in the Hono API routes can leak internal application details, such as stack traces, to the client via default 500 error responses.
 **Learning:** Returning raw Error objects or relying on Hono's default error handling without a custom `onError` hook exposes potentially sensitive debugging information.
 **Prevention:** Always define a global `app.onError((err, c) => { ... })` handler in the main application file (e.g., `apps/api/src/index.ts`) to intercept all unhandled exceptions, log a sanitized version of the error internally, and return a safe, generic JSON response to the user.
+
+## 2026-07-29 - [メモリ制限のないキャッシュによるDoS脆弱性の修正]
+**Vulnerability:** OLEファイルの検証時(`apps/api/src/utils/file.ts`)に使用されるキャッシュ(`loadedFatSectors`)に最大サイズ制限がなく、悪意のあるファイルによってメモリ枯渇(DoS)を引き起こす可能性がありました。
+**Learning:** Cloudflare Workersのような長時間稼働する環境でモジュールレベルのキャッシュ(`Map`など)を実装する場合、時間経過に伴うメモリリークを防ぐために、常に最大サイズ制限を設ける必要があります。
+**Prevention:** キャッシュにデータを追加する前に、キャッシュサイズを確認し、制限を超えた場合は古いデータを破棄するか追加を拒否する処理を必ず実装します。

--- a/apps/api/src/utils/file.ts
+++ b/apps/api/src/utils/file.ts
@@ -96,6 +96,8 @@ async function parseOleHeader(file: File): Promise<OleHeader | null> {
   return { sectorSize, dirSector, fatSectors };
 }
 
+const MAX_FAT_CACHE_SIZE = 1000;
+
 function createFatReader(
   file: File,
   sectorSize: number,
@@ -115,6 +117,10 @@ function createFatReader(
       const buffer = await file
         .slice(offset, offset + sectorSize)
         .arrayBuffer();
+
+      if (loadedFatSectors.size >= MAX_FAT_CACHE_SIZE) {
+        loadedFatSectors.delete(loadedFatSectors.keys().next().value!);
+      }
       loadedFatSectors.set(fatSectorIndex, new DataView(buffer));
     }
 


### PR DESCRIPTION
🚨 **深刻度:** MEDIUM
💡 **脆弱性:** OLEファイルの検証処理(`apps/api/src/utils/file.ts`)において、モジュールレベルのキャッシュ(`loadedFatSectors`)に最大サイズ制限が設定されていませんでした。
🎯 **影響:** 悪意のある細工されたファイルがアップロードされた場合、無制限にメモリを消費し、Denial of Service (DoS)攻撃やワーカーのクラッシュを引き起こす可能性があります。
🔧 **修正:** キャッシュサイズに制限(最大1000件)を設け、これを超える場合は最も古いエントリを削除(FIFO)するロジックを追加しました。
✅ **確認方法:** `pnpm test`および`pnpm lint`が正常に通過することを確認しました。

---
*PR created automatically by Jules for task [8875928509849325671](https://jules.google.com/task/8875928509849325671) started by @is0692vs*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved protection against malicious OLE files that could cause excessive memory usage during file verification.
  * Added a limit to cached FAT sector data and automatically removes older entries when the limit is reached.

* **Documentation**
  * Added a security note documenting the memory exhaustion vulnerability fix.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

OLE形式のPowerPoint検証で使用するFATセクタMapに、1000件の上限とFIFO退避処理を追加します。
- キャッシュ上限の定数と、追加前に最古の要素を削除する処理を追加
- Sentinel文書にメモリ枯渇対策の記録を追加
</details>

<details open><summary><h3>Confidence Score: 4/5</h3></summary>

マージを妨げる実行時不具合は見当たりませんが、到達不能な制限と不正確なセキュリティ記録は整理すべきです。

loadedFatSectorsは関数ローカルで、FATセクタ一覧も最大109件に制限されているため、1000件で作動する今回の退避処理は現在の経路では効果がなく、文書化された脆弱性の前提とも一致していません。

**Files Needing Attention:** apps/api/src/utils/file.ts, .jules/sentinel.md
</details>

<details open><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| apps/api/src/utils/file.ts | FATセクタMapへ1000件の上限を追加していますが、既存の最大109件という実効上限により退避処理へ到達しません。 |
| .jules/sentinel.md | 修正履歴を追加していますが、キャッシュをモジュールレベルかつ無制限とする説明は実装と一致しません。 |

</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
### Issue 1
apps/api/src/utils/file.ts:99
**到達不能なキャッシュ上限**

`fatSectors` は最大109件で範囲外アクセスも読み込み前に終了するため、1000件で発動する退避処理には到達しません。さらに `loadedFatSectors` は関数ローカルなので、今回の変更と Sentinel の「モジュールレベルの無制限キャッシュ」という説明が一致せず、実効性のないセキュリティ対策と誤った修正記録が残ります。

---

For each issue above, determine whether it is valid and should be fixed. If so, fix it directly.
`````

</details>

<sub>Reviews (1): Last reviewed commit: ["🛡️ Sentinel: Fix DoS vulnerability by l..."](https://github.com/hiroki-org/openshelf/commit/ed71e4eaad5e6c20e863ee3ff95ce8ca393c5717) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=48350919)</sub>

> Greptile also left **1 inline comment** on this PR.

**Context used:**

- Context used - 日本語で！！！ ([source](https://app.greptile.com/review/custom-context?memory=instruction-0))
- Knowledge Base — [Paper Upload, Storage, and Viewing Flow](https://app.greptile.com/hiroki-org/-/custom-context/knowledge-base/hiroki-org/openshelf/-/docs/papers-file-flow.md)

<!-- /greptile_comment -->