### PR TITLE
🎨 Palette: キーボードナビゲーションのための focus-visible スタイルの追加

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -35,3 +35,6 @@
 ## 2026-07-20 - Keyboard Focus Visibility
 **Learning:** ブラウザデフォルトのフォーカスリングは背景色によっては視認性が低く、キーボードユーザーが現在どの要素を操作しているのか見失いやすくなります。特にカスタムボタンやリンクコンポーネントでは、Tailwindの `focus-visible:` ユーティリティを使用して明確なフォーカスリングを定義することがアクセシビリティ向上において非常に重要です。
 **Action:** 今後、インタラクティブな要素（ボタン、リンク、タブなど）を実装する際は、マウスユーザーの体験を損なわないよう `focus:` ではなく `focus-visible:` を使用し、十分なコントラストを持つフォーカスリング（例: `focus-visible:ring-2 focus-visible:ring-offset-2`）を必ず追加するようにします。
+## $(date +%Y-%m-%d) - Interactive Button Focus Visibility
+**Learning:** 共有コンポーネント以外でも、招待への「承認 / 拒否」や「Cite」のような独立したアクションボタンを実装する際は、キーボード操作時の明確なフィードバックのために `focus-visible` クラスを追加し、フォーカス状態の視認性を担保する必要があります。
+**Action:** 今後、新しくクリック可能な要素を追加・改善する際は、必ず `focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-offset-2` といったキーボードフォーカスのスタイルを実装し、ダークモードのサポートも含めるようにします。

