### PR TITLE
🎨 Palette: ボタンへのフォーカスリングの追加

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -39,3 +39,7 @@
 ## 2026-07-27 - Focus and Screen Reader Improvements for Upload Components
 **Learning:** Custom drag-and-drop zones (`<button>` tags visually styled as areas) often lack focus indicators because they don't look like traditional buttons, leading to poor keyboard accessibility. Also, decorative text like "+" and "✕" used in place of icons are read aloud by screen readers unless explicitly hidden.
 **Action:** Always add standard `focus-visible` ring styles to interactive elements regardless of their visual shape. Consistently use `aria-hidden="true"` on decorative text characters serving as icons, and `motion-safe:` for spinners.
+
+## $(date +%Y-%m-%d) - Consistent Keyboard Focus Visibility
+**Learning:** インタラクティブな要素（特に様々な画面の主要なボタン）において、`focus-visible:` クラスが欠落しているとキーボード操作時にフォーカス位置を見失う問題があります。Tailwind でスタイリングする際、一部のボタンだけ `focus-visible:` が設定されているとアプリケーション全体で一貫した操作感が得られません。
+**Action:** 今後、新規・既存に関わらずボタンコンポーネントを扱う際は、一貫して `focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-offset-2` （またはコンテキストに応じた適切なリング設定）を追加し、キーボードユーザーへのアクセシビリティを保つようにします。

--- a/apps/web/src/app/collections/new/page.tsx
+++ b/apps/web/src/app/collections/new/page.tsx
@@ -372,7 +372,7 @@ export default function NewCollectionPage() {
             slugStatus === "taken" ||
             slugStatus === "invalid"
           }
-          className="inline-flex items-center justify-center gap-2 rounded-md bg-gray-900 px-4 py-2 text-sm text-white hover:bg-gray-700 disabled:opacity-50 dark:bg-white dark:text-gray-900 dark:hover:bg-gray-200"
+          className="inline-flex items-center justify-center gap-2 rounded-md bg-gray-900 px-4 py-2 text-sm text-white hover:bg-gray-700 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-gray-900 focus-visible:ring-offset-2 disabled:opacity-50 dark:bg-white dark:text-gray-900 dark:hover:bg-gray-200 dark:focus-visible:ring-gray-100 dark:focus-visible:ring-offset-gray-950"
         >
           {submitting && (
             <span

--- a/apps/web/src/app/papers/[id]/badge-snippet.tsx
+++ b/apps/web/src/app/papers/[id]/badge-snippet.tsx
@@ -132,7 +132,7 @@ export function BadgeSnippet({ paperId, title, siteBase }: BadgeSnippetProps) {
               <button
                 type="button"
                 aria-label={`Copy ${snippet.label}`}
-                className="rounded bg-blue-600 px-2 py-1 text-white hover:bg-blue-500"
+                className="rounded bg-blue-600 px-2 py-1 text-white hover:bg-blue-500 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-blue-500 focus-visible:ring-offset-2 dark:focus-visible:ring-blue-400 dark:focus-visible:ring-offset-gray-950"
                 onClick={() => copySnippet(snippet.value)}
               >
                 Copy

--- a/apps/web/src/app/settings/page.tsx
+++ b/apps/web/src/app/settings/page.tsx
@@ -160,7 +160,7 @@ export default function SettingsPage() {
             type="button"
             onClick={handleSave}
             disabled={saving}
-            className="inline-flex min-w-32 items-center justify-center gap-2 rounded-xl bg-gray-900 px-4 py-2.5 text-sm font-medium text-white transition-colors hover:bg-gray-700 disabled:opacity-50 dark:bg-white dark:text-gray-900 dark:hover:bg-gray-200"
+            className="inline-flex min-w-32 items-center justify-center gap-2 rounded-xl bg-gray-900 px-4 py-2.5 text-sm font-medium text-white transition-colors hover:bg-gray-700 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-gray-900 focus-visible:ring-offset-2 disabled:opacity-50 dark:bg-white dark:text-gray-900 dark:hover:bg-gray-200 dark:focus-visible:ring-gray-100 dark:focus-visible:ring-offset-gray-950"
           >
             {saving && (
               <span


### PR DESCRIPTION
💡 What:
設定画面の保存ボタン、新規コレクション作成ボタン、およびバッジのコピースニペットボタンに `focus-visible` スタイル（フォーカスリング）を追加しました。

🎯 Why:
キーボードでナビゲーションするユーザーが、現在どの要素にフォーカスが当たっているかを視覚的に明確に把握できるようにするためです。

📸 Before/After:
(N/A: Visual change applies on keyboard focus)

♿ Accessibility:
キーボードナビゲーション時のフォーカスの視認性が向上しました。

---
*PR created automatically by Jules for task [12009853500175546803](https://jules.google.com/task/12009853500175546803) started by @is0692vs*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Accessibility**
  * Improved keyboard focus visibility for collection creation, snippet copying, and settings save buttons.
  * Added focus indicators that remain clear in both light and dark themes.
* **Documentation**
  * Added accessibility guidance recommending consistent focus styling for interactive elements.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->