### PR TITLE
🎨 Palette: 引用ボタンのキーボードアクセシビリティを改善

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -39,3 +39,6 @@
 ## 2026-07-27 - Focus and Screen Reader Improvements for Upload Components
 **Learning:** Custom drag-and-drop zones (`<button>` tags visually styled as areas) often lack focus indicators because they don't look like traditional buttons, leading to poor keyboard accessibility. Also, decorative text like "+" and "✕" used in place of icons are read aloud by screen readers unless explicitly hidden.
 **Action:** Always add standard `focus-visible` ring styles to interactive elements regardless of their visual shape. Consistently use `aria-hidden="true"` on decorative text characters serving as icons, and `motion-safe:` for spinners.
+## 2026-08-13 - Focus Trap and Keyboard Accessibility in Custom Dropdowns
+**Learning:** `CiteButton`のようなカスタムドロップダウンメニューにおいて、単にメニューを開閉するだけでなく、キーボード操作でメニュー項目の間を移動したり（Tabキー）、メニュー外をクリック/Escapeキーを押下した際にメニューを閉じてフォーカスをトリガーボタンに戻す制御が重要です。また、これに加えて `focus-visible` スタイルを適用することで、視覚的にもフォーカスの位置が明確になります。
+**Action:** 今後、カスタムのドロップダウンやポップオーバーを実装する際は、既存の `useFocusTrap` フックを積極的に活用し、インタラクティブ要素に対する適切なフォーカスリング（`focus-visible:ring-2` など）とキーボードナビゲーションを確保します。

--- a/apps/web/src/app/papers/[id]/__tests__/cite-button.test.tsx
+++ b/apps/web/src/app/papers/[id]/__tests__/cite-button.test.tsx
@@ -97,4 +97,34 @@ describe("CiteButton", () => {
       expect(screen.queryByRole("menu")).not.toBeInTheDocument();
     });
   });
+
+  it("traps focus inside the menu and returns focus to trigger on escape", async () => {
+    render(
+      <div>
+        <button type="button">previous</button>
+        <CiteButton paperId="paper-1" />
+        <button type="button">next</button>
+      </div>,
+    );
+
+    const trigger = screen.getByRole("button", { name: /📋 Cite/ });
+    fireEvent.click(trigger);
+
+    const bibtexButton = await screen.findByRole("menuitem", { name: "BibTeX" });
+    const plainTextButton = screen.getByRole("menuitem", { name: "Plain Text" });
+
+    bibtexButton.focus();
+    fireEvent.keyDown(document, { key: "Tab", shiftKey: true });
+    expect(plainTextButton).toHaveFocus();
+
+    fireEvent.keyDown(document, { key: "Tab" });
+    expect(bibtexButton).toHaveFocus();
+
+    fireEvent.keyDown(document, { key: "Escape" });
+
+    await waitFor(() => {
+      expect(screen.queryByRole("menu")).not.toBeInTheDocument();
+      expect(trigger).toHaveFocus();
+    });
+  });
 });

--- a/apps/web/src/app/papers/[id]/cite-button.tsx
+++ b/apps/web/src/app/papers/[id]/cite-button.tsx
@@ -4,7 +4,8 @@ import { Spinner } from "@/components/spinner";
 import { toast } from "@/components/toast";
 import { apiFetch } from "@/lib/api";
 import { safePath } from "@/lib/sanitization";
-import { useEffect, useRef, useState } from "react";
+import { useRef, useState } from "react";
+import { useFocusTrap } from "@/hooks/use-focus-trap";
 
 type CitationFormat = "bibtex" | "biblatex" | "apa" | "ieee" | "mla" | "plain";
 
@@ -27,34 +28,16 @@ export function CiteButton({ paperId }: CiteButtonProps) {
     null,
   );
   const containerRef = useRef<HTMLDivElement | null>(null);
+  const triggerRef = useRef<HTMLButtonElement | null>(null);
+  const dialogRef = useRef<HTMLDivElement | null>(null);
 
