### PR TITLE
🎨 Palette: キーボードナビゲーションのための focus-visible スタイルの追加

### DIFF
--- a/apps/web/src/app/papers/[id]/badge-snippet.tsx
+++ b/apps/web/src/app/papers/[id]/badge-snippet.tsx
@@ -132,7 +132,7 @@ export function BadgeSnippet({ paperId, title, siteBase }: BadgeSnippetProps) {
               <button
                 type="button"
                 aria-label={`Copy ${snippet.label}`}
-                className="rounded bg-blue-600 px-2 py-1 text-white hover:bg-blue-500"
+                className="rounded bg-blue-600 px-2 py-1 text-white hover:bg-blue-500 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:ring-gray-900 dark:focus-visible:ring-gray-100 dark:focus-visible:ring-offset-gray-950"
                 onClick={() => copySnippet(snippet.value)}
               >
                 Copy

--- a/apps/web/src/app/papers/[id]/cite-button.tsx
+++ b/apps/web/src/app/papers/[id]/cite-button.tsx
@@ -94,7 +94,7 @@ export function CiteButton({ paperId }: CiteButtonProps) {
     <div className="mb-6 relative inline-block" ref={containerRef}>
       <button
         type="button"
-        className="inline-flex items-center gap-2 rounded-md border border-gray-300 bg-white px-4 py-2 text-sm text-gray-700 hover:bg-gray-100 transition-colors dark:border-gray-700 dark:bg-gray-900 dark:text-gray-100 dark:hover:bg-gray-800"
+        className="inline-flex items-center gap-2 rounded-md border border-gray-300 bg-white px-4 py-2 text-sm text-gray-700 hover:bg-gray-100 transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:ring-gray-900 dark:border-gray-700 dark:bg-gray-900 dark:text-gray-100 dark:hover:bg-gray-800 dark:focus-visible:ring-gray-100 dark:focus-visible:ring-offset-gray-950"
         onClick={() => setOpen((prev) => !prev)}
         aria-expanded={open}
         aria-haspopup="menu"
@@ -112,7 +112,7 @@ export function CiteButton({ paperId }: CiteButtonProps) {
             <button
               key={option.value}
               type="button"
-              className="flex w-full items-center justify-between rounded px-3 py-2 text-left text-sm text-gray-700 hover:bg-gray-100 disabled:cursor-not-allowed disabled:opacity-60 dark:text-gray-200 dark:hover:bg-gray-800"
+              className="flex w-full items-center justify-between rounded px-3 py-2 text-left text-sm text-gray-700 hover:bg-gray-100 disabled:cursor-not-allowed disabled:opacity-60 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-inset focus-visible:ring-gray-900 dark:text-gray-200 dark:hover:bg-gray-800 dark:focus-visible:ring-gray-100"
               onClick={() => handleCopy(option.value)}
               disabled={loadingFormat !== null}
               role="menuitem"


### PR DESCRIPTION
💡 **What:** CiteButton と BadgeSnippet 内の各ボタンに focus-visible クラスを追加し、キーボード操作時のフォーカス状態を視覚的に明確にしました。
🎯 **Why:** これまで一部のボタンでキーボードフォーカスがブラウザデフォルトに依存しており、背景色によっては視認性が低くなる課題があったため。
📸 **Before/After:** Before: フォーカスリングが不明瞭または非表示。 After: 2pxのフォーカスリングがオフセット付きで表示され、ダークモードにも対応。
♿ **Accessibility:** キーボードユーザーが現在操作している要素を明確に把握できるようになり、WCAG 2.4.7 Focus Visible に準拠する形で体験が向上しました。

---
*PR created automatically by Jules for task [9117861981400009301](https://jules.google.com/task/9117861981400009301) started by @is0692vs*

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

フォーカス表示を改善するアクセシビリティ向上の変更です。
- BadgeSnippet のコピーボタンに、ライト／ダークモード対応の `focus-visible` リングを追加
- CiteButton のトリガーにオフセット付きフォーカスリングを追加
- 引用形式メニューの各ボタンにインセット型フォーカスリングを追加
</details>

<details open><summary><h3>Confidence Score: 5/5</h3></summary>

このPRは安全にマージできると判断します。

変更は既存ボタンへのTailwind標準フォーカスユーティリティの追加に限定され、対応するツールチェーンや周辺レイアウトと整合しており、動作上の問題は確認されませんでした。
</details>

<details open><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| apps/web/src/app/papers/[id]/badge-snippet.tsx | コピーボタンに既存のデザイン規約と整合するキーボードフォーカス表示を追加しており、問題は確認されませんでした。 |
| apps/web/src/app/papers/[id]/cite-button.tsx | 引用ボタンとメニュー項目に適切な focus-visible スタイルを追加しており、既存動作を損なう変更は確認されませんでした。 |

</details>

<sub>Reviews (1): Last reviewed commit: ["feat: add focus-visible styles to cite a..."](https://github.com/hiroki-org/openshelf/commit/bf6369b089cb81aa381f64869f751fa4f95a789e) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=48719528)</sub>

<!-- /greptile_comment -->