### PR TITLE
🎨 Palette: フォーカス時のアクセシビリティ（focus-visible）の改善

### DIFF
--- a/apps/web/src/app/papers/[id]/cite-button.tsx
+++ b/apps/web/src/app/papers/[id]/cite-button.tsx
@@ -94,7 +94,7 @@ export function CiteButton({ paperId }: CiteButtonProps) {
     <div className="mb-6 relative inline-block" ref={containerRef}>
       <button
         type="button"
-        className="inline-flex items-center gap-2 rounded-md border border-gray-300 bg-white px-4 py-2 text-sm text-gray-700 hover:bg-gray-100 transition-colors dark:border-gray-700 dark:bg-gray-900 dark:text-gray-100 dark:hover:bg-gray-800"
+        className="inline-flex items-center gap-2 rounded-md border border-gray-300 bg-white px-4 py-2 text-sm text-gray-700 hover:bg-gray-100 transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:ring-gray-900 dark:border-gray-700 dark:bg-gray-900 dark:text-gray-100 dark:hover:bg-gray-800 dark:focus-visible:ring-gray-100 dark:focus-visible:ring-offset-gray-950"
         onClick={() => setOpen((prev) => !prev)}
         aria-expanded={open}
         aria-haspopup="menu"
@@ -112,7 +112,7 @@ export function CiteButton({ paperId }: CiteButtonProps) {
             <button
               key={option.value}
               type="button"
-              className="flex w-full items-center justify-between rounded px-3 py-2 text-left text-sm text-gray-700 hover:bg-gray-100 disabled:cursor-not-allowed disabled:opacity-60 dark:text-gray-200 dark:hover:bg-gray-800"
+              className="flex w-full items-center justify-between rounded px-3 py-2 text-left text-sm text-gray-700 hover:bg-gray-100 disabled:cursor-not-allowed disabled:opacity-60 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-inset focus-visible:ring-gray-900 dark:text-gray-200 dark:hover:bg-gray-800 dark:focus-visible:ring-gray-100"
               onClick={() => handleCopy(option.value)}
               disabled={loadingFormat !== null}
               role="menuitem"

--- a/apps/web/src/components/tag-autocomplete-input.tsx
+++ b/apps/web/src/components/tag-autocomplete-input.tsx
@@ -195,7 +195,7 @@ export function TagAutocompleteInput({
         aria-expanded={open}
         aria-controls={listId}
         aria-activedescendant={activeDescendantId}
-        className={className}
+        className={`focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-gray-900 dark:focus-visible:ring-gray-100 ${className ?? ""}`}
         placeholder={placeholder}
       />
 


### PR DESCRIPTION
💡 **What:** `cite-button.tsx` と `tag-autocomplete-input.tsx` に明確なフォーカスリング (`focus-visible`) を追加
🎯 **Why:** キーボード操作時の視認性を向上させるため
♿ **Accessibility:** `focus-visible` クラスを追加し、Tabナビゲーション時のアクセシビリティを改善

---
*PR created automatically by Jules for task [6714275270982050576](https://jules.google.com/task/6714275270982050576) started by @is0692vs*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Improved keyboard-focus indicators for citation controls and format menu buttons.
  * Added visible focus styling to tag autocomplete inputs while preserving custom styling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

キーボード操作時の視認性を改善するため、引用ボタン、引用形式メニュー項目、タグ入力欄に `focus-visible` のフォーカスリングを追加しています。
- ライト／ダークテーマに応じたリング色を指定
- 引用ボタンにはオフセット付き、メニュー項目には inset のリングを追加
- タグ入力欄では任意の既存 `className` を維持しつつフォーカススタイルを付加
</details>

<details open><summary><h3>Confidence Score: 5/5</h3></summary>

今回の変更に起因する具体的な不具合は確認できず、安全にマージできると考えます。

変更は静的な Tailwind フォーカススタイルの追加に限定され、既存の呼び出し元、入力契約、操作ロジックとの競合や到達可能な表示不良は確認されませんでした。
</details>

<details open><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| apps/web/src/app/papers/[id]/cite-button.tsx | 引用ボタンと各メニュー項目に、既存の操作ロジックを変更せずテーマ対応の明確なフォーカスリングを追加しています。 |
| apps/web/src/components/tag-autocomplete-input.tsx | 呼び出し元の任意のクラス名を保持したまま、タグ入力欄へテーマ対応のフォーカスリングを追加しています。 |

</details>

<sub>Reviews (1): Last reviewed commit: ["ボタンと入力フィールドのfocus-visibleアクセシビリティを修正"](https://github.com/hiroki-org/openshelf/commit/a39206d59830b9c7a0f6a753c229ffff590acb59) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=50873993)</sub>

**Context used:**

- Knowledge Base — [Paper Upload, Storage, and Viewing Flow](https://app.greptile.com/hiroki-org/-/custom-context/knowledge-base/hiroki-org/openshelf/-/docs/papers-file-flow.md)
- Knowledge Base — [Web Frontend Shell](https://app.greptile.com/hiroki-org/-/custom-context/knowledge-base/hiroki-org/openshelf/-/docs/web-frontend.md)

<!-- /greptile_comment -->