### PR TITLE
🎨 Palette: CiteButtonのキーボードフォーカスの視認性を向上

### DIFF
--- a/apps/web/src/app/papers/[id]/cite-button.tsx
+++ b/apps/web/src/app/papers/[id]/cite-button.tsx
@@ -94,7 +94,7 @@ export function CiteButton({ paperId }: CiteButtonProps) {
     <div className="mb-6 relative inline-block" ref={containerRef}>
       <button
         type="button"
-        className="inline-flex items-center gap-2 rounded-md border border-gray-300 bg-white px-4 py-2 text-sm text-gray-700 hover:bg-gray-100 transition-colors dark:border-gray-700 dark:bg-gray-900 dark:text-gray-100 dark:hover:bg-gray-800"
+        className="inline-flex items-center gap-2 rounded-md border border-gray-300 bg-white px-4 py-2 text-sm text-gray-700 hover:bg-gray-100 transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:ring-gray-900 dark:border-gray-700 dark:bg-gray-900 dark:text-gray-100 dark:hover:bg-gray-800 dark:focus-visible:ring-gray-100 dark:focus-visible:ring-offset-gray-950"
         onClick={() => setOpen((prev) => !prev)}
         aria-expanded={open}
         aria-haspopup="menu"
@@ -112,7 +112,7 @@ export function CiteButton({ paperId }: CiteButtonProps) {
             <button
               key={option.value}
               type="button"
-              className="flex w-full items-center justify-between rounded px-3 py-2 text-left text-sm text-gray-700 hover:bg-gray-100 disabled:cursor-not-allowed disabled:opacity-60 dark:text-gray-200 dark:hover:bg-gray-800"
+              className="flex w-full items-center justify-between rounded px-3 py-2 text-left text-sm text-gray-700 hover:bg-gray-100 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-inset focus-visible:ring-gray-900 disabled:cursor-not-allowed disabled:opacity-60 dark:text-gray-200 dark:hover:bg-gray-800 dark:focus-visible:ring-gray-100"
               onClick={() => handleCopy(option.value)}
               disabled={loadingFormat !== null}
               role="menuitem"


### PR DESCRIPTION
💡 **What:** CiteButtonコンポーネントおよびそのドロップダウンメニュー内の項目に focus-visible スタイルを追加しました。
🎯 **Why:** キーボードナビゲーションを使用するユーザーが、現在どの要素がフォーカスされているか明確に認識できるようにするため。
♿ Accessibility: フォーカスリングの視認性が向上しました。

---
*PR created automatically by Jules for task [15039532699573206420](https://jules.google.com/task/15039532699573206420) started by @is0692vs*

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

CiteButton のトリガーとドロップダウン項目に、ライト・ダーク両テーマ対応の `focus-visible` リングを追加しています。
- トリガーにオフセット付きのフォーカスリングを追加
- メニュー項目に内側へ描画されるフォーカスリングを追加
- キーボード操作時の現在位置を視認しやすく改善
</details>

<details open><summary><h3>Confidence Score: 5/5</h3></summary>

この変更は安全にマージできると判断します。

追加された Tailwind ユーティリティは現在の構成で有効であり、フォーカスリングを妨げるクリッピングや既存スタイルとの不整合も確認されませんでした。
</details>

<details open><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| apps/web/src/app/papers/[id]/cite-button.tsx | 既存のデザインパターンと整合するキーボードフォーカス表示を追加しており、問題は確認されませんでした。 |

</details>

<sub>Reviews (1): Last reviewed commit: ["🎨 Palette: CiteButtonのキーボードフォーカスの視認性を向上"](https://github.com/hiroki-org/openshelf/commit/cd0f9920fe69e4c86029856a35041f01b1f7653a) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=51453560)</sub>

<!-- /greptile_comment -->