### PR TITLE
🎨 Palette: 動的なエラーメッセージへの role=alert 追加

### DIFF
--- a/apps/web/src/app/collections/new/page.tsx
+++ b/apps/web/src/app/collections/new/page.tsx
@@ -360,7 +360,7 @@ export default function NewCollectionPage() {
           </select>
         </div>
 
-        {error && <p className="text-sm text-red-600">{error}</p>}
+        {error && <p role="alert" className="text-sm text-red-600">{error}</p>}
 
         <button
           type="submit"

--- a/apps/web/src/app/orgs/new/page.tsx
+++ b/apps/web/src/app/orgs/new/page.tsx
@@ -187,7 +187,7 @@ export default function NewOrgPage() {
               required
             />
           </div>
-          <div className="mt-1">{slugStatusText()}</div>
+          <div aria-live="polite" className="mt-1">{slugStatusText()}</div>
         </div>
 
         <div>
@@ -218,7 +218,7 @@ export default function NewOrgPage() {
           </div>
         </div>
 
-        {error && <p className="text-sm text-red-600">{error}</p>}
+        {error && <p role="alert" className="text-sm text-red-600">{error}</p>}
 
         <button
           type="submit"

--- a/apps/web/src/app/papers/[id]/edit/page.tsx
+++ b/apps/web/src/app/papers/[id]/edit/page.tsx
@@ -252,7 +252,7 @@ export default function PaperEditPage() {
       </div>
 
       {error && (
-        <div className="mb-6 rounded-md bg-red-50 p-4 text-sm text-red-700 dark:bg-red-900/30 dark:text-red-400">
+        <div role="alert" className="mb-6 rounded-md bg-red-50 p-4 text-sm text-red-700 dark:bg-red-900/30 dark:text-red-400">
           {error}
         </div>
       )}

--- a/apps/web/src/app/upload/page.tsx
+++ b/apps/web/src/app/upload/page.tsx
@@ -558,7 +558,7 @@ export default function UploadPage() {
         </div>
 
         {error && (
-          <div className="rounded-2xl border border-red-200 bg-red-50 p-4 text-sm text-red-700 dark:border-red-900/50 dark:bg-red-950/40 dark:text-red-300">
+          <div role="alert" className="rounded-2xl border border-red-200 bg-red-50 p-4 text-sm text-red-700 dark:border-red-900/50 dark:bg-red-950/40 dark:text-red-300">
             {error}
           </div>
         )}


### PR DESCRIPTION
💡 **What:**
各ページのエラーメッセージ表示部分に `role="alert"` を追加し、組織作成ページのスラッグチェック結果表示に `aria-live="polite"` を追加しました。

🎯 **Why:**
スクリーンリーダーユーザーにとって、エラーが発生した際やバリデーション結果が返ってきた際に、内容が自動で読み上げられるようにするためです。

📸 **Before/After:**
視覚的な変更はありません。

♿ **Accessibility:**
エラーメッセージに `role="alert"` を付与することで、非同期に発生したエラーがすぐにスクリーンリーダーでアナウンスされるようになります。また、スラッグチェック結果に `aria-live="polite"` を付与することで、ユーザーの入力に応じて結果が適切に通知されるようになります。

---
*PR created automatically by Jules for task [13469635255940720038](https://jules.google.com/task/13469635255940720038) started by @is0692vs*

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

各作成・編集・アップロード画面の動的エラーに `role="alert"` を付与し、組織スラッグの検証結果を `aria-live="polite"` で通知するアクセシビリティ改善です。
- コレクション作成、組織作成、論文編集、アップロード画面のエラーをalertとして通知
- 組織作成画面のスラッグ検証結果をpoliteなライブリージョンとして通知
</details>

<details open><summary><h3>Confidence Score: 4/5</h3></summary>

マージを妨げる問題はありませんが、アップロード画面で同一のファイル検証エラーを連続して発生させた場合の再通知は改善が必要です。

フォーム送信経路では再試行前にエラーがクリアされますが、addFilesの検証経路では同一エラーをそのまま再設定するため、追加されたalertに再度のDOM変化が生じません。

**Files Needing Attention:** apps/web/src/app/upload/page.tsx
</details>

<details open><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| apps/web/src/app/collections/new/page.tsx | 作成エラーへrole="alert"を追加しており、再送信時には既存エラーも適切にクリアされます。 |
| apps/web/src/app/orgs/new/page.tsx | スラッグ検証結果へaria-liveを、作成エラーへrole="alert"を追加しています。 |
| apps/web/src/app/papers/[id]/edit/page.tsx | 編集処理のエラー表示へrole="alert"を追加しており、再試行時の再通知も可能です。 |
| apps/web/src/app/upload/page.tsx | エラー表示へrole="alert"を追加していますが、同じファイル検証エラーが連続した場合は再通知されません。 |

</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
### Issue 1
apps/web/src/app/upload/page.tsx:561
**同一エラーが再通知されない**

未対応形式のファイルを同じ検証結果になるように連続して選択またはドロップすると、`addFiles` は既存エラーをクリアせず同じ文字列を再設定します。alert要素と内容が更新されないため、2回目以降のエラーがスクリーンリーダーへ再通知されません。

---

For each issue above, determine whether it is valid and should be fixed. If so, fix it directly.
`````

</details>

<sub>Reviews (1): Last reviewed commit: ["feat: add role=alert to dynamic error me..."](https://github.com/hiroki-org/openshelf/commit/58475d533e1a711fb943a8a06ffcf9025e7caac7) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=50102043)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Accessibility Improvements**
  * Improved screen reader announcements for errors across collection, organization, paper editing, and upload forms.
  * Organization creation now announces slug availability updates through a live status region.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->