### PR TITLE
🎨 Palette: CiteButtonのキーボードフォーカス視認性向上

### DIFF
--- a/apps/web/src/app/papers/[id]/cite-button.tsx
+++ b/apps/web/src/app/papers/[id]/cite-button.tsx
@@ -94,7 +94,7 @@ export function CiteButton({ paperId }: CiteButtonProps) {
     <div className="mb-6 relative inline-block" ref={containerRef}>
       <button
         type="button"
-        className="inline-flex items-center gap-2 rounded-md border border-gray-300 bg-white px-4 py-2 text-sm text-gray-700 hover:bg-gray-100 transition-colors dark:border-gray-700 dark:bg-gray-900 dark:text-gray-100 dark:hover:bg-gray-800"
+        className="inline-flex items-center gap-2 rounded-md border border-gray-300 bg-white px-4 py-2 text-sm text-gray-700 hover:bg-gray-100 transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:ring-gray-900 dark:border-gray-700 dark:bg-gray-900 dark:text-gray-100 dark:hover:bg-gray-800 dark:focus-visible:ring-gray-100 dark:focus-visible:ring-offset-gray-950"
         onClick={() => setOpen((prev) => !prev)}
         aria-expanded={open}
         aria-haspopup="menu"
@@ -112,7 +112,7 @@ export function CiteButton({ paperId }: CiteButtonProps) {
             <button
               key={option.value}
               type="button"
-              className="flex w-full items-center justify-between rounded px-3 py-2 text-left text-sm text-gray-700 hover:bg-gray-100 disabled:cursor-not-allowed disabled:opacity-60 dark:text-gray-200 dark:hover:bg-gray-800"
+              className="flex w-full items-center justify-between rounded px-3 py-2 text-left text-sm text-gray-700 hover:bg-gray-100 disabled:cursor-not-allowed disabled:opacity-60 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-inset focus-visible:ring-gray-900 dark:text-gray-200 dark:hover:bg-gray-800 dark:focus-visible:ring-gray-100"
               onClick={() => handleCopy(option.value)}
               disabled={loadingFormat !== null}
               role="menuitem"


### PR DESCRIPTION
💡 **What:** CiteButtonのメインボタンとドロップダウンメニュー項目にfocus-visibleスタイルを追加しました。
🎯 **Why:** キーボード操作時のフォーカスの視認性を高め、アクセシビリティを向上させるためです。
♿ **Accessibility:** focus-visibleを用いてキーボードナビゲーション時の現在位置を明確にしました。

---
*PR created automatically by Jules for task [16497573899252074248](https://jules.google.com/task/16497573899252074248) started by @is0692vs*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Improved keyboard-focus visibility for the Cite button and citation format menu buttons.
  * Added dark-mode focus ring styling for better accessibility.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

CiteButtonのメインボタンと引用形式メニュー項目に、ライト・ダーク両テーマ対応のキーボードフォーカス表示を追加しています。
- メインボタンに外側のフォーカスリングとオフセットを追加
- メニュー項目にクリッピングされにくい内側のフォーカスリングを追加
</details>

<details open><summary><h3>Confidence Score: 5/5</h3></summary>

具体的な不具合は確認されず、このPRは安全にマージできると考えます。

変更は標準的なTailwind CSSのフォーカス表示ユーティリティに限定され、既存のクリック処理や引用取得処理には影響せず、周囲のレイアウトにもリングを隠す要因は確認されません。
</details>

<details open><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| apps/web/src/app/papers/[id]/cite-button.tsx | 既存のCiteButtonの挙動を変えず、Tailwind CSSの標準的なfocus-visibleスタイルを一貫して追加しています。 |

</details>

<sub>Reviews (1): Last reviewed commit: ["feat(ui): add focus-visible styles to Ci..."](https://github.com/hiroki-org/openshelf/commit/e91c8852b3761cb604bbda74ce0a15f1372902d7) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=49476340)</sub>

**Context used:**

- Knowledge Base — [Paper Upload, Storage, and Viewing Flow](https://app.greptile.com/hiroki-org/-/custom-context/knowledge-base/hiroki-org/openshelf/-/docs/papers-file-flow.md)

<!-- /greptile_comment -->