### PR TITLE
🎨 Palette: ボタンへのキーボードフォーカス（focus-visible）の追加

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -35,3 +35,6 @@
 ## 2026-07-20 - Keyboard Focus Visibility
 **Learning:** ブラウザデフォルトのフォーカスリングは背景色によっては視認性が低く、キーボードユーザーが現在どの要素を操作しているのか見失いやすくなります。特にカスタムボタンやリンクコンポーネントでは、Tailwindの `focus-visible:` ユーティリティを使用して明確なフォーカスリングを定義することがアクセシビリティ向上において非常に重要です。
 **Action:** 今後、インタラクティブな要素（ボタン、リンク、タブなど）を実装する際は、マウスユーザーの体験を損なわないよう `focus:` ではなく `focus-visible:` を使用し、十分なコントラストを持つフォーカスリング（例: `focus-visible:ring-2 focus-visible:ring-offset-2`）を必ず追加するようにします。
+## $(date +%Y-%m-%d) - [キーボードアクセシビリティ]
+**Learning:** The application had several primary action buttons and dropdown menus missing proper `focus-visible` states, which makes keyboard navigation difficult. Standardizing `focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-offset-2` across all interactive elements is critical for a consistent and accessible experience.
+**Action:** Ensure all new buttons and interactive elements include these focus utility classes by default.

--- a/apps/web/src/app/collections/new/page.tsx
+++ b/apps/web/src/app/collections/new/page.tsx
@@ -372,7 +372,7 @@ export default function NewCollectionPage() {
             slugStatus === "taken" ||
             slugStatus === "invalid"
           }
