### PR TITLE
🎨 Palette: CiteボタンとBadgeボタンにフォーカスリングを追加

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -35,3 +35,7 @@
 ## 2026-07-20 - Keyboard Focus Visibility
 **Learning:** ブラウザデフォルトのフォーカスリングは背景色によっては視認性が低く、キーボードユーザーが現在どの要素を操作しているのか見失いやすくなります。特にカスタムボタンやリンクコンポーネントでは、Tailwindの `focus-visible:` ユーティリティを使用して明確なフォーカスリングを定義することがアクセシビリティ向上において非常に重要です。
 **Action:** 今後、インタラクティブな要素（ボタン、リンク、タブなど）を実装する際は、マウスユーザーの体験を損なわないよう `focus:` ではなく `focus-visible:` を使用し、十分なコントラストを持つフォーカスリング（例: `focus-visible:ring-2 focus-visible:ring-offset-2`）を必ず追加するようにします。
+
+## 2024-08-03 - [Focus Rings]
+**Learning:** ボタンやリンクなどのインタラクティブな要素にフォーカス時の視覚的インジケーター（`focus-visible`）が欠けている箇所を発見しました。これによりキーボードナビゲーションのアクセシビリティが損なわれます。既存のフォーカスリングのパターンは `focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:ring-gray-900 dark:focus-visible:ring-gray-100 dark:focus-visible:ring-offset-gray-950` です。
+**Action:** インタラクティブな要素（`button`, `a`, `input` など）のフォーカス状態を常に確認し、適切な場合には標準化されたフォーカスリングのクラスを適用します。クリップされるコンポーネントやタブリスト内の要素には、フォーカスリングが途切れないように `focus-visible:ring-inset` を使用します。

--- a/apps/web/src/app/papers/[id]/badge-snippet.tsx
+++ b/apps/web/src/app/papers/[id]/badge-snippet.tsx
@@ -132,7 +132,7 @@ export function BadgeSnippet({ paperId, title, siteBase }: BadgeSnippetProps) {
               <button
                 type="button"
                 aria-label={`Copy ${snippet.label}`}
-                className="rounded bg-blue-600 px-2 py-1 text-white hover:bg-blue-500"
+                className="rounded bg-blue-600 px-2 py-1 text-white hover:bg-blue-500 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:ring-gray-900 dark:focus-visible:ring-gray-100 dark:focus-visible:ring-offset-gray-950"
                 onClick={() => copySnippet(snippet.value)}
               >
                 Copy

--- a/apps/web/src/app/papers/[id]/cite-button.tsx
+++ b/apps/web/src/app/papers/[id]/cite-button.tsx
@@ -94,7 +94,7 @@ export function CiteButton({ paperId }: CiteButtonProps) {
     <div className="mb-6 relative inline-block" ref={containerRef}>
       <button
         type="button"
-        className="inline-flex items-center gap-2 rounded-md border border-gray-300 bg-white px-4 py-2 text-sm text-gray-700 hover:bg-gray-100 transition-colors dark:border-gray-700 dark:bg-gray-900 dark:text-gray-100 dark:hover:bg-gray-800"
+        className="inline-flex items-center gap-2 rounded-md border border-gray-300 bg-white px-4 py-2 text-sm text-gray-700 hover:bg-gray-100 transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:ring-gray-900 dark:border-gray-700 dark:bg-gray-900 dark:text-gray-100 dark:hover:bg-gray-800 dark:focus-visible:ring-gray-100 dark:focus-visible:ring-offset-gray-950"
         onClick={() => setOpen((prev) => !prev)}
         aria-expanded={open}
         aria-haspopup="menu"
@@ -112,7 +112,7 @@ export function CiteButton({ paperId }: CiteButtonProps) {
             <button
               key={option.value}
               type="button"
-              className="flex w-full items-center justify-between rounded px-3 py-2 text-left text-sm text-gray-700 hover:bg-gray-100 disabled:cursor-not-allowed disabled:opacity-60 dark:text-gray-200 dark:hover:bg-gray-800"
+              className="flex w-full items-center justify-between rounded px-3 py-2 text-left text-sm text-gray-700 hover:bg-gray-100 disabled:cursor-not-allowed disabled:opacity-60 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-inset focus-visible:ring-gray-900 dark:text-gray-200 dark:hover:bg-gray-800 dark:focus-visible:ring-gray-100"
               onClick={() => handleCopy(option.value)}
               disabled={loadingFormat !== null}
               role="menuitem"


### PR DESCRIPTION
💡 **What:** CiteボタンとBadgeコピーボタンに `focus-visible` クラスを追加しました。
🎯 **Why:** キーボード操作時のフォーカスインジケーターが欠如しており、アクセシビリティ上の課題があったため。
♿ **Accessibility:** キーボードナビゲーションのサポートを改善し、どの要素がフォーカスされているか視覚的にわかるようにしました。

---
*PR created automatically by Jules for task [11726911301094088097](https://jules.google.com/task/11726911301094088097) started by @is0692vs*

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

Cite ボタン、引用形式メニュー項目、Badge のコピーボタンに、ライト／ダークテーマ対応の `focus-visible` フォーカスリングを追加する変更です。
- Cite ボタンにはオフセット付きのフォーカスリングを追加
- メニュー項目にはクリップを避ける inset リングを追加
- Badge コピーボタンにも標準パターンのフォーカスリングを追加
- Palette の学習記録を追記
</details>

<details open><summary><h3>Confidence Score: 4/5</h3></summary>

UI の変更は安全にマージできる内容ですが、学習記録の日付はマージ前に正しい年へ修正することを推奨します。

フォーカスリングの追加は既存の操作ロジックを変更せずアクセシビリティを改善していますが、Palette に追加された記録の日付だけが直前の履歴と矛盾しています。

**Files Needing Attention:** .Jules/palette.md
</details>

<details open><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| apps/web/src/app/papers/[id]/cite-button.tsx | Cite ボタンと各メニュー項目に、配置に応じた視認性の高いフォーカスリングを追加している。 |
| apps/web/src/app/papers/[id]/badge-snippet.tsx | Badge スニペットのコピーボタンにライト／ダークテーマ対応のフォーカスリングを追加している。 |
| .Jules/palette.md | フォーカスリングの標準パターンを記録しているが、追加された見出しの日付が時系列と整合していない。 |

</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
### Issue 1
.Jules/palette.md:39
**学習記録の日付が逆行しています**

2026-07-20 の記録直後に、今回の新しい指針が 2024-08-03 として追加されているため、履歴の順序と導入時期が不正確になります。見出しの日付を実際の追加日である 2026-08-03 に修正してください。

```suggestion
## 2026-08-03 - [Focus Rings]
```

---

For each issue above, determine whether it is valid and should be fixed. If so, fix it directly.
`````

</details>

<sub>Reviews (1): Last reviewed commit: ["🎨 Palette: CiteボタンとBadgeボタンにフォーカスリングを追加"](https://github.com/hiroki-org/openshelf/commit/42edf53855bbb2f8792e8607c524b2c45c131aea) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=49698402)</sub>

> Greptile also left **1 inline comment** on this PR.

**Context used:**

- Context used - 日本語で！！！ ([source](https://app.greptile.com/review/custom-context?memory=instruction-0))

<!-- /greptile_comment -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Accessibility**
  * Improved keyboard navigation visibility with consistent focus outlines and rings for snippet copying and citation controls.
  * Added dark-mode support for focus indicators.
  * Documented focus styling guidance for interactive elements, including clipped components and tab lists.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->