### PR TITLE
🔒 [Migrate JWT storage from localStorage to sessionStorage]

### DIFF
--- a/apps/e2e/helpers/auth.ts
+++ b/apps/e2e/helpers/auth.ts
@@ -59,7 +59,7 @@ export async function loginAsTestUser(page: Page, user?: TestUserInput) {
 
   await page.goto('/');
   await page.evaluate((jwt) => {
-    localStorage.setItem('auth_token', jwt);
+    sessionStorage.setItem('auth_token', jwt);
   }, token);
   await page.reload();
 

--- a/apps/e2e/tests/auth.spec.ts
+++ b/apps/e2e/tests/auth.spec.ts
@@ -16,7 +16,7 @@ test.describe('認証', () => {
         await expect(page.getByRole('heading', { name: 'マイライブラリ' })).toBeVisible();
     });
 
-    test('ログアウト操作後、localStorage からトークンが削除され、未認証状態に戻ること', async ({ page }) => {
+    test('ログアウト操作後、sessionStorage からトークンが削除され、未認証状態に戻ること', async ({ page }) => {
         await loginAsTestUser(page, { name: 'Token User' });
         
         // ログアウトをクリック
@@ -25,8 +25,8 @@ test.describe('認証', () => {
         // 未認証状態ボタンの表示を確認 (ヘッダーとメインコンテンツの複数箇所に存在する可能性があるため、first を使うか、特定の場所を指定する)
         await expect(page.getByRole('button', { name: 'GitHubでログイン' }).first()).toBeVisible();
 
-        // localStorage の確認
-        const token = await page.evaluate(() => localStorage.getItem('auth_token'));
+        // sessionStorage の確認
+        const token = await page.evaluate(() => sessionStorage.getItem('auth_token'));
         expect(token).toBeNull();
     });
 });

--- a/apps/e2e/tests/papers.spec.ts
+++ b/apps/e2e/tests/papers.spec.ts
@@ -25,7 +25,7 @@ async function uploadPaper(page: Page, options: { title: string; visibility: 'pu
 }
 
 async function getFirstFileId(page: Page, paperId: string): Promise<string> {
-    const token = await page.evaluate(() => localStorage.getItem('auth_token'));
+    const token = await page.evaluate(() => sessionStorage.getItem('auth_token'));
     expect(token, 'auth_token が未設定です').toBeTruthy();
 
     const detailRes = await page.request.get(`/api/papers/${paperId}`, {
@@ -329,7 +329,7 @@ test.describe('論文ダウンロード', () => {
         // 1. メンバーとしてログインし、組織を作成・所属
         const userPayload = await loginAsTestUser(page);
         const memberUserId = userPayload.sub;
-        const memberToken = await page.evaluate(() => localStorage.getItem('auth_token'));
+        const memberToken = await page.evaluate(() => sessionStorage.getItem('auth_token'));
         const authSecret = process.env.TEST_AUTH_SECRET || 'test-secret';
 
         const apiURL = process.env.E2E_API_URL || 'http://localhost:8787';
@@ -381,7 +381,7 @@ test.describe('論文ダウンロード', () => {
         const nonMemberPage = await nonMemberContext.newPage();
         try {
             await loginAsTestUser(nonMemberPage); // 別ユーザー(非メンバー)としてログイン
-            const nonMemberToken = await nonMemberPage.evaluate(() => localStorage.getItem('auth_token'));
+            const nonMemberToken = await nonMemberPage.evaluate(() => sessionStorage.getItem('auth_token'));
 
             const nonMemberDownloadRes = await nonMemberPage.request.get(`${apiURL}/api/papers/${paperId}/files/${fileId}/download`, {
                 headers: { 'Authorization': `Bearer ${nonMemberToken}` }

--- a/apps/e2e/tests/scenarios/auth-flow.spec.ts
+++ b/apps/e2e/tests/scenarios/auth-flow.spec.ts
@@ -12,14 +12,14 @@ test.describe('Auth Flow', () => {
         await page.goto('/upload');
         await expect(page.getByRole('heading', { name: "成果物アップロード" })).toBeVisible();
 
-        // トークンが localStorage に存在すること
-        const token = await page.evaluate(() => localStorage.getItem('auth_token'));
+        // トークンが sessionStorage に存在すること
+        const token = await page.evaluate(() => sessionStorage.getItem('auth_token'));
         expect(token).toBeTruthy();
 
         // ログアウト処理
         await page.getByRole('button', { name: 'ログアウト' }).click();
         await expect.poll(async () => {
-            return page.evaluate(() => localStorage.getItem('auth_token'));
+            return page.evaluate(() => sessionStorage.getItem('auth_token'));
         }).toBeNull();
 
         // '/upload' にアクセスすると未認証状態としてルートなどにリダイレクトされることを確認
@@ -33,7 +33,7 @@ test.describe('Auth Flow', () => {
 
     test('認証トークンで API にアクセスでき、ログアウト後は未認証になること', async ({ page }) => {
         const user = await loginAsTestUser(page);
-        const token = await page.evaluate(() => localStorage.getItem('auth_token'));
+        const token = await page.evaluate(() => sessionStorage.getItem('auth_token'));
         expect(token).toBeTruthy();
 
         const meRes = await page.request.get('/api/users/me', {
@@ -57,7 +57,7 @@ test.describe('Auth Flow', () => {
 
         await page.getByRole('button', { name: 'ログアウト' }).click();
         await expect.poll(async () => {
-            return page.evaluate(() => localStorage.getItem('auth_token'));
+            return page.evaluate(() => sessionStorage.getItem('auth_token'));
         }).toBeNull();
 
         const unauthRes = await page.request.get('/api/users/me');

--- a/apps/web/src/app/__tests__/auth-callback.test.tsx
+++ b/apps/web/src/app/__tests__/auth-callback.test.tsx
@@ -15,7 +15,7 @@ describe("AuthCallback", () => {
 
   beforeEach(() => {
     replace.mockReset();
-    localStorage.clear();
+    sessionStorage.clear();
     window.location.hash = "";
   });
 
@@ -27,7 +27,7 @@ describe("AuthCallback", () => {
     expect(screen.getByText("ログイン中...")).toBeInTheDocument();
 
     await waitFor(() => {
-      expect(localStorage.getItem("auth_token")).toBe("test-token");
+      expect(sessionStorage.getItem("auth_token")).toBe("test-token");
       expect(replace).toHaveBeenCalledWith("/");
     });
   });

--- a/apps/web/src/app/auth/callback/page.tsx
+++ b/apps/web/src/app/auth/callback/page.tsx
@@ -10,7 +10,7 @@ export default function AuthCallback() {
     const params = new URLSearchParams(hash);
     const token = params.get("token");
     if (token) {
-      localStorage.setItem("auth_token", token);
+      sessionStorage.setItem("auth_token", token);
     }
     router.replace("/");
   }, [router]);

--- a/apps/web/src/components/__tests__/auth-provider.test.tsx
+++ b/apps/web/src/components/__tests__/auth-provider.test.tsx
@@ -39,12 +39,12 @@ describe("AuthProvider", () => {
   });
 
   beforeEach(() => {
-    localStorage.clear();
+    sessionStorage.clear();
     vi.clearAllMocks();
   });
 
   it("sets user when token exists and /api/auth/me succeeds", async () => {
-    localStorage.setItem("auth_token", "token-1");
+    sessionStorage.setItem("auth_token", "token-1");
     vi.mocked(apiFetch).mockResolvedValue(
       new Response(
         JSON.stringify({
@@ -85,8 +85,8 @@ describe("AuthProvider", () => {
     });
   });
 
-  it("logout clears localStorage token and sets user null", async () => {
-    localStorage.setItem("auth_token", "token-1");
+  it("logout clears sessionStorage token and sets user null", async () => {
+    sessionStorage.setItem("auth_token", "token-1");
     vi.mocked(apiFetch).mockResolvedValue(
       new Response(
         JSON.stringify({
@@ -116,7 +116,7 @@ describe("AuthProvider", () => {
     fireEvent.click(screen.getByRole("button", { name: "logout" }));
 
     await waitFor(() => {
-      expect(localStorage.getItem("auth_token")).toBeNull();
+      expect(sessionStorage.getItem("auth_token")).toBeNull();
       expect(screen.getByTestId("user").textContent).toBe("null");
     });
   });
@@ -141,7 +141,7 @@ describe("AuthProvider", () => {
   });
 
   it("keeps user null when /api/auth/me responds with non-ok", async () => {
-    localStorage.setItem("auth_token", "token-1");
+    sessionStorage.setItem("auth_token", "token-1");
     vi.mocked(apiFetch).mockResolvedValue(new Response("{}", { status: 401 }));
 
     render(
@@ -157,7 +157,7 @@ describe("AuthProvider", () => {
   });
 
   it("keeps user null when /api/auth/me throws", async () => {
-    localStorage.setItem("auth_token", "token-1");
+    sessionStorage.setItem("auth_token", "token-1");
     vi.mocked(apiFetch).mockRejectedValue(new Error("network error"));
 
     render(
@@ -242,7 +242,7 @@ describe("AuthProvider", () => {
   });
 
   it("refresh re-fetches user data", async () => {
-    localStorage.setItem("auth_token", "token-1");
+    sessionStorage.setItem("auth_token", "token-1");
     vi.mocked(apiFetch)
       .mockResolvedValueOnce(
         new Response(JSON.stringify({ user: null }), { status: 401 }),

--- a/apps/web/src/components/auth-provider.tsx
+++ b/apps/web/src/components/auth-provider.tsx
@@ -41,7 +41,7 @@ export function AuthProvider({ children }: { children: React.ReactNode }) {
 
   const fetchUser = useCallback(async () => {
     try {
-      const token = localStorage.getItem("auth_token");
+      const token = sessionStorage.getItem("auth_token");
       if (!token) {
         setUser(null);
         setLoading(false);
@@ -78,7 +78,7 @@ export function AuthProvider({ children }: { children: React.ReactNode }) {
   }, []);
 
   const logout = useCallback(async () => {
-    localStorage.removeItem("auth_token");
+    sessionStorage.removeItem("auth_token");
     setUser(null);
   }, []);
 

--- a/apps/web/src/lib/__tests__/api.test.ts
+++ b/apps/web/src/lib/__tests__/api.test.ts
@@ -17,6 +17,12 @@ describe("api helpers", () => {
     expect(authHeaders()).toEqual({});
   });
 
+  it("authHeaders returns empty object when window is undefined", () => {
+    vi.stubGlobal('window', undefined);
+    expect(authHeaders()).toEqual({});
+    vi.unstubAllGlobals();
+  });
+
   it("apiFetch calls API_BASE + path with Authorization header", async () => {
     sessionStorage.setItem("auth_token", "token-x");
     const fetchMock = vi

--- a/apps/web/src/lib/__tests__/api.test.ts
+++ b/apps/web/src/lib/__tests__/api.test.ts
@@ -3,12 +3,12 @@ import { apiFetch, authHeaders } from "../api";
 
 describe("api helpers", () => {
   beforeEach(() => {
-    localStorage.clear();
+    sessionStorage.clear();
     vi.restoreAllMocks();
   });
 
   it("authHeaders returns Authorization header when token exists", () => {
-    localStorage.setItem("auth_token", "abc123");
+    sessionStorage.setItem("auth_token", "abc123");
 
     expect(authHeaders()).toEqual({ Authorization: "Bearer abc123" });
   });
@@ -18,7 +18,7 @@ describe("api helpers", () => {
   });
 
   it("apiFetch calls API_BASE + path with Authorization header", async () => {
-    localStorage.setItem("auth_token", "token-x");
+    sessionStorage.setItem("auth_token", "token-x");
     const fetchMock = vi
       .spyOn(globalThis, "fetch")
       .mockResolvedValue(new Response(null, { status: 200 }));

--- a/apps/web/src/lib/api.ts
+++ b/apps/web/src/lib/api.ts
@@ -2,7 +2,7 @@ const API_BASE = process.env.NEXT_PUBLIC_API_URL ?? "";
 
 export function authHeaders(): HeadersInit {
   const token =
-    typeof window !== "undefined" ? localStorage.getItem("auth_token") : null;
+    typeof window !== "undefined" ? sessionStorage.getItem("auth_token") : null;
   return token ? { Authorization: `Bearer ${token}` } : {};
 }
 


### PR DESCRIPTION
🎯 **What:** Changed JWT storage from `localStorage` to `sessionStorage`.
⚠️ **Risk:** Tokens stored in `localStorage` persist indefinitely and across all tabs, increasing the window of opportunity for XSS attacks and physical device compromise.
🛡️ **Solution:** Migrated token storage to `sessionStorage`. While HttpOnly cookies are the ideal solution, `sessionStorage` provides an immediate improvement by limiting token lifespan to the current session (tab) and preventing persistence on disk, without requiring architectural changes to the API and frontend.

---
*PR created automatically by Jules for task [9717558003122883874](https://jules.google.com/task/9717558003122883874) started by @is0692vs*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Authentication**
  * Authentication tokens are now stored for the current browser session rather than persistently on the device.
  * Logging out removes the session token as expected.
  * API requests continue to use the active session for authorization.

* **Tests**
  * Updated authentication, logout, callback, API, and end-to-end coverage to validate session-based token handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

JWT の保存先を `localStorage` からタブ単位の `sessionStorage` へ移し、認証コールバック、AuthProvider、API クライアント、単体・E2E テストを同期更新しています。ただし、既存の `localStorage` トークンを消去する移行処理がなく、変更目的である旧トークンの露出縮小が既存ユーザーには適用されません。

- OAuth コールバックの JWT 保存先を `sessionStorage` に変更
- 認証初期化、API Authorization ヘッダー、logout を `sessionStorage` に統一
- Playwright ヘルパーおよび認証関連テストを新しい保存方式に更新
</details>

<details open><summary><h3>Confidence Score: 4/5</h3></summary>

既存の localStorage JWT がログアウト後も残存するため、この資格情報を確実に削除する移行処理を追加してからマージすべきです。

認証の通常経路は sessionStorage に統一されていますが、既存ユーザーの旧 JWT を移行・削除する経路がなく、logout も旧資格情報を消さないため、セキュリティ改善が既存トークンに適用されません。

**Files Needing Attention:** apps/web/src/components/auth-provider.tsx
</details>

<details open><summary><h3>Security Review</h3></summary>

既存ユーザーの `localStorage.auth_token` を削除する処理がありません。変更後の logout も `sessionStorage` のみを消すため、旧 JWT はログアウト後も有効期限まで取得・再利用可能な状態で残ります。
</details>

<details open><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| apps/web/src/components/auth-provider.tsx | 認証初期化と logout を sessionStorage に変更したが、既存の localStorage JWT を消去しないため旧資格情報が残存する。 |
| apps/web/src/app/auth/callback/page.tsx | OAuth コールバックで受け取った新規 JWT を sessionStorage に保存するよう整合的に変更している。 |
| apps/web/src/lib/api.ts | API の Authorization ヘッダー生成を sessionStorage に合わせて更新している。 |
| apps/e2e/helpers/auth.ts | E2E の認証注入先を sessionStorage に変更し、実装側の読み取り方式と一致させている。 |
| apps/web/src/components/__tests__/auth-provider.test.tsx | 新しい sessionStorage 動作は検証しているが、旧 localStorage トークンの消去シナリオはカバーしていない。 |

</details>

<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
  participant B as Browser
  participant C as OAuth Callback
  participant S as sessionStorage
  participant P as AuthProvider
  participant A as API
  B->>C: OAuth callback with JWT fragment
  C->>S: Store auth_token
  C->>B: Navigate to /
  P->>S: Read auth_token
  P->>A: GET /api/auth/me with Bearer JWT
  B->>P: Logout
  P->>S: Remove auth_token
  Note over B: Legacy localStorage token is not removed
```

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
### Issue 1
apps/web/src/components/auth-provider.tsx:81
**旧 JWT がログアウト後も残存**

この変更のデプロイ前に `localStorage.auth_token` を保存していたユーザーがログアウトしても、変更後の処理は `sessionStorage` だけを削除するため、旧 JWT が有効期限まで取得・再利用可能な状態で残ります。

**How this was verified:** 旧トークンの保存元から変更後の logout までを追跡し、`localStorage.auth_token` を削除する経路がないことを確認した。

---

For each issue above, determine whether it is valid and should be fixed. If so, fix it directly.
`````

</details>

<sub>Reviews (1): Last reviewed commit: ["🔒 Migrate JWT storage from localStorage..."](https://github.com/hiroki-org/openshelf/commit/eee0c0c3c25ed8f6240b25df2576390320c6ab32) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=49586429)</sub>

> Greptile also left **1 inline comment** on this PR.

<details><summary><h4>Context used (3)</h4></summary>

- Knowledge Base — [Auth flow (GitHub OAuth + JWT)](https://app.greptile.com/hiroki-org/-/custom-context/knowledge-base/hiroki-org/openshelf/-/docs/auth-flow.md)
- Knowledge Base — [Web Frontend Shell](https://app.greptile.com/hiroki-org/-/custom-context/knowledge-base/hiroki-org/openshelf/-/docs/web-frontend.md)
- Knowledge Base — [E2E Testing (Playwright)](https://app.greptile.com/hiroki-org/-/custom-context/knowledge-base/hiroki-org/openshelf/-/docs/e2e-testing.md)
</details>

<!-- /greptile_comment -->