-          className="inline-flex items-center justify-center gap-2 rounded-md bg-gray-900 px-4 py-2 text-sm text-white hover:bg-gray-700 disabled:opacity-50 dark:bg-white dark:text-gray-900 dark:hover:bg-gray-200"
+          className="inline-flex items-center justify-center gap-2 rounded-md bg-gray-900 px-4 py-2 text-sm text-white hover:bg-gray-700 disabled:opacity-50 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:ring-gray-900 dark:bg-white dark:text-gray-900 dark:hover:bg-gray-200 dark:focus-visible:ring-gray-100 dark:focus-visible:ring-offset-gray-950"
         >
           {submitting && (
             <span

--- a/apps/web/src/app/orgs/new/page.tsx
+++ b/apps/web/src/app/orgs/new/page.tsx
@@ -228,7 +228,7 @@ export default function NewOrgPage() {
             slugStatus === "taken" ||
             slugStatus === "invalid"
           }
-          className="inline-flex w-full items-center justify-center gap-2 rounded-md bg-gray-900 px-4 py-2.5 text-sm text-white hover:bg-gray-700 disabled:opacity-50 dark:bg-white dark:text-gray-900 dark:hover:bg-gray-200"
+          className="inline-flex w-full items-center justify-center gap-2 rounded-md bg-gray-900 px-4 py-2.5 text-sm text-white hover:bg-gray-700 disabled:opacity-50 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:ring-gray-900 dark:bg-white dark:text-gray-900 dark:hover:bg-gray-200 dark:focus-visible:ring-gray-100 dark:focus-visible:ring-offset-gray-950"
         >
           {submitting && (
             <span

--- a/apps/web/src/app/papers/[id]/cite-button.tsx
+++ b/apps/web/src/app/papers/[id]/cite-button.tsx
@@ -94,7 +94,7 @@ export function CiteButton({ paperId }: CiteButtonProps) {
     <div className="mb-6 relative inline-block" ref={containerRef}>
       <button
         type="button"
-        className="inline-flex items-center gap-2 rounded-md border border-gray-300 bg-white px-4 py-2 text-sm text-gray-700 hover:bg-gray-100 transition-colors dark:border-gray-700 dark:bg-gray-900 dark:text-gray-100 dark:hover:bg-gray-800"
+        className="inline-flex items-center gap-2 rounded-md border border-gray-300 bg-white px-4 py-2 text-sm text-gray-700 hover:bg-gray-100 transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:ring-gray-900 dark:border-gray-700 dark:bg-gray-900 dark:text-gray-100 dark:hover:bg-gray-800 dark:focus-visible:ring-gray-100 dark:focus-visible:ring-offset-gray-950"
         onClick={() => setOpen((prev) => !prev)}
         aria-expanded={open}
         aria-haspopup="menu"
@@ -112,7 +112,7 @@ export function CiteButton({ paperId }: CiteButtonProps) {
             <button
               key={option.value}
               type="button"
-              className="flex w-full items-center justify-between rounded px-3 py-2 text-left text-sm text-gray-700 hover:bg-gray-100 disabled:cursor-not-allowed disabled:opacity-60 dark:text-gray-200 dark:hover:bg-gray-800"
+              className="flex w-full items-center justify-between rounded px-3 py-2 text-left text-sm text-gray-700 hover:bg-gray-100 disabled:cursor-not-allowed disabled:opacity-60 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:ring-gray-900 dark:text-gray-200 dark:hover:bg-gray-800 dark:focus-visible:ring-gray-100 dark:focus-visible:ring-offset-gray-950"
               onClick={() => handleCopy(option.value)}
               disabled={loadingFormat !== null}
               role="menuitem"

--- a/apps/web/src/app/papers/[id]/edit/page.tsx
+++ b/apps/web/src/app/papers/[id]/edit/page.tsx
@@ -530,7 +530,7 @@ export default function PaperEditPage() {
           <button
             type="submit"
             disabled={submitting}
-            className="inline-flex items-center justify-center gap-2 rounded-md bg-blue-600 px-6 py-2 text-white transition-colors hover:bg-blue-500 disabled:opacity-50 font-medium"
+            className="inline-flex items-center justify-center gap-2 rounded-md bg-blue-600 px-6 py-2 text-white transition-colors hover:bg-blue-500 disabled:opacity-50 font-medium focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:ring-blue-600 dark:focus-visible:ring-blue-400 dark:focus-visible:ring-offset-gray-900"
           >
             {submitting && (
               <span

--- a/apps/web/src/app/settings/page.tsx
+++ b/apps/web/src/app/settings/page.tsx
@@ -160,7 +160,7 @@ export default function SettingsPage() {
             type="button"
             onClick={handleSave}
             disabled={saving}
-            className="inline-flex min-w-32 items-center justify-center gap-2 rounded-xl bg-gray-900 px-4 py-2.5 text-sm font-medium text-white transition-colors hover:bg-gray-700 disabled:opacity-50 dark:bg-white dark:text-gray-900 dark:hover:bg-gray-200"
+            className="inline-flex min-w-32 items-center justify-center gap-2 rounded-xl bg-gray-900 px-4 py-2.5 text-sm font-medium text-white transition-colors hover:bg-gray-700 disabled:opacity-50 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:ring-gray-900 dark:bg-white dark:text-gray-900 dark:hover:bg-gray-200 dark:focus-visible:ring-gray-100 dark:focus-visible:ring-offset-gray-950"
           >
             {saving && (
               <span


### PR DESCRIPTION
💡 **What:** 複数の主要なアクションボタンおよびメニューボタンに `focus-visible` クラスを追加し、キーボード操作時のフォーカス状態を視覚的に明確にしました。
🎯 **Why:** キーボードユーザーが現在どの要素にフォーカスが当たっているかを容易に識別できるようにするため。アクセシビリティの向上を目的としています。
♿ **Accessibility:** キーボードナビゲーション時の視認性向上

---
*PR created automatically by Jules for task [2688639471435057422](https://jules.google.com/task/2688639471435057422) started by @is0692vs*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Accessibility**
  * Added consistent visible focus indicators for keyboard users across buttons, dropdowns, citation controls, and other interactive elements.
  * Focus styling supports both light and dark themes.
* **Documentation**
  * Documented the standardized keyboard-focus styling guidelines.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

このPRは、主要な操作ボタンと引用メニュー項目にキーボード操作向けの `focus-visible` リングを追加します。
- コレクション、組織、論文編集、設定の送信・保存ボタンにライト／ダークテーマ対応のフォーカス表示を追加
- 引用メニューのトリガーと各メニュー項目にフォーカス表示を追加
- Paletteの学習履歴にアクセシビリティ方針を追記
</details>

<details open><summary><h3>Confidence Score: 4/5</h3></summary>

マージを妨げる問題は見当たりませんが、Palette履歴の日付プレースホルダーは実日付へ修正することを推奨します。

ボタンの変更は既存の挙動を維持したままキーボードフォーカスの視認性を改善していますが、付随する学習履歴には未展開の日付式が残っています。

**Files Needing Attention:** .Jules/palette.md
</details>

<details open><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| .Jules/palette.md | キーボードアクセシビリティの学習事項を追記していますが、日付見出しに未展開のシェル式が残っています。 |
| apps/web/src/app/collections/new/page.tsx | コレクション作成ボタンにテーマ対応の `focus-visible` リングを追加しています。 |
| apps/web/src/app/orgs/new/page.tsx | 組織作成ボタンにテーマ対応の `focus-visible` リングを追加しています。 |
| apps/web/src/app/papers/[id]/cite-button.tsx | 引用メニューのトリガーとメニュー項目にキーボードフォーカス表示を追加しています。 |
| apps/web/src/app/papers/[id]/edit/page.tsx | 論文編集フォームの送信ボタンにテーマ対応の `focus-visible` リングを追加しています。 |
| apps/web/src/app/settings/page.tsx | 設定保存ボタンにテーマ対応の `focus-visible` リングを追加しています。 |

</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
### Issue 1
.Jules/palette.md:38
**未展開の日付プレースホルダー**

見出しに `$(date +%Y-%m-%d)` がそのまま保存されているため、学習履歴を閲覧しても追加日を判別できません。既存項目と同様に、実際の日付を記録してください。

---

For each issue above, determine whether it is valid and should be fixed. If so, fix it directly.
`````

</details>

<sub>Reviews (1): Last reviewed commit: ["feat(a11y): ボタンへのfocus-visible状態の追加"](https://github.com/hiroki-org/openshelf/commit/38e55aea2211d0caa0ec8dd1b8c4483dbbc3fce9) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=51459933)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->