--- a/apps/web/src/app/invites/page.tsx
+++ b/apps/web/src/app/invites/page.tsx
@@ -198,7 +198,7 @@ export default function InvitesPage() {
                         onClick={() => respond(inv.id, "accept")}
                         disabled={isProcessing}
                         aria-busy={processingAction === "accept"}
-                        className="inline-flex min-w-[72px] items-center justify-center gap-2 rounded-xl bg-gray-900 px-4 py-2 text-sm font-medium text-white transition-colors hover:bg-gray-700 disabled:opacity-50 dark:bg-white dark:text-gray-900 dark:hover:bg-gray-200"
+                        className="inline-flex min-w-[72px] items-center justify-center gap-2 rounded-xl bg-gray-900 px-4 py-2 text-sm font-medium text-white transition-colors hover:bg-gray-700 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:ring-gray-900 disabled:opacity-50 dark:bg-white dark:text-gray-900 dark:hover:bg-gray-200 dark:focus-visible:ring-gray-100 dark:focus-visible:ring-offset-gray-950"
                       >
                         {processingAction === "accept" && (
                           <Spinner className="h-4 w-4" />
@@ -218,7 +218,7 @@ export default function InvitesPage() {
                         onClick={() => respond(inv.id, "decline")}
                         disabled={isProcessing}
                         aria-busy={processingAction === "decline"}
-                        className="inline-flex min-w-[72px] items-center justify-center gap-2 rounded-xl border border-gray-300 px-4 py-2 text-sm font-medium text-gray-700 transition-colors hover:bg-gray-50 disabled:opacity-50 dark:border-gray-700 dark:text-gray-200 dark:hover:bg-gray-900"
+                        className="inline-flex min-w-[72px] items-center justify-center gap-2 rounded-xl border border-gray-300 px-4 py-2 text-sm font-medium text-gray-700 transition-colors hover:bg-gray-50 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:ring-gray-900 disabled:opacity-50 dark:border-gray-700 dark:text-gray-200 dark:hover:bg-gray-900 dark:focus-visible:ring-gray-100 dark:focus-visible:ring-offset-gray-950"
                       >
                         {processingAction === "decline" && (
                           <Spinner className="h-4 w-4" />

--- a/apps/web/src/app/papers/[id]/cite-button.tsx
+++ b/apps/web/src/app/papers/[id]/cite-button.tsx
@@ -94,7 +94,7 @@ export function CiteButton({ paperId }: CiteButtonProps) {
     <div className="mb-6 relative inline-block" ref={containerRef}>
       <button
         type="button"
-        className="inline-flex items-center gap-2 rounded-md border border-gray-300 bg-white px-4 py-2 text-sm text-gray-700 hover:bg-gray-100 transition-colors dark:border-gray-700 dark:bg-gray-900 dark:text-gray-100 dark:hover:bg-gray-800"
+        className="inline-flex items-center gap-2 rounded-md border border-gray-300 bg-white px-4 py-2 text-sm text-gray-700 transition-colors hover:bg-gray-100 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:ring-gray-900 dark:border-gray-700 dark:bg-gray-900 dark:text-gray-100 dark:hover:bg-gray-800 dark:focus-visible:ring-gray-100 dark:focus-visible:ring-offset-gray-950"
         onClick={() => setOpen((prev) => !prev)}
         aria-expanded={open}
         aria-haspopup="menu"
@@ -112,7 +112,7 @@ export function CiteButton({ paperId }: CiteButtonProps) {
             <button
               key={option.value}
               type="button"
-              className="flex w-full items-center justify-between rounded px-3 py-2 text-left text-sm text-gray-700 hover:bg-gray-100 disabled:cursor-not-allowed disabled:opacity-60 dark:text-gray-200 dark:hover:bg-gray-800"
+              className="flex w-full items-center justify-between rounded px-3 py-2 text-left text-sm text-gray-700 hover:bg-gray-100 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:ring-gray-900 disabled:cursor-not-allowed disabled:opacity-60 dark:text-gray-200 dark:hover:bg-gray-800 dark:focus-visible:ring-gray-100 dark:focus-visible:ring-offset-gray-950"
               onClick={() => handleCopy(option.value)}
               disabled={loadingFormat !== null}
               role="menuitem"


### PR DESCRIPTION
💡 **What:**

- `apps/web/src/app/invites/page.tsx` の「承認」「拒否」ボタンに `focus-visible` スタイルを追加。
- `apps/web/src/app/papers/[id]/cite-button.tsx` の「Cite」ボタンおよびメニュー項目に `focus-visible` スタイルを追加。

🎯 **Why:**

ブラウザデフォルトのフォーカスリングは見えにくい場合があり、キーボード操作ユーザーが現在どの要素を操作しているか見失う原因になります。既存のデザインシステムに合わせて `focus-visible:ring-2` などを追加し、キーボードでのアクセス性を向上させます。("2026-07-20 - Keyboard Focus Visibility" の学習に基づく)

📸 **Before/After:**

視覚的なフォーカスリングが追加されました。

♿ **Accessibility:**

キーボードフォーカス時の視認性が向上し、キーボードユーザーがより迷わず操作できるようになりました。

---
*PR created automatically by Jules for task [240833380637077448](https://jules.google.com/task/240833380637077448) started by @is0692vs*

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

キーボード操作時のフォーカス視認性を改善する変更です。
- 招待の承認・拒否ボタンに、ライト／ダークモード対応の `focus-visible` リングを追加
- Cite ボタンと引用形式メニュー項目に同様のフォーカス表示を追加
- フォーカス表示に関する学習記録を `.Jules/palette.md` に追記
</details>

<details open><summary><h3>Confidence Score: 4/5</h3></summary>

マージを妨げる不具合は見当たりませんが、学習記録の未展開の日付プレースホルダーは修正することを推奨します。

フォーカス関連のクラスは既存の Tailwind 構成および同種の利用パターンと整合しており、実行時の挙動を壊す変更は確認できません。唯一の指摘は Markdown 記録の日付がリテラルのシェル式になっている非ブロッキングな品質上の問題です。

**Files Needing Attention:** .Jules/palette.md
</details>

<details open><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| .Jules/palette.md | フォーカス表示の学習記録を追加していますが、見出しの日付式が展開されずに残っています。 |
| apps/web/src/app/invites/page.tsx | 承認・拒否ボタンへ既存のデザインパターンに沿ったフォーカスリングを追加しています。 |
| apps/web/src/app/papers/[id]/cite-button.tsx | Cite ボタンと各メニュー項目へライト／ダークモード対応のフォーカスリングを追加しています。 |

</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
### Issue 1
.Jules/palette.md:38
**未展開の日付プレースホルダー**

Markdown では `$(date +%Y-%m-%d)` が展開されず、そのまま見出しに表示されるため、この学習記録の日付と時系列を判別できません。実際の日付を記録してください。

```suggestion
## 2026-07-31 - Interactive Button Focus Visibility
```

---

For each issue above, determine whether it is valid and should be fixed. If so, fix it directly.
`````

</details>

<sub>Reviews (1): Last reviewed commit: ["Add focus-visible styles to cite and inv..."](https://github.com/hiroki-org/openshelf/commit/688d6852a4b003fa8617bfb7a2da08b9c7086335) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=49068518)</sub>

> Greptile also left **1 inline comment** on this PR.

**Context used:**

- Context used - 日本語で！！！ ([source](https://app.greptile.com/review/custom-context?memory=instruction-0))

<!-- /greptile_comment -->