### PR TITLE
🎨 Palette: PDFビューアのアクセシビリティ改善（aria-labelの追加）

### DIFF
--- a/apps/web/src/components/__tests__/pdf-viewer.test.tsx
+++ b/apps/web/src/components/__tests__/pdf-viewer.test.tsx
@@ -284,7 +284,7 @@ describe("PdfViewer", () => {
       expect(screen.getByText("1 / 2")).toBeInTheDocument();
     });
 
-    fireEvent.click(screen.getByRole("button", { name: "次の一致" }));
+    fireEvent.click(screen.getByRole("button", { name: "次の一致へ" }));
 
     await waitFor(() => {
       expect(screen.getByText("2 / 2")).toBeInTheDocument();
@@ -294,13 +294,13 @@ describe("PdfViewer", () => {
       expect(renderedPages).toContain(3);
     });
 
-    fireEvent.click(screen.getByRole("button", { name: "前の一致" }));
+    fireEvent.click(screen.getByRole("button", { name: "前の一致へ" }));
 
     await waitFor(() => {
       expect(screen.getByText("1 / 2")).toBeInTheDocument();
     });
 
-    fireEvent.click(screen.getByRole("button", { name: "次の一致" }));
+    fireEvent.click(screen.getByRole("button", { name: "次の一致へ" }));
     await waitFor(() => {
       expect(screen.getByText("2 / 2")).toBeInTheDocument();
     });
@@ -362,8 +362,8 @@ describe("PdfViewer", () => {
     fireEvent.click(screen.getByRole("button", { name: "ズームアウト" }));
     expect(zoomSelect.value).toBe("1.75");
 
-    fireEvent.click(screen.getByRole("button", { name: "次へ" }));
-    fireEvent.click(screen.getByRole("button", { name: "前へ" }));
+    fireEvent.click(screen.getByRole("button", { name: "次のページへ" }));
+    fireEvent.click(screen.getByRole("button", { name: "前のページへ" }));
     fireEvent.click(screen.getByRole("button", { name: "連続スクロール" }));
 
     // Mock requestFullscreen

--- a/apps/web/src/components/pdf-viewer.tsx
+++ b/apps/web/src/components/pdf-viewer.tsx
@@ -461,6 +461,7 @@ export function PdfViewer({ fileUrl, onDownloadFallback }: PdfViewerProps) {
         <div className="flex items-center gap-2">
           <button
             type="button"
+            aria-label="前のページへ"
             onClick={() => goToPage(activePage - 1)}
             disabled={!canPrev}
             title={!canPrev ? "最初のページです" : undefined}
@@ -473,6 +474,7 @@ export function PdfViewer({ fileUrl, onDownloadFallback }: PdfViewerProps) {
           </span>
           <button
             type="button"
+            aria-label="次のページへ"
             onClick={() => goToPage(activePage + 1)}
             disabled={!canNext}
             title={!canNext ? "最後のページです" : undefined}
@@ -557,6 +559,7 @@ export function PdfViewer({ fileUrl, onDownloadFallback }: PdfViewerProps) {
         />
         <button
           type="button"
+          aria-label="前の一致へ"
           disabled={searchMatches.length === 0}
           onClick={() => moveMatchCursor(-1)}
           title={
@@ -568,6 +571,7 @@ export function PdfViewer({ fileUrl, onDownloadFallback }: PdfViewerProps) {
         </button>
         <button
           type="button"
+          aria-label="次の一致へ"
           disabled={searchMatches.length === 0}
           onClick={() => moveMatchCursor(1)}
           title={


### PR DESCRIPTION
💡 **What:** PDFビューアの各ボタン（ページ移動、検索）に `aria-label` を追加しました。
🎯 **Why:** スクリーンリーダーを利用するユーザーが各ボタンの目的をより明確に理解できるようにするため。
📸 **Before/After:** 視覚的な変更はありません。
♿ **Accessibility:** 簡潔なテキストのみのボタンに詳細な `aria-label` を提供することで、アクセシビリティを向上させました。

---
*PR created automatically by Jules for task [9644083797690224470](https://jules.google.com/task/9644083797690224470) started by @is0692vs*

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

PDFビューアのページ移動ボタンと検索一致移動ボタンに、目的を明確に表す日本語の `aria-label` を追加しています。
- ページ移動ボタンのアクセシブルネームを「前のページへ」「次のページへ」に変更
- 検索結果移動ボタンのアクセシブルネームを「前の一致へ」「次の一致へ」に変更
- 対応するコンポーネントテストのロールクエリを更新
</details>

<details open><summary><h3>Confidence Score: 5/5</h3></summary>

アクセシブルネームのみを改善する限定的な変更であり、安全にマージできると判断します。

追加された aria-label は各ボタンの既存動作を正確に表し、テストも変更後のアクセシブルネームに追従しているため、ブロッキングとなる不具合は見つかりませんでした。
</details>

<details open><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| apps/web/src/components/pdf-viewer.tsx | 既存の4つの操作ボタンへ明確な aria-label を追加しており、動作ロジックへの変更や問題はありません。 |
| apps/web/src/components/__tests__/pdf-viewer.test.tsx | 新しいアクセシブルネームに合わせてボタン取得条件を更新しており、実装と整合しています。 |

</details>

<sub>Reviews (1): Last reviewed commit: ["🎨 Palette: PDFビューアのボタンにaria-labelを追加"](https://github.com/hiroki-org/openshelf/commit/14e5faf934a6caf605a2865eea7b8489d7d88c51) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=51220749)</sub>

<!-- /greptile_comment -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Accessibility Improvements**
  - Added descriptive accessible labels to PDF viewer controls for navigating between pages and search matches.
- **Tests**
  - Updated PDF viewer tests to reflect the revised control names.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->