### PR TITLE
🎨 Palette: [削除ボタンのキーボードフォーカス時の視認性向上]

### DIFF
--- a/apps/web/src/app/orgs/[slug]/settings/page.tsx
+++ b/apps/web/src/app/orgs/[slug]/settings/page.tsx
@@ -645,7 +645,7 @@ export default function OrgSettingsPage() {
                       type="button"
                       onClick={() => handleRemoveMember(m.userId)}
                       aria-label={`${m.displayName ?? m.name}をメンバーから削除`}
-                      className="text-red-500 hover:text-red-700 text-xs"
+                      className="text-red-500 hover:text-red-700 text-xs rounded-sm focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:ring-red-500"
                     >
                       削除
                     </button>
@@ -721,7 +721,7 @@ export default function OrgSettingsPage() {
                     type="button"
                     onClick={() => handleRemovePaper(p.id)}
                     aria-label={`${p.title}の紐づけを解除`}
-                    className="text-red-500 hover:text-red-700 text-xs shrink-0 ml-2"
+                    className="text-red-500 hover:text-red-700 text-xs shrink-0 ml-2 rounded-sm focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:ring-red-500"
                   >
                     解除
                   </button>


### PR DESCRIPTION
💡 What: 組織設定ページの「メンバーから削除」ボタンおよび「成果物の紐づけを解除」ボタンに、キーボードフォーカス時のスタイル（赤いリング）を追加しました。
🎯 Why: キーボードで操作する際、現在どのボタンにフォーカスが当たっているかが視覚的に分かりにくかったため、他のボタンと同様に明確なフィードバックを提供するためです。
📸 Before/After: 
- Before: キーボードでタブ移動しても、フォーカスを示す枠線が表示されませんでした。
- After: タブ移動時に、赤いアウトラインのリングが表示され、フォーカス位置が明確に分かるようになりました。
♿ Accessibility: キーボードナビゲーションのサポートを向上させ、キーボードユーザーが破壊的アクション（削除）をより安全・確実に操作できるようにしました。

---
*PR created automatically by Jules for task [4491334017917630445](https://jules.google.com/task/4491334017917630445) started by @is0692vs*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Added visible keyboard-focus indicators to member-removal and paper-unlink buttons for improved accessibility.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->