### PR TITLE
🎨 Palette: ボタンへのフォーカスリング追加

### DIFF
--- a/apps/web/src/app/papers/[id]/badge-snippet.tsx
+++ b/apps/web/src/app/papers/[id]/badge-snippet.tsx
@@ -132,7 +132,7 @@ export function BadgeSnippet({ paperId, title, siteBase }: BadgeSnippetProps) {
               <button
                 type="button"
                 aria-label={`Copy ${snippet.label}`}
-                className="rounded bg-blue-600 px-2 py-1 text-white hover:bg-blue-500"
+                className="rounded bg-blue-600 px-2 py-1 text-white hover:bg-blue-500 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:ring-blue-600 dark:focus-visible:ring-blue-400 dark:focus-visible:ring-offset-gray-900"
                 onClick={() => copySnippet(snippet.value)}
               >
                 Copy

--- a/apps/web/src/app/papers/[id]/cite-button.tsx
+++ b/apps/web/src/app/papers/[id]/cite-button.tsx
@@ -94,7 +94,7 @@ export function CiteButton({ paperId }: CiteButtonProps) {
     <div className="mb-6 relative inline-block" ref={containerRef}>
       <button
         type="button"
-        className="inline-flex items-center gap-2 rounded-md border border-gray-300 bg-white px-4 py-2 text-sm text-gray-700 hover:bg-gray-100 transition-colors dark:border-gray-700 dark:bg-gray-900 dark:text-gray-100 dark:hover:bg-gray-800"
+        className="inline-flex items-center gap-2 rounded-md border border-gray-300 bg-white px-4 py-2 text-sm text-gray-700 hover:bg-gray-100 transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:ring-gray-900 dark:border-gray-700 dark:bg-gray-900 dark:text-gray-100 dark:hover:bg-gray-800 dark:focus-visible:ring-gray-100 dark:focus-visible:ring-offset-gray-950"
         onClick={() => setOpen((prev) => !prev)}
         aria-expanded={open}
         aria-haspopup="menu"
@@ -112,7 +112,7 @@ export function CiteButton({ paperId }: CiteButtonProps) {
             <button
               key={option.value}
               type="button"
-              className="flex w-full items-center justify-between rounded px-3 py-2 text-left text-sm text-gray-700 hover:bg-gray-100 disabled:cursor-not-allowed disabled:opacity-60 dark:text-gray-200 dark:hover:bg-gray-800"
+              className="flex w-full items-center justify-between rounded px-3 py-2 text-left text-sm text-gray-700 hover:bg-gray-100 disabled:cursor-not-allowed disabled:opacity-60 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-inset focus-visible:ring-gray-900 dark:text-gray-200 dark:hover:bg-gray-800 dark:focus-visible:ring-gray-100"
               onClick={() => handleCopy(option.value)}
               disabled={loadingFormat !== null}
               role="menuitem"


### PR DESCRIPTION
💡 **What:** CiteボタンとBadgeSnippetのCopyボタンに `focus-visible` によるフォーカスリングを追加しました。
🎯 **Why:** キーボード操作時に現在フォーカスが当たっている要素が視覚的に明確になり、キーボードユーザーの操作性が向上します。
📸 **Before/After:** （視覚的な変更のため動画とスクリーンショットを参照してください）
♿ **Accessibility:** WCAG Focus Visible に準拠し、キーボード操作のアクセシビリティを改善しました。

---
*PR created automatically by Jules for task [16892464064463600655](https://jules.google.com/task/16892464064463600655) started by @is0692vs*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Improved keyboard-focus visibility for Copy and Cite controls.
  * Added clearer focus rings and dark-mode focus styling across citation menu actions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

フォーカス表示を改善するアクセシビリティ更新です。
- BadgeSnippet の Copy ボタンに、ライト・ダークテーマ対応の `focus-visible` リングを追加
- Cite ボタンと引用形式メニュー項目に、レイアウトに適した外側・内側のフォーカスリングを追加
</details>

<details open><summary><h3>Confidence Score: 5/5</h3></summary>

このPRは安全にマージできると判断します。

変更はサポート済みの標準的なフォーカス表示ユーティリティに限定され、既存の操作、状態管理、レイアウト、セキュリティ境界を損なう具体的な問題は確認されませんでした。
</details>

<details open><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| apps/web/src/app/papers/[id]/badge-snippet.tsx | Copy ボタンへ既存デザインと整合するキーボードフォーカス表示を追加しており、問題は確認されませんでした。 |
| apps/web/src/app/papers/[id]/cite-button.tsx | Cite ボタンとメニュー項目へ、ライト・ダークテーマに対応したフォーカスリングを追加しており、問題は確認されませんでした。 |

</details>

<sub>Reviews (1): Last reviewed commit: ["🎨 Palette: ボタンへのフォーカスリング追加"](https://github.com/hiroki-org/openshelf/commit/39883c281e4c5f0d201e3de65e37953756ecbf8b) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=48713451)</sub>

<!-- /greptile_comment -->