-  useEffect(() => {
-    if (!open) return;
-
-    const handlePointerDown = (event: PointerEvent) => {
-      const target = event.target;
-      if (
-        target instanceof Node &&
-        containerRef.current &&
-        !containerRef.current.contains(target)
-      ) {
-        setOpen(false);
-      }
-    };
-
-    const handleEscape = (event: KeyboardEvent) => {
-      if (event.key === "Escape") {
-        setOpen(false);
-      }
-    };
-
-    document.addEventListener("pointerdown", handlePointerDown);
-    document.addEventListener("keydown", handleEscape);
-    return () => {
-      document.removeEventListener("pointerdown", handlePointerDown);
-      document.removeEventListener("keydown", handleEscape);
-    };
-  }, [open]);
+  useFocusTrap({
+    open,
+    setOpen,
+    containerRef,
+    triggerRef,
+    dialogRef,
+  });
 
   const handleCopy = async (format: CitationFormat) => {
     setLoadingFormat(format);
@@ -93,8 +76,9 @@ export function CiteButton({ paperId }: CiteButtonProps) {
   return (
     <div className="mb-6 relative inline-block" ref={containerRef}>
       <button
+        ref={triggerRef}
         type="button"
-        className="inline-flex items-center gap-2 rounded-md border border-gray-300 bg-white px-4 py-2 text-sm text-gray-700 hover:bg-gray-100 transition-colors dark:border-gray-700 dark:bg-gray-900 dark:text-gray-100 dark:hover:bg-gray-800"
+        className="inline-flex items-center gap-2 rounded-md border border-gray-300 bg-white px-4 py-2 text-sm text-gray-700 hover:bg-gray-100 transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:ring-gray-900 dark:border-gray-700 dark:bg-gray-900 dark:text-gray-100 dark:hover:bg-gray-800 dark:focus-visible:ring-gray-100 dark:focus-visible:ring-offset-gray-950"
         onClick={() => setOpen((prev) => !prev)}
         aria-expanded={open}
         aria-haspopup="menu"
@@ -105,6 +89,7 @@ export function CiteButton({ paperId }: CiteButtonProps) {
 
       {open && (
         <div
+          ref={dialogRef}
           className="absolute z-20 mt-2 w-44 rounded-md border border-gray-200 bg-white p-1 shadow-lg dark:border-gray-700 dark:bg-gray-900"
           role="menu"
         >
@@ -112,7 +97,7 @@ export function CiteButton({ paperId }: CiteButtonProps) {
             <button
               key={option.value}
               type="button"
-              className="flex w-full items-center justify-between rounded px-3 py-2 text-left text-sm text-gray-700 hover:bg-gray-100 disabled:cursor-not-allowed disabled:opacity-60 dark:text-gray-200 dark:hover:bg-gray-800"
+              className="flex w-full items-center justify-between rounded px-3 py-2 text-left text-sm text-gray-700 hover:bg-gray-100 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-inset focus-visible:ring-gray-900 disabled:cursor-not-allowed disabled:opacity-60 dark:text-gray-200 dark:hover:bg-gray-800 dark:focus-visible:ring-gray-100"
               onClick={() => handleCopy(option.value)}
               disabled={loadingFormat !== null}
               role="menuitem"


### PR DESCRIPTION
## 💡 What:
`CiteButton`（引用ボタン）とそのドロップダウンメニューに、キーボードナビゲーションのためのフォーカス制御（`useFocusTrap`）と、視認性の高いフォーカスリングスタイル（`focus-visible`）を追加しました。また、この動作を保証するテストを追加しました。

## 🎯 Why:
これまで引用ボタンやそのメニュー項目にはフォーカス時の明確な視覚フィードバックがなく、キーボードユーザーが現在どこを操作しているのか見失いやすい状態でした。また、メニューを開いた際に自動でメニュー内にフォーカスが移動せず、Tabキーでの移動やEscapeキーでのキャンセルも正しく機能していませんでした。これらの課題を解決し、すべてのユーザーがスムーズに操作できるようにするためです。

## 📸 Before/After:
* **Before:** キーボードでボタンにフォーカスを合わせても視覚的な変化が乏しく、メニューを開いた後はTabキーでページ内の他の要素にフォーカスが漏れてしまっていました。
* **After:** ボタンやメニュー項目にフォーカスが当たると、明確なリング（`ring-2`）が表示されます。メニューを開くとフォーカスがメニュー内に閉じ込められ（フォーカストラップ）、Escapeキーを押すとメニューが閉じて元のボタンにフォーカスが戻ります。

## ♿ Accessibility:
* **キーボード操作の向上:** `useFocusTrap` フックを統合し、メニュー展開時のTabキー/Escapeキーによる論理的なフォーカス移動を実装しました。
* **視覚的フィードバック:** `focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-offset-2` 等のユーティリティクラスを追加し、WCAGのフォーカスインジケータ要件に準拠する明確な視覚的フィードバックを提供しました（メニュー項目がコンテナと隣接するため、項目には `focus-visible:ring-inset` を使用）。

---
*PR created automatically by Jules for task [3067896891119079166](https://jules.google.com/task/3067896891119079166) started by @is0692vs*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Accessibility**
  * Improved keyboard navigation in the citation menu, including focus trapping and cycling through options.
  * Pressing Escape or clicking outside closes the menu and returns focus to the trigger.
  * Added clearer visible focus indicators for keyboard users.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->