### PR TITLE
🎨 Palette: キーボード操作時のフォーカス視認性向上

### DIFF
--- a/apps/web/src/app/papers/[id]/badge-snippet.tsx
+++ b/apps/web/src/app/papers/[id]/badge-snippet.tsx
@@ -132,7 +132,7 @@ export function BadgeSnippet({ paperId, title, siteBase }: BadgeSnippetProps) {
               <button
                 type="button"
                 aria-label={`Copy ${snippet.label}`}
-                className="rounded bg-blue-600 px-2 py-1 text-white hover:bg-blue-500"
+                className="rounded bg-blue-600 px-2 py-1 text-white hover:bg-blue-500 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:ring-blue-600 dark:focus-visible:ring-offset-gray-900"
                 onClick={() => copySnippet(snippet.value)}
               >
                 Copy

--- a/apps/web/src/app/papers/[id]/cite-button.tsx
+++ b/apps/web/src/app/papers/[id]/cite-button.tsx
@@ -94,7 +94,7 @@ export function CiteButton({ paperId }: CiteButtonProps) {
     <div className="mb-6 relative inline-block" ref={containerRef}>
       <button
         type="button"
-        className="inline-flex items-center gap-2 rounded-md border border-gray-300 bg-white px-4 py-2 text-sm text-gray-700 hover:bg-gray-100 transition-colors dark:border-gray-700 dark:bg-gray-900 dark:text-gray-100 dark:hover:bg-gray-800"
+        className="inline-flex items-center gap-2 rounded-md border border-gray-300 bg-white px-4 py-2 text-sm text-gray-700 hover:bg-gray-100 transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:ring-gray-900 dark:border-gray-700 dark:bg-gray-900 dark:text-gray-100 dark:hover:bg-gray-800 dark:focus-visible:ring-gray-100 dark:focus-visible:ring-offset-gray-950"
         onClick={() => setOpen((prev) => !prev)}
         aria-expanded={open}
         aria-haspopup="menu"
@@ -112,7 +112,7 @@ export function CiteButton({ paperId }: CiteButtonProps) {
             <button
               key={option.value}
               type="button"
-              className="flex w-full items-center justify-between rounded px-3 py-2 text-left text-sm text-gray-700 hover:bg-gray-100 disabled:cursor-not-allowed disabled:opacity-60 dark:text-gray-200 dark:hover:bg-gray-800"
+              className="flex w-full items-center justify-between rounded px-3 py-2 text-left text-sm text-gray-700 hover:bg-gray-100 disabled:cursor-not-allowed disabled:opacity-60 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:ring-gray-900 dark:text-gray-200 dark:hover:bg-gray-800 dark:focus-visible:ring-gray-100 dark:focus-visible:ring-offset-gray-950"
               onClick={() => handleCopy(option.value)}
               disabled={loadingFormat !== null}
               role="menuitem"


### PR DESCRIPTION
🎯 **What:**
- 引用ボタン (`CiteButton`) および バッジスニペットのコピーボタン (`BadgeSnippet`) に対し、`focus-visible` ユーティリティクラス（`focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-offset-2` 等）を追加し、フォーカスリングを明確に表示するようにしました。

💡 **Why:**
- キーボードナビゲーションを使用するユーザーが、現在フォーカスしている要素を明確に視認できるようにするためです (WCAG 2.4.7 Focus Visible への対応とUX向上)。

📸 **Before/After:**
- Before: フォーカス時にフォーカスリングが明確に表示されないか、ブラウザのデフォルトスタイル（視認性が低い場合がある）に依存していました。
- After: フォーカス時にコントラストの高いリングが表示され、視認性が向上しました。

♿ **Accessibility:**
- キーボードナビゲーションによるフォーカスの視認性が大きく改善しました。

---
*PR created automatically by Jules for task [9597624948608941005](https://jules.google.com/task/9597624948608941005) started by @is0692vs*

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

引用およびバッジスニペットのコピー操作で、キーボードフォーカスの視認性を向上させる変更です。
- `BadgeSnippet` のコピーボタンに、ライト／ダークモード対応の `focus-visible` リングを追加
- `CiteButton` のトリガーと引用形式メニュー項目に、高コントラストな `focus-visible` リングを追加
</details>

<details open><summary><h3>Confidence Score: 5/5</h3></summary>

このPRは安全にマージできると判断します。

変更はサポート済みのTailwindユーティリティによるフォーカス表示の追加に限定され、既存の操作、状態遷移、データ処理を変更せず、具体的な不具合は確認されませんでした。
</details>

<details open><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| apps/web/src/app/papers/[id]/badge-snippet.tsx | バッジスニペットのコピーボタンに、既存の操作を変えずキーボードフォーカス表示を追加しています。 |
| apps/web/src/app/papers/[id]/cite-button.tsx | 引用ボタンとメニュー項目に、ライト／ダークモード双方で視認可能なフォーカスリングを追加しています。 |

</details>

<sub>Reviews (1): Last reviewed commit: ["feat: add focus-visible ring classes to ..."](https://github.com/hiroki-org/openshelf/commit/85ecf40fe596759ab24185c81d9cbfa55c7995b9) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=48353217)</sub>

<!-- /greptile_comment -->